### PR TITLE
Deprecated features: prevent local configuration from being overridden by cluster peers

### DIFF
--- a/deps/rabbit/src/rabbit_deprecated_features.erl
+++ b/deps/rabbit/src/rabbit_deprecated_features.erl
@@ -119,6 +119,8 @@
          get_warning/1]).
 -export([extend_properties/2,
          should_be_permitted/2,
+         is_permit_explicitly_configured/1,
+         is_feature_in_use/2,
          enable_underlying_feature_flag_cb/1,
          list/1]).
 
@@ -510,7 +512,8 @@ should_be_permitted(FeatureName, FeatureProps) ->
         denied_by_default ->
             is_permitted_in_configuration(FeatureName, false);
         Phase ->
-            case is_permitted_in_configuration(FeatureName, false) of
+            Permitted = is_permitted_in_configuration(FeatureName, false),
+            case Permitted andalso should_log_warning(FeatureName) of
                 true ->
                     ?LOG_WARNING(
                        "Deprecated features: `~ts`: ~ts feature, it "
@@ -522,6 +525,35 @@ should_be_permitted(FeatureName, FeatureProps) ->
             end,
             false
     end.
+
+-spec is_permit_explicitly_configured(FeatureName) -> IsConfigured when
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      IsConfigured :: boolean().
+%% @doc Indicates whether `permit_deprecated_features' has an explicit
+%% entry (key) for the given feature. In other words, returns `true`
+%% if the feature is explicitly permitted in the local configuration file(s).
+%%
+%% @private
+
+is_permit_explicitly_configured(FeatureName) ->
+    Settings = application:get_env(rabbit, permit_deprecated_features, #{}),
+    maps:is_key(FeatureName, Settings).
+
+-spec is_feature_in_use(FeatureName, FeatureProps) -> InUse when
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      FeatureProps :: feature_props_extended(),
+      InUse :: boolean() | undefined.
+%% @doc Invokes the `is_feature_used' callback for the given deprecated
+%% feature on the local node. Returns `undefined' when no callback is
+%% registered.
+%%
+%% @private
+
+is_feature_in_use(FeatureName, FeatureProps) ->
+    is_deprecated_feature_in_use(
+      #{feature_name => FeatureName,
+        feature_props => FeatureProps,
+        nodes => [node()]}).
 
 -spec is_permitted_in_configuration(FeatureName, Default) -> IsPermitted when
       FeatureName :: rabbit_feature_flags:feature_name(),

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -299,9 +299,61 @@ maybe_initialize_registry(NewSupportedFeatureFlags,
                       State
               end;
           (FeatureName, FeatureProps) when ?IS_DEPRECATION(FeatureProps) ->
+              %% When `permit_deprecated_features` is explicitly set in `rabbitmq.conf`,
+              %% make sure that the local setting wins over any state propagated from a cluster
+              %% peer. Without this, during a rolling upgrade different nodes
+              %% can end up with a different deprecated feature state, leading the
+              %% user (operator) to believe that the setting has no effect.
+              %% See rabbitmq/rabbitmq#16324 for details.
+              %%
+              %% If not, preserve the existing state to keep explicit
+              %% `rabbit_feature_flags:enable/1' calls and the
+              %% dependency cascade below effective.
+              Phase = rabbit_deprecated_features:get_phase(FeatureProps),
+              Configured =
+              (Phase =:= permitted_by_default orelse
+               Phase =:= denied_by_default)
+              andalso
+              rabbit_deprecated_features:is_permit_explicitly_configured(
+                FeatureName),
               case FeatureStates0 of
-                  #{FeatureName := FeatureState} ->
+                  #{FeatureName := FeatureState} when not Configured ->
                       FeatureState;
+                  #{FeatureName := false = FeatureState} when Configured ->
+                      %% Denying a currently permitted feature from
+                      %% configuration bypasses the `is_feature_used/1`
+                      %% callback check that
+                      %% `rabbit_feature_flags:enable/1` runs. Re-do
+                      %% that check here so an in-use feature is not
+                      %% silently denied.
+                      NewState = not rabbit_deprecated_features:
+                                       should_be_permitted(
+                                         FeatureName, FeatureProps),
+                      case NewState of
+                          true ->
+                              case rabbit_deprecated_features:
+                                     is_feature_in_use(
+                                       FeatureName, FeatureProps) of
+                                  true ->
+                                      ?LOG_WARNING(
+                                         "Deprecated features: `~ts`: "
+                                         "configuration would deny "
+                                         "this feature, but it is "
+                                         "actively used and remains "
+                                         "permitted. Stop using the "
+                                         "feature before changing "
+                                         "`deprecated_features.permit"
+                                         ".~ts`",
+                                         [FeatureName, FeatureName],
+                                         #{domain =>
+                                           ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+                                      FeatureState;
+                                  _ ->
+                                      NewState
+                              end;
+                          false ->
+                              NewState
+                      end;
                   _ ->
                       not rabbit_deprecated_features:should_be_permitted(
                             FeatureName, FeatureProps)

--- a/deps/rabbit/test/deprecated_features_SUITE.erl
+++ b/deps/rabbit/test/deprecated_features_SUITE.erl
@@ -36,6 +36,9 @@
          get_appropriate_warning_when_disconnected/1,
          get_appropriate_warning_when_removed/1,
          deprecated_feature_enabled_if_feature_flag_depends_on_it/1,
+         re_permit_denied_feature_after_config_change/1,
+         permit_config_does_not_override_dependency_cascade/1,
+         config_flip_to_deny_respects_is_feature_used_cb/1,
          list_all_deprecated_features/1,
          list_used_deprecated_features/1,
 
@@ -70,6 +73,9 @@ groups() ->
              get_appropriate_warning_when_disconnected,
              get_appropriate_warning_when_removed,
              deprecated_feature_enabled_if_feature_flag_depends_on_it,
+             re_permit_denied_feature_after_config_change,
+             permit_config_does_not_override_dependency_cascade,
+             config_flip_to_deny_respects_is_feature_used_cb,
              list_all_deprecated_features,
              list_used_deprecated_features
             ],
@@ -527,7 +533,7 @@ get_appropriate_warning_when_permitted(Config) ->
          || Node <- AllNodes].
 
 get_appropriate_warning_when_denied(Config) ->
