### PR TITLE
`rabbitmq.conf`: fix `rabbitmq_mqtt.tcp_listen_options` translation

### DIFF
--- a/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
+++ b/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
@@ -199,12 +199,12 @@ end}.
 
 %% TCP listener section ======================================================
 
-{mapping, "mqtt.tcp_listen_options", "rabbitmq_mqtt.rabbit.tcp_listen_options", [
+{mapping, "mqtt.tcp_listen_options", "rabbitmq_mqtt.tcp_listen_options", [
     {datatype, {enum, [none]}}]}.
 
-{translation, "rabbitmq_mqtt.rabbit.tcp_listen_options",
+{translation, "rabbitmq_mqtt.tcp_listen_options",
 fun(Conf) ->
-    case cuttlefish:conf_get("mqtt.tcp_listen_options") of
+    case cuttlefish:conf_get("mqtt.tcp_listen_options", Conf) of
         none -> [];
         _    -> cuttlefish:invalid("Invalid mqtt.tcp_listen_options")
     end

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
@@ -197,6 +197,11 @@
   {max_connections_infinity,
    "mqtt.max_connections = infinity",
    [{rabbitmq_mqtt,[{max_connections, infinity}]}],
+   [rabbitmq_mqtt]},
+
+  {tcp_listen_options_none_disables_via_shortcut,
+   "mqtt.tcp_listen_options = none",
+   [{rabbitmq_mqtt,[{tcp_listen_options, []}]}],
    [rabbitmq_mqtt]}
 
 ].


### PR DESCRIPTION
It had a copy-and-paste artifact, an additional "rabbit" prefix.

Spotted while working on a large new feature for Cuttlefish, https://github.com/Kyorai/cuttlefish/pull/79.