### PR TITLE
Fix blocked consumer status not returned by the HTTP API

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -440,7 +440,10 @@ code_change(_OldVsn, State, _Extra) ->
 %%----------------------------------------------------------------------------
 
 maybe_notify_decorators(false, State) -> State;
-maybe_notify_decorators(true,  State) -> notify_decorators(State), State.
+maybe_notify_decorators(true,  State) -> 
+    notify_decorators(State),
+    notify_consumers_state_changed(State),
+    State.
 
 notify_decorators_if_became_empty(WasEmpty, State) ->
     case (not WasEmpty) andalso is_empty(State) of
@@ -1502,6 +1505,27 @@ maybe_notify_consumer_updated(#q{single_active_consumer_on = true} = State, _Pre
         _ ->
             ok
     end.
+
+%% Refresh the consumer_created ETS table for every consumer on this queue,
+%% so the management API reflects the current activity_status
+%% including `blocked` for consumers wedged by the per-
+%% consumer unsent_message_count limit of 200.
+notify_consumers_state_changed(State = #q{consumers                 = Consumers,
+                                          active_consumer           = SACHolder,
+                                          single_active_consumer_on = SACOn}) ->
+    QName = qname(State),
+    All = rabbit_queue_consumers:all(Consumers, SACHolder, SACOn),
+    lists:foreach(
+        fun({ChPid, CTag, AckReq, Prefetch, Active, Status, Args, _User}) ->
+            Exclusive = case {SACOn, SACHolder} of
+                            {false, {ChPid, CTag}} -> true;
+                            _                      -> false
+                        end,
+            rabbit_core_metrics:consumer_updated(
+                ChPid, CTag, Exclusive, AckReq, QName,
+                Prefetch, Active, Status, Args)
+        end, All),
+    ok.
 
 handle_cast(init, State) ->
     init_it({no_barrier, non_clean_shutdown}, none, State);

--- a/deps/rabbit/src/rabbit_queue_consumers.erl
+++ b/deps/rabbit/src/rabbit_queue_consumers.erl
@@ -350,8 +350,12 @@ deliver_to_consumer(FetchFun,
     R.
 
 is_blocked(Consumer = {ChPid, _C}) ->
-    #cr{blocked_consumers = BlockedConsumers} = lookup_ch(ChPid),
-    priority_queue:member(Consumer, BlockedConsumers).
+    case lookup_ch(ChPid) of
+        not_found ->
+            false;
+        #cr{blocked_consumers = BlockedConsumers} ->
+            priority_queue:member(Consumer, BlockedConsumers)
+    end.
 
 -spec record_ack(ch(), pid(), ack()) -> 'ok'.
 

--- a/deps/rabbit/src/rabbit_queue_consumers.erl
+++ b/deps/rabbit/src/rabbit_queue_consumers.erl
@@ -115,7 +115,13 @@ consumers(Consumers, SingleActiveConsumer, SingleActiveConsumerOn, Acc) ->
                                           end
                                       end;
                                   false ->
-                                      fun(_) -> {true, up} end
+                                      %% C = {ChPid, Consumer}
+                                      fun(C) ->
+                                          case is_blocked(C) of
+                                              true  -> {true, blocked};
+                                              false -> {true, up}
+                                          end
+                                      end
                               end,
     priority_queue:fold(
       fun ({ChPid, Consumer}, _P, Acc1) ->

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
@@ -424,7 +424,8 @@ aggregate_entry({Id, Exclusive, AckRequired, PrefetchCount,
             {NextStats, Ops , State};
         [{_K, V}] ->
             CurrentActive = proplists:get_value(active, V, undefined),
-            case Active =:= CurrentActive of
+            CurrentActivityStatus = proplists:get_value(activity_status, V, undefined),
+            case {Active, ActivityStatus} =:= {CurrentActive, CurrentActivityStatus} of
                 false ->
                     Fmt = rabbit_mgmt_format:format([{exclusive, Exclusive},
                                                      {ack_required, AckRequired},


### PR DESCRIPTION
## Proposed Changes

While developing our OCPP plugin we got into a situation where the messages were not notified to the queue after delivery, so after exactly 200 messages, nothing was delivered, even tho there was a consumer connected.

https://github.com/rabbitmq/rabbitmq-server/blob/b5059a8492decf6de2acc2f665283725a70b286c/deps/rabbit/src/rabbit_queue_consumers.erl#L26

This PR adds the visibility so a consumer is correctly shown as blocked when this is the case. I also had to fix some caching layer conditions for this to work.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [ ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Hope this will save someone's time, we wasted two days figuring out what was happening.

Thank you!
R