-    [FirstNode | _] = AllNodes = ?config(nodes, Config),
+    AllNodes = ?config(nodes, Config),
     feature_flags_v2_SUITE:connect_nodes(AllNodes),
     feature_flags_v2_SUITE:override_running_nodes(AllNodes),
 
@@ -564,14 +570,24 @@ get_appropriate_warning_when_denied(Config) ->
            end)
          || Node <- AllNodes],
 
-    ok = feature_flags_v2_SUITE:run_on_node(
-           FirstNode,
+    %% Switch the configuration to deny the deprecated feature and refresh the
+    %% registry on every node. The new state and warning must reflect
+    %% the local configuration, including in a cluster where a peer's
+    %% prior state could otherwise be "propagated back".
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
            fun() ->
+                   application:set_env(
+                     rabbit, permit_deprecated_features,
+                     #{FeatureName => false}, [{persistent, false}]),
                    ?assertEqual(
                       ok,
-                      rabbit_feature_flags:enable(FeatureName)),
+                      rabbit_feature_flags:
+                        refresh_feature_flags_after_app_load()),
                    ok
-           end),
+           end)
+         || Node <- AllNodes],
 
     _ = [ok =
          feature_flags_v2_SUITE:run_on_node(
@@ -727,6 +743,181 @@ deprecated_feature_enabled_if_feature_flag_depends_on_it(Config) ->
                       rabbit_deprecated_features:is_permitted(FeatureName)),
                    ok
            end )
