### PR TITLE
`rabbitmq_auth_backend_cache`: a follow-up to #16258 #16255

### DIFF
--- a/deps/rabbit/src/rabbit_auth_mechanism_plain.erl
+++ b/deps/rabbit/src/rabbit_auth_mechanism_plain.erl
@@ -53,7 +53,9 @@ handle_response(Response, _State) ->
 
 build_auth_props(Pass, Socket) ->
     %% Pass a precomputed boolean, not the raw socket, so that AuthProps is
-    %% stable across reconnections of the same client. See issue #16255.
+    %% stable across reconnections of the same client. See rabbitmq/rabbitmq-server#16255 [1].
+    %%
+    %% 1. https://github.com/rabbitmq/rabbitmq-server/issues/16255
     [{password, Pass}, {is_loopback, rabbit_net:is_loopback(Socket)}].
 
 extract_user_pass(Response) ->

--- a/deps/rabbitmq_auth_backend_cache/Makefile
+++ b/deps/rabbitmq_auth_backend_cache/Makefile
@@ -17,7 +17,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 DEPS = rabbit_common rabbit
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers proper
 
 PLT_APPS += rabbitmq_cli
 

--- a/deps/rabbitmq_auth_backend_cache/Makefile
+++ b/deps/rabbitmq_auth_backend_cache/Makefile
@@ -19,7 +19,7 @@ endef
 DEPS = rabbit_common rabbit
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers proper
 
-PLT_APPS += rabbitmq_cli
+PLT_APPS += rabbitmq_cli crypto
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
+++ b/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
@@ -15,7 +15,8 @@
 -export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4, check_topic_access/4,
          update_state/2, expiry_timestamp/1,
-         clear_cache_cluster_wide/0, clear_cache/0]).
+         clear_cache_cluster_wide/0, clear_cache/0,
+         init_key_salt/0, cache_key/2]).
 
 %% API
 
@@ -110,7 +111,8 @@ clear_cache() ->
 with_cache(BackendType, {F, A}, Fun) ->
     {ok, AuthCache} = application:get_env(rabbitmq_auth_backend_cache,
                                           cache_module),
-    case AuthCache:get({F, A}) of
+    Key = cache_key(F, A),
+    case AuthCache:get(Key) of
         {ok, Result} ->
             Result;
         {error, not_found} ->
@@ -119,11 +121,55 @@ with_cache(BackendType, {F, A}, Fun) ->
                                             cache_ttl),
             BackendResult = apply(Backend, F, A),
             case should_cache(BackendResult, Fun) of
-                true  -> ok = AuthCache:put({F, A}, BackendResult, TTL);
+                true  -> ok = AuthCache:put(Key, BackendResult, TTL);
                 false -> ok
             end,
             BackendResult
     end.
