### PR TITLE
HTTP API: format empty proplists as empty JSON objects in a few more places

### DIFF
--- a/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
+++ b/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
@@ -111,7 +111,7 @@ format(Node, Info, Chs) ->
                       %% was restarted on another node, we might get duplicates;
                       %% we don't really know which one is the most up-to-date
                       %% so let's just take the first one
-                      [{local_channel, Ch}];
+                      [{local_channel, rabbit_mgmt_format:clean_connection_details(Ch)}];
                   []   -> []
               end,
     [{node, Node} | format_info(Info)] ++ LocalCh.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_channel.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_channel.erl
@@ -37,8 +37,9 @@ resource_exists(ReqData, Context) ->
 to_json(ReqData, Context) ->
     case rabbit_mgmt_util:disable_stats(ReqData) of
         false ->
-            Payload = rabbit_mgmt_format:clean_consumer_details(
-                        rabbit_mgmt_format:strip_pids(channel(ReqData))),
+            Payload = rabbit_mgmt_format:clean_connection_details(
+                        rabbit_mgmt_format:clean_consumer_details(
+                          rabbit_mgmt_format:strip_pids(channel(ReqData)))),
             rabbit_mgmt_util:reply(
               maps:from_list(Payload),
               ReqData, Context);

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_channels.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_channels.erl
@@ -43,6 +43,7 @@ is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).
 
 augmented(ReqData, Context) ->
-    rabbit_mgmt_util:filter_conn_ch_list(
-      rabbit_mgmt_db:get_all_channels(
-        rabbit_mgmt_util:range(ReqData)), ReqData, Context).
+    [rabbit_mgmt_format:clean_connection_details(Ch)
+     || Ch <- rabbit_mgmt_util:filter_conn_ch_list(
+                rabbit_mgmt_db:get_all_channels(
+                  rabbit_mgmt_util:range(ReqData)), ReqData, Context)].

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_channels_vhost.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_channels_vhost.erl
@@ -47,6 +47,7 @@ is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_vhost(ReqData, Context).
 
 augmented(ReqData, Context) ->
-    rabbit_mgmt_util:filter_conn_ch_list(
-      rabbit_mgmt_db:get_all_channels(
-        rabbit_mgmt_util:range(ReqData)), ReqData, Context).
+    [rabbit_mgmt_format:clean_connection_details(Ch)
+     || Ch <- rabbit_mgmt_util:filter_conn_ch_list(
+                rabbit_mgmt_db:get_all_channels(
+                  rabbit_mgmt_util:range(ReqData)), ReqData, Context)].

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection_channels.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection_channels.erl
@@ -33,8 +33,9 @@ to_json(ReqData, Context) ->
     Name = proplists:get_value(name, rabbit_mgmt_wm_connection:conn(ReqData)),
     Chs = rabbit_mgmt_db:get_all_channels(rabbit_mgmt_util:range(ReqData)),
     rabbit_mgmt_util:reply_list(
-      [Ch || Ch <- rabbit_mgmt_util:filter_conn_ch_list(Chs, ReqData, Context),
-             conn_name(Ch) =:= Name],
+      [rabbit_mgmt_format:clean_connection_details(Ch)
+       || Ch <- rabbit_mgmt_util:filter_conn_ch_list(Chs, ReqData, Context),
+          conn_name(Ch) =:= Name],
       ReqData, Context).
 
 is_authorized(ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue.erl
@@ -46,8 +46,9 @@ to_json(ReqData, Context) ->
                         [queue(ReqData, StatsDisabled)],
                         rabbit_mgmt_util:range_ceil(ReqData),
                         full),
-                Payload = rabbit_mgmt_format:clean_consumer_details(
-                            rabbit_mgmt_format:strip_pids(Q)),
+                Payload = rabbit_mgmt_format:clean_owner_pid_details(
+                            rabbit_mgmt_format:clean_consumer_details(
+                              rabbit_mgmt_format:strip_pids(Q))),
                 rabbit_mgmt_util:reply(ensure_defaults(Payload), ReqData, Context);
             true ->
                 Q = case rabbit_mgmt_util:enable_queue_totals(ReqData) of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
@@ -138,9 +138,11 @@ augment(Mode) ->
                                 {_, _, all} -> basic;
                                 _ -> detailed
                             end,
-                    rabbit_mgmt_db:augment_queues(Basic,
-                                                  rabbit_mgmt_util:range_ceil(ReqData),
-                                                  Stats);
+                    [rabbit_mgmt_format:clean_owner_pid_details(Q)
+                     || Q <- rabbit_mgmt_db:augment_queues(
+                               Basic,
+                               rabbit_mgmt_util:range_ceil(ReqData),
+                               Stats)];
                 true ->
                     Basic
             end

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_user_queues.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_user_queues.erl
@@ -104,9 +104,11 @@ augment() ->
                                 all -> basic;
                                 _ -> detailed
                             end,
-                    rabbit_mgmt_db:augment_queues(Basic,
-                                                  rabbit_mgmt_util:range_ceil(ReqData),
-                                                  Stats);
+                    [rabbit_mgmt_format:clean_owner_pid_details(Q)
+                     || Q <- rabbit_mgmt_db:augment_queues(
+                               Basic,
+                               rabbit_mgmt_util:range_ceil(ReqData),
+                               Stats)];
                 true ->
                     Basic
             end

