### PR TITLE
`rabbitmq.conf`: make cipher suites configurable for TLS clients in three more places (plugins)

### DIFF
--- a/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
+++ b/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
@@ -83,15 +83,6 @@ end}.
 {mapping, "auth_http.ssl_options.honor_cipher_order", "rabbitmq_auth_backend_http.ssl_options.honor_cipher_order",
     [{datatype, {enum, [true, false]}}]}.
 
-{mapping, "auth_http.ssl_options.ciphers.$cipher", "rabbitmq_auth_backend_http.ssl_options.ciphers",
-    [{datatype, string}]}.
-
-{translation, "rabbitmq_auth_backend_http.ssl_options.ciphers",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.ciphers", Conf),
-    lists:reverse([V || {_, V} <- Settings])
-end}.
-
 {mapping, "auth_http.ssl_options.honor_ecc_order", "rabbitmq_auth_backend_http.ssl_options.honor_ecc_order",
     [{datatype, {enum, [true, false]}}]}.
 
@@ -137,6 +128,15 @@ end}.
 fun(Conf) ->
     Settings = cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.versions", Conf),
     [ V || {_, V} <- Settings ]
+end}.
+
+{mapping, "auth_http.ssl_options.ciphers.$cipher", "rabbitmq_auth_backend_http.ssl_options.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_http.ssl_options.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.ciphers", Conf),
+    lists:reverse([V || {_, V} <- Settings])
 end}.
 
 {mapping, "auth_http.ssl_options.sni", "rabbitmq_auth_backend_http.ssl_options.server_name_indication",

--- a/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
+++ b/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
@@ -83,6 +83,15 @@ end}.
 {mapping, "auth_http.ssl_options.honor_cipher_order", "rabbitmq_auth_backend_http.ssl_options.honor_cipher_order",
     [{datatype, {enum, [true, false]}}]}.
 
+{mapping, "auth_http.ssl_options.ciphers.$cipher", "rabbitmq_auth_backend_http.ssl_options.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_http.ssl_options.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.ciphers", Conf),
+    lists:reverse([V || {_, V} <- Settings])
+end}.
+
 {mapping, "auth_http.ssl_options.honor_ecc_order", "rabbitmq_auth_backend_http.ssl_options.honor_ecc_order",
     [{datatype, {enum, [true, false]}}]}.
 

--- a/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
+++ b/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
@@ -217,6 +217,7 @@
    auth_http.ssl_options.ciphers.7 = ECDH-ECDSA-AES256-SHA384
    auth_http.ssl_options.ciphers.8 = ECDH-RSA-AES256-SHA384
    auth_http.ssl_options.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [],
   [{rabbitmq_auth_backend_http,
     [{ssl_options,
       [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},

--- a/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
+++ b/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
@@ -203,5 +203,34 @@
        {versions,['tlsv1.2','tlsv1.1']}
       ]}
     ]}],
+  []},
+ {ssl_options_ciphers,
+  "auth_http.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   auth_http.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   auth_http.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   auth_http.ssl_options.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.4 = ECDHE-RSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
+   auth_http.ssl_options.ciphers.7 = ECDH-ECDSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.8 = ECDH-RSA-AES256-SHA384
+   auth_http.ssl_options.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [{rabbitmq_auth_backend_http,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {ciphers,
+        ["ECDHE-ECDSA-AES256-GCM-SHA384",
+         "ECDHE-RSA-AES256-GCM-SHA384",
+         "ECDHE-ECDSA-AES256-SHA384",
+         "ECDHE-RSA-AES256-SHA384",
+         "ECDH-ECDSA-AES256-GCM-SHA384",
+         "ECDH-RSA-AES256-GCM-SHA384",
+         "ECDH-ECDSA-AES256-SHA384",
+         "ECDH-RSA-AES256-SHA384",
+         "DHE-RSA-AES256-GCM-SHA384"]}]}]}],
   []}
 ].

--- a/deps/rabbitmq_auth_backend_ldap/priv/schema/rabbitmq_auth_backend_ldap.schema
+++ b/deps/rabbitmq_auth_backend_ldap/priv/schema/rabbitmq_auth_backend_ldap.schema
@@ -310,6 +310,15 @@ fun(Conf) ->
     [ V || {_, V} <- Settings ]
 end}.
 
