### PR TITLE
Test flake chase: `v4.2.x`, Apr 30, 2026 (round 1)

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -737,6 +737,10 @@ handle_info({'DOWN', _MRef, process, Pid, normal}, State) ->
     ?LOG_DEBUG("Process ~0p monitored by channel ~0p exited", [Pid, self()]),
     {noreply, State};
 
+%% `erpc` encodes a successful return as `{Ref, return, Value}` and the spawned
+%% helper exits with that reason; ignore it rather than crashing the channel.
+handle_info({'EXIT', _Pid, {Ref, return, _}}, State) when is_reference(Ref) ->
+    noreply(State);
 handle_info({'EXIT', _Pid, Reason}, State) ->
     {stop, Reason, State};
 

--- a/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
@@ -253,9 +253,10 @@ lost_return_is_resent_on_applied_after_leader_change(Config) ->
     %% by the new leader, not the old
     {ok, F6, _} = rabbit_fifo_client:handle_ra_event(ClusterName, NextLeader,
                                                      RaEvt, F5),
-    %% this should resend the never applied enqueue
-    {_, _, F7} = process_ra_events(receive_ra_events(1, 0), ClusterName, F6),
-    {_, _, F8} = process_ra_events(receive_ra_events(1, 0), ClusterName, F7),
+    %% this should resend the never applied enqueue; extra leader changes can
+    %% arrive on mixed-version clusters, so retry if the applied event is missed
+    {_, _, F7} = receive_applied_retrying(ClusterName, F6),
+    {_, _, F8} = receive_applied_retrying(ClusterName, F7),
 
     ?assertEqual(0, rabbit_fifo_client:pending_size(F8)),
 
@@ -926,6 +927,25 @@ receive_ra_events(Applied, Deliveries, Acc) ->
             receive_ra_events(Applied, Deliveries, [Evt | Acc])
     after ?TIMEOUT ->
             exit({missing_events, Applied, Deliveries, Acc})
+    end.
+
+%% Waits for exactly one applied event. On mixed-version clusters an extra
+%% `leader_change` event may arrive before the applied event, causing
+%% `receive_ra_events/2` to time out. When that happens the accumulated
+%% `leader_change` events are fed through the client so it updates its leader
+%% pointer and resends pending commands, then the wait is retried.
+receive_applied_retrying(ClusterName, State) ->
+    receive_applied_retrying(ClusterName, State, 3).
+
+receive_applied_retrying(_ClusterName, _State, 0) ->
+    exit(missing_applied_event);
+receive_applied_retrying(ClusterName, State, Retries) ->
+    try
+        process_ra_events(receive_ra_events(1, 0), ClusterName, State)
+    catch
+        exit:{missing_events, _, _, Acc} ->
+            {_, _, State1} = process_ra_events(lists:reverse(Acc), ClusterName, State),
+            receive_applied_retrying(ClusterName, State1, Retries - 1)
     end.
 
 %% Flusing the mailbox to later check that deliveries hasn't been received

--- a/deps/rabbitmq_ct_client_helpers/src/rabbit_ct_client_helpers.erl
+++ b/deps/rabbitmq_ct_client_helpers/src/rabbit_ct_client_helpers.erl
@@ -287,14 +287,12 @@ consume_without_acknowledging(Ch, QName, Count) ->
     CTag = receive #'basic.consume_ok'{consumer_tag = C} -> C end,
     accumulate_without_acknowledging(Ch, CTag, Count, []).
 
-accumulate_without_acknowledging(Ch, CTag, Remaining, Acc) when Remaining =:= 0 ->
-    amqp_channel:call(Ch, #'basic.cancel'{consumer_tag = CTag}),
+accumulate_without_acknowledging(_Ch, _CTag, Remaining, Acc) when Remaining =:= 0 ->
     lists:reverse(Acc);
 accumulate_without_acknowledging(Ch, CTag, Remaining, Acc) ->
     receive {#'basic.deliver'{consumer_tag = CTag, delivery_tag = DTag}, _Msg} ->
            accumulate_without_acknowledging(Ch, CTag, Remaining - 1, [DTag | Acc])
     after 5000 ->
-           amqp_channel:call(Ch, #'basic.cancel'{consumer_tag = CTag}),
            exit(timeout)
     end.
 

--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -598,7 +598,8 @@ events(Config) ->
     ok = rabbit_ct_broker_helpers:add_code_path_to_all_nodes(Config, event_recorder),
     Server = get_node_config(Config, 0, nodename),
     ok = gen_event:add_handler({rabbit_event, Server}, event_recorder, []),
-
+    %% Drain any residual events left over from a previous test case.
+    _ = get_events(Server),
     ClientId = atom_to_binary(?FUNCTION_NAME),
     C = connect(ClientId, Config),
 

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -446,6 +446,20 @@ session_expiry_disconnect_decrease(QueueType, Config) ->
     rabbit_ct_helpers:eventually(
         ?_assertEqual(0, rpc(Config, rabbit_amqqueue, count, [])),
         200, 50),
+    %% For quorum queues, Khepri may remove the DB record before the Ra process
+    %% exits. Wait until the Ra server process is also gone to avoid hitting
+    %% a half-torn-down queue on reconnect.
+    case QueueType of
+        rabbit_quorum_queue ->
+            QName = amqqueue:get_name(Q1),
+            {ok, LocalName} = rpc(Config, rabbit_queue_type_util,
+                                  qname_to_internal_name, [QName]),
+            rabbit_ct_helpers:eventually(
+                ?_assertEqual(undefined, rpc(Config, erlang, whereis, [LocalName])),
+                200, 50);
+        _ ->
+            ok
+    end,
     C2 = connect(ClientId, Config, [{clean_start, false}]),
     %% Server should reply in CONNACK that it does not have session state for our client ID.
     ?assertEqual({session_present, 0},


### PR DESCRIPTION
Fix a few test flakes first discovered via failures on the `v4.2.x` branch.