### PR TITLE
Add `mqtt.max_connections` per-node connection limit

### DIFF
--- a/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
+++ b/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
@@ -160,6 +160,19 @@ end}.
     {datatype, integer}
 ]}.
 
+{mapping, "mqtt.max_connections", "rabbitmq_mqtt.max_connections",
+    [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbitmq_mqtt.max_connections",
+fun(Conf) ->
+    case cuttlefish:conf_get("mqtt.max_connections", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        infinity  -> infinity;
+        Val when is_integer(Val) -> Val;
+        _         -> cuttlefish:invalid("should be a non-negative integer")
+    end
+end}.
+
 {mapping, "mqtt.ssl_cert_login", "rabbitmq_mqtt.ssl_cert_login", [
     {datatype, {enum, [true, false]}}]}.
 

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -188,7 +188,6 @@ process_connect(
     end,
     Result0 =
     maybe
-        ok ?= check_node_connection_limit(),
         ok ?= check_extended_auth(ConnectProps),
         {ok, ClientId1} ?= extract_client_id_from_certificate(ClientId0, Socket),
         {ok, ClientId} ?= ensure_client_id(ClientId1, CleanStart, ProtoVer),
@@ -197,6 +196,7 @@ process_connect(
         ?LOG_DEBUG("MQTT connection ~s picked vhost using ~s", [ConnName0, VHostPickedUsing]),
         ok ?= check_vhost_exists(VHost, Username2, PeerIp),
         ok ?= check_vhost_alive(VHost),
+        ok ?= check_node_connection_limit(),
         ok ?= check_vhost_connection_limit(VHost),
         {ok, User = #user{username = Username}} ?= check_user_login(VHost, Username2, Password,
                                                                     ClientId, PeerIp, ConnName0),
@@ -1083,10 +1083,10 @@ check_vhost_exists(VHost, Username, PeerIp) ->
     end.
 
 check_node_connection_limit() ->
-    case application:get_env(rabbitmq_mqtt, max_connections, infinity) of
+    case application:get_env(?APP_NAME, max_connections, infinity) of
         infinity ->
             ok;
-        Limit when is_integer(Limit), Limit >= 0 ->
+        Limit when is_integer(Limit) andalso Limit >= 0 ->
             PgScope = persistent_term:get(?PG_SCOPE),
             %% pg:init/1 creates a named ETS table using the scope atom as the table
             %% name. Each row holds one group: {Group, AllPids, LocalPids}. Since
@@ -1098,8 +1098,8 @@ check_node_connection_limit() ->
             %% expensive when the node hosts a large number of MQTT connections.
             %% Note: OTP-27.3.4.11 source code used as a reference.
             case ets:info(PgScope, size) of
-                ActiveConns when is_integer(ActiveConns), ActiveConns >= Limit ->
-                    ?LOG_ERROR("MQTT connection failed: node connection limit ~tp is reached",
+                MqttConns when is_integer(MqttConns) andalso MqttConns >= Limit ->
+                    ?LOG_ERROR("MQTT connection failed: node connection limit ~b is reached",
                                [Limit]),
                     {error, ?RC_QUOTA_EXCEEDED};
                 _ ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -1102,7 +1102,11 @@ check_node_connection_limit() ->
                     ?LOG_ERROR("MQTT connection failed: node connection limit ~b is reached",
                                [Limit]),
                     {error, ?RC_QUOTA_EXCEEDED};
-                _ ->
+                MqttConns when is_integer(MqttConns) ->
+                    ok;
+                Other ->
+                    ?LOG_WARNING("MQTT pg scope ETS table '~ts' size is ~tp",
+                                 [PgScope, Other]),
                     ok
             end;
         _ ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -188,6 +188,7 @@ process_connect(
     end,
     Result0 =
     maybe
+        ok ?= check_node_connection_limit(),
         ok ?= check_extended_auth(ConnectProps),
         {ok, ClientId1} ?= extract_client_id_from_certificate(ClientId0, Socket),
         {ok, ClientId} ?= ensure_client_id(ClientId1, CleanStart, ProtoVer),
@@ -1079,6 +1080,33 @@ check_vhost_exists(VHost, Username, PeerIp) ->
             ?LOG_ERROR("MQTT connection failed: virtual host '~s' does not exist", [VHost]),
             auth_attempt_failed(PeerIp, Username),
             {error, ?RC_BAD_USER_NAME_OR_PASSWORD}
+    end.
+
+check_node_connection_limit() ->
+    case application:get_env(rabbitmq_mqtt, max_connections, infinity) of
+        infinity ->
+            ok;
+        Limit when is_integer(Limit), Limit >= 0 ->
+            PgScope = persistent_term:get(?PG_SCOPE),
+            %% pg:init/1 creates a named ETS table using the scope atom as the table
+            %% name. Each row holds one group: {Group, AllPids, LocalPids}. Since
+            %% MQTT enforces unique client IDs per vhost, every connected client
+            %% occupies exactly one group, so the table size equals the number of
+            %% active connections node-wide across all listeners and transports.
+            %% We use ets:info/2 (O(1)) rather than pg:which_groups/1, which
+            %% performs a full table scan via ets:match/2 and is O(N) — too
+            %% expensive when the node hosts a large number of MQTT connections.
+            %% Note: OTP-27.3.4.11 source code used as a reference.
+            case ets:info(PgScope, size) of
+                ActiveConns when is_integer(ActiveConns), ActiveConns >= Limit ->
+                    ?LOG_ERROR("MQTT connection failed: node connection limit ~tp is reached",
+                               [Limit]),
+                    {error, ?RC_QUOTA_EXCEEDED};
+                _ ->
+                    ok
+            end;
+        _ ->
+            ok
     end.
 
 check_vhost_connection_limit(VHost) ->

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -359,11 +359,6 @@ init_per_testcase(T, Config)
        T =:= client_id_from_cert_dn ->
     SetupProcess = setup_rabbit_auth_backend_mqtt_mock(Config),
     rabbit_ct_helpers:set_config(Config, {mock_setup_process, SetupProcess});
-
-init_per_testcase(T = node_connection_limit, Config) ->
-    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
-                                 [rabbitmq_mqtt, max_connections, 0]),
-    testcase_started(Config, T);
 init_per_testcase(Testcase, Config) ->
     testcase_started(Config, Testcase).
 
@@ -504,11 +499,6 @@ end_per_testcase(T, Config)
     SetupProcess ! stop,
     close_all_connections(Config);
 
-end_per_testcase(node_connection_limit = T, Config) ->
-    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
-                                 [rabbitmq_mqtt, max_connections, infinity]),
-    close_all_connections(Config),
-    rabbit_ct_helpers:testcase_finished(Config, T);
 end_per_testcase(Testcase, Config) ->
     close_all_connections(Config),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
@@ -1332,10 +1322,12 @@ user_connection_limit(Config) ->
     ok = rabbit_ct_broker_helpers:clear_user_limits(Config, DefaultUser, max_connections).
 
 node_connection_limit(Config) ->
+    ok = rpc(Config, 0, application, set_env, [rabbitmq_mqtt, max_connections, 0]),
     {ok, C} = connect_anonymous(Config, <<"client1">>),
     ExpectedError = expected_connection_limit_error(Config),
     unlink(C),
-    ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C)).
+    ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C)),
+    ok = rpc(Config, 0, application, unset_env, [rabbitmq_mqtt, max_connections]).
 
 expected_connection_limit_error(Config) ->
     case ?config(mqtt_version, Config) of

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -122,7 +122,9 @@ sub_groups() ->
       [vhost_connection_limit,
        vhost_queue_limit,
        user_connection_limit,
-       node_connection_limit
+       node_connection_limit,
+       node_connection_limit_cross_listener,
+       node_connection_limit_infinity
       ]}
     ].
 
