### PR TITLE
[selenium] Remove obsolete chromedriver dependency

### DIFF
--- a/selenium/test/basic-auth/ac-administrator-without-vhost-permissions.js
+++ b/selenium/test/basic-auth/ac-administrator-without-vhost-permissions.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/basic-auth/ac-management-without-vhost-permissions.js
+++ b/selenium/test/basic-auth/ac-management-without-vhost-permissions.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/basic-auth/ac-management.js
+++ b/selenium/test/basic-auth/ac-management.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/basic-auth/ac-monitoring-without-vhost-permissions.js
+++ b/selenium/test/basic-auth/ac-monitoring-without-vhost-permissions.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/basic-auth/happy-login.js
+++ b/selenium/test/basic-auth/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/basic-auth/landing.js
+++ b/selenium/test/basic-auth/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/basic-auth/logout.js
+++ b/selenium/test/basic-auth/logout.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/basic-auth/session-expired-with-no-refresh.js
+++ b/selenium/test/basic-auth/session-expired-with-no-refresh.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/basic-auth/session-expired.js
+++ b/selenium/test/basic-auth/session-expired.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/basic-auth/unauthorized.js
+++ b/selenium/test/basic-auth/unauthorized.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/connections/amqp10/sessions-for-monitoring-user.js
+++ b/selenium/test/connections/amqp10/sessions-for-monitoring-user.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { open: openAmqp, once: onceAmqp, on: onAmqp, close: closeAmqp } = require('../../amqp')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay, doUntil } = require('../../utils')

--- a/selenium/test/connections/mqtt/list-connections.js
+++ b/selenium/test/connections/mqtt/list-connections.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, doUntil } = require('../../utils')
 const { openConnection, getConnectionOptions } = require('../../mqtt')

--- a/selenium/test/definitions/export.js
+++ b/selenium/test/definitions/export.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/definitions/import.js
+++ b/selenium/test/definitions/import.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/exchanges/management.js
+++ b/selenium/test/exchanges/management.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/feature-flags/feature-flags.js
+++ b/selenium/test/feature-flags/feature-flags.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../utils')
 

--- a/selenium/test/limits/users.js
+++ b/selenium/test/limits/users.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/limits/virtual-hosts.js
+++ b/selenium/test/limits/virtual-hosts.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/multi-oauth/with-basic-auth-idps-down/happy-login.js
+++ b/selenium/test/multi-oauth/with-basic-auth-idps-down/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/multi-oauth/with-basic-auth-idps-down/landing.js
+++ b/selenium/test/multi-oauth/with-basic-auth-idps-down/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, teardown, captureScreensFor } = require('../../utils')
 

--- a/selenium/test/multi-oauth/with-basic-auth/happy-login.js
+++ b/selenium/test/multi-oauth/with-basic-auth/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/multi-oauth/with-basic-auth/landing-with-login-preferences.js
+++ b/selenium/test/multi-oauth/with-basic-auth/landing-with-login-preferences.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, goToLogin, captureScreensFor, teardown, findOption } = require('../../utils')
 

--- a/selenium/test/multi-oauth/with-basic-auth/landing.js
+++ b/selenium/test/multi-oauth/with-basic-auth/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, assertAllOptions, hasProfile } = require('../../utils')
 

--- a/selenium/test/multi-oauth/without-basic-auth/happy-login.js
+++ b/selenium/test/multi-oauth/without-basic-auth/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage, hasProfile } = require('../../utils')
 

--- a/selenium/test/multi-oauth/without-basic-auth/landing.js
+++ b/selenium/test/multi-oauth/without-basic-auth/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, assertAllOptions, hasProfile } = require('../../utils')
 

--- a/selenium/test/oauth/with-basic-auth-idp-down/happy-login.js
+++ b/selenium/test/oauth/with-basic-auth-idp-down/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../../utils')
 

--- a/selenium/test/oauth/with-basic-auth-idp-down/landing.js
+++ b/selenium/test/oauth/with-basic-auth-idp-down/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, teardown, captureScreensFor } = require('../../utils')
 

--- a/selenium/test/oauth/with-basic-auth/happy-login.js
+++ b/selenium/test/oauth/with-basic-auth/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage, log } = require('../../utils')
 

--- a/selenium/test/oauth/with-basic-auth/landing.js
+++ b/selenium/test/oauth/with-basic-auth/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../../utils')
 

--- a/selenium/test/oauth/with-basic-auth/unauthorized.js
+++ b/selenium/test/oauth/with-basic-auth/unauthorized.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/oauth/with-idp-down/landing.js
+++ b/selenium/test/oauth/with-idp-down/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, teardown, captureScreensFor } = require('../../utils')
 

--- a/selenium/test/oauth/with-idp-initiated-via-proxy/happy-login.js
+++ b/selenium/test/oauth/with-idp-initiated-via-proxy/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../../utils')
 

--- a/selenium/test/oauth/with-idp-initiated/happy-login.js
+++ b/selenium/test/oauth/with-idp-initiated/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, captureScreensFor, teardown } = require('../../utils')
 

