### PR TITLE
Add validation for consumer timeout arguments

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -974,6 +974,8 @@ declare_args() ->
      {<<"x-overflow">>, fun check_overflow/2},
      {<<"x-queue-version">>, fun check_queue_version/2},
      {<<"x-single-active-consumer">>, fun check_single_active_consumer_arg/2},
+     {<<"x-consumer-timeout">>, fun check_non_neg_int_arg/2},
+     {<<"x-consumer-disconnected-timeout">>, fun check_non_neg_int_arg/2},
      {<<"x-queue-type">>, fun check_queue_type/2},
      {<<"x-quorum-initial-group-size">>, fun check_initial_cluster_size_arg/2},
      {<<"x-max-age">>, fun check_max_age_arg/2},
@@ -983,6 +985,7 @@ declare_args() ->
      {<<"x-queue-leader-locator">>, fun check_queue_leader_locator_arg/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
+                   {<<"x-consumer-timeout">>,      fun check_non_neg_int_arg/2},
                    {<<"x-stream-offset">>, fun check_stream_offset_arg/2}].
 
 check_int_arg({Type, _}, _) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -619,6 +619,7 @@ capabilities() ->
                           <<"x-message-ttl">>,
                           <<"x-queue-leader-locator">>,
                           <<"x-consumer-disconnected-timeout">>,
+                          <<"x-consumer-timeout">>,
                           <<"x-delayed-retry-type">>,
                           <<"x-delayed-retry-min">>,
                           <<"x-delayed-retry-max">>],

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -155,9 +155,13 @@ all_tests() ->
      declare_invalid_arg_1,
      declare_invalid_arg_2,
      declare_invalid_arg_3,
+     declare_invalid_consumer_timeout,
+     declare_invalid_consumer_disconnected_timeout,
      relaxed_argument_equivalence_checks_on_qq_redeclare,
      consume_invalid_arg_1,
      consume_invalid_arg_2,
+     consume_invalid_consumer_timeout_negative,
+     consume_invalid_consumer_timeout_wrong_type,
      start_queue,
      long_name,
      stop_queue,
@@ -538,6 +542,26 @@ declare_invalid_arg_3(Config) ->
        declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"quorum">>},
                        {<<"x-max-length">>, long, -5}])).
 
+declare_invalid_consumer_timeout(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Q = ?config(queue_name, Config),
+
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                       {<<"x-consumer-timeout">>, long, -1}])).
+
+declare_invalid_consumer_disconnected_timeout(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Q = ?config(queue_name, Config),
+
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                       {<<"x-consumer-disconnected-timeout">>, long, -1}])).
+
 
 relaxed_argument_equivalence_checks_on_qq_redeclare(Config) ->
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
@@ -611,6 +635,40 @@ consume_invalid_arg_2(Config) ->
        amqp_channel:subscribe(Ch, #'basic.consume'{
                                      queue = Q,
                                      arguments = [{<<"x-priority">>, longstr, <<"important">>}],
+                                     no_ack = false,
+                                     consumer_tag = <<"ctag">>},
+                              self())).
+
+consume_invalid_consumer_timeout_negative(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Q = ?config(queue_name, Config),
+
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       amqp_channel:subscribe(Ch, #'basic.consume'{
+                                     queue = Q,
+                                     arguments = [{<<"x-consumer-timeout">>, long, -1}],
+                                     no_ack = false,
+                                     consumer_tag = <<"ctag">>},
+                              self())).
+
+consume_invalid_consumer_timeout_wrong_type(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Q = ?config(queue_name, Config),
+
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       amqp_channel:subscribe(Ch, #'basic.consume'{
+                                     queue = Q,
+                                     arguments = [{<<"x-consumer-timeout">>, longstr, <<"never">>}],
                                      no_ack = false,
                                      consumer_tag = <<"ctag">>},
                               self())).

--- a/selenium/bin/components/prodkeycloak-proxy
+++ b/selenium/bin/components/prodkeycloak-proxy
@@ -31,7 +31,7 @@ start_prodkeycloak-proxy() {
   MOUNT_HTTPD_CONFIG_DIR=$CONF_DIR/httpd
 
   mkdir -p $MOUNT_HTTPD_CONFIG_DIR
-  ${BIN_DIR}/gen-httpd-conf" "${HTTPD_CONFIG_DIR} $ENV_FILE $MOUNT_HTTPD_CONFIG_DIR/httpd.conf
+  "${BIN_DIR}/gen-httpd-conf" "${HTTPD_CONFIG_DIR}" "$ENV_FILE" "$MOUNT_HTTPD_CONFIG_DIR/httpd.conf"
   print "> EFFECTIVE HTTPD_CONFIG_FILE: $MOUNT_HTTPD_CONFIG_DIR/httpd.conf"
   cp ${HTTPD_CONFIG_DIR}/.htpasswd $MOUNT_HTTPD_CONFIG_DIR
   


### PR DESCRIPTION
Validate 'x-consumer-timeout' and 'x-consumer-disconnected-timeout' when declaring a queue.