@@ -1322,12 +1324,71 @@ user_connection_limit(Config) ->
     ok = rabbit_ct_broker_helpers:clear_user_limits(Config, DefaultUser, max_connections).
 
 node_connection_limit(Config) ->
-    ok = rpc(Config, 0, application, set_env, [rabbitmq_mqtt, max_connections, 0]),
-    {ok, C} = connect_anonymous(Config, <<"client1">>),
+    %% Wait connections from other tests to drain (`pg` cleanup is asynchronous).
+    ?awaitMatch(0, count_local_mqtt_connections(Config), 30000),
+    ok = set_node_max_connections(Config, 2),
     ExpectedError = expected_connection_limit_error(Config),
-    unlink(C),
-    ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C)),
-    ok = rpc(Config, 0, application, unset_env, [rabbitmq_mqtt, max_connections]).
+    try
+        {ok, C1} = connect_anonymous(Config, <<"client1">>),
+        {ok, _} = emqtt:connect(C1),
+        {ok, C2} = connect_anonymous(Config, <<"client2">>),
+        {ok, _} = emqtt:connect(C2),
+        {ok, C3} = connect_anonymous(Config, <<"client3">>),
+        unlink(C3),
+        ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C3)),
+        ok = emqtt:disconnect(C1),
+        ?awaitMatch(1, count_local_mqtt_connections(Config), 30000),
+        {ok, C4} = connect_anonymous(Config, <<"client4">>),
+        {ok, _} = emqtt:connect(C4),
+        ok = emqtt:disconnect(C2),
+        ok = emqtt:disconnect(C4)
+    after
+        ok = unset_node_max_connections(Config)
+    end.
+
+node_connection_limit_cross_listener(Config) ->
+    %% Wait connections from other tests to drain (`pg` cleanup is asynchronous).
+    ?awaitMatch(0, count_local_mqtt_connections(Config), 30000),
+    ok = set_node_max_connections(Config, 2),
+    ExpectedError = expected_connection_limit_error(Config),
+    try
+        {ok, C1} = connect_anonymous(Config, <<"plain-client">>),
+        {ok, _} = emqtt:connect(C1),
+        {ok, C2} = connect_ssl(<<"tls-client">>, Config),
+        {ok, _} = emqtt:connect(C2),
+        {ok, C3} = connect_anonymous(Config, <<"extra-client">>),
+        unlink(C1),
+        unlink(C2),
+        unlink(C3),
+        ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C3)),
+        ok = emqtt:disconnect(C1),
+        ok = emqtt:disconnect(C2)
+    after
+        ok = unset_node_max_connections(Config)
+    end.
+
+node_connection_limit_infinity(Config) ->
+    ok = set_node_max_connections(Config, infinity),
+    try
+        Clients = [begin
+                       Id = list_to_binary("infinity-" ++ integer_to_list(N)),
+                       {ok, C} = connect_anonymous(Config, Id),
+                       {ok, _} = emqtt:connect(C),
+                       C
+                   end || N <- lists:seq(1, 5)],
+        [ok = emqtt:disconnect(C) || C <- Clients]
+    after
+        ok = unset_node_max_connections(Config)
+    end.
+
+set_node_max_connections(Config, Limit) ->
+    rpc(Config, 0, application, set_env, [rabbitmq_mqtt, max_connections, Limit]).
+
+unset_node_max_connections(Config) ->
+    rpc(Config, 0, application, unset_env, [rabbitmq_mqtt, max_connections]).
+
+count_local_mqtt_connections(Config) ->
+    length(rpc(Config, 0, rabbit_mqtt, local_connection_pids, [])).
 
 expected_connection_limit_error(Config) ->
     case ?config(mqtt_version, Config) of

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -121,7 +121,8 @@ sub_groups() ->
      {limit, [shuffle],
       [vhost_connection_limit,
        vhost_queue_limit,
-       user_connection_limit
+       user_connection_limit,
+       node_connection_limit
       ]}
     ].
 