+{mapping, "auth_ldap.ssl_options.ciphers.$cipher", "rabbitmq_auth_backend_ldap.ssl_options.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_ldap.ssl_options.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("auth_ldap.ssl_options.ciphers", Conf),
+    lists:reverse([V || {_, V} <- Settings])
+end}.
+
 {mapping, "auth_ldap.ssl_options.sni", "rabbitmq_auth_backend_ldap.ssl_options.server_name_indication",
     [{datatype, [{enum, [none]}, string]}]}.
 

--- a/deps/rabbitmq_auth_backend_ldap/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
+++ b/deps/rabbitmq_auth_backend_ldap/test/config_schema_SUITE_data/rabbitmq_auth_backend_ldap.snippets
@@ -339,6 +339,39 @@
         {use_ssl, true}]}],
   []},
 
+ {ssl_options_ciphers,
+  "auth_ldap.use_ssl = true
+   auth_ldap.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   auth_ldap.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   auth_ldap.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   auth_ldap.ssl_options.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
+   auth_ldap.ssl_options.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
+   auth_ldap.ssl_options.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
+   auth_ldap.ssl_options.ciphers.4 = ECDHE-RSA-AES256-SHA384
+   auth_ldap.ssl_options.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
+   auth_ldap.ssl_options.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
+   auth_ldap.ssl_options.ciphers.7 = ECDH-ECDSA-AES256-SHA384
+   auth_ldap.ssl_options.ciphers.8 = ECDH-RSA-AES256-SHA384
+   auth_ldap.ssl_options.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [],
+  [{rabbitmq_auth_backend_ldap,
+       [{ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+             {ciphers,
+              ["ECDHE-ECDSA-AES256-GCM-SHA384",
+               "ECDHE-RSA-AES256-GCM-SHA384",
+               "ECDHE-ECDSA-AES256-SHA384",
+               "ECDHE-RSA-AES256-SHA384",
+               "ECDH-ECDSA-AES256-GCM-SHA384",
+               "ECDH-RSA-AES256-GCM-SHA384",
+               "ECDH-ECDSA-AES256-SHA384",
+               "ECDH-RSA-AES256-SHA384",
+               "DHE-RSA-AES256-GCM-SHA384"]}]},
+        {use_ssl, true}]}],
+  []},
+
  {vhost_access_query,
   "auth_ldap.queries.vhost_access = '''
        {in_group,\"ou=${vhost}-users,ou=vhosts,dc=example,dc=com\"}

--- a/deps/rabbitmq_trust_store/priv/schema/rabbitmq_trust_store.schema
+++ b/deps/rabbitmq_trust_store/priv/schema/rabbitmq_trust_store.schema
@@ -147,3 +147,12 @@ fun(Conf) ->
     Settings = cuttlefish_variable:filter_by_prefix("trust_store.ssl_options.versions", Conf),
     [ V || {_, V} <- Settings ]
 end}.
+
+{mapping, "trust_store.ssl_options.ciphers.$cipher", "rabbitmq_trust_store.ssl_options.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_trust_store.ssl_options.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("trust_store.ssl_options.ciphers", Conf),
+    lists:reverse([V || {_, V} <- Settings])
+end}.

--- a/deps/rabbitmq_trust_store/src/rabbit_trust_store_http_provider.erl
+++ b/deps/rabbitmq_trust_store/src/rabbit_trust_store_http_provider.erl
@@ -14,7 +14,7 @@
 
 -define(PROFILE, ?MODULE).
 
--export([list_certs/1, list_certs/2, load_cert/3]).
+-export([list_certs/1, list_certs/2, load_cert/3, prepare_ssl_opts/1]).
 
 -record(http_state,{
     url :: string(),
@@ -80,9 +80,13 @@ init_state(Config) ->
     HttpOptions0 = [{timeout, Timeout}, {connect_timeout, Timeout}],
     HttpOptions = case proplists:get_value(ssl_options, Config) of
         undefined -> HttpOptions0;
-        SslOpts   -> [{ssl, SslOpts} | HttpOptions0]
+        SslOpts   -> [{ssl, prepare_ssl_opts(SslOpts)} | HttpOptions0]
     end,
     #http_state{url = Url, http_options = HttpOptions, headers = [{"connection", "close"} | Headers]}.
+
+-spec prepare_ssl_opts(proplists:proplist()) -> proplists:proplist().
+prepare_ssl_opts(SslOpts) ->
+    rabbit_ssl_options:fix_client(SslOpts).
 
 https_request_timeout() ->
     application:get_env(rabbitmq_trust_store, https_request_timeout, 20000).

--- a/deps/rabbitmq_trust_store/test/config_schema_SUITE_data/rabbitmq_trust_store.snippets
+++ b/deps/rabbitmq_trust_store/test/config_schema_SUITE_data/rabbitmq_trust_store.snippets
@@ -29,4 +29,37 @@
            {ssl_options,
                [{certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
                 {password,<<"i_am_password">>}]}]}],
-     [rabbitmq_trust_store]}].
+     [rabbitmq_trust_store]},
+ {ssl_options_ciphers,
+  "trust_store.providers.1 = http
+   trust_store.url = https://example.com
+   trust_store.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   trust_store.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   trust_store.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   trust_store.ssl_options.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
+   trust_store.ssl_options.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
+   trust_store.ssl_options.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
+   trust_store.ssl_options.ciphers.4 = ECDHE-RSA-AES256-SHA384
+   trust_store.ssl_options.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
+   trust_store.ssl_options.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
+   trust_store.ssl_options.ciphers.7 = ECDH-ECDSA-AES256-SHA384
+   trust_store.ssl_options.ciphers.8 = ECDH-RSA-AES256-SHA384
+   trust_store.ssl_options.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [{rabbitmq_trust_store,
+       [{providers,[rabbit_trust_store_http_provider]},
+        {url,"https://example.com"},
+        {ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+             {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+             {ciphers,
+              ["ECDHE-ECDSA-AES256-GCM-SHA384",
+               "ECDHE-RSA-AES256-GCM-SHA384",
+               "ECDHE-ECDSA-AES256-SHA384",
+               "ECDHE-RSA-AES256-SHA384",
+               "ECDH-ECDSA-AES256-GCM-SHA384",
+               "ECDH-RSA-AES256-GCM-SHA384",
+               "ECDH-ECDSA-AES256-SHA384",
+               "ECDH-RSA-AES256-SHA384",
+               "DHE-RSA-AES256-GCM-SHA384"]}]}]}],
+  [rabbitmq_trust_store]}].

