### PR TITLE
Fix oci-make workflow sha

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -31,9 +31,12 @@ on:
         default: false
 env:
   REGISTRY_IMAGE: pivotalrabbitmq/rabbitmq
-  VERSION: 4.3.0+${{ github.sha }}
+  # For pull_request events github.sha is an ephemeral merge commit, not the branch HEAD.
+  # For workflow_run events github.sha is the default branch HEAD, not the triggering branch HEAD.
+  # Use the actual branch HEAD SHA in both cases.
+  VERSION: 4.3.0+${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 jobs:
   build-package-generic-unix:
@@ -58,6 +61,8 @@ jobs:
       - name: Checkout
         if: steps.authorized.outputs.authorized == 'true'
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
       - name: Configure Erlang
         if: steps.authorized.outputs.authorized == 'true'
         uses: erlef/setup-beam@v1
@@ -87,6 +92,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
       - name: Download package-generic-unix
         uses: actions/download-artifact@v8
         with:
@@ -107,7 +114,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,format=long
+            type=raw,value=sha-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -35,7 +35,7 @@ env:
   # For workflow_run events github.sha is the default branch HEAD, not the triggering branch HEAD.
   # Use the actual branch HEAD SHA in both cases.
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
-  VERSION: 4.3.0+${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+  VERSION: 4.3.0+${{ env.HEAD_SHA }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -35,6 +35,7 @@ env:
   # For workflow_run events github.sha is the default branch HEAD, not the triggering branch HEAD.
   # Use the actual branch HEAD SHA in both cases.
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+  VERSION: 4.3.0+${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
@@ -72,7 +73,7 @@ jobs:
       - name: make package-generic-unix
         if: steps.authorized.outputs.authorized == 'true'
         run: |
-          make package-generic-unix PROJECT_VERSION=4.3.0+${{ env.HEAD_SHA }}
+          make package-generic-unix PROJECT_VERSION=${{ env.VERSION }}
       - name: Upload package-generic-unix
         if: steps.authorized.outputs.authorized == 'true'
         uses: actions/upload-artifact@v7
@@ -137,4 +138,4 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.otp_version }}
           build-args: |
             OTP_VERSION=${{ matrix.otp_version }}
-            RABBITMQ_VERSION=4.3.0+${{ env.HEAD_SHA }}
+            RABBITMQ_VERSION=${{ env.VERSION }}

--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -34,7 +34,7 @@ env:
   # For pull_request events github.sha is an ephemeral merge commit, not the branch HEAD.
   # For workflow_run events github.sha is the default branch HEAD, not the triggering branch HEAD.
   # Use the actual branch HEAD SHA in both cases.
-  VERSION: 4.3.0+${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+  HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
@@ -62,7 +62,7 @@ jobs:
         if: steps.authorized.outputs.authorized == 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ env.HEAD_SHA }}
       - name: Configure Erlang
         if: steps.authorized.outputs.authorized == 'true'
         uses: erlef/setup-beam@v1
@@ -72,7 +72,7 @@ jobs:
       - name: make package-generic-unix
         if: steps.authorized.outputs.authorized == 'true'
         run: |
-          make package-generic-unix PROJECT_VERSION=${{ env.VERSION }}
+          make package-generic-unix PROJECT_VERSION=4.3.0+${{ env.HEAD_SHA }}
       - name: Upload package-generic-unix
         if: steps.authorized.outputs.authorized == 'true'
         uses: actions/upload-artifact@v7
@@ -93,7 +93,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ env.HEAD_SHA }}
       - name: Download package-generic-unix
         uses: actions/download-artifact@v8
         with:
@@ -114,7 +114,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=raw,value=sha-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+            type=raw,value=sha-${{ env.HEAD_SHA }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -137,4 +137,4 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.otp_version }}
           build-args: |
             OTP_VERSION=${{ matrix.otp_version }}
-            RABBITMQ_VERSION=${{ env.VERSION }}
+            RABBITMQ_VERSION=4.3.0+${{ env.HEAD_SHA }}


### PR DESCRIPTION
oci-make can be triggered by `workflow_run` of the AWS peer discovery job. In such cases, it pushed an image with an incorrect SHA - the SHA of an ephemeral merge commit. The oci-make job "succeeded", but the AWS peer discovery job would time out waiting for an OCI image, because it expected the SHA of the head of the PR branch.

With this changes, the image should indeed have the SHA of the HEAD of the PR branch. This should fix failures like this:
https://github.com/rabbitmq/rabbitmq-server/actions/runs/25493629370/job/74807662488?pr=16343