### PR TITLE
HTTP API /connection could crash (return 500) when STOMP clients were connected

### DIFF
--- a/deps/rabbit_common/src/rabbit_json.erl
+++ b/deps/rabbit_common/src/rabbit_json.erl
@@ -54,5 +54,14 @@ encode_value(V, Encode) when is_function(V) ->
     json:encode_value(rabbit_data_coercion:to_binary(V), Encode);
 encode_value([{_, _} | _] = List, Encode) ->
     json:encode_key_value_list(List, Encode);
+%% IPv4 address tuple, e.g. {192, 168, 1, 1}
+encode_value({A, B, C, D} = IP, Encode)
+  when is_integer(A), is_integer(B), is_integer(C), is_integer(D) ->
+    json:encode_value(list_to_binary(rabbit_misc:ntoa(IP)), Encode);
+%% IPv6 address tuple, e.g. {0, 0, 0, 0, 0, 0, 0, 1}
+encode_value({A, B, C, D, E, F, G, H} = IP, Encode)
+  when is_integer(A), is_integer(B), is_integer(C), is_integer(D),
+       is_integer(E), is_integer(F), is_integer(G), is_integer(H) ->
+    json:encode_value(list_to_binary(rabbit_misc:ntoa(IP)), Encode);
 encode_value(Other, Encode) ->
     json:encode_value(Other, Encode).