--- a/deps/rabbitmq_management/test/clustering_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_SUITE.erl
@@ -330,13 +330,15 @@ queue_consumer_channel_closed(Config) ->
     force_stats(Config), % ensure channel stats have been written
 
     amqp_channel:close(Chan),
-    force_stats(Config),
 
     ?awaitMatch([],
                 %% assert there are no consumer details
-                maps:get(consumer_details,
-                         http_get(Config, "/queues/%2F/some-queue")),
-                30000),
+                begin
+                    force_stats(Config),
+                    maps:get(consumer_details,
+                             http_get(Config, "/queues/%2F/some-queue"))
+                end,
+                60000),
     ?awaitMatch(<<"some-queue">>,
                 maps:get(name,
                          http_get(Config, "/queues/%2F/some-queue")),

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -26,7 +26,7 @@
 
 -export([strip_queue_pids/1]).
 
--export([clean_consumer_details/1, clean_channel_details/1]).
+-export([clean_consumer_details/1, clean_channel_details/1, clean_connection_details/1]).
 
 -export([args_hash/1]).
 
@@ -610,6 +610,17 @@ clean_channel_details(Obj) ->
 
 format_channel_details([]) -> #{};
 format_channel_details(Any) -> Any.
+
+-spec clean_connection_details(proplists:proplist()) -> proplists:proplist().
+clean_connection_details(Obj) ->
+    case pget(connection_details, Obj) of
+        undefined -> Obj;
+        Cnd ->
+            pset(connection_details, format_connection_details(Cnd), Obj)
+    end.
+
+format_connection_details([]) -> #{};
+format_connection_details(Any) -> Any.
 
 -spec format_consumer_arguments(proplists:proplist()) -> proplists:proplist().
 format_consumer_arguments(Obj) ->

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -26,7 +26,8 @@
 
 -export([strip_queue_pids/1]).
 
--export([clean_consumer_details/1, clean_channel_details/1, clean_connection_details/1]).
+-export([clean_consumer_details/1, clean_channel_details/1, clean_connection_details/1,
+         clean_owner_pid_details/1]).
 
 -export([args_hash/1]).
 
@@ -621,6 +622,17 @@ clean_connection_details(Obj) ->
 
 format_connection_details([]) -> #{};
 format_connection_details(Any) -> Any.
+
+-spec clean_owner_pid_details(proplists:proplist()) -> proplists:proplist().
+clean_owner_pid_details(Obj) ->
+    case pget(owner_pid_details, Obj) of
+        undefined -> Obj;
+        Opd ->
+            pset(owner_pid_details, format_owner_pid_details(Opd), Obj)
+    end.
+
+format_owner_pid_details([]) -> #{};
+format_owner_pid_details(Any) -> Any.
 
 -spec format_consumer_arguments(proplists:proplist()) -> proplists:proplist().
 format_consumer_arguments(Obj) ->

--- a/deps/rabbitmq_stream_management/src/rabbit_stream_consumers_mgmt.erl
+++ b/deps/rabbitmq_stream_management/src/rabbit_stream_consumers_mgmt.erl
@@ -56,8 +56,9 @@ to_json(ReqData, Context = #context{user = User}) ->
                           VHost
                   end,
             Consumers =
-                rabbit_mgmt_format:strip_pids(
-                    rabbit_stream_mgmt_db:get_all_consumers(Arg)),
+                [rabbit_mgmt_format:clean_connection_details(I)
+                 || I <- rabbit_mgmt_format:strip_pids(
+                           rabbit_stream_mgmt_db:get_all_consumers(Arg))],
             rabbit_mgmt_util:reply_list(filter_user(Consumers, User),
                                         [],
                                         ReqData,

--- a/deps/rabbitmq_stream_management/src/rabbit_stream_publishers_mgmt.erl
+++ b/deps/rabbitmq_stream_management/src/rabbit_stream_publishers_mgmt.erl
@@ -68,7 +68,7 @@ to_json(ReqData, Context = #context{user = User}) ->
                         V
                 end,
             Queue = rabbit_mgmt_util:id(queue, ReqData),
-            Publishers =
+            Publishers0 =
                 case {VHost, Queue} of
                     {VHost, none} ->
                         rabbit_mgmt_format:strip_pids(
@@ -81,6 +81,8 @@ to_json(ReqData, Context = #context{user = User}) ->
                         rabbit_mgmt_format:strip_pids(
                             rabbit_stream_mgmt_db:get_stream_publishers(QueueResource))
                 end,
+            Publishers = [rabbit_mgmt_format:clean_connection_details(I)
+                          || I <- Publishers0],
             rabbit_mgmt_util:reply_list(filter_user(Publishers, User),
                                         [],
                                         ReqData,


### PR DESCRIPTION
For the umpteenth time, we have to avoid the well known scenario where an empty proplist ends up being serialized as an empty JSON array where an empty JSON object is expected by the HTTP API clients.

For example, this can happen when a channel info endpoint is called before the connection had a chance to emit its first stats (metric samples).

Found by a few integration tests in the [HTTP API client for Zig](https://github.com/michaelklishin/rabbitmq-http-api-zig).