### PR TITLE
Add metrics for connections by client library

### DIFF
--- a/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Overview.json
+++ b/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Overview.json
@@ -8398,6 +8398,71 @@
       ],
       "title": "Connections closed / s",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Distribution of client connections by library and platform.\n\nHelps identify which client libraries and language runtimes are connecting to the cluster.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 89
+      },
+      "id": 76,
+      "options": {
+        "displayLabels": ["name", "value"],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": ["value"]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rabbitmq_connections_by_client_library * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\", namespace=\"$namespace\", rabbitmq_endpoint=\"$endpoint\"}) by(product, platform)",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "{{product}} ({{platform}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Client libraries",
+      "type": "piechart"
     }
   ],
   "refresh": "15s",

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -308,6 +308,7 @@ collect_mf('detailed', Callback) ->
 collect_mf('per-object', Callback) ->
     collect(true, ?METRIC_NAME_PREFIX, false, false, ?METRICS_RAW, Callback),
     totals(Callback),
+    emit_client_library_metrics(Callback),
     emit_queue_info(?METRIC_NAME_PREFIX, false, false, Callback),
     emit_identity_info(<<"per-object">>, Callback),
     ok;
@@ -319,6 +320,7 @@ collect_mf(_Registry, Callback) ->
     PerObjectMetrics = application:get_env(rabbitmq_prometheus, return_per_object_metrics, false),
     collect(PerObjectMetrics, ?METRIC_NAME_PREFIX, false, false, ?METRICS_RAW, Callback),
     totals(Callback),
+    emit_client_library_metrics(Callback),
     case PerObjectMetrics of
         true ->
             emit_identity_info(<<"per-object">>, Callback),
@@ -346,6 +348,62 @@ emit_identity_info(Endpoint, Callback) ->
     add_metric_family(build_info(), Callback),
     add_metric_family(identity_info(Endpoint), Callback),
     ok.
+
+emit_client_library_metrics(Callback) ->
+    Counts = ets:foldl(
+        fun({_Pid, Infos}, Acc) ->
+            Product = client_product(Infos),
+            Platform = client_platform(Infos),
+            Protocol = format_protocol(proplists:get_value(protocol, Infos)),
+            Key = {Product, Platform, Protocol},
+            maps:update_with(Key, fun(V) -> V + 1 end, 1, Acc)
+        end, #{}, connection_created),
+    Metrics = maps:fold(
+        fun({Product, Platform, Protocol}, Count, Acc) ->
+            [{[{product, Product}, {platform, Platform}, {protocol, Protocol}], Count} | Acc]
+        end, [], Counts),
+    add_metric_family(
+        {connections_by_client_library, gauge,
+         "Connections grouped by client library and protocol", Metrics},
+        Callback).
+
+client_product(Infos) ->
+    client_property(Infos, <<"product">>).
+
+client_platform(Infos) ->
+    normalize_platform(client_property(Infos, <<"platform">>)).
+
+client_property(Infos, Key) ->
+    case proplists:get_value(client_properties, Infos) of
+        Props when is_list(Props) ->
+            case rabbit_misc:table_lookup(Props, Key) of
+                {_Type, Value} -> Value;
+                undefined -> <<>>
+            end;
+        _ ->
+            <<>>
+    end.
+
+%% Normalize platform to just the language/runtime name. Strip version details
+%% to keep cardinality bounded.
+normalize_platform(Platform) ->
+    hd(binary:split(Platform, <<" ">>)).
+
+format_protocol({0, 9, 1}) -> <<"amqp091">>;
+format_protocol({1, 0}) -> <<"amqp10">>;
+format_protocol({'AMQP', {0, 9, 1}}) -> <<"amqp091">>;
+format_protocol({'AMQP', {1, 0}}) -> <<"amqp10">>;
+format_protocol({'Web AMQP', {1, 0}}) -> <<"amqp10">>;
+format_protocol({'MQTT', {5, 0}}) -> <<"mqtt50">>;
+format_protocol({'MQTT', {3, 1, 1}}) -> <<"mqtt311">>;
+format_protocol({'MQTT', {3, 1}}) -> <<"mqtt310">>;
+format_protocol({'STOMP', {1, 0}}) -> <<"stomp10">>;
+format_protocol({'STOMP', {1, 1}}) -> <<"stomp11">>;
+format_protocol({'STOMP', {1, 2}}) -> <<"stomp12">>;
+format_protocol({'Web MQTT', V}) -> format_protocol({'MQTT', V});
+format_protocol({'Web STOMP', V}) -> format_protocol({'STOMP', V});
+format_protocol(P) when is_binary(P) -> P;
+format_protocol(_) -> <<"unknown">>.
 
 %% Aggregated `auth``_attempt_detailed_metrics` and
 %% `auth_attempt_metrics` are the same numbers. The former is just

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -445,7 +445,9 @@ aggregated_metrics_test(Config) ->
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_entries{", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_mem_tables{", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_segments{", [{capture, none}, multiline])),
-    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files{", [{capture, none}, multiline])).
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files{", [{capture, none}, multiline])),
+    %% Check client library metrics
+    ?assertEqual(match, re:run(Body, "^rabbitmq_connections_by_client_library{product=\"RabbitMQ\",platform=\"Erlang\",protocol=\"amqp091\"}", [{capture, none}, multiline])).
 
 %% Verify that the aggregated endpoint does not emit duplicate TYPE
 %% lines for Raft metrics that belong to different Ra systems.
@@ -515,7 +517,9 @@ per_object_metrics_test(Config, Path) ->
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_commit_latency_seconds{", [{capture, none}, multiline])),
     %% Check the first TOTALS metric value
     ?assertEqual(match, re:run(Body, "^rabbitmq_connections ", [{capture, none}, multiline])),
-    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_num_segments{", [{capture, none}, multiline])).
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_num_segments{", [{capture, none}, multiline])),
+    %% Check client library metrics
+    ?assertEqual(match, re:run(Body, "^rabbitmq_connections_by_client_library{product=\"RabbitMQ\",platform=\"Erlang\",protocol=\"amqp091\"}", [{capture, none}, multiline])).
 
 memory_breakdown_metrics_test(Config) ->
     {_Headers, Body} = http_get_with_pal(Config, "/metrics/memory-breakdown", [], 200),


### PR DESCRIPTION
These Prometheus gauges are broken down by connection product and protocol which should be enough to distinguish client library. The version property (and parts of the platform field) is not included since it would increase cardinality. Prometheus tracks a time series per unique set of dimensions, so we don't want to track version / platform specifics.

    # TYPE rabbitmq_connections_by_client_library gauge
    # HELP rabbitmq_connections_by_client_library Connections grouped by client library and protocol
    rabbitmq_connections_by_client_library{product="RabbitMQ Stream",platform="Java",protocol="stream"} 2
    rabbitmq_connections_by_client_library{product="RabbitMQ",platform="Java",protocol="amqp091"} 14
