### PR TITLE
Selenium suites: use a fixed HTTPD version rather than the `latest` tag

### DIFF
--- a/selenium/bin/components/forward-proxy
+++ b/selenium/bin/components/forward-proxy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:latest}
+HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:2.4.66}
 
 ensure_forward-proxy() {
   if docker ps | grep forward-proxy &> /dev/null; then

--- a/selenium/bin/components/prodkeycloak-proxy
+++ b/selenium/bin/components/prodkeycloak-proxy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:latest}
+HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:2.4.66}
 
 ensure_prodkeycloak-proxy() {
   if docker ps | grep prodkeycloak-proxy &> /dev/null; then

--- a/selenium/bin/components/proxy
+++ b/selenium/bin/components/proxy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:latest}
+HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:2.4.66}
 
 ensure_proxy() {
   if docker ps | grep proxy &> /dev/null; then


### PR DESCRIPTION
CI jobs in tanzu are failing because the registry does not recognize the latest tag for httpd image.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI
