### PR TITLE
[skip ci] OCI: set revision to HEAD_SHA

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -116,6 +116,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=sha-${{ env.HEAD_SHA }}
+          labels: |
+            org.opencontainers.image.revision=${{ env.HEAD_SHA }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx


### PR DESCRIPTION
set the revision, as expected by `int128/wait-for-docker-image-action` in `peer-discovery-aws.yaml`