### PR TITLE
4.4: fix json encoding for of certain OAuth 2-specific types

### DIFF
--- a/deps/rabbit_common/src/rabbit_json.erl
+++ b/deps/rabbit_common/src/rabbit_json.erl
@@ -63,5 +63,13 @@ encode_value({A, B, C, D, E, F, G, H} = IP, Encode)
   when is_integer(A), is_integer(B), is_integer(C), is_integer(D),
        is_integer(E), is_integer(F), is_integer(G), is_integer(H) ->
     json:encode_value(list_to_binary(rabbit_misc:ntoa(IP)), Encode);
+%% OTP 27's json:key/2 does not support string (list) keys.
+%% Convert any list keys to binary to avoid a function_clause error.
+encode_value(Map, Encode) when is_map(Map) ->
+    NormMap = maps:fold(fun
+        (K, V, Acc) when is_list(K) -> maps:put(list_to_binary(K), V, Acc);
+        (K, V, Acc)                 -> maps:put(K, V, Acc)
+    end, #{}, Map),
+    json:encode_map(NormMap, Encode);
 encode_value(Other, Encode) ->
     json:encode_value(Other, Encode).

--- a/deps/rabbit_common/test/unit_json_SUITE.erl
+++ b/deps/rabbit_common/test/unit_json_SUITE.erl
@@ -25,6 +25,8 @@ groups() ->
             encode_primitives,
             encode_proplist_as_object,
             encode_map,
+            encode_map_with_string_keys,
+            encode_map_with_string_keys_in_nested_proplist,
             encode_nested_structures,
             encode_function_as_string,
             try_encode_returns_ok_tuple
@@ -70,6 +72,22 @@ encode_proplist_as_object(_Config) ->
 encode_map(_Config) ->
     Encoded = rabbit_json:encode(#{<<"k">> => <<"v">>}),
     ?assertEqual(#{<<"k">> => <<"v">>}, rabbit_json:decode(Encoded)).
+
+encode_map_with_string_keys(_Config) ->
+    %% OTP 27's json:key/2 does not support string (list) keys; they must be
+    %% silently converted to binary before encoding.
+    Encoded = rabbit_json:encode(#{"key" => <<"value">>}),
+    ?assertEqual(#{<<"key">> => <<"value">>}, rabbit_json:decode(Encoded)).
+
+encode_map_with_string_keys_in_nested_proplist(_Config) ->
+    %% Mirrors rabbit_mgmt_wm_auth:produce_auth_settings/2 where
+    %% oauth_resource_servers values are maps keyed by resource server IDs
+    %% that may be stored as strings rather than binaries.
+    Term = [{<<"resource_servers">>, #{"rabbitmq" => [{<<"id">>, <<"rabbitmq">>}]}}],
+    Encoded = rabbit_json:encode(Term),
+    ?assertEqual(
+        #{<<"resource_servers">> => #{<<"rabbitmq">> => #{<<"id">> => <<"rabbitmq">>}}},
+        rabbit_json:decode(Encoded)).
 
 encode_nested_structures(_Config) ->
     Term = [{<<"outer">>, [{<<"inner">>, [1, 2, 3]}]}],


### PR DESCRIPTION
## Proposed Changes

Due to the upgrade to Erlang Json library there are certain data types no longer supported and required by oauth2 flows.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

