### PR TITLE
`rabbitmq.conf`: support encryption for two more keys in the Prometheus plugin

### DIFF
--- a/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
+++ b/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
@@ -112,7 +112,12 @@ end}.
 {mapping, "prometheus.ssl.cacertfile", "rabbitmq_prometheus.ssl_config.ssl_opts.cacertfile",
     [{datatype, string}, {validators, ["pem_file"]}]}.
 {mapping, "prometheus.ssl.password", "rabbitmq_prometheus.ssl_config.ssl_opts.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_string, string]}]}.
+
+{translation, "rabbitmq_prometheus.ssl_config.ssl_opts.password",
+fun(Conf) ->
+    rabbit_cuttlefish:optionally_tagged_string("prometheus.ssl.password", Conf)
+end}.
 
 {mapping, "prometheus.ssl.verify", "rabbitmq_prometheus.ssl_config.ssl_opts.verify", [
     {datatype, {enum, [verify_peer, verify_none]}}]}.

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
@@ -341,5 +341,27 @@
                             {authentication, [{enabled, true}]}
                            ]}
     ], [rabbitmq_prometheus]
-   }
+   },
+
+   {tls_listener_password_plain,
+    "prometheus.ssl.password = t0p$3cr3t",
+    [{rabbitmq_prometheus,[
+                           {ssl_config,[
+                                        {ssl_opts, [
+                                          {password, "t0p$3cr3t"}
+                                        ]}
+                                       ]}
+                          ]}],
+    [rabbitmq_prometheus]},
+
+   {tls_listener_password_encrypted,
+    "prometheus.ssl.password = encrypted:GhC4J5lh2DUkbdyKO0aMI8aYJ54mwe4eEWzou4yRFAHMF82IbD6cRiYAiBa8UIzR",
+    [{rabbitmq_prometheus,[
+                           {ssl_config,[
+                                        {ssl_opts, [
+                                          {password, {encrypted, "GhC4J5lh2DUkbdyKO0aMI8aYJ54mwe4eEWzou4yRFAHMF82IbD6cRiYAiBa8UIzR"}}
+                                        ]}
+                                       ]}
+                          ]}],
+    [rabbitmq_prometheus]}
 ].


### PR DESCRIPTION
A follow-up to #16516.
