### PR TITLE
Reduce boot time

### DIFF
--- a/deps/oauth2_client/Makefile
+++ b/deps/oauth2_client/Makefile
@@ -1,8 +1,8 @@
 PROJECT = oauth2_client
 PROJECT_DESCRIPTION = OAuth2 client from the RabbitMQ Project
 
-BUILD_DEPS = rabbit
-DEPS = rabbit_common jose
+BUILD_DEPS = rabbit jose
+DEPS = rabbit_common
 TEST_DEPS = rabbitmq_ct_helpers cowboy meck
 LOCAL_DEPS = ssl inets crypto public_key
 

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -761,6 +761,11 @@ module_attributes_from_apps(Name, Apps) ->
             [[{App, Module} || Module <- Modules] ||
                 App           <- Apps,
                 {ok, Modules} <- [application:get_key(App, modules)]])),
+    Unloaded = [M || {_, M} <- Targets, not erlang:module_loaded(M)],
+    _ = case Unloaded of
+            [] -> ok;
+            _ -> code:ensure_modules_loaded(Unloaded)
+        end,
     lists:foldl(
       fun ({App, Module}, Acc) ->
               case lists:append([Atts || {N, Atts} <- module_attributes(Module),


### PR DESCRIPTION
This PR has two changes to cut cold boot time of a virgin node. (And I love cutting this time since it helps anyone running `make run-broker` iterate faster :slightly_smiling_face:.) On my machine this change reduces the cold boot time from 1827ms to 1489ms (saving 338ms, 18.5%) according to the startup banner.

1. Eagerly load modules in parallel with `code:ensure_modules_loaded/1` when scanning module attributes. Saves 250 ms on my machine.
2. Avoid loading `jose` when the auth mechanism is not OAuth2. Saves 88ms on my machine.

The commits have more details on each change.