+
+%% Keep plaintext credentials out of the cache key. The full args are still
+%% passed to the underlying backend; only the lookup key is redacted.
+-spec cache_key(atom(), [term()]) -> {atom(), [term()]}.
+cache_key(user_login_authentication = F, [Username, AuthProps]) ->
+    {F, [Username, redact_credentials(AuthProps)]};
+cache_key(F, A) ->
+    {F, A}.
+
+redact_credentials(AuthProps) when is_list(AuthProps) ->
+    [redact_pair(Pair) || Pair <- AuthProps];
+redact_credentials(AuthProps) when is_map(AuthProps) ->
+    maps:map(fun (password, V) -> hash_secret(V);
+                 (_K, V)        -> V
+             end, AuthProps);
+redact_credentials(AuthProps) ->
+    AuthProps.
+
+redact_pair({password, V}) -> {password, hash_secret(V)};
+redact_pair(Other)         -> Other.
+
+%% Use HMAC-SHA-256 with a per-node random salt rather than a plain
+%% digest. The salt defeats precomputed (rainbow-table) attacks against
+%% the low-entropy plaintext if cache contents are ever exposed (memory
+%% dump, debug shell). The salt is initialised once at app start (see
+%% `rabbit_auth_backend_cache_app:init/1') and regenerated on node
+%% restart along with the cache itself.
+hash_secret(V) ->
+    {hmac_sha256, crypto:mac(hmac, sha256, key_salt(), term_to_binary(V))}.
+
+-define(KEY_SALT_PT, {?MODULE, cache_key_salt}).
+
+%% Idempotent: a supervisor restart must not regenerate the salt or
+%% existing cache entries would become unreachable.
+init_key_salt() ->
+    case persistent_term:get(?KEY_SALT_PT, undefined) of
+        undefined ->
+            persistent_term:put(?KEY_SALT_PT, crypto:strong_rand_bytes(32));
+        _Existing ->
+            ok
+    end.
+
+key_salt() ->
+    persistent_term:get(?KEY_SALT_PT).
 
 get_cached_backend(Type) ->
     {ok, BackendConfig} = application:get_env(rabbitmq_auth_backend_cache,

--- a/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache_app.erl
+++ b/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache_app.erl
@@ -24,6 +24,7 @@ stop(_State) ->
 %%----------------------------------------------------------------------------
 
 init([]) ->
+    ok = rabbit_auth_backend_cache:init_key_salt(),
     {ok, AuthCache} = application:get_env(rabbitmq_auth_backend_cache,
                                           cache_module),
 

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_counting_mock.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_counting_mock.erl
@@ -5,9 +5,16 @@
 %% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
-%% Counting authentication and authorization backend used by
-%% rabbit_auth_backend_cache_SUITE to verify that the cache backend hits
-%% across reconnections that share the same credentials.
+%% Counting auth backend used by the cache plugin's tests. Tracks how
+%% many authentication requests reached the backend so tests can pin
+%% down cache hit/miss behaviour.
+%%
+%% Response modes:
+%%
+%%  * `always_ok' (default): every authentication request succeeds
+%%  * `refuse_non_loopback': requests carrying `{is_loopback, true}' in
+%%                           `AuthProps' succeed; everything else is refused. Used
+%%                           in several `cache_refusals' tests
 
 -module(rabbit_auth_backend_cache_counting_mock).
 -include_lib("rabbit_common/include/rabbit.hrl").
@@ -19,25 +26,39 @@
          check_vhost_access/3, check_resource_access/4, check_topic_access/4,
          expiry_timestamp/1]).
 
--export([init/0, reset/0, authentication_call_count/0]).
+-export([init/0, reset/0, set_mode/1,
+         authentication_call_count/0]).
 
--define(KEY, {?MODULE, authentication_calls}).
+-define(COUNTER_KEY, {?MODULE, authentication_calls}).
+-define(MODE_KEY,    {?MODULE, response_mode}).
 
 init() ->
     reset().
 
 reset() ->
-    persistent_term:put(?KEY, counters:new(1, [])),
+    persistent_term:put(?COUNTER_KEY, counters:new(1, [])),
+    persistent_term:put(?MODE_KEY, always_ok),
+    ok.
+
+set_mode(Mode) when Mode =:= always_ok;
+                    Mode =:= refuse_non_loopback ->
+    persistent_term:put(?MODE_KEY, Mode),
     ok.
 
 authentication_call_count() ->
-    counters:get(persistent_term:get(?KEY), 1).
+    counters:get(persistent_term:get(?COUNTER_KEY), 1).
 
-user_login_authentication(Username, _AuthProps) ->
-    counters:add(persistent_term:get(?KEY), 1, 1),
-    {ok, #auth_user{username = Username,
-                    tags = [],
-                    impl = fun() -> none end}}.
+user_login_authentication(Username, AuthProps) ->
+    counters:add(persistent_term:get(?COUNTER_KEY), 1, 1),
+    case mode() of
+        always_ok ->
+            ok_user(Username);
+        refuse_non_loopback ->
+            case is_loopback(AuthProps) of
+                true -> ok_user(Username);
+                _    -> {refused, "denied: peer is not on loopback", []}
+            end
+    end.
 
 user_login_authorization(_Username, _AuthProps) ->
     {ok, fun() -> none end, []}.