--- a/deps/rabbit_common/test/unit_json_SUITE.erl
+++ b/deps/rabbit_common/test/unit_json_SUITE.erl
@@ -1,0 +1,142 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(unit_json_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+        {group, encoding},
+        {group, ip_address_encoding},
+        {group, decoding}
+    ].
+
+groups() ->
+    [
+        {encoding, [parallel], [
+            encode_primitives,
+            encode_proplist_as_object,
+            encode_map,
+            encode_nested_structures,
+            encode_function_as_string,
+            try_encode_returns_ok_tuple
+        ]},
+        {ip_address_encoding, [parallel], [
+            encode_ipv4_tuple,
+            encode_ipv6_tuple,
+            encode_ipv4_mapped_ipv6_tuple,
+            encode_ipv4_loopback,
+            encode_ipv6_loopback,
+            encode_ip_tuple_inside_proplist,
+            encode_ip_tuple_inside_map
+        ]},
+        {decoding, [parallel], [
+            decode_object_to_map,
+            try_decode_returns_ok_tuple,
+            try_decode_returns_error_for_invalid_input
+        ]}
+    ].
+
+init_per_suite(Config) -> Config.
+end_per_suite(Config) -> Config.
+init_per_group(_, Config) -> Config.
+end_per_group(_, Config) -> Config.
+init_per_testcase(_, Config) -> Config.
+end_per_testcase(_, Config) -> Config.
+
+%%
+%% Encoding
+%%
+
+encode_primitives(_Config) ->
+    ?assertEqual(<<"1">>, rabbit_json:encode(1)),
+    ?assertEqual(<<"true">>, rabbit_json:encode(true)),
+    ?assertEqual(<<"false">>, rabbit_json:encode(false)),
+    ?assertEqual(<<"null">>, rabbit_json:encode(null)),
+    ?assertEqual(<<"\"hello\"">>, rabbit_json:encode(<<"hello">>)).
+
+encode_proplist_as_object(_Config) ->
+    Encoded = rabbit_json:encode([{<<"a">>, 1}, {<<"b">>, 2}]),
+    ?assertEqual(#{<<"a">> => 1, <<"b">> => 2}, rabbit_json:decode(Encoded)).
+
+encode_map(_Config) ->
+    Encoded = rabbit_json:encode(#{<<"k">> => <<"v">>}),
+    ?assertEqual(#{<<"k">> => <<"v">>}, rabbit_json:decode(Encoded)).
+
+encode_nested_structures(_Config) ->
+    Term = [{<<"outer">>, [{<<"inner">>, [1, 2, 3]}]}],
+    Encoded = rabbit_json:encode(Term),
+    ?assertEqual(#{<<"outer">> => #{<<"inner">> => [1, 2, 3]}},
+                 rabbit_json:decode(Encoded)).
+
+encode_function_as_string(_Config) ->
+    %% Functions are coerced to a binary representation rather than crashing.
+    F = fun() -> ok end,
+    Encoded = rabbit_json:encode(F),
+    Decoded = rabbit_json:decode(Encoded),
+    ?assert(is_binary(Decoded)).
+
+try_encode_returns_ok_tuple(_Config) ->
+    ?assertEqual({ok, <<"1">>}, rabbit_json:try_encode(1)),
+    ?assertEqual({ok, <<"\"a\"">>}, rabbit_json:try_encode(<<"a">>)).
+
+%%
+%% IP address tuple encoding
+%%
+
+encode_ipv4_tuple(_Config) ->
+    ?assertEqual(<<"\"192.168.1.1\"">>,
+                 rabbit_json:encode({192, 168, 1, 1})).
+
+encode_ipv6_tuple(_Config) ->
+    ?assertEqual(<<"\"2001:db8::1\"">>,
+                 rabbit_json:encode({16#2001, 16#db8, 0, 0, 0, 0, 0, 1})).
+
+encode_ipv4_mapped_ipv6_tuple(_Config) ->
+    %% rabbit_misc:ntoa/1 collapses IPv4-mapped IPv6 addresses back to
+    %% their IPv4 form.
+    ?assertEqual(<<"\"1.2.3.4\"">>,
+                 rabbit_json:encode({0, 0, 0, 0, 0, 16#ffff, 16#0102, 16#0304})).
+
+encode_ipv4_loopback(_Config) ->
+    ?assertEqual(<<"\"127.0.0.1\"">>,
+                 rabbit_json:encode({127, 0, 0, 1})).
+
+encode_ipv6_loopback(_Config) ->
+    ?assertEqual(<<"\"::1\"">>,
+                 rabbit_json:encode({0, 0, 0, 0, 0, 0, 0, 1})).
+
+encode_ip_tuple_inside_proplist(_Config) ->
+    %% This mirrors the real-world shape of a connection_created event
+    %% with an unformatted peer_addr.
+    Encoded = rabbit_json:encode([{<<"peer_addr">>, {10, 0, 0, 1}}]),
+    ?assertEqual(#{<<"peer_addr">> => <<"10.0.0.1">>},
+                 rabbit_json:decode(Encoded)).
+
+encode_ip_tuple_inside_map(_Config) ->
+    Encoded = rabbit_json:encode(#{<<"peer_addr">> => {10, 0, 0, 1}}),
+    ?assertEqual(#{<<"peer_addr">> => <<"10.0.0.1">>},
+                 rabbit_json:decode(Encoded)).
+
+%%
+%% Decoding
+%%
+
+decode_object_to_map(_Config) ->
+    ?assertEqual(#{<<"a">> => 1, <<"b">> => [1, 2]},
+                 rabbit_json:decode(<<"{\"a\":1,\"b\":[1,2]}">>)).
+
+try_decode_returns_ok_tuple(_Config) ->
+    ?assertEqual({ok, #{<<"a">> => 1}},
+                 rabbit_json:try_decode(<<"{\"a\":1}">>)).
+
+try_decode_returns_error_for_invalid_input(_Config) ->
+    ?assertMatch({error, _}, rabbit_json:try_decode(<<"{not json">>)).

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -138,6 +138,8 @@ format_connection_created({host, Value}) ->
     {host, addr(Value)};
 format_connection_created({peer_host, Value}) ->
     {peer_host, addr(Value)};
+format_connection_created({peer_addr, Value}) ->
+    {peer_addr, addr(Value)};
 format_connection_created({port, Value}) ->
     {port, port(Value)};
 format_connection_created({peer_port, Value}) ->


### PR DESCRIPTION
STOMP connection details contained a tuple-formatted IP address in peer_addr, leading to the Management API crashing if STOMP connections were present (and perhaps in some other circumstances as well).

The fix has two parts:
1. handle peer_addr explicitly, just like we do for other values with IP addresses
2. Defensive fix in rabbit_json in case some other data containing IP addresses is ever encoded

The issue was only reproducible on main and v4.3.x for me, but backporting to 4.2 just in case.

Repro:
```
$ make run-broker
$ omq stomp -r 1 -t /amq/queue/foo -T /amq/queue/foo --queues classic
# after a few seconds, try:
$ curl -u guest:guest http://127.0.0.1:15672/api/connections
```

```
crasher:
  initial call: cowboy_stream_h:request_process/3
  pid: <0.8651.0>
  registered_name: []
  exception error: {unsupported_type,{0,0,0,0,0,0,0,1}}
    in function  json:do_encode/2 (json.erl:203)
    in call from json:'-encode_key_value_list/2-lc$^0/1-0-'/2 (json.erl:287)
    in call from json:'-encode_key_value_list/2-lc$^0/1-0-'/2 (json.erl:287)
    in call from json:encode_key_value_list/2 (json.erl:287)
    in call from json:do_encode_list/2 (json.erl:245)
    in call from rabbit_json:encode/1 (rabbit_json.erl:35)
    in call from rabbit_mgmt_util:reply0/3 (rabbit_mgmt_util.erl:273)
    in call from rabbit_mgmt_util:with_valid_pagination/3 (rabbit_mgmt_util.erl:333)
```