### PR TITLE
Follow-up to #16341: rename `stream.connection_max` to `stream.max_connections`

### DIFF
--- a/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
+++ b/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
@@ -210,16 +210,15 @@ end}.
     {datatype, integer}
 ]}.
 
-{mapping, "stream.connection_max", "rabbitmq_stream.connection_max",
-  [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
+{mapping, "stream.max_connections", "rabbitmq_stream.max_connections",
+    [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
 
-{translation, "rabbitmq_stream.connection_max",
- fun(Conf) ->
-  case cuttlefish:conf_get("stream.connection_max", Conf, undefined) of
-      undefined -> cuttlefish:unset();
-      infinity  -> infinity;
-      Val when is_integer(Val) -> Val;
-      _         -> cuttlefish:invalid("should be a non-negative integer")
-  end
- end
-}.
+{translation, "rabbitmq_stream.max_connections",
+fun(Conf) ->
+    case cuttlefish:conf_get("stream.max_connections", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        infinity  -> infinity;
+        Val when is_integer(Val) -> Val;
+        _         -> cuttlefish:invalid("should be a non-negative integer")
+    end
+end}.

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -4247,7 +4247,7 @@ advertised_port_fun(ssl) ->
 check_node_connection_limit(undefined) ->
     ok;
 check_node_connection_limit(RanchRef) ->
-    case application:get_env(rabbitmq_stream, connection_max, infinity) of
+    case application:get_env(rabbitmq_stream, max_connections, infinity) of
         infinity ->
             ok;
         Limit when is_integer(Limit), Limit >= 0 ->

--- a/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
+++ b/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
@@ -74,8 +74,8 @@
       [{rabbitmq_stream,[{initial_credits, 100000},
                          	{credits_required_for_unblocking, 25000}]}],
       [rabbitmq_stream]},
-  {connection_max,
-      "stream.connection_max = 10",
-      [{rabbitmq_stream,[{connection_max, 10}]}],
+  {max_connections,
+      "stream.max_connections = 10",
+      [{rabbitmq_stream,[{max_connections, 10}]}],
       [rabbitmq_stream]}
 ].

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -209,7 +209,7 @@ init_per_testcase(user_connection_limit = TestCase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, TestCase);
 
 init_per_testcase(node_connection_limit = TestCase, Config) ->
-    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_stream, connection_max, 0]),
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_stream, max_connections, 0]),
     rabbit_ct_helpers:testcase_started(Config, TestCase);
 
 init_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
@@ -258,7 +258,7 @@ end_per_testcase(user_connection_limit = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:clear_user_limits(Config, <<"guest">>, max_connections),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(node_connection_limit = TestCase, Config) ->
-    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_stream, connection_max, infinity]),
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_stream, max_connections, infinity]),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),


### PR DESCRIPTION
To match the pattern other protocol plugins use. #16341 hasn't shipped, so now is the right time to do this.

Once we bump Cuttlefish to `3.7.0` (not yet released), we can consider supporting both via the new key aliases feature.

Part of #16347.