@@ -53,3 +74,16 @@ check_topic_access(#auth_user{}, #resource{}, _Permission, _TopicContext) ->
 
 expiry_timestamp(_) ->
     never.
+
+mode() ->
+    persistent_term:get(?MODE_KEY, always_ok).
+
+ok_user(Username) ->
+    {ok, #auth_user{username = Username,
+                    tags     = [],
+                    impl     = fun() -> none end}}.
+
+is_loopback(AuthProps) when is_list(AuthProps) ->
+    proplists:get_value(is_loopback, AuthProps);
+is_loopback(AuthProps) when is_map(AuthProps) ->
+    maps:get(is_loopback, AuthProps, undefined).

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_prop_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_prop_SUITE.erl
@@ -25,7 +25,9 @@ all() ->
      prop_identical_authprops_hit_cache,
      prop_separates_loopback_from_non_loopback,
      prop_different_passwords_yield_different_keys,
-     prop_different_usernames_yield_different_keys
+     prop_different_usernames_yield_different_keys,
+     prop_password_is_absent_from_cache_key,
+     prop_redaction_is_deterministic
     ].
 
 init_per_suite(Config) ->
@@ -96,6 +98,25 @@ prop_different_usernames_yield_different_keys(Config) ->
                                distinct_username_count_two(Config, U1, U2, P)))
       end, [], ?NUMTESTS).
 
+%% Security invariant: the plaintext password must not be a substring of
+%% the cache key, regardless of username and loopback flag.
+prop_password_is_absent_from_cache_key(Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL({U, P, L},
+                      {username(), non_trivial_password(), boolean()},
+                      password_absent_from_key(Config, U, P, L))
+      end, [], ?NUMTESTS).
+
+%% Equality invariant: redacting the same AuthProps twice must produce
+%% byte-identical keys, otherwise repeat logins miss.
+prop_redaction_is_deterministic(Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL({U, P, L}, {username(), password(), boolean()},
+                      redaction_deterministic(Config, U, P, L))
+      end, [], ?NUMTESTS).
+
 %%%=========================================================================
 %%% Property bodies
 %%%=========================================================================
@@ -125,6 +146,16 @@ distinct_username_count_two(Config, U1, U2, P) ->
     {ok, _} = login(Config, U2, [{password, P}]),
     2 =:= call_count(Config).
 
+password_absent_from_key(Config, U, P, L) ->
+    Key = cache_key(Config, user_login_authentication,
+                    [U, [{password, P}, {is_loopback, L}]]),
+    binary:match(term_to_binary(Key), P) =:= nomatch.
+
+redaction_deterministic(Config, U, P, L) ->
+    Args = [U, [{password, P}, {is_loopback, L}]],
+    cache_key(Config, user_login_authentication, Args)
+        =:= cache_key(Config, user_login_authentication, Args).
+
 %%%=========================================================================
 %%% Helpers
 %%%=========================================================================
@@ -136,6 +167,9 @@ fresh_state(Config) ->
 login(Config, U, Props) ->
     rpc(Config, rabbit_auth_backend_cache, user_login_authentication,
         [U, Props]).
