### PR TITLE
Rename property test funs which run within broker nodes

### DIFF
--- a/deps/rabbit/test/topic_permission_SUITE.erl
+++ b/deps/rabbit/test/topic_permission_SUITE.erl
@@ -454,14 +454,14 @@ topic_permission_khepri_error_fails_closed_prop1(_Config) ->
            <<"guest">>, <<"/">>, <<"amq.topic">>, "^a", "^a", <<"acting-user">>),
     ok = meck:new(rabbit_khepri, [passthrough]),
     try
-        Property = fun() -> prop_khepri_error_fails_closed() end,
+        Property = fun() -> khepri_error_fails_closed_prop() end,
         rabbit_ct_proper_helpers:run_proper(Property, [], 100)
     after
         meck:unload(rabbit_khepri)
     end,
     ok.
 
-prop_khepri_error_fails_closed() ->
+khepri_error_fails_closed_prop() ->
     ?FORALL(
        {ErrorReason, RoutingKey, Permission},
        {khepri_error_reason(), topic_routing_key(), oneof([read, write])},

--- a/deps/rabbit/test/user_tags_count_limit_SUITE.erl
+++ b/deps/rabbit/test/user_tags_count_limit_SUITE.erl
@@ -225,13 +225,13 @@ put_user_list_above_limit_rejected1() ->
 %% the cap is rejected, regardless of contents.
 prop_set_tags_count_bound(Config) ->
     rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, prop_set_tags_count_bound1, []).
+      ?MODULE, set_tags_count_bound_prop, []).
 
-prop_set_tags_count_bound1() ->
+set_tags_count_bound_prop() ->
     rabbit_ct_proper_helpers:run_proper(
-      fun prop_tag_count_bound/0, [], 50).
+      fun tag_count_bound_prop/0, [], 50).
 
-prop_tag_count_bound() ->
+tag_count_bound_prop() ->
     ?FORALL(N, range(0, ?MAX_USER_TAGS * 2),
         begin
             Username = <<"proper_user">>,


### PR DESCRIPTION
These test functions are meant to be run within brokers via RPC. `make proper` would pick them up as property testing cases though, since they are named with a `prop_` prefix and have arity zero. The cases would run correctly through `make ct` but `make proper` would try to run them directly outside of a broker process, and that would fail.