### PR TITLE
Reduce test time of config_schema_SUITEs

### DIFF
--- a/deps/rabbit/test/config_schema_SUITE.erl
+++ b/deps/rabbit/test/config_schema_SUITE.erl
@@ -28,27 +28,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_auth_backend_cache/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_auth_backend_ldap/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE.erl
@@ -25,25 +25,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [{rmq_nodename_suffix, Testcase}]),
-    rabbit_ct_helpers:run_steps(Config1,
-                                rabbit_ct_broker_helpers:setup_steps()
-                                ++ rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 =
-        rabbit_ct_helpers:run_steps(Config,
-                                    rabbit_ct_client_helpers:teardown_steps()
-                                    ++ rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_aws/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_aws/test/config_schema_SUITE.erl
@@ -27,27 +27,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_config_schema.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_config_schema.erl
@@ -24,6 +24,12 @@ init_schemas(App, Config) ->
 run_snippets(Config) ->
     {ok, [Snippets]} = file:consult(?config(conf_snippets, Config)),
     ct:pal("Loaded config schema snippets: ~tp", [Snippets]),
+    %% Snippets may reference relative paths (e.g. cert files).
+    %% Set CWD to the plugin source directory so they resolve.
+    case ?config(current_srcdir, Config) of
+        undefined -> ok;
+        SrcDir -> ok = file:set_cwd(SrcDir)
+    end,
     %% Parse schemas once and reuse across all snippets to avoid
     %% re-discovering and re-parsing all schema files per snippet.
     Schema = load_schema(),

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_config_schema.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_config_schema.erl
@@ -24,13 +24,16 @@ init_schemas(App, Config) ->
 run_snippets(Config) ->
     {ok, [Snippets]} = file:consult(?config(conf_snippets, Config)),
     ct:pal("Loaded config schema snippets: ~tp", [Snippets]),
+    %% Parse schemas once and reuse across all snippets to avoid
+    %% re-discovering and re-parsing all schema files per snippet.
+    Schema = load_schema(),
     lists:foreach(
       fun({N, S, C, P}) ->
-              ok = test_snippet(Config, {snippet_id(N), S, []}, C, P, true);
+              ok = test_snippet(Config, Schema, {snippet_id(N), S, []}, C, P, true);
          ({N, S, A, C, P}) ->
-              ok = test_snippet(Config, {snippet_id(N), S, A},  C, P, true);
+              ok = test_snippet(Config, Schema, {snippet_id(N), S, A},  C, P, true);
          ({N, S, A, C, P, nosort}) ->
-              ok = test_snippet(Config, {snippet_id(N), S, A},  C, P, false)
+              ok = test_snippet(Config, Schema, {snippet_id(N), S, A},  C, P, false)
       end,
       Snippets),
     ok.
@@ -44,15 +47,15 @@ snippet_id(A) when is_atom(A) ->
 snippet_id(L) when is_list(L) ->
     L.
 
-test_snippet(Config, Snippet = {SnipID, _, _}, Expected, _Plugins, Sort) ->
+test_snippet(Config, Schema, Snippet = {SnipID, _, _}, Expected, _Plugins, Sort) ->
     {ConfFile, AdvancedFile} = write_snippet(Config, Snippet),
     %% We ignore the rabbit -> log portion of the config on v3.9+, where the lager
     %% dependency has been dropped
     Generated = case code:which(lager) of
                     non_existing ->
-                        without_rabbit_log(generate_config(ConfFile, AdvancedFile));
+                        without_rabbit_log(generate_config(Schema, ConfFile, AdvancedFile));
                     _ ->
-                        generate_config(ConfFile, AdvancedFile)
+                        generate_config(Schema, ConfFile, AdvancedFile)
                 end,
     {Exp, Gen} = case Sort of
                      true ->
@@ -78,10 +81,31 @@ write_snippet(Config, {Name, Conf, Advanced}) ->
     ok = rabbit_file:write_term_file(AdvancedFile, [Advanced]),
     {ConfFile, AdvancedFile}.
 
-generate_config(ConfFile, AdvancedFile) ->
+generate_config(Schema, ConfFile, AdvancedFile) ->
+    case cuttlefish_conf:files([ConfFile]) of
+        {errorlist, Errors} ->
+            throw({error, {failed_to_parse_configuration_file, Errors}});
+        Conf ->
+            Config = case cuttlefish_generator:map(Schema, Conf) of
+                         {error, Phase, {errorlist, Errors}} ->
+                             throw({error, {failed_to_prepare_configuration, Phase, Errors}});
+                         ValidConfig ->
+                             proplists:delete(vm_args, ValidConfig)
+                     end,
+            case rabbit_prelaunch_file:consult_file(AdvancedFile) of
+                {ok, [AdvancedConfig]} ->
+                    cuttlefish_advanced:overlay(Config, AdvancedConfig);
+                {ok, _} ->
+                    Config;
+                {error, _} ->
+                    Config
+            end
+    end.
+
+load_schema() ->
     Context = rabbit_env:get_context(),
-    rabbit_prelaunch_conf:generate_config_from_cuttlefish_files(
-      Context, [ConfFile], AdvancedFile).
+    SchemaFiles = rabbit_prelaunch_conf:find_cuttlefish_schemas(Context),
+    cuttlefish_schema:files(SchemaFiles).
 
 without_rabbit_log(ErlangConfig) ->
     case proplists:get_value(rabbit, ErlangConfig) of

--- a/deps/rabbitmq_event_exchange/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_event_exchange/test/config_schema_SUITE.erl
@@ -28,27 +28,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_exchange_federation/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/config_schema_SUITE.erl
@@ -28,27 +28,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Test Cases
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_management/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_management/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE.erl
@@ -33,37 +33,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase},
-        {start_rmq_with_plugins_disabled, true}
-      ]),
-    Config2 = rabbit_ct_helpers:run_steps(
-                Config1,
-                rabbit_ct_broker_helpers:setup_steps() ++
-                    rabbit_ct_client_helpers:setup_steps()),
-    case Config2 of
-        _ when is_list(Config2) ->
-            util:enable_plugin(Config2, rabbitmq_mqtt),
-            Config2;
-        {skip, _} ->
-            Config2
-    end.
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_peer_discovery_aws/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_aws/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_peer_discovery_common/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_common/test/config_schema_SUITE.erl
@@ -27,28 +27,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_peer_discovery_consul/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_consul/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_peer_discovery_etcd/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_etcd/test/config_schema_SUITE.erl
@@ -27,28 +27,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -9,6 +9,7 @@
 -export([setup/1,
          get_config_state/0,
          generate_config_from_cuttlefish_files/3,
+         find_cuttlefish_schemas/1,
          decrypt_config/1]).
 
 %% Only used in tests.

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE.erl
@@ -28,27 +28,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_queue_federation/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_queue_federation/test/config_schema_SUITE.erl
@@ -28,27 +28,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Test Cases
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_stomp/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_stream/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_stream/test/config_schema_SUITE.erl
@@ -25,32 +25,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 =
-        rabbit_ct_helpers:set_config(Config,
-                                     [{rmq_nodename_suffix, Testcase}]),
-    rabbit_ct_helpers:run_steps(Config1,
-                                rabbit_ct_broker_helpers:setup_steps()
-                                ++ rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 =
-        rabbit_ct_helpers:run_steps(Config,
-                                    rabbit_ct_client_helpers:teardown_steps()
-                                    ++ rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok =
-        rabbit_ct_broker_helpers:rpc(Config,
-                                     0,
-                                     ?MODULE,
-                                     run_snippets1,
-                                     [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_tracing/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_tracing/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-    ]),
-    rabbit_ct_helpers:run_steps(Config1,
-        rabbit_ct_broker_helpers:setup_steps() ++
-        rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-        rabbit_ct_client_helpers:teardown_steps() ++
-        rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Test cases
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-        ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_trust_store/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_trust_store/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_web_dispatch/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_web_dispatch/test/config_schema_SUITE.erl
@@ -28,27 +28,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_web_mqtt/test/web_mqtt_config_schema_SUITE.erl
+++ b/deps/rabbitmq_web_mqtt/test/web_mqtt_config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 

--- a/deps/rabbitmq_web_stomp/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/config_schema_SUITE.erl
@@ -28,28 +28,15 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
-      ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    Config1 = rabbit_ct_helpers:run_steps(Config,
-      rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
-    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
 
 run_snippets(Config) ->
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, run_snippets1, [Config]).
-
-run_snippets1(Config) ->
     rabbit_ct_config_schema:run_snippets(Config).
 


### PR DESCRIPTION
There are two easy improvements we can make to cut the time it takes to run a `config_schema_SUITE` in any plugin. These tests currently take around 10 seconds on my machine but we can get them all down to around a second.

1. Reuse schemas for each snippet. Previously each snippet re-loaded all schemas. We can reuse the full schema for each snippet. `config_schema_SUITE` took linear time per snippet, now we can test in constant time.
2. Avoid spawning a broker. This was originally necessary with the way that schema generation worked, but since https://github.com/rabbitmq/rabbitmq-server/commit/cbfb11efe629ce919796adc6f6b614343739b9cf it hasn't been. We need to set the CWD for some tests which assume the CWD for paths for certificates, for example, but we can avoid spawning a broker at all.