### PR TITLE
Capture streams protocol in message size histogram metrics

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream.erl
@@ -46,6 +46,7 @@ start(_Type, _Args) ->
                                 ?PROTOCOL_COUNTERS),
     rabbit_global_counters:init(#{protocol => stream,
                                   queue_type => ?STREAM_QUEUE_TYPE}),
+    rabbit_msg_size_metrics:init(stream),
     rabbit_stream_sup:start_link().
 
 tls_host() ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -72,7 +72,7 @@ write_messages(?VERSION_1 = V, ClusterLeader,
                  Message:MessageSize/binary,
                  Rest/binary>>) ->
     write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, Message, Rest);
+                    PublishingId, MessageSize, Message, Rest);
 write_messages(?VERSION_1 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -88,7 +88,7 @@ write_messages(?VERSION_1 = V, ClusterLeader,
                  Rest/binary>>) ->
     Data = {batch, MessageCount, CompressionType, UncompressedSize, Batch},
     write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, Data, Rest);
+                    PublishingId, undefined, Data, Rest);
 write_messages(?VERSION_2 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -100,7 +100,7 @@ write_messages(?VERSION_2 = V, ClusterLeader,
                  Message:MessageSize/binary,
                  Rest/binary>>) ->
     write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, Message, Rest);
+                    PublishingId, MessageSize, Message, Rest);
 write_messages(?VERSION_2 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -112,9 +112,10 @@ write_messages(?VERSION_2 = V, ClusterLeader,
                  Message:MessageSize/binary,
                  Rest/binary>>) ->
     write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, {FilterValue, Message}, Rest).
+                    PublishingId, MessageSize, {FilterValue, Message}, Rest).
 
-write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, PublishingId, Data, Rest) ->
+write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId,
+                PublishingId, MessageSize, Data, Rest) ->
     Corr = case PublisherRef of
                undefined ->
                    %% we add the internal ID to detect late confirms from a stale publisher
@@ -124,6 +125,12 @@ write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Publi
                    %% when deduplication is activated.
                    PublishingId
            end,
+    case MessageSize of
+        undefined ->
+            ok;
+        _ ->
+            rabbit_msg_size_metrics:observe(stream, MessageSize)
+    end,
     ok = osiris:write(ClusterLeader, PublisherRef, Corr, Data),
     write_messages(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Rest).
 

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -86,7 +86,8 @@ groups() ->
       ]},
      %% Run `test_global_counters` on its own so the global metrics are
      %% initialised to 0 for each testcase
-     {single_node_1, [], [test_global_counters]},
+     {single_node_1, [], [test_global_counters,
+                          test_message_size_metrics]},
      {cluster, [], [test_stream, test_stream_tls, test_metadata, java,
                     test_resolve_offset_spec]}].
 
@@ -284,6 +285,36 @@ test_global_counters(Config) ->
                    stream_error_unknown_frame_total => 0,
                    stream_error_vhost_access_failure_total => 0},
                  get_global_counters(Config)),
+    ok.
+
+test_message_size_metrics(Config) ->
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    Transport = gen_tcp,
+    {S, C0} = connect_and_authenticate(Transport, Config),
+    C1 = test_create_stream(Transport, S, Stream, C0),
+    PublisherId = 1,
+    C2 = test_declare_publisher(Transport, S, PublisherId, Stream, C1),
+
+    BucketsBefore = rpc(Config, 0, rabbit_msg_size_metrics, raw_buckets, [stream]),
+
+    Body5B = <<"hello">>,
+    Body500B = binary:copy(<<"x">>, 500),
+    Body5KB = binary:copy(<<"x">>, 5_000),
+
+    C3 = test_publish_confirm(Transport, S, PublisherId, 1, Body5B, C2),
+    C4 = test_publish_confirm(Transport, S, PublisherId, 2, Body500B, C3),
+    C5 = test_publish_confirm(Transport, S, PublisherId, 3, Body5KB, C4),
+
+    BucketsAfter = rpc(Config, 0, rabbit_msg_size_metrics, raw_buckets, [stream]),
+    ?assertEqual(
+       [{100, 1},
+        {1_000, 1},
+        {10_000, 1}],
+       rabbit_msg_size_metrics:diff_raw_buckets(BucketsAfter, BucketsBefore)),
+
+    C6 = test_delete_stream(Transport, S, Stream, C5),
+    _C7 = test_close(Transport, S, C6),
+    closed = wait_for_socket_close(Transport, S, 10),
     ok.
 
 test_stream(Config) ->


### PR DESCRIPTION
Currently the streams protocol does not affect the message size histogram metrics. This change takes a look at adding them.

I suspect that this wasn't added in the original PR because of batching? With batches we know the batch size and number of messages, but we'd need to scan or even decompress a batch to know the message sizes within. This change currently skips batches but we should discuss how to handle them properly.