### PR TITLE
Log missed net ticks, if possible

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1026,6 +1026,8 @@ do_run_postlaunch_phase(Plugins) ->
         ok = application:set_env(prometheus, instrumenters, [],
                                  [{persistent, true}]),
 
+        ok = application:set_env(kernel, log_missed_net_ticks, true),
+
         %% However, we want to run their boot steps and actually start
         %% them one by one, to ensure a dependency is fully started
         %% before a plugin which depends on it gets a chance to start.


### PR DESCRIPTION
This functionality was just added to OTP in https://github.com/erlang/otp/pull/11031
and currently is not present in any released OTP versions.

One day, it will give us some additional info in the logs though.