### PR TITLE
Fix prodkeycloak-proxy command invocation

### DIFF
--- a/selenium/bin/components/prodkeycloak-proxy
+++ b/selenium/bin/components/prodkeycloak-proxy
@@ -31,7 +31,7 @@ start_prodkeycloak-proxy() {
   MOUNT_HTTPD_CONFIG_DIR=$CONF_DIR/httpd
 
   mkdir -p $MOUNT_HTTPD_CONFIG_DIR
-  ${BIN_DIR}/gen-httpd-conf" "${HTTPD_CONFIG_DIR} $ENV_FILE $MOUNT_HTTPD_CONFIG_DIR/httpd.conf
+  "${BIN_DIR}/gen-httpd-conf" "${HTTPD_CONFIG_DIR}" "$ENV_FILE" "$MOUNT_HTTPD_CONFIG_DIR/httpd.conf"
   print "> EFFECTIVE HTTPD_CONFIG_FILE: $MOUNT_HTTPD_CONFIG_DIR/httpd.conf"
   cp ${HTTPD_CONFIG_DIR}/.htpasswd $MOUNT_HTTPD_CONFIG_DIR
   


### PR DESCRIPTION
## Summary
- restore the `gen-httpd-conf` invocation in `prodkeycloak-proxy`

## Why
- the current line merges the script path and first argument into the command name
- that makes Bash try to execute a non-existent path before the container starts
- this restores the known-good form of the command

## Validation
- `bash -n selenium/bin/components/prodkeycloak-proxy`
- `git diff --check`
