### PR TITLE
add back rabbit_global_counters:init/2 with list/proplist labels

### DIFF
--- a/deps/rabbit/src/rabbit_global_counters.erl
+++ b/deps/rabbit/src/rabbit_global_counters.erl
@@ -179,6 +179,14 @@ boot_step() ->
 init(Labels) ->
     init(Labels, []).
 
+%% Backwards compatibility for plugins before v4.2.0
+init(Labels = [{protocol, _Protocol}, {queue_type, _QueueType}], Extra) ->
+    init(maps:from_list(Labels), Extra);
+init(Labels = [{protocol, _Protocol}], Extra) ->
+    init(maps:from_list(Labels), Extra);
+init(Labels = [{queue_type, _QueueType}, {dead_letter_strategy, _DLS}], Extra) ->
+    init(maps:from_list(Labels), Extra);
+
 init(Labels = #{protocol := Protocol, queue_type := QueueType}, Extra) ->
     _ = seshat:new_group(?MODULE),
     Counters = seshat:new(?MODULE, Labels, ?PROTOCOL_QUEUE_TYPE_COUNTERS ++ Extra, Labels),


### PR DESCRIPTION
This was a breaking change in v4.2.0, commit a5106c6

## Proposed Changes

We tried to compile our plugin on the new version and it fails here. While I understand the reasons behind breaking changes on a new minor version, I think this is easily avoidable and it was also not clearly specified in the CHANGELOG.

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

