### PR TITLE
Bump Cuttlefish to `3.7.0`

### DIFF
--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -46,7 +46,7 @@ endif
 dep_cowboy = hex 2.14.1
 dep_cowlib = hex 2.16.0
 dep_credentials_obfuscation = hex 3.5.0
-dep_cuttlefish = hex 3.6.0
+dep_cuttlefish = hex 3.7.0
 dep_gen_batch_server = hex 0.10.0
 dep_jose = hex 1.11.12
 dep_khepri = hex 0.18.0


### PR DESCRIPTION
To get support for key aliasing https://github.com/Kyorai/cuttlefish/issues/69.

## Change Log

[Release notes](https://github.com/Kyorai/cuttlefish/releases/tag/v3.7.0).


## Further COmments

Part of https://github.com/rabbitmq/rabbitmq-server/issues/16347.