### PR TITLE
Fix return value of `rabbit_networking:unregister_connection/1`

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -477,9 +477,9 @@ register_connection(Pid) ->
     pg:join(pg_scope_amqp091_connection(), Pid, Pid).
 
 -spec unregister_connection(pid()) -> ok.
-
 unregister_connection(Pid) ->
-    pg:leave(pg_scope_amqp091_connection(), Pid, Pid).
+    _ = pg:leave(pg_scope_amqp091_connection(), Pid, Pid),
+    ok.
 
 -spec connections() -> [rabbit_types:connection()].
 connections() ->


### PR DESCRIPTION
Previously the type spec declared 'ok' as return value, but the function could return 'not_joined' since the changes in
https://github.com/rabbitmq/rabbitmq-server/pull/14825