### PR TITLE
Fix groovy-all dependency resolution

### DIFF
--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
@@ -110,6 +110,7 @@
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-all</artifactId>
               <version>${groovy.version}</version>
+              <type>pom</type>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
Fix groovy-all dependency resolution in java_SUITE_data pom.xml Groovy 3.0+ packages `groovy-all` as a `pom` rather than a `jar`. This commit adds `<type>pom</type>` to the `groovy-all` plugin dependency in `deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml` to fix the resolution error introduced by the recent dependency version bump to 3.0.25 in https://github.com/rabbitmq/rabbitmq-server/pull/16363