--- a/deps/rabbitmq_trust_store/test/http_provider_tls_prop_SUITE.erl
+++ b/deps/rabbitmq_trust_store/test/http_provider_tls_prop_SUITE.erl
@@ -1,0 +1,192 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(http_provider_tls_prop_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    [{group, unit},
+     {group, prop}].
+
+groups() ->
+    [{unit, [parallel],
+      [sslv3_filtered_from_versions,
+       other_versions_preserved,
+       hibernate_after_added_when_absent,
+       hibernate_after_preserved_when_set,
+       cacertfile_prevents_cacerts_injection,
+       cacerts_preserved_when_set,
+       user_options_preserved]},
+     {prop, [parallel],
+      [prop_sslv3_never_present,
+       prop_hibernate_after_always_set,
+       prop_cacertfile_prevents_cacerts_injection,
+       prop_user_options_preserved]}].
+
+suite() ->
+    [{timetrap, {seconds, 60}}].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok.
+
+%% -------------------------------------------------------------------
+%% Unit tests
+%% -------------------------------------------------------------------
+
+sslv3_filtered_from_versions(_Config) ->
+    Opts = prepare([{versions, [sslv3, 'tlsv1.2', 'tlsv1.3']}]),
+    Versions = opt(versions, Opts),
+    false = lists:member(sslv3, Versions),
+    true  = lists:member('tlsv1.2', Versions),
+    true  = lists:member('tlsv1.3', Versions).
+
+other_versions_preserved(_Config) ->
+    Opts = prepare([{versions, ['tlsv1.2', 'tlsv1.3']}]),
+    ['tlsv1.2', 'tlsv1.3'] = opt(versions, Opts).
+
+hibernate_after_added_when_absent(_Config) ->
+    Opts = prepare([]),
+    6000 = opt(hibernate_after, Opts).
+
+hibernate_after_preserved_when_set(_Config) ->
+    Opts = prepare([{hibernate_after, 12000}]),
+    12000 = opt(hibernate_after, Opts).
+
+cacertfile_prevents_cacerts_injection(_Config) ->
+    Opts = prepare([{cacertfile, "/path/to/ca.pem"}]),
+    undefined = opt(cacerts, Opts).
+
+cacerts_preserved_when_set(_Config) ->
+    MyCaCerts = [<<1, 2, 3>>],
+    Opts = prepare([{cacerts, MyCaCerts}]),
+    MyCaCerts = opt(cacerts, Opts).
+
+user_options_preserved(_Config) ->
+    Input = [{certfile, "/path/to/cert.pem"},
+             {keyfile, "/path/to/key.pem"},
+             {versions, ['tlsv1.2', 'tlsv1.3']}],
+    Opts = prepare(Input),
+    "/path/to/cert.pem" = opt(certfile, Opts),
+    "/path/to/key.pem"  = opt(keyfile, Opts),
+    ['tlsv1.2', 'tlsv1.3'] = opt(versions, Opts).
+
+%% -------------------------------------------------------------------
+%% Property-based tests
+%% -------------------------------------------------------------------
+
+prop_sslv3_never_present(_Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL(
+                 UserOpts, ssl_options(),
+                 not lists:member(sslv3, proplists:get_value(versions, prepare(UserOpts), [])))
+      end).
+
+prop_hibernate_after_always_set(_Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL(
+                 UserOpts, ssl_options(),
+                 is_integer(opt(hibernate_after, prepare(UserOpts))))
+      end).
+
+prop_cacertfile_prevents_cacerts_injection(_Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL(
+                 BaseOpts, ssl_options_without_ca(),
+                 undefined =:= opt(cacerts, prepare([{cacertfile, "/path/to/ca.pem"} | BaseOpts])))
+      end).
+
+prop_user_options_preserved(_Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL(
+                 UserOpts, ssl_options(),
+                 begin
+                     Result = prepare(UserOpts),
+                     %% Keys that fix_client may normalise or supplement.
+                     Normalised = [versions, hibernate_after, cacerts],
+                     lists:all(
+                       fun({K, V}) ->
+                               lists:member(K, Normalised) orelse
+                                   opt(K, Result) =:= V
+                       end, UserOpts)
+                 end)
+      end).
+
+%% -------------------------------------------------------------------
+%% Generators
+%% -------------------------------------------------------------------
+
+ssl_options() ->
+    ?LET(Opts, list(ssl_option()),
+         unique_keys(Opts)).
+
+ssl_options_without_ca() ->
+    ?LET(Opts, ssl_options(),
+         lists:filter(fun({K, _}) ->
+                              K =/= cacerts andalso K =/= cacertfile
+                      end, Opts)).
+
+ssl_option() ->
+    oneof([
+        {versions, list(oneof(['tlsv1.2', 'tlsv1.3']))},
+        {hibernate_after, range(1000, 60000)},
+        {certfile, binary()},
+        {keyfile, binary()},
+        {cacerts, list(binary())},
+        {cacertfile, binary()},
+        {ciphers, list(binary())}
+    ]).
+
+unique_keys(Opts) ->
+    lists:foldl(fun({K, _} = Opt, Acc) ->
+                        case lists:keymember(K, 1, Acc) of
+                            true  -> Acc;
+                            false -> [Opt | Acc]
+                        end
+                end, [], Opts).
+
+%% -------------------------------------------------------------------
+%% Helpers
+%% -------------------------------------------------------------------
+
+prepare(Opts) ->
+    rabbit_trust_store_http_provider:prepare_ssl_opts(Opts).
+
+opt(Key, Options) ->
+    proplists:get_value(Key, Options).
+
+run_proper(Fun) ->
+    ?assert(proper:counterexample(
+              Fun(),
+              [{numtests, 100},
+               {on_output, fun(".", _) -> ok;
+                              (F, A) -> ct:pal(?LOW_IMPORTANCE, F, A)
+                           end}])).


### PR DESCRIPTION
Includes and supersedes https://github.com/rabbitmq/rabbitmq-server/pull/16222 by @gomoripeti.

As a drive-by change, this also applies the TLS options post-processing fix in the Trust Store plugin for overriding Erlang/OTP's `ssl` app defaults, both to enforce the defaults we want TLS clients to have but also to pre-configure system CA certificate bundles returned by `public_key:cacerts_get/0`.