+
+cache_key(Config, F, A) ->
+    rpc(Config, rabbit_auth_backend_cache, cache_key, [F, A]).
 
 call_count(Config) ->
     rpc(Config, rabbit_auth_backend_cache_counting_mock,
@@ -153,3 +187,8 @@ username() ->
 
 password() ->
     non_empty(binary()).
+
+%% A password long enough that random collisions with hash output bytes
+%% are negligible, used by the "password absent from key" property.
+non_trivial_password() ->
+    ?LET(B, non_empty(binary()), <<"pw-", B/binary, "-marker">>).

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_prop_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_prop_SUITE.erl
@@ -1,0 +1,155 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% Property-based tests for `rabbit_auth_backend_cache' key invariants.
+%% The cache plugin sits in front of a counting mock backend; each
+%% property asserts how many cache calls reach the mock.
+
+-module(rabbit_auth_backend_cache_prop_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-import(rabbit_ct_proper_helpers, [run_proper/3]).
+
+-define(NUMTESTS, 200).
+
+all() ->
+    [
+     prop_identical_authprops_hit_cache,
+     prop_separates_loopback_from_non_loopback,
+     prop_different_passwords_yield_different_keys,
+     prop_different_usernames_yield_different_keys
+    ].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(
+      Config, rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config, rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(_TestCase, Config) ->
+    ok = rabbit_ct_broker_helpers:add_code_path_to_all_nodes(
+           Config, rabbit_auth_backend_cache_counting_mock),
+    ok = rpc(Config, rabbit_auth_backend_cache_counting_mock, init, []),
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cached_backend,
+              rabbit_auth_backend_cache_counting_mock]),
+    ok = rpc(Config, application, set_env,
+             [rabbit, auth_backends, [rabbit_auth_backend_cache]]),
+    ok = rpc(Config, rabbit_auth_backend_cache, clear_cache, []),
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cached_backend,
+              rabbit_auth_backend_internal]),
+    ok = rpc(Config, application, set_env,
+             [rabbit, auth_backends, [rabbit_auth_backend_internal]]),
+    ok = rpc(Config, rabbit_auth_backend_cache, clear_cache, []),
+    Config.
+
+%%%=========================================================================
+%%% Properties
+%%%=========================================================================
+
+%% A repeated, byte-identical login must not be forwarded twice.
+prop_identical_authprops_hit_cache(Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL({U, P, L}, {username(), password(), boolean()},
+                      identical_calls_count_one(Config, U, P, L))
+      end, [], ?NUMTESTS).
+
+%% A loopback approval must never be served back to a non-loopback peer.
+prop_separates_loopback_from_non_loopback(Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL({U, P}, {username(), password()},
+                      loopback_separation_count_two(Config, U, P))
+      end, [], ?NUMTESTS).
+
+%% A login cached for one password must not be served at a different password.
+prop_different_passwords_yield_different_keys(Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL({U, P1, P2}, {username(), password(), password()},
+                      ?IMPLIES(P1 =/= P2,
+                               distinct_password_count_two(Config, U, P1, P2)))
+      end, [], ?NUMTESTS).
+
+%% A login cached for one user must not be served as another user's login.
+prop_different_usernames_yield_different_keys(Config) ->
+    run_proper(
+      fun() ->
+              ?FORALL({U1, U2, P}, {username(), username(), password()},
+                      ?IMPLIES(U1 =/= U2,
+                               distinct_username_count_two(Config, U1, U2, P)))
+      end, [], ?NUMTESTS).
+
+%%%=========================================================================
+%%% Property bodies
+%%%=========================================================================
+
+identical_calls_count_one(Config, U, P, L) ->
+    fresh_state(Config),
+    Props = [{password, P}, {is_loopback, L}],
+    {ok, _} = login(Config, U, Props),
+    {ok, _} = login(Config, U, Props),
+    1 =:= call_count(Config).
+
+loopback_separation_count_two(Config, U, P) ->
+    fresh_state(Config),
+    {ok, _} = login(Config, U, [{password, P}, {is_loopback, true}]),
+    {ok, _} = login(Config, U, [{password, P}, {is_loopback, false}]),
+    2 =:= call_count(Config).
+
+distinct_password_count_two(Config, U, P1, P2) ->
+    fresh_state(Config),
+    {ok, _} = login(Config, U, [{password, P1}]),
+    {ok, _} = login(Config, U, [{password, P2}]),
+    2 =:= call_count(Config).
+
+distinct_username_count_two(Config, U1, U2, P) ->
+    fresh_state(Config),
+    {ok, _} = login(Config, U1, [{password, P}]),
+    {ok, _} = login(Config, U2, [{password, P}]),
+    2 =:= call_count(Config).
+
+%%%=========================================================================
+%%% Helpers
+%%%=========================================================================
+
+fresh_state(Config) ->
+    ok = rpc(Config, rabbit_auth_backend_cache_counting_mock, reset, []),
+    ok = rpc(Config, rabbit_auth_backend_cache, clear_cache, []).
+
+login(Config, U, Props) ->
+    rpc(Config, rabbit_auth_backend_cache, user_login_authentication,
+        [U, Props]).
+
+call_count(Config) ->
+    rpc(Config, rabbit_auth_backend_cache_counting_mock,
+        authentication_call_count, []).
+
+rpc(Config, M, F, A) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, M, F, A).
+
+%%%=========================================================================
+%%% Generators
+%%%=========================================================================
+
+username() ->
+    non_empty(binary()).
+
+password() ->
+    non_empty(binary()).

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_reconnect_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_reconnect_SUITE.erl
@@ -1,0 +1,125 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% Integration tests for `rabbit_auth_backend_cache' key invariants:
+%% identical inputs must hit the cache, semantically distinct inputs
+%% must not. The cache plugin is wired to a counting mock backend; each
+%% test asserts how many cache calls reached the mock.
+
+-module(rabbit_auth_backend_cache_reconnect_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [
+     cache_hits_with_stable_authprops,
+     cache_separates_loopback_from_non_loopback,
+     cache_separates_passwords,
+     cache_separates_usernames,
+     cache_hits_for_map_authprops,
+     cache_hits_when_authprops_have_no_loopback_marker,
+     refusal_for_non_loopback_does_not_leak_to_loopback
+    ].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(
+      Config, rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config, rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(_TestCase, Config) ->
+    ok = rabbit_ct_broker_helpers:add_code_path_to_all_nodes(
+           Config, rabbit_auth_backend_cache_counting_mock),
+    ok = rpc(Config, rabbit_auth_backend_cache_counting_mock, init, []),
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cached_backend,
+              rabbit_auth_backend_cache_counting_mock]),
+    ok = rpc(Config, application, set_env,
+             [rabbit, auth_backends, [rabbit_auth_backend_cache]]),
+    ok = rpc(Config, rabbit_auth_backend_cache, clear_cache, []),
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    %% Restore the project's PROJECT_ENV so subsequent suites are unaffected.
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cached_backend,
+              rabbit_auth_backend_internal]),
+    ok = rpc(Config, application, set_env,
+             [rabbit, auth_backends, [rabbit_auth_backend_internal]]),
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cache_refusals, false]),
+    ok = rpc(Config, rabbit_auth_backend_cache_counting_mock, set_mode,
+             [always_ok]),
+    ok = rpc(Config, rabbit_auth_backend_cache, clear_cache, []),
+    Config.
+
+cache_hits_with_stable_authprops(Config) ->
+    Props = [{password, <<"p">>}, {is_loopback, false}],
+    {ok, _} = login(Config, <<"u">>, Props),
+    {ok, _} = login(Config, <<"u">>, Props),
+    1 = call_count(Config).
+
+cache_separates_loopback_from_non_loopback(Config) ->
+    {ok, _} = login(Config, <<"u">>,
+                    [{password, <<"p">>}, {is_loopback, true}]),
+    {ok, _} = login(Config, <<"u">>,
+                    [{password, <<"p">>}, {is_loopback, false}]),
+    2 = call_count(Config).
+
+cache_separates_passwords(Config) ->
+    {ok, _} = login(Config, <<"u">>, [{password, <<"p1">>}]),
+    {ok, _} = login(Config, <<"u">>, [{password, <<"p2">>}]),
+    2 = call_count(Config).
+
+cache_separates_usernames(Config) ->
+    {ok, _} = login(Config, <<"u1">>, [{password, <<"p">>}]),
+    {ok, _} = login(Config, <<"u2">>, [{password, <<"p">>}]),
+    2 = call_count(Config).
+
+%% Map-shaped `AuthProps' must cache like proplists; the callback spec
+%% accepts both.
+cache_hits_for_map_authprops(Config) ->
+    Props = #{password => <<"p">>, is_loopback => true},
+    {ok, _} = login(Config, <<"u">>, Props),
+    {ok, _} = login(Config, <<"u">>, Props),
+    1 = call_count(Config).
+
+%% Pre-4.2 wire shape: `AuthProps' without a peer marker must still cache.
+cache_hits_when_authprops_have_no_loopback_marker(Config) ->
+    Props = [{password, <<"p">>}],
+    {ok, _} = login(Config, <<"u">>, Props),
+    {ok, _} = login(Config, <<"u">>, Props),
+    1 = call_count(Config).
+
+%% Security invariant: with `cache_refusals = true', a refusal cached
+%% for a non-loopback peer must not be served to a loopback peer.
+refusal_for_non_loopback_does_not_leak_to_loopback(Config) ->
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cache_refusals, true]),
+    ok = rpc(Config, rabbit_auth_backend_cache_counting_mock, set_mode,
+             [refuse_non_loopback]),
+    {refused, _, _} = login(Config, <<"u">>,
+                            [{password, <<"p">>}, {is_loopback, false}]),
+    {ok, _}         = login(Config, <<"u">>,
+                            [{password, <<"p">>}, {is_loopback, true}]),
+    2 = call_count(Config).
+
+login(Config, Username, AuthProps) ->
+    rpc(Config, rabbit_auth_backend_cache, user_login_authentication,
+        [Username, AuthProps]).
+
+call_count(Config) ->
+    rpc(Config, rabbit_auth_backend_cache_counting_mock,
+        authentication_call_count, []).
+
+rpc(Config, M, F, A) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, M, F, A).

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
@@ -1,0 +1,121 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% Tests that the plaintext password never reaches the auth cache key.
+%% Two angles are covered:
+%%
+%%  * direct inspection of the key produced by `cache_key/2', confirming
+%%    the password is absent in proplist and map shapes
+%%  * end-to-end behaviour: identical credentials hit, distinct
+%%    credentials miss, non-password fields still differentiate
+
+-module(rabbit_auth_backend_cache_redaction_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [
+     password_is_not_present_in_cache_key_for_proplist_authprops,
+     password_is_not_present_in_cache_key_for_map_authprops,
+     non_authn_calls_are_not_redacted,
+     identical_passwords_still_hit_the_cache,
+     different_passwords_still_miss_the_cache,
+     non_password_authprops_pass_through_unchanged
+    ].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(
+      Config, rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config, rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(_TestCase, Config) ->
+    ok = rabbit_ct_broker_helpers:add_code_path_to_all_nodes(
+           Config, rabbit_auth_backend_cache_counting_mock),
+    ok = rpc(Config, rabbit_auth_backend_cache_counting_mock, init, []),
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cached_backend,
+              rabbit_auth_backend_cache_counting_mock]),
+    ok = rpc(Config, application, set_env,
+             [rabbit, auth_backends, [rabbit_auth_backend_cache]]),
+    ok = rpc(Config, rabbit_auth_backend_cache, clear_cache, []),
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_auth_backend_cache, cached_backend,
+              rabbit_auth_backend_internal]),
+    ok = rpc(Config, application, set_env,
+             [rabbit, auth_backends, [rabbit_auth_backend_internal]]),
+    ok = rpc(Config, rabbit_auth_backend_cache, clear_cache, []),
+    Config.
+
+%% Security invariant: the plaintext password must not appear in the key
+%% produced by `cache_key/2'.
+password_is_not_present_in_cache_key_for_proplist_authprops(Config) ->
+    Password = <<"super-secret-marker-7f3a">>,
+    Props = [{password, Password}, {is_loopback, false}],
+    Key = cache_key(Config, user_login_authentication, [<<"u">>, Props]),
+    false = contains_binary(Key, Password).
+
+password_is_not_present_in_cache_key_for_map_authprops(Config) ->
+    Password = <<"another-secret-9c1b">>,
+    Props = #{password => Password, is_loopback => true},
+    Key = cache_key(Config, user_login_authentication, [<<"u">>, Props]),
+    false = contains_binary(Key, Password).
+
+%% Only authentication carries a password; other call sites must be
+%% pass-through to avoid changing established cache semantics.
+non_authn_calls_are_not_redacted(Config) ->
+    Args = [a, b, c],
+    {check_vhost_access, Args} =
+        cache_key(Config, check_vhost_access, Args).
+
+%% Equality invariant: redaction must be deterministic so identical
+%% credentials still hit the cache.
+identical_passwords_still_hit_the_cache(Config) ->
+    Props = [{password, <<"p">>}, {is_loopback, false}],
+    {ok, _} = login(Config, <<"u">>, Props),
+    {ok, _} = login(Config, <<"u">>, Props),
+    1 = call_count(Config).
+
+%% Distinguishability invariant: different passwords must still produce
+%% different keys.
+different_passwords_still_miss_the_cache(Config) ->
+    {ok, _} = login(Config, <<"u">>, [{password, <<"p1">>}]),
+    {ok, _} = login(Config, <<"u">>, [{password, <<"p2">>}]),
+    2 = call_count(Config).
+
+%% Non-password AuthProps fields must remain part of the key.
+non_password_authprops_pass_through_unchanged(Config) ->
+    {ok, _} = login(Config, <<"u">>,
+                    [{password, <<"p">>}, {is_loopback, true}]),
+    {ok, _} = login(Config, <<"u">>,
+                    [{password, <<"p">>}, {is_loopback, false}]),
+    2 = call_count(Config).
+
+login(Config, Username, AuthProps) ->
+    rpc(Config, rabbit_auth_backend_cache, user_login_authentication,
+        [Username, AuthProps]).
+
+call_count(Config) ->
+    rpc(Config, rabbit_auth_backend_cache_counting_mock,
+        authentication_call_count, []).
+
+cache_key(Config, F, A) ->
+    rpc(Config, rabbit_auth_backend_cache, cache_key, [F, A]).
+
+contains_binary(Term, Needle) when is_binary(Needle) ->
+    binary:match(term_to_binary(Term), Needle) =/= nomatch.
+
+rpc(Config, M, F, A) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, M, F, A).

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_clear_cache_command_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_clear_cache_command_SUITE.erl
@@ -104,9 +104,10 @@ rpc(Config, N, M, F, A) ->
     rabbit_ct_broker_helpers:rpc(Config, N, M, F, A).
 
 has_cache_entry(Config, Node, {F, A}) ->
-    {ok, AuthCache} = rpc(Config, Node, application, get_env, 
+    {ok, AuthCache} = rpc(Config, Node, application, get_env,
         [rabbitmq_auth_backend_cache, cache_module]),
-    case rpc(Config, Node, AuthCache, get, [{F, A}]) of
+    Key = rpc(Config, Node, rabbit_auth_backend_cache, cache_key, [F, A]),
+    case rpc(Config, Node, AuthCache, get, [Key]) of
         {ok, _} -> ok;
         {error, not_found} = E -> E
     end.


### PR DESCRIPTION
1. Avoid using credentials in cache keys, use a salted hash instead (the 2nd issue brought up in #16255)
2. More tests (mostly property-based)

## Why Not use `credential_obfuscation`?

This may seem like a case where we could reuse `credential_obfuscation`. Unfortunately,
this is not the case, even though the change in this PR is heavily inspired by it:

1. `credential_obfuscation` is non-deterministic, every `encrypt/{1,5}` call generates a new salt value
2. `credential_obfuscation` produces reversible value (an encrypted value can be decrypted using the same library on the same node without restarts) compared to hashing, and we do not need that to obfuscate the cache key component
3. This change is entirely node-local, while `credential_obfuscation` to a certain extent must take clustering into account for decryption of values stored on other nodes, namely runtime parameters with sensitive values: shovels

## References

References #16258 #16255.
