### PR TITLE
QQ: allow delayed-retry policies

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -187,7 +187,7 @@
 
 -rabbit_boot_step(
    {?MODULE,
-    [{description, "QQ target group size policies. "
+    [{description, "QQ policies. "
       "target-group-size controls the targeted number of "
       "member nodes for the queue. If set, RabbitMQ will try to "
       "grow the queue members to the target size. "
@@ -198,18 +198,78 @@
             [operator_policy_validator, <<"target-group-size">>, ?MODULE]}},
      {mfa, {rabbit_registry, register,
             [policy_merge_strategy, <<"target-group-size">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_validator, <<"delayed-retry-type">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_validator, <<"delayed-retry-min">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_validator, <<"delayed-retry-max">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [operator_policy_validator, <<"delayed-retry-type">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [operator_policy_validator, <<"delayed-retry-min">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [operator_policy_validator, <<"delayed-retry-max">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_merge_strategy, <<"delayed-retry-type">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_merge_strategy, <<"delayed-retry-min">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_merge_strategy, <<"delayed-retry-max">>, ?MODULE]}},
      {requires, [rabbit_registry]},
      {enables, recovery}]}).
 
 validate_policy(Args) ->
-    Count = proplists:get_value(<<"target-group-size">>, Args, none),
-    case is_integer(Count) andalso Count > 0 of
-        true -> ok;
-        false -> {error, "~tp is not a valid qq target count value", [Count]}
+    case lists:foldl(fun ({Key, Value}, ok) -> validate_policy0(Key, Value);
+                         (_, Error)         -> Error
+                     end, ok, Args) of
+        ok    -> validate_delayed_retry_constraints(Args);
+        Error -> Error
     end.
 
+validate_delayed_retry_constraints(Args) ->
+    Type = proplists:get_value(<<"delayed-retry-type">>, Args),
+    Min  = proplists:get_value(<<"delayed-retry-min">>, Args),
+    Max  = proplists:get_value(<<"delayed-retry-max">>, Args),
+    case {Type, Min} of
+        {T, undefined} when T =/= undefined, T =/= <<"disabled">> ->
+            {error, "delayed-retry-min is required when delayed-retry-type is ~ts", [T]};
+        _ when is_integer(Min), is_integer(Max), Max < Min ->
+            {error, "delayed-retry-max (~b) must not be smaller than delayed-retry-min (~b)", [Max, Min]};
+        _ ->
+            ok
+    end.
+
+validate_policy0(<<"target-group-size">>, Value) ->
+    case is_integer(Value) andalso Value > 0 of
+        true  -> ok;
+        false -> {error, "~tp is not a valid qq target count value", [Value]}
+    end;
+validate_policy0(<<"delayed-retry-type">>, <<"all">>)      -> ok;
+validate_policy0(<<"delayed-retry-type">>, <<"failed">>)   -> ok;
+validate_policy0(<<"delayed-retry-type">>, <<"returned">>) -> ok;
+validate_policy0(<<"delayed-retry-type">>, <<"disabled">>) -> ok;
+validate_policy0(<<"delayed-retry-type">>, Value) ->
+    {error, "~tp is not a valid delayed retry type. Must be one of: all, failed, returned, disabled", [Value]};
+validate_policy0(<<"delayed-retry-min">>, Value)
+  when is_integer(Value), Value > 0 ->
+    ok;
+validate_policy0(<<"delayed-retry-min">>, Value) ->
+    {error, "~tp is not a valid delayed retry minimum delay. Must be a positive integer", [Value]};
+validate_policy0(<<"delayed-retry-max">>, Value)
+  when is_integer(Value), Value > 0 ->
+    ok;
+validate_policy0(<<"delayed-retry-max">>, Value) ->
+    {error, "~tp is not a valid delayed retry maximum delay. Must be a positive integer", [Value]}.
+
 merge_policy_value(<<"target-group-size">>, Val, OpVal) ->
-    max(Val, OpVal).
+    max(Val, OpVal);
+merge_policy_value(<<"delayed-retry-type">>, _Val, OpVal) ->
+    OpVal;
+merge_policy_value(<<"delayed-retry-min">>, Val, OpVal) ->
+    max(Val, OpVal);
+merge_policy_value(<<"delayed-retry-max">>, Val, OpVal) ->
+    min(Val, OpVal).
 
 %%----------- rabbit_queue_type ---------------------------------------------
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -221,7 +221,7 @@
 
 validate_policy(Args) ->
     case lists:foldl(fun ({Key, Value}, ok) -> validate_policy0(Key, Value);
-                         (_, Error)         -> Error
+                         (_, Error) -> Error
                      end, ok, Args) of
         ok    -> validate_delayed_retry_constraints(Args);
         Error -> Error

--- a/deps/rabbit/test/unit_policy_validators_SUITE.erl
+++ b/deps/rabbit/test/unit_policy_validators_SUITE.erl
@@ -31,7 +31,12 @@ groups() ->
           max_in_memory_length,
           delivery_limit,
           classic_queue_lazy_mode,
-          length_limit_overflow_mode
+          length_limit_overflow_mode,
+          delayed_retry_type,
+          delayed_retry_min,
+          delayed_retry_max,
+          delayed_retry_min_required_with_type,
+          delayed_retry_max_not_less_than_min
         ]}
     ].
 
@@ -148,3 +153,49 @@ requires_integer_value(Key) ->
     test_valid_and_invalid_values(Key,
         [-1, 0, 1, 1000, -10000],
         [<<"a.binary">>, 0.1]).
+
+delayed_retry_type(_Config) ->
+    [?assertEqual(ok,
+                  rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, T},
+                                                       {<<"delayed-retry-min">>, 1000}]))
+     || T <- [<<"all">>, <<"failed">>, <<"returned">>]],
+    ?assertEqual(ok,
+                 rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, <<"disabled">>}])),
+    [?assertMatch({error, _, _},
+                  rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, T},
+                                                       {<<"delayed-retry-min">>, 1000}]))
+     || T <- [<<"none">>, <<"unknown">>, 0, true]].
+
+delayed_retry_min(_Config) ->
+    test_valid_and_invalid_values(rabbit_quorum_queue, <<"delayed-retry-min">>,
+        [1, 100, 5000],
+        [0, -1, <<"100">>, 0.1]).
+
+delayed_retry_max(_Config) ->
+    test_valid_and_invalid_values(rabbit_quorum_queue, <<"delayed-retry-max">>,
+        [1, 100, 5000],
+        [0, -1, <<"100">>, 0.1]).
+
+delayed_retry_min_required_with_type(_Config) ->
+    %% delayed-retry-min must be present when type is not disabled
+    [?assertMatch({error, _, _},
+                  rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, T}]))
+     || T <- [<<"all">>, <<"failed">>, <<"returned">>]],
+    %% disabled and absent type do not require delayed-retry-min
+    ?assertEqual(ok, rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, <<"disabled">>}])),
+    ?assertEqual(ok, rabbit_quorum_queue:validate_policy([{<<"delayed-retry-min">>, 1000}])).
+
+delayed_retry_max_not_less_than_min(_Config) ->
+    %% max must not be smaller than min
+    ?assertMatch({error, _, _},
+                 rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, <<"all">>},
+                                                     {<<"delayed-retry-min">>, 5000},
+                                                     {<<"delayed-retry-max">>, 1000}])),
+    ?assertEqual(ok,
+                 rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, <<"all">>},
+                                                     {<<"delayed-retry-min">>, 1000},
+                                                     {<<"delayed-retry-max">>, 1000}])),
+    ?assertEqual(ok,
+                 rabbit_quorum_queue:validate_policy([{<<"delayed-retry-type">>, <<"all">>},
+                                                     {<<"delayed-retry-min">>, 1000},
+                                                     {<<"delayed-retry-max">>, 5000}])).


### PR DESCRIPTION
We missed that in the original implementation,
even though the documentation says delayed-retry-* can be set through a policy. Now they can be indeed.

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/16394