--- a/selenium/test/oauth/with-idp-initiated/landing.js
+++ b/selenium/test/oauth/with-idp-initiated/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../../utils')
 

--- a/selenium/test/oauth/with-idp-initiated/logout.js
+++ b/selenium/test/oauth/with-idp-initiated/logout.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, captureScreensFor, teardown, delay } = require('../../utils')
 

--- a/selenium/test/oauth/with-idp-initiated/token-expires.js
+++ b/selenium/test/oauth/with-idp-initiated/token-expires.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, captureScreensFor, teardown, delay } = require('../../utils')
 

--- a/selenium/test/oauth/with-idp-initiated/unauthorized.js
+++ b/selenium/test/oauth/with-idp-initiated/unauthorized.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, captureScreensFor, teardown } = require('../../utils')
 

--- a/selenium/test/oauth/with-multi-resources/happy-login.js
+++ b/selenium/test/oauth/with-multi-resources/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/oauth/with-multi-resources/landing.js
+++ b/selenium/test/oauth/with-multi-resources/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../../utils')
 

--- a/selenium/test/oauth/with-sp-initiated/happy-login.js
+++ b/selenium/test/oauth/with-sp-initiated/happy-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/oauth/with-sp-initiated/landing.js
+++ b/selenium/test/oauth/with-sp-initiated/landing.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../../utils')
 

--- a/selenium/test/oauth/with-sp-initiated/logout.js
+++ b/selenium/test/oauth/with-sp-initiated/logout.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/oauth/with-sp-initiated/redirection-after-login.js
+++ b/selenium/test/oauth/with-sp-initiated/redirection-after-login.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToExchanges, captureScreensFor, teardown, goToHome, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/oauth/with-sp-initiated/token-refresh.js
+++ b/selenium/test/oauth/with-sp-initiated/token-refresh.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay, idpLoginPage } = require('../../utils')
 

--- a/selenium/test/oauth/with-sp-initiated/unauthorized.js
+++ b/selenium/test/oauth/with-sp-initiated/unauthorized.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, idpLoginPage, delay } = require('../../utils')
 

--- a/selenium/test/queuesAndStreams/add-classic.js
+++ b/selenium/test/queuesAndStreams/add-classic.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/queuesAndStreams/add-quorum.js
+++ b/selenium/test/queuesAndStreams/add-quorum.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/queuesAndStreams/add-stream.js
+++ b/selenium/test/queuesAndStreams/add-stream.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
 

--- a/selenium/test/queuesAndStreams/autodelete-mqtt-qos0.js
+++ b/selenium/test/queuesAndStreams/autodelete-mqtt-qos0.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, goToQueue, captureScreensFor, teardown, doUntil, findTableRow } = require('../utils')
 const { createQueue, getManagementUrl, basicAuthorization } = require('../mgt-api')

--- a/selenium/test/queuesAndStreams/list.js
+++ b/selenium/test/queuesAndStreams/list.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, doUntil } = require('../utils')
 

--- a/selenium/test/queuesAndStreams/view-mqtt-qos0.js
+++ b/selenium/test/queuesAndStreams/view-mqtt-qos0.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, goToQueue, captureScreensFor, teardown, doUntil, findTableRow } = require('../utils')
 const { createQueue, deleteQueue, getManagementUrl, basicAuthorization } = require('../mgt-api')

--- a/selenium/test/queuesAndStreams/view-qq-consumers.js
+++ b/selenium/test/queuesAndStreams/view-qq-consumers.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, doUntil, goToQueue,delay } = require('../utils')
 const { createQueue, deleteQueue, getManagementUrl, basicAuthorization } = require('../mgt-api')

--- a/selenium/test/utils.js
+++ b/selenium/test/utils.js
@@ -4,7 +4,6 @@ const fsp = fs.promises
 const path = require('path')
 const { By, Key, until, Builder, logging, Capabilities } = require('selenium-webdriver')
 const proxy = require('selenium-webdriver/proxy')
-require('chromedriver')
 var chrome = require("selenium-webdriver/chrome");
 const UAALoginPage = require('./pageobjects/UAALoginPage')
 const KeycloakLoginPage = require('./pageobjects/KeycloakLoginPage')

--- a/selenium/test/vhosts/admin-vhosts.js
+++ b/selenium/test/vhosts/admin-vhosts.js
@@ -1,5 +1,4 @@
 const { By, Key, until, Builder } = require('selenium-webdriver')
-require('chromedriver')
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown, doUntil, log, delay } = require('../utils')
 const { getManagementUrl, basicAuthorization, createVhost, deleteVhost } = require('../mgt-api')


### PR DESCRIPTION
Removes `require('chromedriver')` from all selenium test files. Since selenium-webdriver v4.6.0+, Selenium Manager is natively included, which automatically detects the installed browser and downloads/configures the appropriate chromedriver in the background. Explicitly requiring chromedriver is now redundant and occasionally causes version mismatches.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI