### PR TITLE
LDAP: restore log event domain

### DIFF
--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -525,16 +525,25 @@ with_ldap({ok, Creds}, Fun, Servers) ->
     Opts1 = case env(log) of
                 network ->
                     Pre = "    LDAP network traffic: ",
-                    ?LOG_INFO("LDAP connecting to servers: ~tp", [Servers]),
-                    [{log, fun(1, S, A) -> ?LOG_WARNING(Pre ++ S, A);
+                    ?LOG_INFO("LDAP connecting to servers: ~tp", [Servers],
+                              #{domain => ?RMQLOG_DOMAIN_LDAP}),
+                    [{log, fun(1, S, A) ->
+                                   ?LOG_WARNING(Pre ++ S, A,
+                                                #{domain => ?RMQLOG_DOMAIN_LDAP});
                               (2, S, A) ->
-                                   ?LOG_INFO(Pre ++ S, scrub_creds(A, []))
+                                   ?LOG_INFO(Pre ++ S, scrub_creds(A, []),
+                                             #{domain => ?RMQLOG_DOMAIN_LDAP})
                            end} | Opts0];
                 network_unsafe ->
                     Pre = "    LDAP network traffic: ",
-                    ?LOG_INFO("    LDAP connecting to servers: ~tp", [Servers]),
-                    [{log, fun(1, S, A) -> ?LOG_WARNING(Pre ++ S, A);
-                              (2, S, A) -> ?LOG_INFO(   Pre ++ S, A)
+                    ?LOG_INFO("    LDAP connecting to servers: ~tp", [Servers],
+                              #{domain => ?RMQLOG_DOMAIN_LDAP}),
+                    [{log, fun(1, S, A) ->
+                                   ?LOG_WARNING(Pre ++ S, A,
+                                                #{domain => ?RMQLOG_DOMAIN_LDAP});
+                              (2, S, A) ->
+                                   ?LOG_INFO(Pre ++ S, A,
+                                             #{domain => ?RMQLOG_DOMAIN_LDAP})
                            end} | Opts0];
                 _ ->
                     Opts0
@@ -559,7 +568,8 @@ with_ldap({ok, Creds}, Fun, Servers) ->
 with_login(Creds, Servers, Opts, Fun) ->
     with_login(Creds, Servers, Opts, Fun, ?LDAP_OPERATION_RETRIES).
 with_login(_Creds, _Servers, _Opts, _Fun, 0 = _RetriesLeft) ->
-    ?LOG_WARNING("LDAP failed to perform an operation. TCP connection to a LDAP server was closed or otherwise defunct. Exhausted all retries."),
+    ?LOG_WARNING("LDAP failed to perform an operation. TCP connection to a LDAP server was closed or otherwise defunct. Exhausted all retries.",
+                 #{domain => ?RMQLOG_DOMAIN_LDAP}),
     {error, ldap_connect_error};
 with_login(Creds, Servers, Opts, Fun, RetriesLeft) ->
     case get_or_create_conn(Creds == anon, Servers, Opts) of
@@ -618,9 +628,11 @@ with_login(Creds, Servers, Opts, Fun, RetriesLeft) ->
 
 purge_connection(Creds, Servers, Opts) ->
     %% purge and retry with a new connection
-    ?LOG_WARNING("TCP connection to a LDAP server was closed or otherwise defunct."),
+    ?LOG_WARNING("TCP connection to a LDAP server was closed or otherwise defunct.",
+                 #{domain => ?RMQLOG_DOMAIN_LDAP}),
     purge_conn(Creds == anon, Servers, Opts),
-    ?LOG_WARNING("LDAP will retry with a new connection.").
+    ?LOG_WARNING("LDAP will retry with a new connection.",
+                 #{domain => ?RMQLOG_DOMAIN_LDAP}).
 
 call_ldap_fun(Fun, LDAP) ->
     call_ldap_fun(Fun, LDAP, "").
@@ -734,7 +746,8 @@ purge_conn(IsAnon, Servers, Opts) ->
     Conns = get(ldap_conns),
     Key = {IsAnon, Servers, Opts},
     {ok, Conn} = maps:find(Key, Conns),
-    ?LOG_WARNING("LDAP will purge an already closed or defunct LDAP server connection from the pool"),
+    ?LOG_WARNING("LDAP will purge an already closed or defunct LDAP server connection from the pool",
+                 #{domain => ?RMQLOG_DOMAIN_LDAP}),
     % We cannot close the connection with eldap:close/1 because as of OTP-13327
     % eldap will try to do_unbind first and will fail with a `{gen_tcp_error, closed}`.
     % Since we know that the connection is already closed, we just
@@ -782,7 +795,8 @@ ssl_options(Opts0) ->
     Opts1 = rabbit_ssl_options:fix_client(Opts0),
     case env(ssl_hostname_verification, undefined) of
         wildcard ->
-            ?LOG_DEBUG("Enabling wildcard-aware hostname verification for LDAP client connections"),
+            ?LOG_DEBUG("Enabling wildcard-aware hostname verification for LDAP client connections",
+                       #{domain => ?RMQLOG_DOMAIN_LDAP}),
             %% Needed for non-HTTPS connections that connect to servers that use wildcard certificates.
             %% See https://erlang.org/doc/man/public_key.html#pkix_verify_hostname_match_fun-1.
             [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | Opts1];
@@ -799,8 +813,9 @@ get_expected_env_str(Key, Default) ->
     V = case env(Key) of
             Default ->
                 ?LOG_WARNING("rabbitmq_auth_backend_ldap configuration key '~tp' is set to "
-                                        "the default value of '~tp', expected to get a non-default value",
-                                        [Key, Default]),
+                             "the default value of '~tp', expected to get a non-default value",
+                             [Key, Default],
+                             #{domain => ?RMQLOG_DOMAIN_LDAP}),
                 Default;
             V0 ->
                 V0
@@ -899,7 +914,8 @@ dn_lookup(Username, LDAP) ->
             DN;
         {ok, {eldap_search_result, Entries, _Referrals, _Controls}} ->
             ?LOG_WARNING("Searching for DN for ~ts, got back ~tp",
-                               [Filled, Entries]),
+                         [Filled, Entries],
+                         #{domain => ?RMQLOG_DOMAIN_LDAP}),
             Filled;
         {error, _} = E ->
             exit(E)
@@ -978,7 +994,8 @@ is_dn(_S) -> false.
 
 log(Fmt,  Args) -> case env(log) of
                        false -> ok;
-                       _     -> ?LOG_INFO(Fmt ++ "", Args)
+                       _     -> ?LOG_INFO(Fmt ++ "", Args,
+                                          #{domain => ?RMQLOG_DOMAIN_LDAP})
                    end.
 
 fill(Fmt, Args) ->

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_app.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_app.erl
@@ -33,7 +33,8 @@ start(_Type, _StartArgs) ->
         true  -> ok;
         false -> ?LOG_WARNING(
                    "LDAP plugin loaded, but rabbit_auth_backend_ldap is not "
-                   "in the list of auth_backends. LDAP auth will not work.")
+                   "in the list of auth_backends. LDAP auth will not work.",
+                   #{domain => ?RMQLOG_DOMAIN_LDAP})
     end,
     {ok, SSL} = application:get_env(rabbitmq_auth_backend_ldap, use_ssl),
     {ok, TLS} = application:get_env(rabbitmq_auth_backend_ldap, use_starttls),
@@ -56,6 +57,4 @@ configured(M,  [_    |T]) -> configured(M, T).
 
 %%----------------------------------------------------------------------------
 
-init([]) ->
-    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_LDAP}),
-    {ok, {{one_for_one, 3, 10}, []}}.
+init([]) -> {ok, {{one_for_one, 3, 10}, []}}.

--- a/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_auth_backend_ldap/include/logging.hrl").
 
 -compile([export_all]).
 
@@ -19,7 +20,9 @@ all() ->
      rfc4514_escape_value,
      rfc4514_fill_dn,
      user_dn_pattern_gh_7161,
-     format_different_types_of_ldap_attribute_values
+     format_different_types_of_ldap_attribute_values,
+     ldap_log_domain_routing,
+     ldap_log_callsites_carry_domain
     ].
 
 fill(_Config) ->
@@ -45,7 +48,7 @@ rfc4514_escape_value(_Config) ->
     E("", ""),
     E(<<"binary">>, <<"binary">>),
     E(atom, "atom"),
-    %% Comma — the primary injection vector
+    %% Comma escaping
     E("user,ou=Evil", "user\\,ou=Evil"),
     %% All special characters
     E("a+b", "a\\+b"),
@@ -65,7 +68,7 @@ rfc4514_escape_value(_Config) ->
     E("a b", "a b"),
     %% Multiple specials
     E("a,b+c", "a\\,b\\+c"),
-    %% Backslash + comma (escape-the-escape attack)
+    %% Backslash followed by comma
     E("a\\,b", "a\\\\\\,b"),
     %% NUL byte
     E([0], [$\\, 0]),
@@ -133,4 +136,65 @@ format_different_types_of_ldap_attribute_values(_Config) ->
     ?assertEqual("28000-ß", rabbit_auth_backend_ldap:format_multi_attr(NonAsciiAttr)),
 
     ?assertEqual("one; 28000-ß; two; ", rabbit_auth_backend_ldap:format_multi_attr(["one", NonAsciiAttr, "two"])),
+    ok.
+
+%% `?RMQLOG_DOMAIN_LDAP` log even routing
+ldap_log_domain_routing(_Config) ->
+    HandlerId = ldap_log_capture,
+    Ref = make_ref(),
+    HandlerCfg = #{config => #{pid => self(), ref => Ref},
+                   filter_default => stop,
+                   filters => [{ldap_domain,
+                                {fun logger_filters:domain/2,
+                                 {log, sub, ?RMQLOG_DOMAIN_LDAP}}}],
+                   level => all},
+    ok = logger:add_handler(HandlerId, ?MODULE, HandlerCfg),
+    try
+        %% `notice` is higher than the default primary logger level used by CT;
+        %% thherefore `info` and `debug` messages  would be dropped before reaching any handler
+        logger:log(notice, "ldap-domain event ~tp", [Ref],
+                   #{domain => ?RMQLOG_DOMAIN_LDAP}),
+        logger:log(notice, "other-domain event ~tp", [Ref],
+                   #{domain => [rabbitmq, somewhere_else]}),
+        logger:log(notice, "no-domain event ~tp", [Ref], #{}),
+        receive
+            {Ref, Event} ->
+                ?assertMatch(#{meta := #{domain := [rabbitmq, ldap]}}, Event)
+        after 5000 ->
+            ct:fail("LDAP-domain event was not captured by the test handler")
+        end,
+        receive
+            {Ref, Unexpected} -> ct:fail({non_ldap_event_leaked, Unexpected})
+        after 200 ->
+            ok
+        end
+    after
+        _ = logger:remove_handler(HandlerId)
+    end.
+
+%% Verifies that every `?LOG_*` call site in the LDAP plugin sources passes the
+%% LDAP domain in its metadata
+ldap_log_callsites_carry_domain(_Config) ->
+    SrcDir = filename:join(code:lib_dir(rabbitmq_auth_backend_ldap), "src"),
+    Files = ["rabbit_auth_backend_ldap.erl",
+             "rabbit_auth_backend_ldap_app.erl"],
+    [check_log_callsite_invariant(filename:join(SrcDir, F)) || F <- Files],
+    ok.
+
+check_log_callsite_invariant(Path) ->
+    {ok, Bin} = file:read_file(Path),
+    LogCalls = count_substr(<<"?LOG_">>, Bin),
+    Domains  = count_substr(<<"RMQLOG_DOMAIN_LDAP">>, Bin),
+    ?assertEqual(LogCalls, Domains,
+                 lists:flatten(io_lib:format(
+                   "~ts: ~b ?LOG_ macro callsites but ~b RMQLOG_DOMAIN_LDAP "
+                   "references; every callsite must pass the LDAP domain",
+                   [Path, LogCalls, Domains]))).
+
+count_substr(Needle, Haystack) ->
+    length(binary:matches(Haystack, Needle)).
+
+%% Used by `ldap_log_domain_routing/1`
+log(LogEvent, #{config := #{pid := Pid, ref := Ref}}) ->
+    Pid ! {Ref, LogEvent},
     ok.


### PR DESCRIPTION
It was removed in 81dff33587 even through the
loggign macros do support the `domain` option.

This can affect certain environments where logs for individual domains
are handled differently.

References #16400.