### PR TITLE
Reject empty and invalid `default_queue_type` values

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -781,6 +781,7 @@ augment_declare_args(VHost, Durable, Exclusive, AutoDelete, Args0) ->
         #{default_queue_type := DefaultQueueType}
           when is_binary(DefaultQueueType) andalso
                DefaultQueueType =/= <<"undefined">> andalso
+               DefaultQueueType =/= <<>> andalso
                not HasQTypeArg ->
             update_args_table_with_queue_type(DefaultQueueType, Durable, Exclusive, AutoDelete, Args0);
         _ ->

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -807,7 +807,8 @@ add_vhost(VHost, ActingUser) ->
         ok ->
             ok;
         {error, invalid_queue_type, DQT} ->
-            Msg = rabbit_misc:format("~ts is not a valid queue type", [DQT]),
+            Msg = rabbit_data_coercion:to_binary(
+                    rabbit_misc:format("~ts is not a valid queue type", [DQT])),
             throw({error, Msg});
         {error, _} = Err1 ->
             throw(Err1)

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -806,6 +806,9 @@ add_vhost(VHost, ActingUser) ->
     case rabbit_vhost:put_vhost(Name, Description, Tags, DefaultQueueType, IsTracingEnabled, ActingUser) of
         ok ->
             ok;
+        {error, invalid_queue_type, DQT} ->
+            Msg = rabbit_misc:format("~ts is not a valid queue type", [DQT]),
+            throw({error, Msg});
         {error, _} = Err1 ->
             throw(Err1)
     end,

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -877,14 +877,14 @@ validate_default_queue_type(Value) when is_binary(Value) ->
                 true ->
                     ok;
                 false ->
-                    Msg = iolist_to_binary(
-                            io_lib:format(
+                    Msg = rabbit_data_coercion:to_binary(
+                            rabbit_misc:format(
                               "queue type ~ts is not enabled", [Value])),
                     {error, Msg}
             end
     catch _:_ ->
-              Msg = iolist_to_binary(
-                      io_lib:format("~ts is not a valid queue type", [Value])),
+              Msg = rabbit_data_coercion:to_binary(
+                      rabbit_misc:format("~ts is not a valid queue type", [Value])),
               {error, Msg}
     end;
 validate_default_queue_type(_) -> ok.

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -871,12 +871,21 @@ validate_default_queue_type(<<"undefined">>) -> ok;
 validate_default_queue_type(<<>>) ->
     {error, <<"default_queue_type must not be an empty string">>};
 validate_default_queue_type(Value) when is_binary(Value) ->
-    case lists:member(Value, known_queue_type_names()) of
-        true -> ok;
-        false ->
-            Msg = iolist_to_binary(
-                    io_lib:format("~ts is not a valid queue type", [Value])),
-            {error, Msg}
+    try discover(Value) of
+        QueueType when is_atom(QueueType) ->
+            case is_enabled(QueueType) of
+                true ->
+                    ok;
+                false ->
+                    Msg = iolist_to_binary(
+                            io_lib:format(
+                              "queue type ~ts is not enabled", [Value])),
+                    {error, Msg}
+            end
+    catch _:_ ->
+              Msg = iolist_to_binary(
+                      io_lib:format("~ts is not a valid queue type", [Value])),
+              {error, Msg}
     end;
 validate_default_queue_type(_) -> ok.
 

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -79,7 +79,8 @@
          added_to_rabbit_registry/2,
          removed_from_rabbit_registry/1,
          known_queue_type_names/0,
-         known_queue_type_modules/0
+         known_queue_type_modules/0,
+         validate_default_queue_type/1
         ]).
 
 -type queue_name() :: rabbit_amqqueue:name().
@@ -859,6 +860,25 @@ known_queue_type_names() ->
     Registered = rabbit_registry:lookup_all(queue),
     {QueueTypes, _} = lists:unzip(Registered),
     lists:map(fun(X) -> atom_to_binary(X) end, QueueTypes).
