### PR TITLE
Federation: handle {error, already_present} in link supervisors

### DIFF
--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -50,6 +50,13 @@ start_child(X) ->
           ?LOG_DEBUG("Federation link for exchange ~tp was already started",
                      [rabbit_misc:rs(ExchangeName)]),
           ok;
+        {error, already_present} ->
+          #exchange{name = ExchangeName} = X,
+          ?LOG_WARNING("Federation link for exchange ~tp had a stale child spec; "
+                       "removing it so the link can be restarted",
+                       [rabbit_misc:rs(ExchangeName)]),
+          _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(X)),
+          ok;
         %% A link returned {stop, gone}, the link_sup shut down, that's OK.
         {error, {shutdown, _}} -> ok
     catch

--- a/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
@@ -8,6 +8,7 @@
 -module(unit_SUITE).
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 
 -include("rabbit_exchange_federation.hrl").
 
@@ -17,7 +18,8 @@ all() -> [
     reconnect_all_empty_scope,
     reconnect_all_broadcasts_to_members,
     adjust_when_supervisor_not_running,
-    adjust_clear_upstream_when_supervisor_not_running
+    adjust_clear_upstream_when_supervisor_not_running,
+    start_child_handles_already_present
 ].
 
 init_per_suite(Config) ->
@@ -77,3 +79,24 @@ adjust_clear_upstream_when_supervisor_not_running(_Config) ->
     %% adjust/1 with clear_upstream should not fail
     ?assertEqual(ok, rabbit_federation_exchange_link_sup_sup:adjust({clear_upstream, <<"/">>, <<"test">>})),
     ?assertEqual(ok, rabbit_federation_exchange_link_sup_sup:adjust({clear_upstream_set, <<"test">>})).
+
+start_child_handles_already_present(_Config) ->
+    XName = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"x">>},
+    X = #exchange{name = XName, type = direct, durable = true,
+                  auto_delete = false, internal = false, arguments = []},
+    Self = self(),
+    ok = meck:new(mirrored_supervisor, [unstick, passthrough]),
+    ok = meck:expect(mirrored_supervisor, start_child,
+                     fun(_Sup, _ChildSpec) -> {error, already_present} end),
+    ok = meck:expect(mirrored_supervisor, delete_child,
+                     fun(_Sup, _Id) -> Self ! delete_child_called, ok end),
+    try
+        ?assertEqual(ok, rabbit_federation_exchange_link_sup_sup:start_child(X)),
+        receive
+            delete_child_called -> ok
+        after 1000 ->
+            ct:fail("delete_child/2 was not called to clean up stale spec")
+        end
+    after
+        ok = meck:unload(mirrored_supervisor)
+    end.

--- a/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link_sup_sup.erl
+++ b/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link_sup_sup.erl
@@ -48,6 +48,13 @@ start_child(Q) ->
           ?LOG_WARNING("Federation link for queue ~tp was already started",
                        [rabbit_misc:rs(QueueName)]),
           ok;
+        {error, already_present} ->
+          QueueName = amqqueue:get_name(Q),
+          ?LOG_WARNING("Federation link for queue ~tp had a stale child spec; "
+                       "removing it so the link can be restarted",
+                       [rabbit_misc:rs(QueueName)]),
+          _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(Q)),
+          ok;
         %% A link returned {stop, gone}, the link_sup shut down, that's OK.
         {error, {shutdown, _}} -> ok
     catch

--- a/deps/rabbitmq_queue_federation/test/unit_SUITE.erl
+++ b/deps/rabbitmq_queue_federation/test/unit_SUITE.erl
@@ -8,6 +8,7 @@
 -module(unit_SUITE).
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 
 -include("rabbit_queue_federation.hrl").
 
@@ -17,7 +18,8 @@ all() -> [
     reconnect_all_empty_scope,
     reconnect_all_broadcasts_to_members,
     adjust_when_supervisor_not_running,
-    adjust_clear_upstream_when_supervisor_not_running
+    adjust_clear_upstream_when_supervisor_not_running,
+    start_child_handles_already_present
 ].
 
 init_per_suite(Config) ->
@@ -77,3 +79,23 @@ adjust_clear_upstream_when_supervisor_not_running(_Config) ->
     %% adjust/1 with clear_upstream should not fail
     ?assertEqual(ok, rabbit_federation_queue_link_sup_sup:adjust({clear_upstream, <<"/">>, <<"test">>})),
     ?assertEqual(ok, rabbit_federation_queue_link_sup_sup:adjust({clear_upstream_set, <<"test">>})).
+
+start_child_handles_already_present(_Config) ->
+    Name = #resource{virtual_host = <<"/">>, kind = queue, name = <<"q">>},
+    Q = amqqueue:new(Name, none, true, false, none, [], <<"/">>, #{}),
+    Self = self(),
+    ok = meck:new(mirrored_supervisor, [unstick, passthrough]),
+    ok = meck:expect(mirrored_supervisor, start_child,
+                     fun(_Sup, _ChildSpec) -> {error, already_present} end),
+    ok = meck:expect(mirrored_supervisor, delete_child,
+                     fun(_Sup, _Id) -> Self ! delete_child_called, ok end),
+    try
+        ?assertEqual(ok, rabbit_federation_queue_link_sup_sup:start_child(Q)),
+        receive
+            delete_child_called -> ok
+        after 1000 ->
+            ct:fail("delete_child/2 was not called to clean up stale spec")
+        end
+    after
+        ok = meck:unload(mirrored_supervisor)
+    end.


### PR DESCRIPTION
## Proposed Changes

Fixes #16224.

`rabbit_federation_queue_link_sup_sup:start_child/1` and its exchange counterpart `rabbit_federation_exchange_link_sup_sup:start_child/1` use a `try ... of` block to dispatch on the return value of `mirrored_supervisor:start_child/2`. The `of` clauses cover `{ok, _}`, `{error, {already_started, _}}` and `{error, {shutdown, _}}` but do **not** cover `{error, already_present}`. When `mirrored_supervisor` returns `{error, already_present}` (its child spec is registered but no process is currently running for it — a transient child that exited with a non-normal reason and whose spec was not cleaned up), the unhandled value falls through, Erlang raises `try_clause`, the calling process dies, and the link supervisor counts a restart. With many concurrent calls (for example during a quorum-queue leader rebalance), the supervisor exhausts `max_restart_intensity` and stops, leaving federation broken on that node until the federation upstream/policy is re-declared.

This bug was introduced in **9b2cee83 (2020-09-14, "Use mirrored_supervisor for queue federation")**: that commit changed the underlying supervisor from `supervisor2` to `mirrored_supervisor`. `supervisor2:start_child` does not return `{error, already_present}`; `mirrored_supervisor:start_child` does, because its child specs persist across the cluster. The case clauses that were complete for `supervisor2` became incomplete the moment the supervisor module changed and have stayed incomplete on every release since (still present on `main`).

The crash signature looks like this:

```
[error] {{try_clause,{error,already_present}},
          [{rabbit_federation_queue_link_sup_sup,start_child,1,
               [{file,"rabbit_federation_queue_link_sup_sup.erl"},{line,40}]},
           {rabbit_federation_queue,startup,1,
               [{file,"rabbit_federation_queue.erl"},{line,33}]},
           {rabbit_quorum_queue,'-notify_decorators/3-lc$^1/1-0-',4,
               [{file,"rabbit_quorum_queue.erl"},{line,2406}]},
           {rabbit_quorum_queue,notify_decorators,3,
               [{file,"rabbit_quorum_queue.erl"},{line,2406}]}]}
```

See #16224 for a detailed reproducing trigger.

### What this PR does

Adds the missing `{error, already_present}` clause to both queue-federation and exchange-federation link supervisors. The new clause logs a warning, calls `mirrored_supervisor:delete_child/2` to remove the stale spec, and returns `ok`. This is consistent with the existing `stop_child/1` cleanup pattern (which also calls `delete_child/2` after `terminate_child/2`), is idempotent, and unblocks the next call to `start_child/1`. The next `start_child/1` will be driven by `notify_decorators` on the next quorum-queue tick, by a policy refresh, or by `reconnect_all`.

Adds unit tests for both the queue and exchange variants. Each test mocks `mirrored_supervisor:start_child/2` to return `{error, already_present}`, asserts that `start_child/1` returns `ok` (instead of crashing with a `try_clause` exception), and confirms that `mirrored_supervisor:delete_child/2` is called to remove the stale spec.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #16224)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [ ] **Mandatory**: I (or my employer/client) have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective
- [ ] All tests pass locally with my changes (no local Erlang toolchain available; CI will validate)
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Alternative considered: instead of `delete_child` + `ok`, recurse into `start_child/1` after removing the stale spec to immediately re-establish the link. I went with `delete_child` + `ok` for safety (no recursion, no risk of unbounded retry loops) and because the federation system already has multiple paths that will retry: `rabbit_quorum_queue:notify_decorators/3` re-fires on the next leader event, `rabbit_federation_queue_link:reconnect_all/0` covers the worker's reconnect logic, and policy refreshes call `policy_changed_local/2` → `shutdown` → `startup`. Happy to switch to recurse-after-delete if the reviewers prefer.
