### PR TITLE
Add peer_cert_serial_number and fix validity

### DIFF
--- a/deps/amqp_client/src/amqp_direct_connection.erl
+++ b/deps/amqp_client/src/amqp_direct_connection.erl
@@ -241,6 +241,8 @@ ssl_cert_info(Sock) ->
                                     rabbit_cert_info:issuer(Cert))},
              {peer_cert_subject,  list_to_binary(
                                     rabbit_cert_info:subject(Cert))},
+             {peer_cert_serial_number, list_to_binary(
+                                    rabbit_cert_info:serial_number(Cert))},
              {peer_cert_validity, list_to_binary(
                                     rabbit_cert_info:validity(Cert))}];
         _ ->

--- a/deps/rabbit/docs/rabbitmq-streams.8
+++ b/deps/rabbit/docs/rabbitmq-streams.8
@@ -181,6 +181,8 @@ DNS failed or was disabled.
 The issuer of the peer's SSL certificate, in RFC4514 form.
 .It Cm peer_cert_subject
 The subject of the peer's SSL certificate, in RFC4514 form.
+.lt Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate in HEX form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm peer_host

--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -965,6 +965,8 @@ SSL hash function (e.g.\&
 The subject of the peer's SSL certificate in RFC4514 form.
 .It Cm peer_cert_issuer
 The issuer of the peer's SSL certificate, in RFC4514 form.
+.lt Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate in HEX form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm state
@@ -2177,6 +2179,8 @@ SSL hash function (e.g.\&
 The subject of the peer's SSL certificate, in RFC4514 form.
 .It Cm peer_cert_issuer
 The issuer of the peer's SSL certificate, in RFC4514 form.
+.lt Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate in HEX form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm node

--- a/deps/rabbit/include/rabbit_amqp.hrl
+++ b/deps/rabbit/include/rabbit_amqp.hrl
@@ -31,6 +31,7 @@
          ssl_hash,
          peer_cert_issuer,
          peer_cert_subject,
+         peer_cert_serial_number,
          peer_cert_validity]).
 
 -define(ITEMS,

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -1091,6 +1091,7 @@ i(SSL, #v1{sock = Sock, proxy_socket = ProxySock})
 i(Cert, #v1{sock = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(client_properties, #v1{connection = #v1_connection{properties = Props}}) ->

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -340,6 +340,7 @@ tracked_connection_from_connection_created(EventDetails) ->
     %%  {ssl,false},
     %%  {peer_cert_subject,''},
     %%  {peer_cert_issuer,''},
+    %%  {peer_cert_serial_number,''},
     %%  {peer_cert_validity,''},
     %%  {auth_mechanism,<<"PLAIN">>},
     %%  {ssl_protocol,''},

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -127,7 +127,7 @@
 -define(CREATION_EVENT_KEYS,
         [pid, name, port, peer_port, host,
         peer_host, ssl, peer_cert_subject, peer_cert_issuer,
-        peer_cert_validity, auth_mechanism, ssl_protocol,
+        peer_cert_serial_number, peer_cert_validity, auth_mechanism, ssl_protocol,
         ssl_key_exchange, ssl_cipher, ssl_hash, protocol, user, vhost,
         timeout, frame_max, channel_max, client_properties, connected_at,
         node, user_who_performed_action]).
@@ -135,7 +135,7 @@
 -define(AUTH_NOTIFICATION_INFO_KEYS,
         [host, name, peer_host, peer_port, protocol, auth_mechanism,
          ssl, ssl_protocol, ssl_cipher, peer_cert_issuer, peer_cert_subject,
-         peer_cert_validity]).
+         peer_cert_serial_number, peer_cert_validity]).
 
 -define(IS_RUNNING(State),
         (State#v1.connection_state =:= running orelse
@@ -1620,6 +1620,7 @@ i(SSL, #v1{sock = Sock, proxy_socket = ProxySock})
 i(Cert, #v1{sock = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(channels,           #v1{channel_count = ChannelCount}) -> ChannelCount;

--- a/deps/rabbit/src/rabbit_ssl.erl
+++ b/deps/rabbit/src/rabbit_ssl.erl
@@ -10,7 +10,8 @@
 -include_lib("public_key/include/public_key.hrl").
 -include_lib("kernel/include/logger.hrl").
 
--export([peer_cert_issuer/1, peer_cert_subject/1, peer_cert_validity/1]).
+-export([peer_cert_issuer/1, peer_cert_subject/1, 
+         peer_cert_serial_number/1, peer_cert_validity/1]).
 -export([peer_cert_subject_items/2, peer_cert_auth_name/1, peer_cert_auth_name/2]).
 -export([cipher_suites_erlang/2, cipher_suites_erlang/1,
          cipher_suites_openssl/2, cipher_suites_openssl/1,
@@ -111,6 +112,9 @@ peer_cert_subject_items(Cert, Type) ->
 peer_cert_subject_alternative_names(Cert, Type) ->
     SANs = rabbit_cert_info:subject_alternative_names(Cert),
     lists:filter(fun({Key, _}) -> Key =:= Type end, SANs).
+
+peer_cert_serial_number(Cert) ->
+    rabbit_cert_info:serial_number(Cert).
 
 %% Return a string describing the certificate's validity.
 peer_cert_validity(Cert) ->
@@ -234,6 +238,8 @@ cert_info(peer_cert_issuer, Sock) ->
     cert_info0(fun peer_cert_issuer/1, Sock);
 cert_info(peer_cert_subject, Sock) ->
     cert_info0(fun peer_cert_subject/1, Sock);
+cert_info(peer_cert_serial_number, Sock) ->
+    cert_info0(fun peer_cert_serial_number/1, Sock);
 cert_info(peer_cert_validity, Sock) ->
     cert_info0(fun peer_cert_validity/1, Sock).
 

--- a/deps/rabbit_common/src/rabbit_cert_info.erl
+++ b/deps/rabbit_common/src/rabbit_cert_info.erl
@@ -13,6 +13,7 @@
          subject/1,
          subject_alternative_names/1,
          validity/1,
+         serial_number/1,
          subject_items/2,
          extensions/1
 ]).
@@ -80,6 +81,14 @@ subject_alternative_names(Cert) ->
         #'Extension'{extnValue = Val} -> Val
     catch _:_ -> []
     end.
+
+-spec serial_number(certificate()) -> string().
+serial_number(Cert) ->
+    cert_info(fun(#'OTPCertificate' {
+                     tbsCertificate = #'OTPTBSCertificate' {
+                       serialNumber = SN }}) ->
+                      integer_to_list(SN, 16)
+              end, Cert).
 
 %% Return a string describing the certificate's validity.
 -spec validity(certificate()) -> string().
@@ -197,6 +206,10 @@ format_asn1_value({utcTime, [Y1, Y2, M1, M2, D1, D2, H1, H2,
                              Min1, Min2, S1, S2, $Z]}) ->
     rabbit_misc:format("20~c~c-~c~c-~c~cT~c~c:~c~c:~c~cZ",
                        [Y1, Y2, M1, M2, D1, D2, H1, H2, Min1, Min2, S1, S2]);
+format_asn1_value({generalTime,
+                   [Y1,Y2,Y3,Y4,Mo1,Mo2,D1,D2,H1,H2,Mi1,Mi2,S1,S2,$Z]}) ->
+    rabbit_misc:format("~c~c~c~c-~c~c-~c~cT~c~c:~c~c:~c~cZ",
+                  [Y1,Y2,Y3,Y4, Mo1,Mo2, D1,D2,H1,H2, Mi1,Mi2, S1,S2]);
 %% We appear to get an untagged value back for an ia5string
 %% (e.g. domainComponent).
 format_asn1_value(V) when is_list(V) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -16,7 +16,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
 
   @info_keys ~w(pid name port host peer_port peer_host ssl ssl_protocol
                 ssl_key_exchange ssl_cipher ssl_hash peer_cert_subject
-                peer_cert_issuer peer_cert_validity state
+                peer_cert_issuer peer_cert_serial_number peer_cert_validity state
                 channels protocol auth_mechanism user vhost container_id timeout frame_max
                 channel_max client_properties recv_oct recv_cnt send_oct
                 send_cnt send_pend connected_at)a

--- a/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
@@ -134,6 +134,10 @@
 <% if (connection.peer_cert_issuer != '') { %>
 <table class="facts">
   <tr>
+    <th>Peer Certificate Serial Number</th>
+    <td><%= connection.peer_cert_serial_number %></td>
+  </tr>
+  <tr>
     <th>Peer Certificate Issuer</th>
     <td><%= fmt_string(connection.peer_cert_issuer) %></td>
   </tr>
@@ -154,7 +158,7 @@
 <% if (properties_size(connection.client_properties) > 0) { %>
 <div class="section-hidden" id="connection-client-properies-section">
 <h2>Client properties</h2>
-<div class="hider">
+<div class="hider updatable">
 <%= fmt_table_long(connection.client_properties) %>
 </div>
 </div>

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
@@ -65,6 +65,7 @@
          client_properties,
          peer_cert_issuer,
          peer_cert_subject,
+         peer_cert_serial_number,
          peer_cert_validity,
          auth_mechanism,
          timeout,

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -529,6 +529,7 @@ i(SSL, #state{socket = Sock, proxy_socket = ProxySock})
 i(Cert, #state{socket = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(timeout, #state{keepalive = KState}) ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -43,6 +43,7 @@
          ssl,
          peer_cert_subject,
          peer_cert_issuer,
+         peer_cert_serial_number,
          peer_cert_validity,
          auth_mechanism,
          ssl_protocol,
@@ -80,6 +81,7 @@
          ssl_cipher,
          peer_cert_issuer,
          peer_cert_subject,
+         peer_cert_serial_number,
          peer_cert_validity]).
 -define(UNKNOWN_FIELD, unknown_field).
 -define(SILENT_CLOSE_DELAY, 3_000).
@@ -4083,6 +4085,7 @@ i(SSL, #stream_connection{socket = Sock, proxy_socket = ProxySock}, _)
 i(Cert, #stream_connection{socket = Sock},_)
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(channels, _, _) ->

--- a/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
+++ b/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
@@ -97,6 +97,7 @@
     host,
     peer_cert_issuer,
     peer_cert_subject,
+    peer_cert_serial_number,
     peer_cert_validity,
     peer_host,
     user,

--- a/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
+++ b/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
@@ -98,6 +98,10 @@
 <% if (connection.peer_cert_issuer != '') { %>
 <table class="facts">
   <tr>
+    <th>Peer Certificate Serial Number</th>
+    <td><%= connection.peer_cert_serial_number %></td>
+  </tr>
+  <tr>
     <th>Peer Certificate Issuer</th>
     <td><%= connection.peer_cert_issuer %></td>
   </tr>
@@ -132,7 +136,7 @@
 <% if (properties_size(connection.client_properties) > 0) { %>
 <div class="section-hidden">
 <h2>Client properties</h2>
-<div class="hider">
+<div class="hider updatable">
 <%= fmt_table_long(connection.client_properties) %>
 </div>
 </div>

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -542,6 +542,7 @@ i(conn_name, #state{conn_name = Val}) ->
 i(Cert, #state{socket = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, rabbit_net:unwrap_socket(Sock));
 i(state, S) ->


### PR DESCRIPTION
## Proposed Changes

Fix the peer cert end date rendered as a tuple
X.509 encodes dates two different ways depending on whether the year fits in two digits:
- `UTCTime` — YYMMDDHHMMSSZ, used for years 1950–2049.
- `GeneralizedTime` — YYYYMMDDHHMMSSZ, used for 2050 and later.

<img width="879" height="153" alt="Screenshot 2026-05-16 at 23 45 28" src="https://github.com/user-attachments/assets/0cbec688-fe90-4cdc-a209-6377cdad2e56" />

## Types of Changes

What types of changes does your code introduce to this project?

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [ ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

We run a fairly large mTLS fleet of IoT devices and the serial number is a must to be able to check the exact cert a device is using or if it rotated it's cert correctly. I'm sure it will come in handy for other users as well.

<img width="863" height="141" alt="Screenshot 2026-05-17 at 00 30 15" src="https://github.com/user-attachments/assets/b7b8c933-febd-4e6f-a6bd-1e5e04b2eae3" />
