### PR TITLE
Test flake chase: adapt an upgrade test to `omq`s [1] exclusive queue naming pattern

### DIFF
--- a/.github/workflows/test-upgrades.sh
+++ b/.github/workflows/test-upgrades.sh
@@ -50,7 +50,8 @@ case "$scenario" in
 		sleep 1
 
 		# Ensure we the queue exists.
-		$old_rabbitmqctl -n rabbit-1 list_queues name durable | grep -qE 'omq-0\s*false'
+		# omq 0.49.0+ appends a random hex suffix to exclusive queue names.
+		$old_rabbitmqctl -n rabbit-1 list_queues name durable | grep -qE 'omq-0[-0-9a-f]*\s+false'
 
 		# Upgrade RabbitMQ on two out of three nodes.
 		# We can't upgrade all of them because omq(1) would be
@@ -59,7 +60,7 @@ case "$scenario" in
 		$make -C "$new_dist" restart-cluster NODES=2
 
 		# Ensure the queue is still there.
-		$new_rabbitmqctl -n rabbit-1 list_queues name durable | grep -qE 'omq-0\s*false'
+		$new_rabbitmqctl -n rabbit-1 list_queues name durable | grep -qE 'omq-0[-0-9a-f]*\s+false'
 
 		# Stop omq(1)
 		pkill omq


### PR DESCRIPTION
Starting with `0.49.0`, exclusive queue names have a randomized suffix appended.
