### PR TITLE
Introduce Ranch-based `management.*.max_connections` and `prometheus.*.max_connections` limits

### DIFF
--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -59,6 +59,20 @@ end}.
     [{datatype, string},
      {validators, ["is_ip"]}]}.
 
+{mapping, "management.tcp.max_connections", "rabbitmq_management.tcp_config.max_connections",
+    [{datatype, [{atom, infinity}, integer]},
+     {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbitmq_management.tcp_config.max_connections",
+fun(Conf) ->
+    case cuttlefish:conf_get("management.tcp.max_connections", Conf, undefined) of
+        undefined                -> cuttlefish:unset();
+        infinity                 -> infinity;
+        Val when is_integer(Val) -> Val;
+        _                        -> cuttlefish:invalid("should be a non-negative integer")
+    end
+end}.
+
 {mapping, "management.tcp.compress", "rabbitmq_management.tcp_config.cowboy_opts.compress",
     [{datatype, {enum, [true, false]}}]}.
 {mapping, "management.tcp.idle_timeout", "rabbitmq_management.tcp_config.cowboy_opts.idle_timeout",
@@ -89,6 +103,21 @@ end}.
     [{datatype, integer}]}.
 {mapping, "management.ssl.ip", "rabbitmq_management.ssl_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
+
+{mapping, "management.ssl.max_connections", "rabbitmq_management.ssl_config.max_connections",
+    [{datatype, [{atom, infinity}, integer]},
+     {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbitmq_management.ssl_config.max_connections",
+fun(Conf) ->
+    case cuttlefish:conf_get("management.ssl.max_connections", Conf, undefined) of
+        undefined                -> cuttlefish:unset();
+        infinity                 -> infinity;
+        Val when is_integer(Val) -> Val;
+        _                        -> cuttlefish:invalid("should be a non-negative integer")
+    end
+end}.
+
 {mapping, "management.ssl.certfile", "rabbitmq_management.ssl_config.certfile",
     [{datatype, string}, {validators, ["pem_file"]}]}.
 {mapping, "management.ssl.keyfile", "rabbitmq_management.ssl_config.keyfile",

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -99,6 +99,24 @@
   ], [rabbitmq_management]
  },
 
+ {tcp_listener_max_connections_integer,
+  "management.tcp.max_connections = 4096",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{max_connections, 4096}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tcp_listener_max_connections_infinity,
+  "management.tcp.max_connections = infinity",
+  [
+   {rabbitmq_management, [
+                          {tcp_config, [{max_connections, infinity}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
 
  %%
  %% TLS listener
@@ -266,6 +284,24 @@
   [
    {rabbitmq_management, [
                           {ssl_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tls_listener_max_connections_integer,
+  "management.ssl.max_connections = 4096",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{max_connections, 4096}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {tls_listener_max_connections_infinity,
+  "management.ssl.max_connections = infinity",
+  [
+   {rabbitmq_management, [
+                          {ssl_config, [{max_connections, infinity}]}
                          ]}
   ], [rabbitmq_management]
  },

--- a/deps/rabbitmq_management/test/node_connection_limit_SUITE.erl
+++ b/deps/rabbitmq_management/test/node_connection_limit_SUITE.erl
@@ -1,0 +1,87 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% Tests `management.tcp.max_connections`.
+
+-module(node_connection_limit_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% Distinct from Ranch's internal default of 1024 so a silent
+%% propagation failure surfaces as an assertion mismatch.
+-define(CAP, 4096).
+
+all() ->
+    [configured_cap_reaches_ranch,
+     limit_can_be_modified_at_runtime].
+
+init_per_suite(Config0) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(Config0,
+                [{rmq_nodename_suffix, ?MODULE},
+                 {rmq_nodes_count, 1}]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+configured_cap_reaches_ranch(Config) ->
+    Ref = mgmt_ranch_ref(Config),
+    restart_listener_with_cap(Config, ?CAP),
+    ?assertEqual(?CAP,
+                 rabbit_ct_broker_helpers:rpc(
+                   Config, 0, ranch, get_max_connections, [Ref])).
+
+limit_can_be_modified_at_runtime(Config) ->
+    Ref = mgmt_ranch_ref(Config),
+    Original = rabbit_ct_broker_helpers:rpc(
+                 Config, 0, ranch, get_max_connections, [Ref]),
+    try
+        ok = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ranch, set_max_connections, [Ref, 7]),
+        ?assertEqual(7,
+                     rabbit_ct_broker_helpers:rpc(
+                       Config, 0, ranch, get_max_connections, [Ref]))
+    after
+        rabbit_ct_broker_helpers:rpc(
+          Config, 0, ranch, set_max_connections, [Ref, Original])
+    end.
+
+%% --- helpers ---
+
+restart_listener_with_cap(Config, Cap) ->
+    Existing = rabbit_ct_broker_helpers:rpc(
+                 Config, 0, application, get_env,
+                 [rabbitmq_management, tcp_config, []]),
+    Updated = lists:keystore(max_connections, 1, Existing,
+                             {max_connections, Cap}),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, set_env,
+           [rabbitmq_management, tcp_config, Updated]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, rabbit_mgmt_app, reset_dispatcher, [[]]).
+
+mgmt_ranch_ref(Config) ->
+    Port = rabbit_ct_broker_helpers:get_node_config(
+             Config, 0, tcp_port_mgmt),
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0, rabbit_networking, ranch_ref, [[{port, Port}]]).

--- a/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
+++ b/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
@@ -47,6 +47,20 @@
     end
 }.
 
+{mapping, "prometheus.tcp.max_connections", "rabbitmq_prometheus.tcp_config.max_connections",
+    [{datatype, [{atom, infinity}, integer]},
+     {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbitmq_prometheus.tcp_config.max_connections",
+fun(Conf) ->
+    case cuttlefish:conf_get("prometheus.tcp.max_connections", Conf, undefined) of
+        undefined                -> cuttlefish:unset();
+        infinity                 -> infinity;
+        Val when is_integer(Val) -> Val;
+        _                        -> cuttlefish:invalid("should be a non-negative integer")
+    end
+end}.
+
 {mapping, "prometheus.tcp.compress", "rabbitmq_prometheus.tcp_config.cowboy_opts.compress",
     [{datatype, {enum, [true, false]}}]}.
 {mapping, "prometheus.tcp.idle_timeout", "rabbitmq_prometheus.tcp_config.cowboy_opts.idle_timeout",
@@ -76,6 +90,20 @@
     [{datatype, integer}]}.
 {mapping, "prometheus.ssl.ip", "rabbitmq_prometheus.ssl_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
+
+{mapping, "prometheus.ssl.max_connections", "rabbitmq_prometheus.ssl_config.max_connections",
+    [{datatype, [{atom, infinity}, integer]},
+     {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbitmq_prometheus.ssl_config.max_connections",
+fun(Conf) ->
+    case cuttlefish:conf_get("prometheus.ssl.max_connections", Conf, undefined) of
+        undefined                -> cuttlefish:unset();
+        infinity                 -> infinity;
+        Val when is_integer(Val) -> Val;
+        _                        -> cuttlefish:invalid("should be a non-negative integer")
+    end
+end}.
 
 {mapping, "prometheus.ssl.certfile", "rabbitmq_prometheus.ssl_config.ssl_opts.certfile",
     [{datatype, string}, {validators, ["pem_file"]}]}.

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
@@ -107,6 +107,24 @@
     ], [rabbitmq_prometheus]
    },
 
+   {tcp_listener_max_connections_integer,
+    "prometheus.tcp.max_connections = 4096",
+    [
+     {rabbitmq_prometheus, [
+                            {tcp_config, [{max_connections, 4096}]}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
+   {tcp_listener_max_connections_infinity,
+    "prometheus.tcp.max_connections = infinity",
+    [
+     {rabbitmq_prometheus, [
+                            {tcp_config, [{max_connections, infinity}]}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
    {tcp_listener,
     "prometheus.tcp.listener = 192.1.1.2:15676",
     [{rabbitmq_prometheus,[
@@ -294,6 +312,24 @@
     [
      {rabbitmq_prometheus, [
                             {ssl_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
+   {tls_listener_max_connections_integer,
+    "prometheus.ssl.max_connections = 4096",
+    [
+     {rabbitmq_prometheus, [
+                            {ssl_config, [{max_connections, 4096}]}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
+   {tls_listener_max_connections_infinity,
+    "prometheus.ssl.max_connections = infinity",
+    [
+     {rabbitmq_prometheus, [
+                            {ssl_config, [{max_connections, infinity}]}
                            ]}
     ], [rabbitmq_prometheus]
    },

--- a/deps/rabbitmq_web_dispatch/Makefile
+++ b/deps/rabbitmq_web_dispatch/Makefile
@@ -14,7 +14,7 @@ endef
 
 LOCAL_DEPS = inets
 DEPS = amqp_client rabbit_common rabbit cowboy
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers proper
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_sup.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_sup.erl
@@ -14,8 +14,15 @@
 
 -define(SUP, ?MODULE).
 
+%% Ranch reads these keys from the top of its `transport_opts` map.
+-define(RANCH_TRANSPORT_OPT_KEYS, [max_connections, num_acceptors, num_conns_sups]).
+
 %% External exports
 -export([start_link/0, ensure_listener/1, stop_listener/1]).
+
+-ifdef(TEST).
+-export([build_ranch_transport_opts/1]).
+-endif.
 
 %% supervisor callbacks
 -export([init/1]).
@@ -31,7 +38,8 @@ ensure_listener(Listener) ->
             {error, {no_port_given, Listener}};
         _ ->
             {Transport, TransportOpts0, ProtoOpts} = preprocess_config(Listener),
-            TransportOpts = rabbit_ssl_options:wrap_password_opt(TransportOpts0),
+            TransportOpts1 = rabbit_ssl_options:wrap_password_opt(TransportOpts0),
+            TransportOpts = build_ranch_transport_opts(TransportOpts1),
             ProtoOptsMap = maps:from_list(ProtoOpts),
             StreamHandlers = stream_handlers_config(ProtoOpts),
             ?LOG_DEBUG("Starting HTTP[S] listener with transport ~ts", [Transport]),
@@ -111,6 +119,24 @@ transport_config(Options0) ->
 
 protocol_config(Options) ->
     proplists:get_value(cowboy_opts, Options, []).
+
+%% Ranch options such as `max_connections` must sit at the top of a
+%% `transport_opts` map, not under `socket_opts` (where they would reach
+%% `gen_tcp:listen` and fail). Build that map when any are present;
+%% otherwise pass the proplist through and let Ranch wrap it as
+%% `#{socket_opts => Proplist}` itself.
+build_ranch_transport_opts(Options) ->
+    {RanchOpts, SocketOpts} =
+        lists:partition(fun is_ranch_transport_opt/1, Options),
+    case RanchOpts of
+        []    -> Options;
+        [_|_] -> (proplists:to_map(RanchOpts))#{socket_opts => SocketOpts}
+    end.
+
+is_ranch_transport_opt({Key, _}) ->
+    lists:member(Key, ?RANCH_TRANSPORT_OPT_KEYS);
+is_ranch_transport_opt(_) ->
+    false.
 
 stream_handlers_config(Options) ->
     case lists:keyfind(compress, 1, Options) of

--- a/deps/rabbitmq_web_dispatch/test/transport_opts_SUITE.erl
+++ b/deps/rabbitmq_web_dispatch/test/transport_opts_SUITE.erl
@@ -1,0 +1,205 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(transport_opts_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(BUILD(Opts),
+        rabbit_web_dispatch_sup:build_ranch_transport_opts(Opts)).
+-define(PROP_ITERATIONS, 500).
+
+all() ->
+    [{group, unit_tests},
+     {group, property_tests}].
+
+groups() ->
+    [{unit_tests, [parallel],
+      [no_ranch_opts_returns_input_list,
+       empty_proplist_returns_empty_list,
+       max_connections_lifted_to_map,
+       num_acceptors_lifted_to_map,
+       num_conns_sups_lifted_to_map,
+       all_ranch_opts_together,
+       infinity_value_is_preserved,
+       socket_opts_preserved_alongside_ranch_opt,
+       bare_atoms_stay_in_socket_opts,
+       ranch_opt_value_passed_through_verbatim]},
+     {property_tests, [],
+      [prop_legacy_form_is_passthrough,
+       prop_map_form_when_any_ranch_opt,
+       prop_no_ranch_opt_in_socket_opts,
+       prop_non_ranch_entries_preserved_in_socket_opts,
+       prop_ranch_opt_values_preserved]}].
+
+init_per_suite(Config) -> Config.
+end_per_suite(_Config) -> ok.
+
+init_per_group(_, Config) -> Config.
+end_per_group(_, Config) -> Config.
+
+init_per_testcase(_, Config) -> Config.
+end_per_testcase(_, Config) -> Config.
+
+%%--------------------------------------------------------------------
+%% Unit cases
+%%--------------------------------------------------------------------
+
+no_ranch_opts_returns_input_list(_) ->
+    Input = [{port, 15672}, {ip, {127, 0, 0, 1}}, {backlog, 128}],
+    ?assertEqual(Input, ?BUILD(Input)).
+
+empty_proplist_returns_empty_list(_) ->
+    ?assertEqual([], ?BUILD([])).
+
+max_connections_lifted_to_map(_) ->
+    Result = ?BUILD([{port, 15672}, {max_connections, 1024}]),
+    ?assertMatch(#{max_connections := 1024,
+                   socket_opts     := [{port, 15672}]},
+                 Result),
+    ?assertNot(maps:is_key(num_acceptors, Result)).
+
+num_acceptors_lifted_to_map(_) ->
+    Result = ?BUILD([{port, 15672}, {num_acceptors, 16}]),
+    ?assertMatch(#{num_acceptors := 16,
+                   socket_opts   := [{port, 15672}]},
+                 Result).
+
+num_conns_sups_lifted_to_map(_) ->
+    Result = ?BUILD([{port, 15672}, {num_conns_sups, 4}]),
+    ?assertMatch(#{num_conns_sups := 4,
+                   socket_opts    := [{port, 15672}]},
+                 Result).
+
+all_ranch_opts_together(_) ->
+    Result = ?BUILD([{port, 15672},
+                     {ip, {127, 0, 0, 1}},
+                     {max_connections, 2048},
+                     {num_acceptors, 8},
+                     {num_conns_sups, 2}]),
+    ?assertMatch(#{max_connections := 2048,
+                   num_acceptors   := 8,
+                   num_conns_sups  := 2}, Result),
+    SocketOpts = maps:get(socket_opts, Result),
+    ?assertEqual(lists:sort([{port, 15672}, {ip, {127, 0, 0, 1}}]),
+                 lists:sort(SocketOpts)).
+
+infinity_value_is_preserved(_) ->
+    ?assertMatch(#{max_connections := infinity},
+                 ?BUILD([{max_connections, infinity}])).
+
+socket_opts_preserved_alongside_ranch_opt(_) ->
+    Socket = [{port, 15672}, {ip, {127, 0, 0, 1}}, {backlog, 256}],
+    Result = ?BUILD(Socket ++ [{max_connections, 100}]),
+    ?assertEqual(lists:sort(Socket),
+                 lists:sort(maps:get(socket_opts, Result))).
+
+bare_atoms_stay_in_socket_opts(_) ->
+    Result = ?BUILD([binary, {port, 15672}, {max_connections, 10}]),
+    SocketOpts = maps:get(socket_opts, Result),
+    ?assert(lists:member(binary, SocketOpts)),
+    ?assert(lists:member({port, 15672}, SocketOpts)).
+
+ranch_opt_value_passed_through_verbatim(_) ->
+    Sentinel = {tagged, 42},
+    Result = ?BUILD([{max_connections, Sentinel}]),
+    ?assertMatch(#{max_connections := Sentinel}, Result).
+
+%%--------------------------------------------------------------------
+%% Property cases
+%%--------------------------------------------------------------------
+
+prop_legacy_form_is_passthrough(_) ->
+    rabbit_ct_proper_helpers:run_proper(
+      fun () ->
+              ?FORALL(Opts, socket_only_proplist(),
+                      ?BUILD(Opts) =:= Opts)
+      end, [], ?PROP_ITERATIONS).
+
+prop_map_form_when_any_ranch_opt(_) ->
+    rabbit_ct_proper_helpers:run_proper(
+      fun () ->
+              ?FORALL(Opts, proplist_with_ranch_opt(),
+                      is_map(?BUILD(Opts)))
+      end, [], ?PROP_ITERATIONS).
+
+prop_no_ranch_opt_in_socket_opts(_) ->
+    rabbit_ct_proper_helpers:run_proper(
+      fun () ->
+              ?FORALL(Opts, proplist_with_ranch_opt(),
+                      begin
+                          #{socket_opts := SocketOpts} = ?BUILD(Opts),
+                          lists:all(fun(E) -> not is_ranch_entry(E) end,
+                                    SocketOpts)
+                      end)
+      end, [], ?PROP_ITERATIONS).
+
+prop_non_ranch_entries_preserved_in_socket_opts(_) ->
+    rabbit_ct_proper_helpers:run_proper(
+      fun () ->
+              ?FORALL(Opts, proplist_with_ranch_opt(),
+                      begin
+                          #{socket_opts := SocketOpts} = ?BUILD(Opts),
+                          Expected = [E || E <- Opts, not is_ranch_entry(E)],
+                          lists:sort(SocketOpts) =:= lists:sort(Expected)
+                      end)
+      end, [], ?PROP_ITERATIONS).
+
+prop_ranch_opt_values_preserved(_) ->
+    rabbit_ct_proper_helpers:run_proper(
+      fun () ->
+              ?FORALL(Opts, proplist_with_ranch_opt(),
+                      begin
+                          Map = ?BUILD(Opts),
+                          lists:all(
+                            fun({K, V}) ->
+                                    maps:get(K, Map) =:= V
+                            end,
+                            [{K, proplists:get_value(K, Opts)}
+                             || K <- ranch_keys(),
+                                proplists:is_defined(K, Opts)])
+                      end)
+      end, [], ?PROP_ITERATIONS).
+
+%%--------------------------------------------------------------------
+%% Generators and helpers
+%%--------------------------------------------------------------------
+
+ranch_keys() ->
+    [max_connections, num_acceptors, num_conns_sups].
+
+is_ranch_entry({K, _}) -> lists:member(K, ranch_keys());
+is_ranch_entry(_)       -> false.
+
+socket_entry() ->
+    oneof([{port, pos_integer()},
+           {ip, ip_tuple()},
+           {backlog, pos_integer()},
+           {nodelay, boolean()},
+           binary,
+           {keepalive, boolean()}]).
+
+ip_tuple() ->
+    {integer(0, 255), integer(0, 255), integer(0, 255), integer(0, 255)}.
+
+socket_only_proplist() ->
+    list(socket_entry()).
+
+ranch_entry() ->
+    oneof([{max_connections, oneof([infinity, non_neg_integer()])},
+           {num_acceptors, pos_integer()},
+           {num_conns_sups, pos_integer()}]).
+
+%% Always at least one Ranch entry.
+proplist_with_ranch_opt() ->
+    ?LET({RanchHead, RanchRest, Sockets},
+         {ranch_entry(), list(ranch_entry()), socket_only_proplist()},
+         [RanchHead | RanchRest] ++ Sockets).


### PR DESCRIPTION
They use the existing Ranch option to limit the peak number of concurrent TCP connections. 

Imperfect for a request-oriented protocol such as HTTP,
this is a protection mechanism we want every
protocol supported by RabbitMQ to have.

Prometheus endpoints arguably do not need rate limiting in most environments but were covered for completeness' sake.

References #16347.
