### PR TITLE
rabbit_feature_flags: Exclude feature flags enabled everywhere from `list_feature_flags_enabled_somewhere/2`

### DIFF
--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -982,6 +982,8 @@ refresh_after_app_load_task() ->
       Ret :: ok | {error, Reason},
       Reason :: term().
 
+enable_many(#{states_per_node := _}, []) ->
+    ok;
 enable_many(#{states_per_node := _} = Inventory, FeatureNames) ->
     %% We acquire a lock before making any change to the registry. This is not
     %% used by the controller (because it is already using a globally

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -1492,19 +1492,38 @@ merge_feature_flags(FeatureFlagsA, FeatureFlagsB) ->
 list_feature_flags_enabled_somewhere(
   #{states_per_node := StatesPerNode},
   HandleStateChanging) ->
-    %% We want to collect feature flags which are enabled on at least one
-    %% node.
+    %% We want to collect feature flags which are enabled on at least one node.
+    %% We exclude feature flags that are already enabled everywhere.
+    NodeCount = maps:size(StatesPerNode),
     MergedStates = maps:fold(
                      fun(_Node, FeatureStates, Acc1) ->
                              maps:fold(
                                fun
                                    (FeatureName, true, Acc2) ->
-                                       Acc2#{FeatureName => true};
+                                       Count = maps:get(FeatureName, Acc2, 0),
+                                       case Count + 1 of
+                                           NodeCount ->
+                                               %% This feature flag is already
+                                               %% enabled everywhere, remove it
+                                               %% from the list.
+                                               maps:remove(FeatureName, Acc2);
+                                           NewCount ->
+                                               Acc2#{FeatureName => NewCount}
+                                       end;
                                    (_FeatureName, false, Acc2) ->
                                        Acc2;
                                    (FeatureName, state_changing, Acc2)
                                      when HandleStateChanging ->
-                                       Acc2#{FeatureName => true}
+                                       Count = maps:get(FeatureName, Acc2, 0),
+                                       case Count + 1 of
+                                           NodeCount ->
+                                               %% This feature flag is already
+                                               %% enabled everywhere, remove it
+                                               %% from the list.
+                                               maps:remove(FeatureName, Acc2);
+                                           NewCount ->
+                                               Acc2#{FeatureName => NewCount}
+                                       end
                                end, Acc1, FeatureStates)
                      end, #{}, StatesPerNode),
     lists:sort(maps:keys(MergedStates)).


### PR DESCRIPTION
## Why

Before this change, the function would return all feature flags that were enabled somewhere. This included feature flags already enabled everywhere.

This was harmless, just caused extra unnecessary logging.

## How

Instead of maintaining a map of feature flags enabled somewhere, we maintain on how many nodes they are enabled. If they are enabled on all nodes, we remove the feature flag from the returned list.