### PR TITLE
[selenium] Make logging session timeout optional

### DIFF
--- a/selenium/suites/authnz-mgt/basic-auth-behind-proxy.sh
+++ b/selenium/suites/authnz-mgt/basic-auth-behind-proxy.sh
@@ -3,7 +3,7 @@
 SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/basic-auth
-PROFILES="proxy"
+PROFILES="proxy one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template
 runWith rabbitmq proxy

--- a/selenium/suites/authnz-mgt/basic-auth-with-mgt-prefix.sh
+++ b/selenium/suites/authnz-mgt/basic-auth-with-mgt-prefix.sh
@@ -3,7 +3,7 @@
 SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/basic-auth
-PROFILES="mgt-prefix"
+PROFILES="mgt-prefix one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 run

--- a/selenium/suites/authnz-mgt/basic-auth.sh
+++ b/selenium/suites/authnz-mgt/basic-auth.sh
@@ -3,6 +3,7 @@
 SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/basic-auth
+PROFILES="one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 run

--- a/selenium/suites/authnz-mgt/oauth-idp-initiated-with-uaa-and-prefix.sh
+++ b/selenium/suites/authnz-mgt/oauth-idp-initiated-with-uaa-and-prefix.sh
@@ -4,7 +4,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/oauth/with-idp-initiated
 TEST_CONFIG_PATH=/oauth
-PROFILES="uaa fakeportal-mgt-oauth-provider idp-initiated mgt-prefix uaa-oauth-provider"
+PROFILES="uaa fakeportal-mgt-oauth-provider idp-initiated mgt-prefix uaa-oauth-provider one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 runWith uaa fakeportal

--- a/selenium/suites/authnz-mgt/oauth-idp-initiated-with-uaa.sh
+++ b/selenium/suites/authnz-mgt/oauth-idp-initiated-with-uaa.sh
@@ -4,7 +4,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/oauth/with-idp-initiated
 TEST_CONFIG_PATH=/oauth
-PROFILES="uaa idp-initiated uaa-oauth-provider fakeportal-mgt-oauth-provider"
+PROFILES="uaa idp-initiated uaa-oauth-provider fakeportal-mgt-oauth-provider one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 runWith uaa fakeportal

--- a/selenium/suites/authnz-mgt/oauth-with-keycloak-with-regexp-pattern.sh
+++ b/selenium/suites/authnz-mgt/oauth-with-keycloak-with-regexp-pattern.sh
@@ -4,7 +4,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/oauth/with-sp-initiated
 TEST_CONFIG_PATH=/oauth
-PROFILES="keycloak keycloak-oauth-provider keycloak-mgt-oauth-provider tls regexp-pattern"
+PROFILES="keycloak keycloak-oauth-provider keycloak-mgt-oauth-provider tls regexp-pattern one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 runWith keycloak

--- a/selenium/suites/authnz-mgt/oauth-with-keycloak-with-verify-none.sh
+++ b/selenium/suites/authnz-mgt/oauth-with-keycloak-with-verify-none.sh
@@ -4,7 +4,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/oauth/with-sp-initiated
 TEST_CONFIG_PATH=/oauth
-PROFILES="keycloak keycloak-verify-none-oauth-provider keycloak-mgt-oauth-provider tls"
+PROFILES="keycloak keycloak-verify-none-oauth-provider keycloak-mgt-oauth-provider tls one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 runWith keycloak

--- a/selenium/suites/authnz-mgt/oauth-with-keycloak.sh
+++ b/selenium/suites/authnz-mgt/oauth-with-keycloak.sh
@@ -4,7 +4,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/oauth/with-sp-initiated
 TEST_CONFIG_PATH=/oauth
-PROFILES="keycloak keycloak-oauth-provider keycloak-mgt-oauth-provider tls"
+PROFILES="keycloak keycloak-oauth-provider keycloak-mgt-oauth-provider tls one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 runWith keycloak

--- a/selenium/suites/authnz-mgt/oauth-with-uaa-and-mgt-prefix.sh
+++ b/selenium/suites/authnz-mgt/oauth-with-uaa-and-mgt-prefix.sh
@@ -4,7 +4,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/oauth/with-sp-initiated
 TEST_CONFIG_PATH=/oauth
-PROFILES="uaa uaa-oauth-provider mgt-prefix uaa-mgt-oauth-provider"
+PROFILES="uaa uaa-oauth-provider mgt-prefix uaa-mgt-oauth-provider one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 runWith uaa

--- a/selenium/suites/authnz-mgt/oauth-with-uaa.sh
+++ b/selenium/suites/authnz-mgt/oauth-with-uaa.sh
@@ -4,7 +4,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_CASES_PATH=/oauth/with-sp-initiated
 TEST_CONFIG_PATH=/oauth
-PROFILES="uaa uaa-oauth-provider uaa-mgt-oauth-provider tls"
+PROFILES="uaa uaa-oauth-provider uaa-mgt-oauth-provider tls one-minute-session-timeout"
 
 source $SCRIPT/../../bin/suite_template $@
 runWith uaa

--- a/selenium/test/basic-auth/rabbitmq.conf
+++ b/selenium/test/basic-auth/rabbitmq.conf
@@ -2,8 +2,6 @@ auth_backends.1 = rabbit_auth_backend_internal
 
 load_definitions = ${IMPORT_DIR}/users.json
 
-management.login_session_timeout = 1
-
 loopback_users = none
 
 log.console.level = debug

--- a/selenium/test/basic-auth/rabbitmq.one-minute-session-timeout.conf
+++ b/selenium/test/basic-auth/rabbitmq.one-minute-session-timeout.conf
@@ -1,0 +1,1 @@
+management.login_session_timeout = 1

--- a/selenium/test/oauth/rabbitmq.conf
+++ b/selenium/test/oauth/rabbitmq.conf
@@ -1,6 +1,5 @@
 auth_backends.1 = rabbit_auth_backend_oauth2
 
-management.login_session_timeout = 1
 management.oauth_enabled = true
 management.oauth_client_id = rabbitmq_client_code
 management.oauth_scopes = ${OAUTH_SCOPES}

--- a/selenium/test/oauth/rabbitmq.one-minute-session-timeout.conf
+++ b/selenium/test/oauth/rabbitmq.one-minute-session-timeout.conf
@@ -1,0 +1,1 @@
+management.login_session_timeout = 1


### PR DESCRIPTION
Refactor the test cases and configurations so that `management.login_session_timeout = 1` is optional and only enabled when testing session or token expiry.
This change is necessary to prevent the management ui from prematurely terminating a session in the middle of a test which runs a set of tests which last over 1 minute.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI
