### PR TITLE
Display peer (client) certificate serial number in management UI and select CLI commands

### DIFF
--- a/deps/amqp_client/src/amqp_direct_connection.erl
+++ b/deps/amqp_client/src/amqp_direct_connection.erl
@@ -241,6 +241,8 @@ ssl_cert_info(Sock) ->
                                     rabbit_cert_info:issuer(Cert))},
              {peer_cert_subject,  list_to_binary(
                                     rabbit_cert_info:subject(Cert))},
+             {peer_cert_serial_number, list_to_binary(
+                                    rabbit_cert_info:serial_number(Cert))},
              {peer_cert_validity, list_to_binary(
                                     rabbit_cert_info:validity(Cert))}];
         _ ->

--- a/deps/rabbit/docs/rabbitmq-streams.8
+++ b/deps/rabbit/docs/rabbitmq-streams.8
@@ -181,6 +181,8 @@ DNS failed or was disabled.
 The issuer of the peer's SSL certificate, in RFC4514 form.
 .It Cm peer_cert_subject
 The subject of the peer's SSL certificate, in RFC4514 form.
+.lt Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate in HEX form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm peer_host

--- a/deps/rabbit/docs/rabbitmq-streams.8
+++ b/deps/rabbit/docs/rabbitmq-streams.8
@@ -181,8 +181,8 @@ DNS failed or was disabled.
 The issuer of the peer's SSL certificate, in RFC4514 form.
 .It Cm peer_cert_subject
 The subject of the peer's SSL certificate, in RFC4514 form.
-.lt Cm peer_cert_serial_number
-The serial number of the peer's SSL certificate in HEX form.
+.It Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate, in hexadecimal form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm peer_host

--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -965,6 +965,8 @@ SSL hash function (e.g.\&
 The subject of the peer's SSL certificate in RFC4514 form.
 .It Cm peer_cert_issuer
 The issuer of the peer's SSL certificate, in RFC4514 form.
+.lt Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate in HEX form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm state
@@ -2177,6 +2179,8 @@ SSL hash function (e.g.\&
 The subject of the peer's SSL certificate, in RFC4514 form.
 .It Cm peer_cert_issuer
 The issuer of the peer's SSL certificate, in RFC4514 form.
+.lt Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate in HEX form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm node

--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -965,8 +965,8 @@ SSL hash function (e.g.\&
 The subject of the peer's SSL certificate in RFC4514 form.
 .It Cm peer_cert_issuer
 The issuer of the peer's SSL certificate, in RFC4514 form.
-.lt Cm peer_cert_serial_number
-The serial number of the peer's SSL certificate in HEX form.
+.It Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate, in hexadecimal form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm state
@@ -2179,8 +2179,8 @@ SSL hash function (e.g.\&
 The subject of the peer's SSL certificate, in RFC4514 form.
 .It Cm peer_cert_issuer
 The issuer of the peer's SSL certificate, in RFC4514 form.
-.lt Cm peer_cert_serial_number
-The serial number of the peer's SSL certificate in HEX form.
+.It Cm peer_cert_serial_number
+The serial number of the peer's SSL certificate, in hexadecimal form.
 .It Cm peer_cert_validity
 The period for which the peer's SSL certificate is valid.
 .It Cm node

--- a/deps/rabbit/include/rabbit_amqp.hrl
+++ b/deps/rabbit/include/rabbit_amqp.hrl
@@ -31,6 +31,7 @@
          ssl_hash,
          peer_cert_issuer,
          peer_cert_subject,
+         peer_cert_serial_number,
          peer_cert_validity]).
 
 -define(ITEMS,

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -1091,6 +1091,7 @@ i(SSL, #v1{sock = Sock, proxy_socket = ProxySock})
 i(Cert, #v1{sock = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(client_properties, #v1{connection = #v1_connection{properties = Props}}) ->

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -340,6 +340,7 @@ tracked_connection_from_connection_created(EventDetails) ->
     %%  {ssl,false},
     %%  {peer_cert_subject,''},
     %%  {peer_cert_issuer,''},
+    %%  {peer_cert_serial_number,''},
     %%  {peer_cert_validity,''},
     %%  {auth_mechanism,<<"PLAIN">>},
     %%  {ssl_protocol,''},

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -127,7 +127,7 @@
 -define(CREATION_EVENT_KEYS,
         [pid, name, port, peer_port, host,
         peer_host, ssl, peer_cert_subject, peer_cert_issuer,
-        peer_cert_validity, auth_mechanism, ssl_protocol,
+        peer_cert_serial_number, peer_cert_validity, auth_mechanism, ssl_protocol,
         ssl_key_exchange, ssl_cipher, ssl_hash, protocol, user, vhost,
         timeout, frame_max, channel_max, client_properties, connected_at,
         node, user_who_performed_action]).
@@ -135,7 +135,7 @@
 -define(AUTH_NOTIFICATION_INFO_KEYS,
         [host, name, peer_host, peer_port, protocol, auth_mechanism,
          ssl, ssl_protocol, ssl_cipher, peer_cert_issuer, peer_cert_subject,
-         peer_cert_validity]).
+         peer_cert_serial_number, peer_cert_validity]).
 
 -define(IS_RUNNING(State),
         (State#v1.connection_state =:= running orelse
@@ -1620,6 +1620,7 @@ i(SSL, #v1{sock = Sock, proxy_socket = ProxySock})
 i(Cert, #v1{sock = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(channels,           #v1{channel_count = ChannelCount}) -> ChannelCount;

--- a/deps/rabbit/src/rabbit_ssl.erl
+++ b/deps/rabbit/src/rabbit_ssl.erl
@@ -10,7 +10,8 @@
 -include_lib("public_key/include/public_key.hrl").
 -include_lib("kernel/include/logger.hrl").
 
--export([peer_cert_issuer/1, peer_cert_subject/1, peer_cert_validity/1]).
+-export([peer_cert_issuer/1, peer_cert_subject/1, 
+         peer_cert_serial_number/1, peer_cert_validity/1]).
 -export([peer_cert_subject_items/2, peer_cert_auth_name/1, peer_cert_auth_name/2]).
 -export([cipher_suites_erlang/2, cipher_suites_erlang/1,
          cipher_suites_openssl/2, cipher_suites_openssl/1,
@@ -111,6 +112,9 @@ peer_cert_subject_items(Cert, Type) ->
 peer_cert_subject_alternative_names(Cert, Type) ->
     SANs = rabbit_cert_info:subject_alternative_names(Cert),
     lists:filter(fun({Key, _}) -> Key =:= Type end, SANs).
+
+peer_cert_serial_number(Cert) ->
+    rabbit_cert_info:serial_number(Cert).
 
 %% Return a string describing the certificate's validity.
 peer_cert_validity(Cert) ->
@@ -234,6 +238,8 @@ cert_info(peer_cert_issuer, Sock) ->
     cert_info0(fun peer_cert_issuer/1, Sock);
 cert_info(peer_cert_subject, Sock) ->
     cert_info0(fun peer_cert_subject/1, Sock);
+cert_info(peer_cert_serial_number, Sock) ->
+    cert_info0(fun peer_cert_serial_number/1, Sock);
 cert_info(peer_cert_validity, Sock) ->
     cert_info0(fun peer_cert_validity/1, Sock).
 

--- a/deps/rabbit_common/src/rabbit_cert_info.erl
+++ b/deps/rabbit_common/src/rabbit_cert_info.erl
@@ -13,6 +13,7 @@
          subject/1,
          subject_alternative_names/1,
          validity/1,
+         serial_number/1,
          subject_items/2,
          extensions/1
 ]).
@@ -80,6 +81,14 @@ subject_alternative_names(Cert) ->
         #'Extension'{extnValue = Val} -> Val
     catch _:_ -> []
     end.
+
+-spec serial_number(certificate()) -> string().
+serial_number(Cert) ->
+    cert_info(fun(#'OTPCertificate' {
+                     tbsCertificate = #'OTPTBSCertificate' {
+                       serialNumber = SN }}) ->
+                      integer_to_list(SN, 16)
+              end, Cert).
 
 %% Return a string describing the certificate's validity.
 -spec validity(certificate()) -> string().
@@ -197,6 +206,10 @@ format_asn1_value({utcTime, [Y1, Y2, M1, M2, D1, D2, H1, H2,
                              Min1, Min2, S1, S2, $Z]}) ->
     rabbit_misc:format("20~c~c-~c~c-~c~cT~c~c:~c~c:~c~cZ",
                        [Y1, Y2, M1, M2, D1, D2, H1, H2, Min1, Min2, S1, S2]);
+format_asn1_value({generalTime,
+                   [Y1,Y2,Y3,Y4,Mo1,Mo2,D1,D2,H1,H2,Mi1,Mi2,S1,S2,$Z]}) ->
+    rabbit_misc:format("~c~c~c~c-~c~c-~c~cT~c~c:~c~c:~c~cZ",
+                  [Y1,Y2,Y3,Y4, Mo1,Mo2, D1,D2,H1,H2, Mi1,Mi2, S1,S2]);
 %% We appear to get an untagged value back for an ia5string
 %% (e.g. domainComponent).
 format_asn1_value(V) when is_list(V) ->

--- a/deps/rabbit_common/test/unit_rabbit_cert_info_SUITE.erl
+++ b/deps/rabbit_common/test/unit_rabbit_cert_info_SUITE.erl
@@ -1,0 +1,100 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(unit_rabbit_cert_info_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("public_key/include/public_key.hrl").
+
+all() ->
+    [
+     {group, parallel_tests}
+    ].
+
+groups() ->
+    [
+     {parallel_tests, [parallel], [
+        shortest_serial_number,
+        common_serial_number_length,
+        max_serial_number_length,
+        serial_number_is_formatted_using_uppercase_hex,
+        serial_number_matches_decoded_value,
+        subject_and_issuer_from_self_signed
+     ]}
+    ].
+
+shortest_serial_number(_Config) ->
+    {DER, _Key} = generate_self_signed_cert("CN=ShortestSerial", 1),
+    ?assertEqual("1", rabbit_cert_info:serial_number(DER)).
+
+common_serial_number_length(_Config) ->
+    Serial = 16#ABCDEF,
+    {DER, _Key} = generate_self_signed_cert("CN=SerialTypical", Serial),
+    ?assertEqual("ABCDEF", rabbit_cert_info:serial_number(DER)).
+
+%% RFC 5280 permits serial numbers up to 20 octets (160 bits). Make sure
+%% large serials round-trip without truncation.
+max_serial_number_length(_Config) ->
+    %% 20-octet serial
+    Serial = 16#7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+    {DER, _Key} = generate_self_signed_cert("CN=SerialLarge", Serial),
+    Got = rabbit_cert_info:serial_number(DER),
+    ?assertEqual("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", Got).
+
+%% The hex output must be uppercase to match common tooling (namey OpenSSL).
+serial_number_is_formatted_using_uppercase_hex(_Config) ->
+    {DER, _Key} = generate_self_signed_cert("CN=SerialCase", 16#deadbeef),
+    Got = rabbit_cert_info:serial_number(DER),
+    ?assertEqual(Got, string:uppercase(Got)),
+    ?assertEqual("DEADBEEF", Got).
+
+%% Round trips the integer value.
+serial_number_matches_decoded_value(_Config) ->
+    Serial = 16#0123456789ABCDEF,
+    {DER, _Key} = generate_self_signed_cert("CN=SerialRoundtrip", Serial),
+    Hex = rabbit_cert_info:serial_number(DER),
+    ?assertEqual(Serial, list_to_integer(Hex, 16)).
+
+subject_and_issuer_from_self_signed(_Config) ->
+    {DER, _Key} = generate_self_signed_cert("SanityCheck", 7),
+    Subject = rabbit_cert_info:subject(DER),
+    Issuer  = rabbit_cert_info:issuer(DER),
+    ?assertEqual(Subject, Issuer),
+    ?assertEqual("CN=SanityCheck", Subject).
+
+%% ------------------------------------------------------------------
+%% Helpers
+%% ------------------------------------------------------------------
+
+generate_self_signed_cert(SubjectStr, Serial) ->
+    Key = public_key:generate_key({namedCurve, secp256r1}),
+    Subject = {rdnSequence, [[#'AttributeTypeAndValue'{
+                                  type = ?'id-at-commonName',
+                                  value = {utf8String, list_to_binary(SubjectStr)}}]]},
+    TBS = #'OTPTBSCertificate'{
+        version = v3,
+        serialNumber = Serial,
+        signature = #'SignatureAlgorithm'{
+            algorithm = ?'ecdsa-with-SHA256',
+            parameters = asn1_NOVALUE},
+        issuer = Subject,
+        validity = #'Validity'{
+            notBefore = {utcTime, "250101000000Z"},
+            notAfter  = {utcTime, "350101000000Z"}},
+        subject = Subject,
+        subjectPublicKeyInfo = #'OTPSubjectPublicKeyInfo'{
+            algorithm = #'PublicKeyAlgorithm'{
+                algorithm = ?'id-ecPublicKey',
+                parameters = {namedCurve, ?secp256r1}},
+            subjectPublicKey = #'ECPoint'{point = Key#'ECPrivateKey'.publicKey}},
+        extensions = []
+    },
+    CertDER = public_key:pkix_sign(TBS, Key),
+    {CertDER, Key}.

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -16,7 +16,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
 
   @info_keys ~w(pid name port host peer_port peer_host ssl ssl_protocol
                 ssl_key_exchange ssl_cipher ssl_hash peer_cert_subject
-                peer_cert_issuer peer_cert_validity state
+                peer_cert_issuer peer_cert_serial_number peer_cert_validity state
                 channels protocol auth_mechanism user vhost container_id timeout frame_max
                 channel_max client_properties recv_oct recv_cnt send_oct
                 send_cnt send_pend connected_at)a

--- a/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
@@ -134,6 +134,10 @@
 <% if (connection.peer_cert_issuer != '') { %>
 <table class="facts">
   <tr>
+    <th>Peer Certificate Serial Number</th>
+    <td><%= connection.peer_cert_serial_number %></td>
+  </tr>
+  <tr>
     <th>Peer Certificate Issuer</th>
     <td><%= fmt_string(connection.peer_cert_issuer) %></td>
   </tr>
@@ -154,7 +158,7 @@
 <% if (properties_size(connection.client_properties) > 0) { %>
 <div class="section-hidden" id="connection-client-properies-section">
 <h2>Client properties</h2>
-<div class="hider">
+<div class="hider updatable">
 <%= fmt_table_long(connection.client_properties) %>
 </div>
 </div>

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
@@ -65,6 +65,7 @@
          client_properties,
          peer_cert_issuer,
          peer_cert_subject,
+         peer_cert_serial_number,
          peer_cert_validity,
          auth_mechanism,
          timeout,

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -529,6 +529,7 @@ i(SSL, #state{socket = Sock, proxy_socket = ProxySock})
 i(Cert, #state{socket = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(timeout, #state{keepalive = KState}) ->

--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
@@ -23,7 +23,7 @@
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <groovy.version>3.0.25</groovy.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-    <spotless.version>3.4.0</spotless.version>
+    <spotless.version>3.5.1</spotless.version>
     <google-java-format.version>1.17.0</google-java-format.version>
     <test-keystore.ca>${project.build.directory}/ca.keystore</test-keystore.ca>
     <test-keystore.password>bunnychow</test-keystore.password>

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -43,6 +43,7 @@
          ssl,
          peer_cert_subject,
          peer_cert_issuer,
+         peer_cert_serial_number,
          peer_cert_validity,
          auth_mechanism,
          ssl_protocol,
@@ -80,6 +81,7 @@
          ssl_cipher,
          peer_cert_issuer,
          peer_cert_subject,
+         peer_cert_serial_number,
          peer_cert_validity]).
 -define(UNKNOWN_FIELD, unknown_field).
 -define(SILENT_CLOSE_DELAY, 3_000).
@@ -4083,6 +4085,7 @@ i(SSL, #stream_connection{socket = Sock, proxy_socket = ProxySock}, _)
 i(Cert, #stream_connection{socket = Sock},_)
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, Sock);
 i(channels, _, _) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
@@ -29,7 +29,7 @@
         <stream-client.version>[1.2.0-SNAPSHOT,)</stream-client.version>
         <junit.jupiter.version>5.14.4</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.18</logback.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
@@ -33,7 +33,7 @@
         <logback.version>1.5.18</logback.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <spotless.version>3.4.0</spotless.version>
+        <spotless.version>3.5.1</spotless.version>
         <google-java-format.version>1.35.0</google-java-format.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
+++ b/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
@@ -97,6 +97,7 @@
     host,
     peer_cert_issuer,
     peer_cert_subject,
+    peer_cert_serial_number,
     peer_cert_validity,
     peer_host,
     user,

--- a/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
+++ b/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
@@ -98,6 +98,10 @@
 <% if (connection.peer_cert_issuer != '') { %>
 <table class="facts">
   <tr>
+    <th>Peer Certificate Serial Number</th>
+    <td><%= connection.peer_cert_serial_number %></td>
+  </tr>
+  <tr>
     <th>Peer Certificate Issuer</th>
     <td><%= connection.peer_cert_issuer %></td>
   </tr>
@@ -132,7 +136,7 @@
 <% if (properties_size(connection.client_properties) > 0) { %>
 <div class="section-hidden">
 <h2>Client properties</h2>
-<div class="hider">
+<div class="hider updatable">
 <%= fmt_table_long(connection.client_properties) %>
 </div>
 </div>

--- a/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
@@ -29,7 +29,7 @@
         <stream-client.version>[1.2.0-SNAPSHOT,)</stream-client.version>
         <junit.jupiter.version>5.14.4</junit.jupiter.version>
         <assertj.version>3.27.7</assertj.version>
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.18</logback.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>

--- a/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
@@ -33,7 +33,7 @@
         <logback.version>1.5.18</logback.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <spotless.version>3.4.0</spotless.version>
+        <spotless.version>3.5.1</spotless.version>
         <google-java-format.version>1.35.0</google-java-format.version>
         <okhttp.version>5.3.2</okhttp.version>
         <gson.version>2.14.0</gson.version>

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -542,6 +542,7 @@ i(conn_name, #state{conn_name = Val}) ->
 i(Cert, #state{socket = Sock})
   when Cert =:= peer_cert_issuer;
        Cert =:= peer_cert_subject;
+       Cert =:= peer_cert_serial_number;
        Cert =:= peer_cert_validity ->
     rabbit_ssl:cert_info(Cert, rabbit_net:unwrap_socket(Sock));
 i(state, S) ->


### PR DESCRIPTION
This is #16449 by @razvanphp with a man page fix and some (unit) tests for the introduced helper.