+
+-spec validate_default_queue_type(Value) -> Ret when
+      Value :: binary() | atom() | undefined,
+      Ret :: ok | {error, binary()}.
+validate_default_queue_type(undefined) -> ok;
+validate_default_queue_type(null) -> ok;
+validate_default_queue_type(nil) -> ok;
+validate_default_queue_type(<<"undefined">>) -> ok;
+validate_default_queue_type(<<>>) ->
+    {error, <<"default_queue_type must not be an empty string">>};
+validate_default_queue_type(Value) when is_binary(Value) ->
+    case lists:member(Value, known_queue_type_names()) of
+        true -> ok;
+        false ->
+            Msg = iolist_to_binary(
+                    io_lib:format("~ts is not a valid queue type", [Value])),
+            {error, Msg}
+    end;
+validate_default_queue_type(_) -> ok.
 
 inject_dqt(VHost) when ?is_vhost(VHost) ->
     inject_dqt(vhost:to_map(VHost));

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -312,6 +312,8 @@
 -spec discover(binary() | atom()) -> queue_type().
 discover(<<"undefined">>) ->
     fallback();
+discover(<<>>) ->
+    fallback();
 discover(undefined) ->
     fallback();
 discover(TypeDescriptor) ->
@@ -871,6 +873,7 @@ inject_dqt(M) when is_map(M) ->
         nil -> default();
         <<"undefined">> -> default();
         "undefined" -> default();
+        <<>> -> default();
         Valid -> Valid
     end,
     NQT = short_alias_of(DQT),

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -414,7 +414,7 @@ delete_ignoring_protection(Name, ActingUser) ->
     rabbit_queue_type:queue_type() | 'undefined' | binary(),
     boolean(),
     rabbit_types:username()) ->
-    'ok' | {'error', any()} | {'EXIT', any()}.
+    'ok' | {'error', any()} | {'error', 'invalid_queue_type', any()} | {'EXIT', any()}.
 put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
     Tags = case Tags0 of
       undefined   -> <<"">>;

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -194,22 +194,15 @@ do_add(Name, Metadata0, ActingUser) ->
     Description = maps:get(description, Metadata, undefined),
     Tags = maps:get(tags, Metadata, []),
 
-    %% validate default_queue_type
     case Metadata of
         #{default_queue_type := DQT} ->
-            %% check that the queue type is known
             ?LOG_DEBUG("Default queue type of virtual host '~ts' is ~tp",
                              [Name, DQT]),
-            try rabbit_queue_type:discover(DQT) of
-                QueueType when is_atom(QueueType) ->
-                    case rabbit_queue_type:is_enabled(QueueType) of
-                        true ->
-                            ok;
-                        false ->
-                            throw({error, queue_type_feature_flag_is_not_enabled})
-                    end
-            catch _:_ ->
-                      throw({error, invalid_queue_type, DQT})
+            case rabbit_queue_type:validate_default_queue_type(DQT) of
+                ok ->
+                    ok;
+                {error, _} ->
+                    throw({error, invalid_queue_type, DQT})
             end;
         _ ->
             ok

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -320,9 +320,11 @@ update_metadata(Name, Metadata0, _ActingUser) when is_map(Metadata0) andalso map
 update_metadata(Name, Metadata0, ActingUser) ->
     KnownKeys = [description, tags, default_queue_type, protected_from_deletion],
     Metadata1 = maps:with(KnownKeys, Metadata0),
-    %% See rabbitmq/rabbitmq-server#10469
+    %% See rabbitmq/rabbitmq-server#10469, rabbitmq/rabbitmq-server#16481
     Metadata = case Metadata1 of
         #{default_queue_type := <<"undefined">>} ->
+            maps:remove(default_queue_type, Metadata1);
+        #{default_queue_type := <<>>} ->
             maps:remove(default_queue_type, Metadata1);
         #{default_queue_type := null} ->
             maps:remove(default_queue_type, Metadata1);
@@ -613,6 +615,7 @@ default_queue_type(VirtualHost, FallbackQueueType) ->
             case vhost:get_default_queue_type(Record) of
                 undefined       -> NodeDefault;
                 <<"undefined">> -> NodeDefault;
+                <<>>            -> NodeDefault;
                 Type            -> Type
             end
 end.
@@ -735,6 +738,8 @@ i(metadata, VHost) ->
         M = #{default_queue_type := undefined} ->
             M#{default_queue_type => DQT};
         M = #{default_queue_type := <<"undefined">>} ->
+            M#{default_queue_type => DQT};
+        M = #{default_queue_type := <<>>} ->
             M#{default_queue_type => DQT};
         M = #{default_queue_type := null} ->
             M#{default_queue_type => DQT};

--- a/deps/rabbit/src/vhost.erl
+++ b/deps/rabbit/src/vhost.erl
@@ -220,6 +220,9 @@ new_metadata(Description, Tags, undefined) ->
 new_metadata(Description, Tags, <<"undefined">>) ->
     %% See rabbitmq/rabbitmq-server#10469
     new_metadata(Description, Tags, undefined);
+new_metadata(Description, Tags, <<>>) ->
+    %% See rabbitmq/rabbitmq-server#16481
+    new_metadata(Description, Tags, undefined);
 new_metadata(Description, Tags, null) ->
     %% JSON null, see rabbitmq/rabbitmq-server#10469
     new_metadata(Description, Tags, undefined);

--- a/deps/rabbit/test/default_queue_type_prop_SUITE.erl
+++ b/deps/rabbit/test/default_queue_type_prop_SUITE.erl
@@ -114,6 +114,7 @@ prop_preserves_valid_types(Config) ->
                 undefined -> ResultDQT =:= Default;
                 <<"undefined">> -> ResultDQT =:= Default;
                 "undefined" -> ResultDQT =:= Default;
+                <<"">> -> ResultDQT =:= Default;
                 <<"classic">> -> ResultDQT =:= <<"classic">>;
                 <<"quorum">> -> ResultDQT =:= <<"quorum">>;
                 <<"stream">> -> ResultDQT =:= <<"stream">>
@@ -133,6 +134,7 @@ dqt_gen() ->
         undefined,
         <<"undefined">>,
         "undefined",
+        <<"">>,
         <<"classic">>,
         <<"quorum">>,
         <<"stream">>

--- a/deps/rabbit/test/unit_default_queue_type_SUITE.erl
+++ b/deps/rabbit/test/unit_default_queue_type_SUITE.erl
@@ -19,16 +19,20 @@ all() ->
      inject_dqt_undefined_binary,
      inject_dqt_null,
      inject_dqt_nil,
+     inject_dqt_empty_binary,
      inject_dqt_preserves_existing_metadata,
      new_metadata_sanitizes_undefined_binary,
      new_metadata_sanitizes_null,
      new_metadata_sanitizes_nil,
+     new_metadata_sanitizes_empty_binary,
      vhost_import_with_undefined_dqt,
      vhost_import_with_null_dqt,
      vhost_import_with_nil_dqt,
+     vhost_import_with_empty_binary_dqt,
      update_metadata_sanitizes_undefined_binary,
      update_metadata_sanitizes_null,
-     update_metadata_sanitizes_nil
+     update_metadata_sanitizes_nil,
+     update_metadata_sanitizes_empty_binary
     ].
 
 %% -------------------------------------------------------------------
@@ -88,6 +92,14 @@ inject_dqt_nil(Config) ->
         rpc(Config, 0, rabbit_queue_type, inject_dqt, [Input]),
     ok.
 
+inject_dqt_empty_binary(Config) ->
+    Expected = rpc(Config, 0, rabbit_queue_type, default_alias, []),
+    Input = #{default_queue_type => <<"">>, name => <<"/">>},
+    #{default_queue_type := Expected,
+      metadata := #{default_queue_type := Expected}} =
+        rpc(Config, 0, rabbit_queue_type, inject_dqt, [Input]),
+    ok.
+
 %% Existing metadata keys should be preserved when injecting DQT
 inject_dqt_preserves_existing_metadata(Config) ->
     Expected = rpc(Config, 0, rabbit_queue_type, default_alias, []),
@@ -127,6 +139,12 @@ new_metadata_sanitizes_nil(Config) ->
         rpc(Config, 0, vhost, new_metadata, [<<"description">>, [], nil]),
     ok.
 
+new_metadata_sanitizes_empty_binary(Config) ->
+    Expected = rpc(Config, 0, rabbit_queue_type, default_alias, []),
+    #{default_queue_type := Expected} =
+        rpc(Config, 0, vhost, new_metadata, [<<"description">>, [], <<"">>]),
+    ok.
+
 vhost_import_with_undefined_dqt(Config) ->
     VHost = <<"import-undefined-dqt-test">>,
     Expected = rpc(Config, 0, rabbit_queue_type, default_alias, []),
@@ -163,6 +181,21 @@ vhost_import_with_nil_dqt(Config) ->
     try
         ok = rpc(Config, 0, rabbit_vhost, put_vhost,
                  [VHost, <<"test description">>, [], nil, false, <<"test-user">>]),
+        V = rpc(Config, 0, rabbit_vhost, lookup, [VHost]),
+        Metadata = rpc(Config, 0, vhost, get_metadata, [V]),
+        #{default_queue_type := StoredDQT} = Metadata,
+        Expected = StoredDQT
+    after
+        rpc(Config, 0, rabbit_vhost, delete, [VHost, <<"test-user">>])
+    end,
+    ok.
+
+vhost_import_with_empty_binary_dqt(Config) ->
+    VHost = <<"import-empty-binary-dqt-test">>,
+    Expected = rpc(Config, 0, rabbit_queue_type, default_alias, []),
+    try
+        ok = rpc(Config, 0, rabbit_vhost, put_vhost,
+                 [VHost, <<"test description">>, [], <<"">>, false, <<"test-user">>]),
         V = rpc(Config, 0, rabbit_vhost, lookup, [VHost]),
         Metadata = rpc(Config, 0, vhost, get_metadata, [V]),
         #{default_queue_type := StoredDQT} = Metadata,
@@ -216,6 +249,23 @@ update_metadata_sanitizes_nil(Config) ->
         #{default_queue_type := <<"classic">>} = rpc(Config, 0, vhost, get_metadata, [V1]),
         ok = rpc(Config, 0, rabbit_vhost, update_metadata,
                  [VHost, #{default_queue_type => nil}, <<"test-user">>]),
+        V2 = rpc(Config, 0, rabbit_vhost, lookup, [VHost]),
+        #{default_queue_type := StoredDQT} = rpc(Config, 0, vhost, get_metadata, [V2]),
+        <<"classic">> = StoredDQT
+    after
+        rpc(Config, 0, rabbit_vhost, delete, [VHost, <<"test-user">>])
+    end,
+    ok.
+
+update_metadata_sanitizes_empty_binary(Config) ->
+    VHost = <<"update-metadata-empty-binary-dqt-test">>,
+    try
+        ok = rpc(Config, 0, rabbit_vhost, put_vhost,
+                 [VHost, <<"test">>, [], <<"classic">>, false, <<"test-user">>]),
+        V1 = rpc(Config, 0, rabbit_vhost, lookup, [VHost]),
+        #{default_queue_type := <<"classic">>} = rpc(Config, 0, vhost, get_metadata, [V1]),
+        ok = rpc(Config, 0, rabbit_vhost, update_metadata,
+                 [VHost, #{default_queue_type => <<"">>}, <<"test-user">>]),
         V2 = rpc(Config, 0, rabbit_vhost, lookup, [VHost]),
         #{default_queue_type := StoredDQT} = rpc(Config, 0, vhost, get_metadata, [V2]),
         <<"classic">> = StoredDQT

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
@@ -4,6 +4,8 @@
 ##
 ## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 defmodule RabbitMQ.CLI.Core.VirtualHosts do
+  @known_queue_types ["quorum", "stream", "classic"]
+
   def parse_tags(tags) do
     case tags do
       nil ->
@@ -13,6 +15,21 @@ defmodule RabbitMQ.CLI.Core.VirtualHosts do
         String.split(val, ",", trim: true)
         |> Enum.map(&String.trim/1)
         |> Enum.map(&String.to_atom/1)
+    end
+  end
+
+  def validate_default_queue_type(opts) do
+    case opts[:default_queue_type] do
+      nil ->
+        :ok
+
+      val when val in @known_queue_types ->
+        :ok
+
+      other ->
+        {:validation_failure,
+         {:bad_argument,
+          "Default queue type must be one of: #{Enum.join(@known_queue_types, ", ")}. Provided: #{other}"}}
     end
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -16,8 +16,19 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
     {args, Map.merge(%{description: "", tags: ""}, opts)}
   end
 
-  use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def validate(args, _) when length(args) == 0 do
+    {:validation_failure, :not_enough_args}
+  end
+
+  def validate(args, _) when length(args) > 1 do
+    {:validation_failure, :too_many_args}
+  end
+
+  def validate([_vhost], opts) do
+    VirtualHosts.validate_default_queue_type(opts)
+  end
 
   def run([vhost], %{
         node: node_name,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
@@ -36,26 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateVhostMetadataCommand do
         {:validation_failure, :not_enough_args}
 
       _ ->
-        # description and tags can be anything but default queue type must
-        # be a value from a known set
-        case m[:default_queue_type] do
-          nil ->
-            :ok
-
-          "quorum" ->
-            :ok
-
-          "stream" ->
-            :ok
-
-          "classic" ->
-            :ok
-
-          other ->
-            {:validation_failure,
-             {:bad_argument,
-              "Default queue type must be one of: quorum, stream, classic. Provided: #{other}"}}
-        end
+        VirtualHosts.validate_default_queue_type(m)
     end
   end
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
@@ -70,24 +70,29 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
               %% so fall back to it. See rabbitmq/rabbitmq-server#7734.
               FallbackQT = maps:get(defaultqueuetype, BodyMap, undefined),
               DefaultQT = maps:get(default_queue_type, BodyMap, FallbackQT),
-              case rabbit_vhost:put_vhost(Name, Description, Tags, DefaultQT, Trace, Username) of
+              case validate_default_queue_type(DefaultQT) of
                   ok ->
-                      {true, ReqData, Context};
-                  {error, timeout} ->
-                      rabbit_mgmt_util:internal_server_error(
-                        timeout,
-                        "Timed out waiting for the vhost to initialise",
-                        ReqData0, Context);
-                  {error, E} ->
-                      Reason = iolist_to_binary(
-                                 io_lib:format(
-                                   "Error occurred while adding vhost: ~tp",
-                                   [E])),
-                      rabbit_mgmt_util:internal_server_error(
-                        Reason, ReqData0, Context);
-                  {'EXIT', {vhost_limit_exceeded,
-                      Explanation}} ->
-                      rabbit_mgmt_util:bad_request(list_to_binary(Explanation), ReqData, Context)
+                      case rabbit_vhost:put_vhost(Name, Description, Tags, DefaultQT, Trace, Username) of
+                          ok ->
+                              {true, ReqData, Context};
+                          {error, timeout} ->
+                              rabbit_mgmt_util:internal_server_error(
+                                timeout,
+                                "Timed out waiting for the vhost to initialise",
+                                ReqData0, Context);
+                          {error, E} ->
+                              Reason = iolist_to_binary(
+                                         io_lib:format(
+                                           "Error occurred while adding vhost: ~tp",
+                                           [E])),
+                              rabbit_mgmt_util:internal_server_error(
+                                Reason, ReqData0, Context);
+                          {'EXIT', {vhost_limit_exceeded,
+                              Explanation}} ->
+                              rabbit_mgmt_util:bad_request(list_to_binary(Explanation), ReqData, Context)
+                      end;
+                  {error, Msg} ->
+                      rabbit_mgmt_util:bad_request(Msg, ReqData, Context)
               end
       end).
 
@@ -125,4 +130,20 @@ id(ReqData) ->
       [Value] -> Value;
       Value   -> Value
     end.
+
+validate_default_queue_type(undefined) -> ok;
+validate_default_queue_type(null) -> ok;
+validate_default_queue_type(nil) -> ok;
+validate_default_queue_type(<<"undefined">>) -> ok;
+validate_default_queue_type(<<>>) ->
+    {error, <<"default_queue_type must not be an empty string">>};
+validate_default_queue_type(Value) when is_binary(Value) ->
+    case lists:member(Value, rabbit_queue_type:known_queue_type_names()) of
+        true -> ok;
+        false ->
+            Msg = iolist_to_binary(
+                    io_lib:format("~ts is not a valid queue type", [Value])),
+            {error, Msg}
+    end;
+validate_default_queue_type(_) -> ok.
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
@@ -70,7 +70,7 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
               %% so fall back to it. See rabbitmq/rabbitmq-server#7734.
               FallbackQT = maps:get(defaultqueuetype, BodyMap, undefined),
               DefaultQT = maps:get(default_queue_type, BodyMap, FallbackQT),
-              case validate_default_queue_type(DefaultQT) of
+              case rabbit_queue_type:validate_default_queue_type(DefaultQT) of
                   ok ->
                       case rabbit_vhost:put_vhost(Name, Description, Tags, DefaultQT, Trace, Username) of
                           ok ->
@@ -130,20 +130,3 @@ id(ReqData) ->
       [Value] -> Value;
       Value   -> Value
     end.
-
-validate_default_queue_type(undefined) -> ok;
-validate_default_queue_type(null) -> ok;
-validate_default_queue_type(nil) -> ok;
-validate_default_queue_type(<<"undefined">>) -> ok;
-validate_default_queue_type(<<>>) ->
-    {error, <<"default_queue_type must not be an empty string">>};
-validate_default_queue_type(Value) when is_binary(Value) ->
-    case lists:member(Value, rabbit_queue_type:known_queue_type_names()) of
-        true -> ok;
-        false ->
-            Msg = iolist_to_binary(
-                    io_lib:format("~ts is not a valid queue type", [Value])),
-            {error, Msg}
-    end;
-validate_default_queue_type(_) -> ok.
-


### PR DESCRIPTION
## Summary

Setting `default_queue_type` to an empty string (`""`) via the HTTP API on an existing virtual host stores `<<>>` in metadata. Subsequent queue declarations without an explicit `x-queue-type` crash with a `badmatch` in `rabbit_queue_type:discover/1` because the registry has no entry for an empty atom.

This PR:

- Adds `<<>>` to the defensive sentinel guards in the core (alongside existing guards for `<<"undefined">>`, `null`, `nil`)
- Adds input validation at the HTTP API boundary, returning 400 Bad Request for empty or unknown queue types
- Adds input validation to the `add_vhost` CLI command (matching existing validation in `update_vhost_metadata`)
- Extracts `rabbit_queue_type:validate_default_queue_type/1` as the canonical server-side validation function, removing duplication from `rabbit_vhost:do_add/3`
- Extracts `RabbitMQ.CLI.Core.VirtualHosts.validate_default_queue_type/1` as the shared CLI validation function, removing duplication between commands
- Fixes a `case_clause` crash in `rabbit_definitions:add_vhost/2` where `put_vhost` returns a 3-tuple that the existing 2-tuple pattern did not match

Closes #16481

## Test plan

- [x] New unit tests in `unit_default_queue_type_SUITE` (4 cases for empty binary)
- [x] Updated property-based tests in `default_queue_type_prop_SUITE` (empty binary in generator)
- [x] Dialyzer passes on `rabbit` and `rabbitmq_management`
- [x] Manual verification against running broker: HTTP API, CLI (`add_vhost`, `update_vhost_metadata`), definitions import (HTTP and CLI)
