### PR TITLE
QQ: fix negative priority crash bug.

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -3776,7 +3776,7 @@ msg_priority(Msg) ->
         true ->
             case mc:priority(Msg) of
                 P when is_integer(P) ->
-                    min(P, ?MAX_PRIORITY);
+                    max(0, min(P, ?MAX_PRIORITY));
                 _ ->
                     ?DEFAULT_PRIORITY
             end;

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -4889,6 +4889,14 @@ query_single_active_consumer_v7_test(Config) ->
 
     ok.
 
+enqueue_negative_priority_test(Config) ->
+    S0 = test_init(test),
+    Msg = mk_mc(<<"msg">>, #'P_basic'{priority = -1}),
+    {S1, _E1} = enq(Config, ?LINE, 1, Msg, S0),
+    #{detail := Detail} = rabbit_fifo_pq:overview(S1#rabbit_fifo.messages),
+    ?assertEqual(#{0 => 1}, Detail),
+    ok.
+
 query_single_active_consumer_consumer_info_test(Config) ->
     S0 = rabbit_fifo:init(#{name => ?FUNCTION_NAME,
                             single_active_consumer_on => true,


### PR DESCRIPTION
A negative message priority would cause rabbit_fifo and thus a quorum queue to crash as it isn't able to handle negative priorities.

This change maps all negative priorities to 0 allowing the state machine to proceed.

NB: because this bug would have caused a quorum queue to crash we do not need to bump the machine version for this change as the state machine would not have been able to proceed beyond the command that caused the crash.

Fixes: #16279