### PR TITLE
Friendly TLS mismatch errors

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -611,6 +611,15 @@ ranch_handshake(Ref) ->
         %% https://github.com/rabbitmq/rabbitmq-server/pull/12304
         exit:{shutdown, {closed, _}} = Error:Stacktrace ->
             erlang:raise(exit, Error, Stacktrace);
+        %% A non-TLS client connected to a TLS listener. The TLS server sent
+        %% an 'unexpected_message' alert because the first bytes were not a
+        %% valid TLS ClientHello.
+        exit:{shutdown, {{tls_alert, {unexpected_message, _}}, {PeerIp, PeerPort}}} = Error:Stacktrace ->
+            PeerAddress = io_lib:format("~ts:~tp", [rabbit_misc:ntoab(PeerIp), PeerPort]),
+            Protocol = ranch_ref_to_protocol(Ref),
+            ?LOG_WARNING("~ts is connecting to the ~p listener without using TLS",
+                         [PeerAddress, Protocol]),
+            erlang:raise(exit, Error, Stacktrace);
         exit:{shutdown, {Reason, {PeerIp, PeerPort}}} = Error:Stacktrace ->
             PeerAddress = io_lib:format("~ts:~tp", [rabbit_misc:ntoab(PeerIp), PeerPort]),
             Protocol = ranch_ref_to_protocol(Ref),

--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -242,6 +242,15 @@ define test_rabbitmq_config_with_tls
             {honor_cipher_order, true}]}
         ]}
   ]},
+  {rabbitmq_mqtt, [
+      {ssl_listeners, [8883]}
+    ]},
+  {rabbitmq_stomp, [
+      {ssl_listeners, [61614]}
+    ]},
+  {rabbitmq_stream, [
+      {ssl_listeners, [5551]}
+    ]},
   {ra, [
       {data_dir, "$(RABBITMQ_QUORUM_DIR)"}
     ]},

--- a/deps/rabbit_common/src/rabbit_ssl_options.erl
+++ b/deps/rabbit_common/src/rabbit_ssl_options.erl
@@ -42,7 +42,8 @@ wrap_password_opt(Opts0) ->
 fix(Config) ->
     fix_verify_fun(
       fix_ssl_protocol_versions(
-        hibernate_after(Config))).
+        fix_log_level(
+          hibernate_after(Config)))).
 
 -spec fix_client(rabbit_types:infos()) -> rabbit_types:infos().
 fix_client(Config) ->
@@ -137,4 +138,14 @@ hibernate_after(Config) ->
             Config;
         false ->
             [{Key, 6_000} | Config]
+    end.
+
+%% Suppress OTP's TLS state machine process notices by defaulting to warning
+%% level. RabbitMQ logs all relevant TLS handshake errors itself, so the
+%% OTP-level notices for the same events are redundant. Users can override
+%% this by setting the log_level SSL option explicitly.
+fix_log_level(Config) ->
+    case proplists:is_defined(log_level, Config) of
+        true  -> Config;
+        false -> [{log_level, warning} | Config]
     end.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -318,6 +318,16 @@ log_tls_alert(Alert, ConnName) ->
 
 process_received_bytes(<<>>, State) ->
     {noreply, ensure_stats_timer(State), ?HIBERNATE_AFTER};
+%% Detect a TLS ClientHello (TLS record content type 22) sent to a non-TLS
+%% listener and emit a user-friendly error instead of a confusing parse failure
+%% with a large stacktrace.
+process_received_bytes(<<16#16, _/binary>>,
+                       State = #state{proc_state = connect_packet_unprocessed,
+                                      conn_name = ConnName}) ->
+    ?LOG_ERROR("MQTT detected TLS ClientHello from ~ts: TLS-enabled client is "
+               "connecting to a non-TLS MQTT listener",
+               [ConnName]),
+    {stop, {shutdown, tls_connection_on_non_tls_listener}, State};
 process_received_bytes(Bytes, State = #state{socket = Socket,
                                              parse_state = ParseState,
                                              proc_state = ProcState,

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
@@ -248,6 +248,15 @@ handle_info({'EXIT', _From, Reason}, State) ->
 
 process_received_bytes([], State) ->
     {ok, State};
+%% Detect a TLS ClientHello (TLS record content type 22) sent to a non-TLS
+%% listener and emit a user-friendly error instead of a confusing parse failure.
+process_received_bytes(<<16#16, _/binary>>,
+                       State = #reader_state{current_frame_size = 0,
+                                             conn_name = ConnName}) ->
+    ?LOG_ERROR("STOMP detected TLS ClientHello from ~ts: TLS-enabled client is "
+               "connecting to a non-TLS STOMP listener",
+               [ConnName]),
+    {stop, normal, State};
 process_received_bytes(Bytes,
                        State = #reader_state{
                          max_frame_size = MaxFrameSize,

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -237,6 +237,16 @@ tcp_connected(state_timeout, close,
               #statem_data{transport = Transport,
                            connection = #stream_connection{socket = Socket}}) ->
     state_timeout(?FUNCTION_NAME, Transport, Socket);
+%% Detect a TLS ClientHello (TLS record content type 22) sent to a non-TLS
+%% listener and emit a user-friendly error instead of a confusing frame size
+%% error (the TLS record header bytes are misread as a huge frame length).
+tcp_connected(info, {tcp, Socket, <<16#16, _/binary>>},
+              #statem_data{connection = #stream_connection{socket = Socket,
+                                                           name = ConnName}}) ->
+    ?LOG_ERROR("Stream protocol detected TLS ClientHello from ~ts: TLS-enabled "
+               "client is connecting to a non-TLS stream listener",
+               [ConnName]),
+    stop;
 tcp_connected(info, Msg, StateData) ->
     handle_info(Msg, StateData,
                 fun(NextConnectionStep,


### PR DESCRIPTION
When someone mistakenly tried to connect without TLS
to a TLS-enabled listener or with TLS to a non-TLS
listener, we logged all kinds of confusing errors
(bad headers, unexpected messages, frame too large, etc).

Now we just log a user-friendly message