### PR TITLE
Prevent false-positive vhost deletion

### DIFF
--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -65,9 +65,9 @@ create_or_get(VHostName, Limits, Metadata)
     case rabbit_khepri:create(Path, VHost) of
         ok ->
             {new, VHost};
-        {error, {khepri, mismatching_node,
-                 #{node_path := Path,
-                   node_props := #{data := ExistingVHost}}}} ->
+        {error, ?khepri_error(mismatching_node,
+                              #{node_path := Path,
+                                node_props := #{data := ExistingVHost}})} ->
             {existing, ExistingVHost};
         Error ->
             throw(Error)
@@ -115,12 +115,12 @@ do_merge_metadata(VHostName, Metadata) ->
             case Ret2 of
                 ok ->
                     {ok, VHost};
-                {error, {khepri, mismatching_node, _}} ->
+                {error, ?khepri_error(mismatching_node, _)} ->
                     merge_metadata(VHostName, Metadata);
                 {error, _} = Error ->
                     Error
             end;
-        {error, {khepri, node_not_found, _}} ->
+        {error, ?khepri_error(node_not_found, _)} ->
             {error, {no_such_vhost, VHostName}};
         {error, _} = Error ->
             Error
@@ -223,7 +223,7 @@ exists_uncached(VHostName) when is_binary(VHostName) ->
     case rabbit_khepri:get(Path) of
         {ok, _} ->
             true;
-        {error, {khepri, node_not_found, _}} ->
+        {error, ?khepri_error(node_not_found, _)} ->
             false;
         {error, _} = Error ->
             Error
@@ -336,12 +336,12 @@ update(VHostName, UpdateFun)
             case rabbit_khepri:put(Path1, V1) of
                 ok ->
                     V1;
-                {error, {khepri, mismatching_node, _}} ->
+                {error, ?khepri_error(mismatching_node, _)} ->
                     update(VHostName, UpdateFun);
                 Error ->
                     throw(Error)
             end;
-        {error, {khepri, node_not_found, _}} ->
+        {error, ?khepri_error(node_not_found, _)} ->
             throw({error, {no_such_vhost, VHostName}});
         Error ->
             throw(Error)

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -19,6 +19,7 @@
          merge_metadata/2,
          set_tags/2,
          exists/1,
+         exists_uncached/1,
          get/1,
          get_all/0,
          count_all/0,
@@ -200,6 +201,32 @@ exists(VHostName) when is_binary(VHostName) ->
     catch
         error:badarg ->
             false
+    end.
+
+%% -------------------------------------------------------------------
+%% exists_uncached().
+%% -------------------------------------------------------------------
+
+-spec exists_uncached(VHostName) -> Ret when
+      VHostName :: vhost:name(),
+      Ret :: boolean() | {error, any()}.
+%% @doc Checks if the virtual host named `VHostName' exists by querying
+%% Khepri directly, bypassing the ETS-backed projection.
+%%
+%% @returns `true' if the virtual host exists in Khepri, `false' if it does
+%% not exist, or `{error, Reason}' if Khepri is unavailable.
+%%
+%% @private
+
+exists_uncached(VHostName) when is_binary(VHostName) ->
+    Path = khepri_vhost_path(VHostName),
+    case rabbit_khepri:get(Path) of
+        {ok, _} ->
+            true;
+        {error, {khepri, node_not_found, _}} ->
+            false;
+        {error, _} = Error ->
+            Error
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_vhost_process.erl
+++ b/deps/rabbit/src/rabbit_vhost_process.erl
@@ -64,17 +64,35 @@ handle_info(check_vhost, VHost) ->
     case rabbit_vhost:exists(VHost) of
         true  -> {noreply, VHost};
         false ->
-            ?LOG_WARNING("Virtual host '~ts' is gone. "
-                               "Stopping its top level supervisor.",
+            %% The ETS-backed projection may be transiently empty / out-of-sync
+            %% when Khepri Ra server is recovering (which should never happen
+            %% during normal operations). Confirm using a Khepri query before
+            %% taking the destructive shutdown action, to avoid a false
+            %% positive.
+            case rabbit_db_vhost:exists_uncached(VHost) of
+                true ->
+                    %% Vhost exists in Khepri; the ETS projection was out of sync.
+                    ?LOG_DEBUG("Virtual host '~ts' ETS projection was transiently empty "
+                               "(e.g. during Khepri Ra server recovery). Skipping shutdown.",
                                [VHost]),
-            %% Stop vhost's top supervisor in a one-off process to avoid a deadlock:
-            %% us (a child process) waiting for supervisor shutdown and our supervisor(s)
-            %% waiting for us to shutdown.
-            spawn(
-                fun() ->
-                    rabbit_vhost_sup_sup:stop_and_delete_vhost(VHost)
-                end),
-            {noreply, VHost}
+                    {noreply, VHost};
+                false ->
+                    ?LOG_WARNING("Virtual host '~ts' is gone. "
+                                 "Stopping its top level supervisor.",
+                                 [VHost]),
+                    %% Stop vhost's top supervisor in a one-off process to avoid a deadlock:
+                    %% us (a child process) waiting for supervisor shutdown and our supervisor(s)
+                    %% waiting for us to shutdown.
+                    spawn(
+                        fun() ->
+                            rabbit_vhost_sup_sup:stop_and_delete_vhost(VHost)
+                        end),
+                    {noreply, VHost};
+                {error, _} ->
+                    %% Khepri is unavailable. Cannot confirm the vhost is
+                    %% gone, so do nothing to avoid a false positive.
+                    {noreply, VHost}
+            end
     end;
 handle_info(_, VHost) ->
     {noreply, VHost}.


### PR DESCRIPTION
This issue came up during chaos testing. It's very unlikely in real life, but better safe than sorry.

## Why

In the unlikely scenario where Khepri Ra member restarts, the vhost projection can be empty / out-of-sync during recovery. Every 5 seconds, each vhost checks whether it should still exists (in case a vhost was deleted while the node was down) and it the checks happened while the projection is missing/empty/out-of-sync, the vhost concluded it was deleted and would shut down and delete its data (including CQ messages). In other words, a transient Khepri issue could lead to a vhost going down forever and CQ data being permanently deleted.

Repro:
```
$ make run-broker
> ra:stop_server(coordination, {rabbitmq_metadata, node()}), timer:sleep(6000), ra:restart_server(coordination, {rabbitmq_metadata, node()}).
```

Look for `Deleting message store directory for vhost...` in the log file.

## How

To prevent this issue, this PR adds a fallback check - if the vhost doesn't exist in the projection, we check with Khepri directly. If Khepri doesn't respond, we don't shutdown/delete the vhost (the check happens every 5s, so if it's a legitimate deletion, it will go away a bit later).
