### PR TITLE
Selenium: source the test env file instead of `eval`-ing it

### DIFF
--- a/selenium/package.json
+++ b/selenium/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "fakeportal": "node fakeportal/app.js",
     "fakeproxy": "node fakeportal/proxy.js",
-    "test": " eval $(cat $ENV_FILE ) && mocha --recursive --trace-warnings --timeout 40000"
+    "test": ". $ENV_FILE && mocha --recursive --trace-warnings --timeout 40000"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
`eval $(cat $ENV_FILE)` ran every `export` as one command, so `${VAR}` references to earlier lines expanded to an empty string.