@@ -359,6 +360,10 @@ init_per_testcase(T, Config)
     SetupProcess = setup_rabbit_auth_backend_mqtt_mock(Config),
     rabbit_ct_helpers:set_config(Config, {mock_setup_process, SetupProcess});
 
+init_per_testcase(T = node_connection_limit, Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+                                 [rabbitmq_mqtt, max_connections, 0]),
+    testcase_started(Config, T);
 init_per_testcase(Testcase, Config) ->
     testcase_started(Config, Testcase).
 
@@ -499,6 +504,11 @@ end_per_testcase(T, Config)
     SetupProcess ! stop,
     close_all_connections(Config);
 
+end_per_testcase(node_connection_limit = T, Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+                                 [rabbitmq_mqtt, max_connections, infinity]),
+    close_all_connections(Config),
+    rabbit_ct_helpers:testcase_finished(Config, T);
 end_per_testcase(Testcase, Config) ->
     close_all_connections(Config),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
@@ -1320,6 +1330,12 @@ user_connection_limit(Config) ->
     ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C2)),
     ok = emqtt:disconnect(C1),
     ok = rabbit_ct_broker_helpers:clear_user_limits(Config, DefaultUser, max_connections).
+
+node_connection_limit(Config) ->
+    {ok, C} = connect_anonymous(Config, <<"client1">>),
+    ExpectedError = expected_connection_limit_error(Config),
+    unlink(C),
+    ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C)).
 
 expected_connection_limit_error(Config) ->
     case ?config(mqtt_version, Config) of

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
@@ -192,6 +192,11 @@
   {max_connections,
    "mqtt.max_connections = 10",
    [{rabbitmq_mqtt,[{max_connections, 10}]}],
+   [rabbitmq_mqtt]},
+
+  {max_connections_infinity,
+   "mqtt.max_connections = infinity",
+   [{rabbitmq_mqtt,[{max_connections, infinity}]}],
    [rabbitmq_mqtt]}
 
 ].

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
@@ -187,6 +187,11 @@
    [{rabbitmq_mqtt, [
       {message_interceptors, []}
      ]}],
-   []}
+   []},
+
+  {max_connections,
+   "mqtt.max_connections = 10",
+   [{rabbitmq_mqtt,[{max_connections, 10}]}],
+   [rabbitmq_mqtt]}
 
 ].

--- a/deps/rabbitmq_web_mqtt/test/web_mqtt_command_SUITE.erl
+++ b/deps/rabbitmq_web_mqtt/test/web_mqtt_command_SUITE.erl
@@ -28,7 +28,8 @@ groups() ->
     [
      {unit, [], [merge_defaults]},
      {v5, [], [run,
-               user_property]}
+               user_property,
+               node_connection_limit_cross_transport]}
     ].
 
 suite() ->
@@ -171,6 +172,39 @@ user_property(BaseConfig) ->
            {user_property, UserProp}]],
          'Elixir.Enum':to_list(?COMMAND:run([<<"client_id">>, <<"user_property">>], Opts)))),
     ok = emqtt:disconnect(C).
+
+node_connection_limit_cross_transport(BaseConfig) ->
+    %% Wait connections from other tests to drain (`pg` cleanup is asynchronous).
+    rabbit_ct_helpers:eventually(
+      ?_assertEqual(
+         0,
+         length(rabbit_ct_broker_helpers:rpc(
+                  BaseConfig, 0, rabbit_mqtt, local_connection_pids, []))),
+      500, 60),
+    Config = [{websocket, true} | BaseConfig],
+    ok = rabbit_ct_broker_helpers:rpc(
+           BaseConfig, 0, application, set_env,
+           [rabbitmq_mqtt, max_connections, 2]),
+    try
+        C1 = connect(<<"plain-mqtt-client">>, BaseConfig, [{ack_timeout, 1}]),
+        C2 = connect(<<"web-mqtt-client">>, Config, [{ack_timeout, 1}]),
+        {ok, C3} = emqtt:start_link(
+                     [{host, "localhost"},
+                      {port, rabbit_ct_broker_helpers:get_node_config(
+                               Config, 0, tcp_port_web_mqtt)},
+                      {proto_ver, v5},
+                      {clientid, <<"web-mqtt-client-2">>},
+                      {ws_path, "/ws"},
+                      {ack_timeout, 1}]),
+        unlink(C3),
+        ?assertMatch({error, {quota_exceeded, _}}, emqtt:ws_connect(C3)),
+        ok = emqtt:disconnect(C1),
+        ok = emqtt:disconnect(C2)
+    after
+        ok = rabbit_ct_broker_helpers:rpc(
+               BaseConfig, 0, application, unset_env,
+               [rabbitmq_mqtt, max_connections])
+    end.
 
 start_amqp_connection(Type, Node, Port) ->
     amqp_connection:start(amqp_params(Type, Node, Port)).


### PR DESCRIPTION
Closes #16347 (partial - adds `mqtt.max_connections`).

## What this PR does

Adds `mqtt.max_connections`, a per-node connection limit for the MQTT plugin. When the limit is reached, the broker sends a CONNACK with return code `not_authorized` (MQTT 3.x/4) or reason code `quota_exceeded` (MQTT 5) and closes the connection.

## How it works

The limit is checked in `rabbit_mqtt_processor:process_connect/5` as the first step in the CONNECT packet handler, before authentication. It does not operate at the Ranch transport layer, so the TCP listen queue is unaffected and Ranch continues accepting connections normally.

The active connection count uses `ets:info(persistent_term:get(?PG_SCOPE), size)`. The MQTT plugin creates a node-local PG scope in `rabbit_mqtt_sup`; each connection joins it via `pg:join/3` in `register_client_id/4`, using `{VHost, ClientId}` as the group key. Since the MQTT spec requires unique client IDs per vhost, which RabbitMQ enforces, each group has exactly one member. The PG scope ETS table therefore has one row per active connection node-wide, covering all listeners and transports (plain TCP, TLS, and Web MQTT). `ets:info/2` reads this count in O(1) - important given that MQTT nodes can host a very large number of connections.

The check runs before `register_client_id/4`, so the current connection is not yet counted; the limit comparison is `>= max_connections`.

## Configuration

```ini
mqtt.max_connections = 1000
```

The default is `infinity` (no limit). The setting accepts a non-negative integer or `infinity`.

## Testing

Adds `node_connection_limit` to the `limit` group in `auth_SUITE`. The test sets the limit to 0 via RPC so the first CONNECT attempt is rejected, covering both MQTT v4 and v5 via the existing `expected_connection_limit_error/1` helper.
