### PR TITLE
Minor: Add auth_http.ssl_options.ciphers cuttlefish config option

### DIFF
--- a/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
+++ b/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
@@ -83,6 +83,15 @@ end}.
 {mapping, "auth_http.ssl_options.honor_cipher_order", "rabbitmq_auth_backend_http.ssl_options.honor_cipher_order",
     [{datatype, {enum, [true, false]}}]}.
 
+{mapping, "auth_http.ssl_options.ciphers.$cipher", "rabbitmq_auth_backend_http.ssl_options.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_http.ssl_options.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.ciphers", Conf),
+    lists:reverse([V || {_, V} <- Settings])
+end}.
+
 {mapping, "auth_http.ssl_options.honor_ecc_order", "rabbitmq_auth_backend_http.ssl_options.honor_ecc_order",
     [{datatype, {enum, [true, false]}}]}.
 

--- a/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
+++ b/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
@@ -203,5 +203,34 @@
        {versions,['tlsv1.2','tlsv1.1']}
       ]}
     ]}],
+  []},
+ {ssl_options_ciphers,
+  "auth_http.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   auth_http.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   auth_http.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   auth_http.ssl_options.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.4 = ECDHE-RSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.7 = ECDH-ECDSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.8 = ECDH-RSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [{rabbitmq_auth_backend_http,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {ciphers,
+        ["ECDHE-ECDSA-AES256-GCM-SHA384",
+         "ECDHE-RSA-AES256-GCM-SHA384",
+         "ECDHE-ECDSA-AES256-SHA384",
+         "ECDHE-RSA-AES256-SHA384",
+         "ECDH-ECDSA-AES256-GCM-SHA384",
+         "ECDH-RSA-AES256-GCM-SHA384",
+         "ECDH-ECDSA-AES256-SHA384",
+         "ECDH-RSA-AES256-SHA384",
+         "DHE-RSA-AES256-GCM-SHA384"]}]}]}],
   []}
 ].


### PR DESCRIPTION
## Proposed Changes

It is present for various apps like `rabbit`, but was missing for `rabbitmq_auth_backend_http`.

(yes, we had a case which needed a special cipher suite list :( )

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments