### PR TITLE
rabbit_deprecated_features: Honor change of configuration if possible

### DIFF
--- a/deps/rabbit/src/rabbit_deprecated_features.erl
+++ b/deps/rabbit/src/rabbit_deprecated_features.erl
@@ -120,7 +120,8 @@
 -export([extend_properties/2,
          should_be_permitted/2,
          enable_underlying_feature_flag_cb/1,
-         list/1]).
+         list/1,
+         list_denied_but_should_be_permitted/1]).
 
 -type deprecated_feature_modattr() :: {rabbit_feature_flags:feature_name(),
                                        feature_props()}.
@@ -643,3 +644,122 @@ is_deprecated_feature_in_use(
     end;
 is_deprecated_feature_in_use(_) ->
     undefined.
+
+-spec list_denied_but_should_be_permitted(Inventory) -> PermittedList when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      PermittedList :: [rabbit_feature_flags:feature_name()].
+
+list_denied_but_should_be_permitted(
+  #{feature_flags := FeatureFlags,
+    states_per_node := StatesPerNode} = Inventory) ->
+    %% First, we list all feature flags (including denied deprecated features)
+    %% that are enabled on at least one node. We will use this list to figure
+    %% out if some deprecated features should be permitted again among them.
+    AllEnabled0 = maps:fold(
+                    fun(_Node, States, Acc) ->
+                            Enabled = maps:fold(
+                                        fun
+                                            (FN, true, Acc1) ->
+                                                [FN | Acc1];
+                                           (_FN, _State, Acc1) ->
+                                                Acc1
+                                        end, [], States),
+                            Acc ++ Enabled
+                    end, [], StatesPerNode),
+    AllEnabled = lists:usort(AllEnabled0),
+    %% We walk through the list of enabled feature flags and check if some of
+    %% them are deprecated features that should now be permitted.
+    PermittedByConfig = (
+      lists:filter(
+        fun(FeatureName) ->
+                FeatureProps = maps:get(FeatureName, FeatureFlags),
+                if
+                    ?IS_FEATURE_FLAG(FeatureProps) ->
+                        false;
+                    ?IS_DEPRECATION(FeatureProps) ->
+                        should_be_permitted(FeatureName, FeatureProps)
+                end
+        end, AllEnabled)),
+    %% Among this deprecated features that should be permitted again, are there
+    %% any that can't be permitted because another enabled feature flag depends
+    %% on it, directly or through a dependency chain?
+    NeededByOthers = lists:filter(
+                       fun(FeatureName) ->
+                               do_enabled_feature_flags_depend_on(
+                                 Inventory, AllEnabled, FeatureName)
+                       end, PermittedByConfig),
+    case NeededByOthers of
+        [] ->
+            ok;
+        _ ->
+            ?LOG_DEBUG(
+               "Deprecated features: deprecated features that can't be"
+               "permitted from configuration because they are needed "
+               "by other feature flags: ~0p",
+               [NeededByOthers],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS})
+    end,
+    %% Based on the previous step, we can compute the final list of deprecated
+    %% features that should be permitted again.
+    Permitted = PermittedByConfig -- NeededByOthers,
+    case Permitted of
+        [] ->
+            ok;
+        _ ->
+            ?LOG_DEBUG(
+               "Feature flags: deprecated features that should be "
+               "permitted again (i.e. corresponding feature flag "
+               "disabled): ~0p",
+               [Permitted],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS})
+    end,
+    Permitted.
+
+do_enabled_feature_flags_depend_on(
+  #{feature_flags := FeatureFlags} = Inventory,
+  AllEnabled,
+  FeatureName) ->
+    %% Find any feature flags that depend on the given `FeatureName' deprecated
+    %% feature.
+    DependOnIt = maps:fold(
+                   fun
+                       (ParentFeatureName, #{depends_on := DependsOn}, Acc) ->
+                           case lists:member(FeatureName, DependsOn) of
+                               true ->
+                                   %% `FeatureName' is directly needed by
+                                   %% `ParentFeatureName'.
+                                   [ParentFeatureName | Acc];
+                               false ->
+                                   Acc
+                           end;
+                       (_ParentFeatureName, _FeatureProps, Acc) ->
+                           Acc
+                   end, [], FeatureFlags),
+    case DependOnIt of
+        [] ->
+            %% `FeatureName' is not needed by any feature flag.
+            false;
+        _ ->
+            %% We now need to check if the feature flags that depend directly
+            %% on `FeatureName' are enabled.
+            EnabledAndDependOnIt = lists:filter(
+                                     fun(ParentFeatureName) ->
+                                             lists:member(
+                                               ParentFeatureName, AllEnabled)
+                                     end, DependOnIt),
+            case EnabledAndDependOnIt of
+                [_ | _] ->
+                    %% There are enabled feature flags that depend on
+                    %% `FeatureName'.
+                    true;
+                [] ->
+                    %% The feature flags that depend on `FeatureName' are not
+                    %% enabled. However other enabled feature flags could
+                    %% depend on them. Therefore we need to recurse.
+                    lists:any(
+                      fun(ParentFeatureName) ->
+                              do_enabled_feature_flags_depend_on(
+                                Inventory, AllEnabled, ParentFeatureName)
+                      end, DependOnIt)
+            end
+    end.

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -920,8 +920,14 @@ sync_cluster_task(Nodes) ->
                            Inventory),
             case CantEnable of
                 [] ->
-                    FeatureNames = list_feature_flags_enabled_somewhere(
-                                     Inventory, false),
+                    %% Some deprecated features alreay denied in the cluster
+                    %% could be permitted again through configuration. If
+                    %% that's the case, we need to disable their underlying
+                    %% feature flag.
+                    disable_permitted_deprecated_features(Inventory),
+
+                    FeatureNames = (
+                      list_feature_flags_enabled_somewhere(Inventory, false)),
 
                     %% In addition to feature flags enabled somewhere, we also
                     %% ensure required feature flags are enabled accross the
@@ -942,6 +948,11 @@ sync_cluster_task(Nodes) ->
                     FeatureNamesToEnable = lists:usort(
                                              FeatureNames ++
                                              RequiredFeatureNames),
+                    ?LOG_DEBUG(
+                       "Feature flags: feature flags/deprecated features that "
+                       "need to be enabled somewhere: ~0p",
+                       [FeatureNamesToEnable],
+                       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
                     enable_many(Inventory, FeatureNamesToEnable);
                 _ ->
                     ?LOG_ERROR(
@@ -1582,6 +1593,32 @@ list_deprecated_features_that_cant_be_denied(
           (_FeatureName, false, Acc) ->
               Acc
       end, [], States).
+
+-spec disable_permitted_deprecated_features(Inventory) -> ok when
+      Inventory :: rabbit_feature_flags:cluster_inventory().
+
+disable_permitted_deprecated_features(
+  #{states_per_node := StatesPerNode} = Inventory) ->
+    PermittedDeprecatedNames = (
+      rabbit_deprecated_features:list_denied_but_should_be_permitted(
+        Inventory)),
+    case PermittedDeprecatedNames of
+        [] ->
+            ok;
+        _ ->
+            %% Some deprecated features go from denied to permitted again,
+            %% thanks to a configuration setting. We need to marke them as
+            %% disabled everywhere. This is the only case where a feature flag
+            %% can go from "enabled" to "disabled".
+            Nodes = maps:keys(StatesPerNode),
+            lists:foreach(
+              fun(PermittedDeprecatedName) ->
+                      _ = mark_as_enabled_on_nodes(
+                            Nodes, Inventory, PermittedDeprecatedName,
+                            false)
+              end, PermittedDeprecatedNames),
+            ok
+    end.
 
 -spec list_nodes_who_know_the_feature_flag(Inventory, FeatureName) ->
     Ret when

--- a/deps/rabbit/test/deprecated_features_SUITE.erl
+++ b/deps/rabbit/test/deprecated_features_SUITE.erl
@@ -29,6 +29,8 @@
          override_denied_by_default_in_configuration/1,
          override_disconnected_in_configuration/1,
          override_removed_in_configuration/1,
+         change_from_denied_to_permitted_in_configuration_and_restart/1,
+         change_from_denied_to_permitted_in_configuration_but_needed/1,
          has_is_feature_used_cb_returning_false/1,
          has_is_feature_used_cb_returning_true/1,
          get_appropriate_warning_when_permitted/1,
@@ -63,6 +65,8 @@ groups() ->
              override_denied_by_default_in_configuration,
              override_disconnected_in_configuration,
              override_removed_in_configuration,
+             change_from_denied_to_permitted_in_configuration_and_restart,
+             change_from_denied_to_permitted_in_configuration_but_needed,
              has_is_feature_used_cb_returning_false,
              has_is_feature_used_cb_returning_true,
              get_appropriate_warning_when_permitted,
@@ -91,17 +95,27 @@ end_per_suite(Config) ->
     Config.
 
 init_per_group(cluster_size_1, Config) ->
-    rabbit_ct_helpers:set_config(Config, {nodes_count, 1});
+    rabbit_ct_helpers:set_config(Config, {rmq_nodes_count, 1});
 init_per_group(cluster_size_3, Config) ->
-    rabbit_ct_helpers:set_config(Config, {nodes_count, 3});
+    rabbit_ct_helpers:set_config(Config, [{rmq_nodes_count, 3},
+                                          {rmq_nodes_clustered, true}]);
 init_per_group(_Group, Config) ->
     Config.
 
 end_per_group(_Group, Config) ->
     Config.
 
+init_per_testcase(Testcase, Config)
+  when Testcase =:= change_from_denied_to_permitted_in_configuration_and_restart orelse
+       Testcase =:= change_from_denied_to_permitted_in_configuration_but_needed ->
+    Config1 = rabbit_ct_helpers:set_config(
+                Config, [{rmq_nodename_suffix, Testcase}]),
+    Config2 = rabbit_ct_helpers:testcase_started(Config1, Testcase),
+    Config3 = rabbit_ct_helpers:run_steps(
+                Config2, rabbit_ct_broker_helpers:setup_steps()),
+    Config3;
 init_per_testcase(Testcase, Config) ->
-    NodesCount = ?config(nodes_count, Config),
+    NodesCount = ?config(rmq_nodes_count, Config),
     NodenamePrefix = list_to_atom(
                        lists:flatten(
                          io_lib:format("~s-cs~b", [Testcase, NodesCount]))),
@@ -111,6 +125,13 @@ init_per_testcase(Testcase, Config) ->
                feature_flags_v2_SUITE:start_slave_nodes(Cfg, NodenamePrefix)
        end]).
 
+end_per_testcase(Testcase, Config)
+  when Testcase =:= change_from_denied_to_permitted_in_configuration_and_restart orelse
+       Testcase =:= change_from_denied_to_permitted_in_configuration_but_needed ->
+    Config1 = rabbit_ct_helpers:run_steps(
+                Config,
+                rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase);
 end_per_testcase(_Testcase, Config) ->
     rabbit_ct_helpers:run_steps(
       Config,
@@ -409,6 +430,124 @@ override_removed_in_configuration(Config) ->
                    ok
            end)
          || Node <- AllNodes].
+
+change_from_denied_to_permitted_in_configuration_and_restart(Config) ->
+    [FirstNode | _] = AllNodes = rabbit_ct_broker_helpers:get_node_configs(
+                                   Config, nodename),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => rabbit,
+                       deprecation_phase => denied_by_default}},
+
+    Ok = [ok || _ <- AllNodes],
+    True = [true || _ <- AllNodes],
+    False = [false || _ <- AllNodes],
+
+    ?assertEqual(
+       Ok,
+       rabbit_ct_broker_helpers:rpc_all(
+         Config,
+         rabbit_feature_flags, inject_test_feature_flags, [FeatureFlags])),
+    ?assertEqual(
+       Ok,
+       rabbit_ct_broker_helpers:rpc_all(
+         Config,
+         rabbit_feature_flags, refresh_feature_flags_after_app_load, [])),
+
+    ?assertEqual(
+       True,
+       feature_flags_SUITE:is_feature_flag_supported(Config, FeatureName)),
+    ?assertEqual(
+       True,
+       feature_flags_SUITE:is_feature_flag_enabled(Config, FeatureName)),
+    ?assertEqual(
+       False,
+       is_deprecated_feature_permitted(Config, FeatureName)),
+
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, FirstNode,
+           application, set_env,
+           [rabbit, permit_deprecated_features, #{FeatureName => true}, [{persistent, true}]]),
+    ok = rabbit_ct_broker_helpers:restart_broker(Config, FirstNode),
+
+    ?assertEqual(
+       True,
+       feature_flags_SUITE:is_feature_flag_supported(Config, FeatureName)),
+    ?assertEqual(
+       False,
+       feature_flags_SUITE:is_feature_flag_enabled(Config, FeatureName)),
+    ?assertEqual(
+       True,
+       is_deprecated_feature_permitted(Config, FeatureName)).
+
+change_from_denied_to_permitted_in_configuration_but_needed(Config) ->
+    [FirstNode | _] = AllNodes = rabbit_ct_broker_helpers:get_node_configs(
+                                   Config, nodename),
+
+    FeatureName = ?FUNCTION_NAME,
+    ParentFeatureName = parent_feature_flag,
+    GrandParentFeatureName = grand_parent_feature_flag,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => rabbit,
+                       deprecation_phase => denied_by_default},
+                     ParentFeatureName =>
+                     #{provided_by => rabbit,
+                       stability => experimental,
+                       depends_on => [FeatureName]},
+                     GrandParentFeatureName =>
+                     #{provided_by => rabbit,
+                       stability => experimental,
+                       depends_on => [ParentFeatureName]}},
+
+    Ok = [ok || _ <- AllNodes],
+    True = [true || _ <- AllNodes],
+    False = [false || _ <- AllNodes],
+
+    ?assertEqual(
+       Ok,
+       rabbit_ct_broker_helpers:rpc_all(
+         Config,
+         rabbit_feature_flags, inject_test_feature_flags, [FeatureFlags])),
+    ?assertEqual(
+       Ok,
+       rabbit_ct_broker_helpers:rpc_all(
+         Config,
+         rabbit_feature_flags, refresh_feature_flags_after_app_load, [])),
+    ?assertEqual(
+       ok,
+       rabbit_ct_broker_helpers:enable_feature_flag(
+         Config, GrandParentFeatureName)),
+
+    ?assertEqual(
+       True,
+       feature_flags_SUITE:is_feature_flag_supported(Config, FeatureName)),
+    ?assertEqual(
+       True,
+       feature_flags_SUITE:is_feature_flag_enabled(Config, FeatureName)),
+    ?assertEqual(
+       False,
+       is_deprecated_feature_permitted(Config, FeatureName)),
+
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, FirstNode,
+           application, set_env,
+           [rabbit, permit_deprecated_features, #{FeatureName => true}, [{persistent, true}]]),
+    ok = rabbit_ct_broker_helpers:restart_broker(Config, FirstNode),
+
+    ?assertEqual(
+       True,
+       feature_flags_SUITE:is_feature_flag_supported(Config, FeatureName)),
+    ?assertEqual(
+       True,
+       feature_flags_SUITE:is_feature_flag_enabled(Config, FeatureName)),
+    ?assertEqual(
+       False,
+       is_deprecated_feature_permitted(Config, FeatureName)).
+
+is_deprecated_feature_permitted(Config, FeatureName) ->
+    rabbit_ct_broker_helpers:rpc_all(
+      Config, rabbit_deprecated_features, is_permitted, [FeatureName]).
 
 has_is_feature_used_cb_returning_false(Config) ->
     AllNodes = ?config(nodes, Config),

--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -48,7 +48,10 @@
          activating_plugin_with_new_ff_disabled/1,
          activating_plugin_with_new_ff_enabled/1,
          enable_plugin_feature_flag_after_deactivating_plugin/1,
-         restart_node_with_unknown_enabled_feature_flag/1
+         restart_node_with_unknown_enabled_feature_flag/1,
+
+         is_feature_flag_supported/2,
+         is_feature_flag_enabled/2
         ]).
 
 suite() ->

--- a/deps/rabbit/test/feature_flags_v2_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_v2_SUITE.erl
@@ -116,9 +116,9 @@ end_per_suite(Config) ->
 init_per_group(direct, Config) ->
     Config;
 init_per_group(cluster_size_1, Config) ->
-    rabbit_ct_helpers:set_config(Config, {nodes_count, 1});
+    rabbit_ct_helpers:set_config(Config, {rmq_nodes_count, 1});
 init_per_group(cluster_size_3, Config) ->
-    rabbit_ct_helpers:set_config(Config, {nodes_count, 3});
+    rabbit_ct_helpers:set_config(Config, {rmq_nodes_count, 3});
 init_per_group(_Group, Config) ->
     Config.
 
@@ -140,7 +140,7 @@ end_per_testcase(_Testcase, Config) ->
       [fun stop_slave_nodes/1]).
 
 start_slave_nodes(Config, Testcase) ->
-    NodesCount = ?config(nodes_count, Config),
+    NodesCount = ?config(rmq_nodes_count, Config),
     ct:pal("Starting ~b slave node(s):", [NodesCount]),
     Parent = self(),
     Starters = [spawn_link(


### PR DESCRIPTION
## Why

For example, when upgrading from a version of RabbitMQ that documents a deprecated feature but still permit it to a version that denies it by default, a user might want to permit this deprecated feature again after noticing the change.

If they updated their configuration and did a full stop + restart of their cluster, the deprecated feature would be permitted again. However, if they did a rolling restart, which is likely the case, the deprecated feature would remain denied becaue a feature flag can't go back to a "disabled" state.

This patch is here to correct this and allow the underlying feature flag of such a deprecated feature to be disabled again.

## How

When doing the "sync cluster" task, we list all deprecated features which are already denied, but should be permitted again according to the local configuration. We also check that these deprecated features are not needed by other enabled feature flags.

If we find some in that case, we disable them.

The user is still responsible for having the same configuration on all nodes. Otherwise restarting the next could deny the deprecated feature again.

This commit introduces two testcases in `feature_flags_SUITE` to cover the fix:
* `change_from_denied_to_permitted_in_configuration_and_restart`
* `change_from_denied_to_permitted_in_configuration_but_needed`

The first one tests the scenario where a deprecated feature, denied by default, is suddenly permitted from configuration and the cluster is restarted in a rolling fashion.

Before the fix, the deprecated feature was remaining denied because the configuration is not considered after the initial setup of feature flags. However, deprecated features should be restricted like this.

The second does the same thing with a deprecated feature that should remain denied because another enabled feature flag depends on it.

References #16324.
Fixes #16499.