### PR TITLE
Fix three stream argument validation bugs

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1075,7 +1075,7 @@ check_max_age_arg({Type,    _}, _Args) ->
     {error, {unacceptable_type, Type}}.
 
 check_max_age(MaxAge) ->
-    case re:run(MaxAge, "(^[0-9]*)(.*)", [{capture, all_but_first, list}]) of
+    case re:run(MaxAge, "(^[0-9]+)(.*)", [{capture, all_but_first, list}]) of
         {match, [Value, Unit]} ->
             case list_to_integer(Value) of
                 I when I > 0 ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -177,9 +177,14 @@ check_filter_size(Q) ->
     case rabbit_misc:table_lookup(Args, <<"x-stream-filter-size-bytes">>) of
         undefined ->
             ok;
+        {Type, _Val} when Type =/= long, Type =/= short, Type =/= signedint,
+                           Type =/= unsignedint, Type =/= unsignedbyte,
+                           Type =/= unsignedshort, Type =/= byte ->
+            {protocol_error, precondition_failed,
+             "Invalid type for x-stream-filter-size-bytes", []};
         {_Type, Val} when Val > 255 orelse Val < 16 ->
             {protocol_error, precondition_failed,
-             "Invalid value for  x-stream-filter-size-bytes", []};
+             "Invalid value for x-stream-filter-size-bytes", []};
         _ ->
             ok
     end.
@@ -1467,6 +1472,7 @@ capabilities() ->
                                <<"selector-field-max-bytes">>],
       queue_arguments => [<<"x-max-length-bytes">>, <<"x-queue-type">>,
                           <<"x-max-age">>, <<"x-stream-max-segment-size-bytes">>,
+                          <<"x-stream-filter-size-bytes">>,
                           <<"x-initial-cluster-size">>, <<"x-queue-leader-locator">>],
       consumer_arguments => [<<"x-stream-offset">>,
                              <<"x-stream-filter">>,

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -344,6 +344,13 @@ declare_max_age(Config) ->
                [{<<"x-queue-type">>, longstr, <<"stream">>},
                 {<<"x-max-age">>, longstr, <<"1A">>}])),
 
+    %% "D" has no leading digits; must return a clean error, not crash
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       declare(Config, Server, Q,
+               [{<<"x-queue-type">>, longstr, <<"stream">>},
+                {<<"x-max-age">>, longstr, <<"D">>}])),
+
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
                  declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                              {<<"x-max-age">>, longstr, <<"1Y">>}])),
@@ -402,11 +409,17 @@ declare_invalid_filter_size(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     Q = ?config(queue_name, Config),
 
-    ExpectedError = <<"PRECONDITION_FAILED - Invalid value for  x-stream-filter-size-bytes">>,
+    ExpectedError = <<"PRECONDITION_FAILED - Invalid value for x-stream-filter-size-bytes">>,
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, ExpectedError}}, _},
        declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                   {<<"x-stream-filter-size-bytes">>, long, 256}])).
+                                   {<<"x-stream-filter-size-bytes">>, long, 256}])),
+
+    %% Non-integer type must be rejected now that the arg is in stream capabilities
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                   {<<"x-stream-filter-size-bytes">>, longstr, <<"128">>}])).
 
 consume_invalid_arg(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),


### PR DESCRIPTION
## Summary

Fix three stream argument validation bugs in `rabbit_amqqueue.erl` and `rabbit_stream_queue.erl`.

## What changed

**Bug 1: `check_max_age` crashes on malformed input**

The regex `(^[0-9]*)(.*)` uses `*` (zero or more digits), so an input like `"D"` matches with an empty digit capture. Then `list_to_integer("")` raises `error:badarg` and crashes the channel instead of returning a clean validation error. Fix: change `[0-9]*` to `[0-9]+`.

**Bug 2: `x-stream-filter-size-bytes` not in stream capabilities**

`x-stream-filter-size-bytes` is listed in `declare_args()` with a `check_non_neg_int_arg` validator, but is missing from `rabbit_stream_queue:capabilities().queue_arguments`. Since `check_declare_arguments` only runs validators for args that appear in both lists, the type validator is dead code. Fix: add the arg to stream capabilities.

**Bug 3: `check_filter_size` has no type guard**

The value-range comparison `Val > 255 orelse Val < 16` uses Erlang term ordering without checking the type first. A non-integer value (e.g., a binary string) produces incorrect results because binaries are always "greater than" numbers in Erlang term ordering. Fix: add a type guard clause that rejects non-integer types. Also fix a double-space typo in the error message.

## What was tested

Full `rabbit_stream_queue_SUITE` CT suite - 100% pass. New test assertions added:

- `declare_max_age`: assert that `"D"` (no leading digits) produces a clean 406 error
- `declare_invalid_filter_size`: assert that passing a `longstr` type for `x-stream-filter-size-bytes` produces a 406 error; updated expected error string to match the fixed single-space message

## Related issues

- Discovered while investigating rabbitmq/rabbitmqadmin-ng#145 and michaelklishin/rabbitmq-http-api-rs#118