+         || Node <- AllNodes].
+
+%% Verifies that a deprecated feature in the `denied_by_default'
+%% phase can be permitted again by setting
+%% `deprecated_features.permit.X = true' in `rabbitmq.conf' and
+%% refreshing the registry, including in a cluster where peers
+%% still hold the previously denied state and would otherwise
+%% propagate it back during the refresh.
+re_permit_denied_feature_after_config_change(Config) ->
+    AllNodes = ?config(nodes, Config),
+    feature_flags_v2_SUITE:connect_nodes(AllNodes),
+    feature_flags_v2_SUITE:override_running_nodes(AllNodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => rabbit,
+                       deprecation_phase => denied_by_default}},
+    ?assertEqual(
+       ok,
+       feature_flags_v2_SUITE:inject_on_nodes(AllNodes, FeatureFlags)),
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ?assertNot(
+                      rabbit_deprecated_features:is_permitted(FeatureName)),
+                   ok
+           end)
+         || Node <- AllNodes],
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   application:set_env(
+                     rabbit, permit_deprecated_features,
+                     #{FeatureName => true}, [{persistent, false}]),
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:
+                        refresh_feature_flags_after_app_load()),
+                   ok
+           end)
+         || Node <- AllNodes],
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ?assert(
+                      rabbit_deprecated_features:is_permitted(FeatureName)),
+                   ok
+           end)
+         || Node <- AllNodes].
+
+%% When a regular feature flag depends on a deprecated feature,
+%% enabling it must deny the deprecated feature regardless of
+%% what `permit_deprecated_features' says.
+permit_config_does_not_override_dependency_cascade(Config) ->
+    [FirstNode | _] = AllNodes = ?config(nodes, Config),
+    feature_flags_v2_SUITE:connect_nodes(AllNodes),
+    feature_flags_v2_SUITE:override_running_nodes(AllNodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => rabbit,
+                       deprecation_phase => permitted_by_default},
+
+                     my_feature_flag =>
+                     #{provided_by => rabbit,
+                       stability => experimental,
+                       depends_on => [FeatureName]}},
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   application:set_env(
+                     rabbit, permit_deprecated_features,
+                     #{FeatureName => true}, [{persistent, false}])
+           end)
+         || Node <- AllNodes],
+
+    ?assertEqual(
+       ok,
+       feature_flags_v2_SUITE:inject_on_nodes(AllNodes, FeatureFlags)),
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ?assert(
+                      rabbit_deprecated_features:is_permitted(FeatureName)),
+                   ok
+           end)
+         || Node <- AllNodes],
+
+    ok = feature_flags_v2_SUITE:run_on_node(
+           FirstNode,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:enable(my_feature_flag)),
+                   ok
+           end),
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_enabled(my_feature_flag)),
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ?assertNot(
+                      rabbit_deprecated_features:is_permitted(FeatureName)),
+                   ok
+           end)
+         || Node <- AllNodes].
+
+%% A deprecated feature whose `is_feature_used' callback returns
+%% `true' (here, the `feature_is_used/1' stub) must not be denied
+%% by a configuration change alone: the existing safeguard that
+%% gates denials on the callback must remain effective even when
+%% the new state is computed during registry init rather than via
+%% an explicit `rabbit_feature_flags:enable/1' call.
+config_flip_to_deny_respects_is_feature_used_cb(Config) ->
+    AllNodes = ?config(nodes, Config),
+    feature_flags_v2_SUITE:connect_nodes(AllNodes),
+    feature_flags_v2_SUITE:override_running_nodes(AllNodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => rabbit,
+                       deprecation_phase => permitted_by_default,
+                       callbacks => #{is_feature_used =>
+                                      {?MODULE, feature_is_used}}}},
+    ?assertEqual(
+       ok,
+       feature_flags_v2_SUITE:inject_on_nodes(AllNodes, FeatureFlags)),
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   ?assert(
+                      rabbit_deprecated_features:is_permitted(FeatureName)),
+                   ok
+           end)
+         || Node <- AllNodes],
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   application:set_env(
+                     rabbit, permit_deprecated_features,
+                     #{FeatureName => false}, [{persistent, false}]),
+                   _ = rabbit_feature_flags:
+                         refresh_feature_flags_after_app_load(),
+                   ok
+           end)
+         || Node <- AllNodes],
+
+    _ = [ok =
+         feature_flags_v2_SUITE:run_on_node(
+           Node,
+           fun() ->
+                   ?assert(
+                      rabbit_deprecated_features:is_permitted(FeatureName)),
+                   ok
+           end)
          || Node <- AllNodes].
 
 list_all_deprecated_features(Config) ->


### PR DESCRIPTION
Much of this PR description is my earlier findings from #16324 with a few clarifying edits.

## Upgrading to `4.3.0`: Problem Definition

In 4.2.x, `transient_nonexcl_queues` is permitted by default, so its underlying feature flag stays disabled across the cluster.

During an upgrade to `4.3.0`, the deprecated feature phase changes to `denied-by-default`. Without an explicit override in the local `rabbitmq.conf` in place, every node figures
"this FF should be enable" (the deprecated feature should be denied) and that enabled state is replicated cluster-wide.

The deployment tooling adds an exclusion to `rabbitmq.conf` and restarts the node. But the FF state is already "enabled" on other cluster nodes, so after the restart, the state on the reconfigured `4.3.0` node is synced back, and the registry keeps the synced value.

In other words, once any node in the cluster computes the underlying [the deprecated feature] feature flag as enabled, the metadata sync sets it that way on every node, and node-specific configuration is silently ignored on subsequent restarts.

Re-creating the cluster and starting fresh with the config in place works because no node ever computed "enabled" for the underlying FF in the first place, and there's nothing to sync.


## An Available Workaround

Pre-configuring the `4.2.x` nodes to explicitly enable the deprecated features
that `4.3.0` disables by default and restarting all nodes so that they pick up
their updated configs should be enough of a workaround, and I will add it
to the release notes.


## A Low Risk Solution

It would be great to eliminate this less-than-obvious behavior.

An oversimplified solution is therefore:

1. Add a way for a node to determine whether a specific deprecated feature was explicitly configured locally
2. When the deprecated feature FFs syncs, if the corresponding deprecated feature is explicitly listed as permitted locally, use the local value and ignore the value received from the peer


## Notes for Reviewers

**Important**: note that you can only reproduce the problematic behavior
with a multi-node cluster.

I have edited the multi-line comments in tests several times and it's
never abundantly clear. I guess it's one of those issues where you need
to have the entire context, otherwise a single comment won't tell you
that much.
