### PR TITLE
`v4.3.x`: migrate to Cuttlefish 3.9.1, reduce schema duplication

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -297,51 +297,58 @@ end}.
 {mapping, "ssl_allow_poodle_attack", "rabbit.ssl_allow_poodle_attack",
 [{datatype, boolean}]}.
 
-{mapping, "ssl_options", "rabbit.ssl_options", [
-    {datatype, {enum, [none]}}
-]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "ssl_options"},
+     {app_prefix, "rabbit.ssl_options"},
+     {disable_with, none}]}.
 
-{translation, "rabbit.ssl_options",
+%% `key.*` is kept inline so the no-match branch stays
+%% `cuttlefish:unset/0`: the historical primary-listener behavior.
+
+{mapping, "ssl_options.key.RSAPrivateKey", "rabbit.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "ssl_options.key.DSAPrivateKey", "rabbit.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "ssl_options.key.PrivateKeyInfo", "rabbit.ssl_options.key",
+    [{datatype, string}]}.
+
+{translation, "rabbit.ssl_options.key",
 fun(Conf) ->
-    case cuttlefish:conf_get("ssl_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid ssl_options")
+    case cuttlefish_variable:filter_by_prefix("ssl_options.key", Conf) of
+        [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
+        _ -> cuttlefish:unset()
     end
 end}.
 
-{mapping, "ssl_options.verify", "rabbit.ssl_options.verify", [
-    {datatype, {enum, [verify_peer, verify_none]}}]}.
+%% Primary listener extras on top of the shared partial.
 
-{mapping, "ssl_options.fail_if_no_peer_cert", "rabbit.ssl_options.fail_if_no_peer_cert", [
-    {datatype, boolean}]}.
-
-{mapping, "ssl_options.cacertfile", "rabbit.ssl_options.cacertfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "ssl_options.certfile", "rabbit.ssl_options.certfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "ssl_options.cert", "rabbit.ssl_options.cert",
-    [{datatype, string}]}.
-
-{translation, "rabbit.ssl_options.cert",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("ssl_options.cert", Conf))
-end}.
-
-{mapping, "ssl_options.client_renegotiation", "rabbit.ssl_options.client_renegotiation",
+{mapping, "ssl_options.client_renegotiation",
+    "rabbit.ssl_options.client_renegotiation",
     [{datatype, boolean}]}.
 
-{mapping, "ssl_options.crl_check", "rabbit.ssl_options.crl_check",
-    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+{mapping, "ssl_options.honor_cipher_order",
+    "rabbit.ssl_options.honor_cipher_order",
+    [{datatype, boolean}]}.
+
+{mapping, "ssl_options.honor_ecc_order",
+    "rabbit.ssl_options.honor_ecc_order",
+    [{datatype, boolean}]}.
+
+{mapping, "ssl_options.log_level", "rabbit.ssl_options.log_level",
+    [{datatype, {enum, [emergency, alert, critical, error,
+                        warning, notice, info, debug]}}]}.
 
 {mapping, "ssl_options.crl_sources.$index", "rabbit.ssl_options.crl_cache",
     [{datatype, {enum, [http, dir]}}]}.
 
-{mapping, "ssl_options.crl_sources.$index.timeout", "rabbit.ssl_options.crl_cache",
+{mapping, "ssl_options.crl_sources.$index.timeout",
+    "rabbit.ssl_options.crl_cache",
     [{datatype, integer}]}.
 
-{mapping, "ssl_options.crl_sources.$index.path", "rabbit.ssl_options.crl_cache",
+{mapping, "ssl_options.crl_sources.$index.path",
+    "rabbit.ssl_options.crl_cache",
     [{datatype, string}]}.
 
 {translation, "rabbit.ssl_options.crl_cache",
@@ -379,85 +386,12 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "ssl_options.depth", "rabbit.ssl_options.depth",
-    [{datatype, byte}]}.
-
-{mapping, "ssl_options.dh", "rabbit.ssl_options.dh",
-    [{datatype, string}]}.
-
-{translation, "rabbit.ssl_options.dh",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("ssl_options.dh", Conf))
-end}.
-
-{mapping, "ssl_options.dhfile", "rabbit.ssl_options.dhfile",
-    [{datatype, string}, {validators, ["file_accessible"]}]}.
-
-{mapping, "ssl_options.honor_cipher_order", "rabbit.ssl_options.honor_cipher_order",
-    [{datatype, boolean}]}.
-
-{mapping, "ssl_options.honor_ecc_order", "rabbit.ssl_options.honor_ecc_order",
-    [{datatype, boolean}]}.
-
-{mapping, "ssl_options.key.RSAPrivateKey", "rabbit.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "ssl_options.key.DSAPrivateKey", "rabbit.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "ssl_options.key.PrivateKeyInfo", "rabbit.ssl_options.key",
-    [{datatype, string}]}.
-
-{translation, "rabbit.ssl_options.key",
-fun(Conf) ->
-    case cuttlefish_variable:filter_by_prefix("ssl_options.key", Conf) of
-        [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
-        _ -> cuttlefish:unset()
-    end
-end}.
-
-{mapping, "ssl_options.keyfile", "rabbit.ssl_options.keyfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "ssl_options.log_level", "rabbit.ssl_options.log_level",
-    [{datatype, {enum, [emergency, alert, critical, error, warning, notice, info, debug]}}]}.
-
-{mapping, "ssl_options.log_alert", "rabbit.ssl_options.log_alert",
-    [{datatype, boolean}]}.
-
-{mapping, "ssl_options.password", "rabbit.ssl_options.password",
-    [{datatype, [tagged_binary, binary]}]}.
+%% Replace the partial's plain pass-through translation for password
+%% with the rabbit-specific optionally-tagged binary handler.
 
 {translation, "rabbit.ssl_options.password",
 fun(Conf) ->
     rabbit_cuttlefish:optionally_tagged_binary("ssl_options.password", Conf)
-end}.
-
-{mapping, "ssl_options.psk_identity", "rabbit.ssl_options.psk_identity",
-    [{datatype, string}]}.
-
-{mapping, "ssl_options.reuse_sessions", "rabbit.ssl_options.reuse_sessions",
-    [{datatype, boolean}]}.
-
-{mapping, "ssl_options.secure_renegotiate", "rabbit.ssl_options.secure_renegotiate",
-    [{datatype, boolean}]}.
-
-{mapping, "ssl_options.versions.$version", "rabbit.ssl_options.versions",
-    [{datatype, atom}]}.
-
-{translation, "rabbit.ssl_options.versions",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("ssl_options.versions", Conf),
-    [V || {_, V} <- Settings]
-end}.
-
-{mapping, "ssl_options.ciphers.$cipher", "rabbit.ssl_options.ciphers",
-    [{datatype, string}]}.
-
-{translation, "rabbit.ssl_options.ciphers",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("ssl_options.ciphers", Conf),
-    lists:reverse([V || {_, V} <- Settings])
 end}.
 
 {mapping, "ssl_options.bypass_pem_cache", "ssl.bypass_pem_cache",
@@ -1069,88 +1003,10 @@ end}.
 
 %% TCP listener section ======================================================
 
-{mapping, "tcp_listen_options", "rabbit.tcp_listen_options", [
-    {datatype, {enum, [none]}}]}.
-
-{translation, "rabbit.tcp_listen_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("tcp_listen_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid tcp_listen_options")
-    end
-end}.
-
-{mapping, "tcp_listen_options.backlog", "rabbit.tcp_listen_options.backlog", [
-    {datatype, integer}
-]}.
-
-{mapping, "tcp_listen_options.nodelay", "rabbit.tcp_listen_options.nodelay", [
-    {datatype, boolean}
-]}.
-
-{mapping, "tcp_listen_options.buffer", "rabbit.tcp_listen_options.buffer",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.delay_send", "rabbit.tcp_listen_options.delay_send",
-    [{datatype, boolean}]}.
-
-{mapping, "tcp_listen_options.dontroute", "rabbit.tcp_listen_options.dontroute",
-    [{datatype, boolean}]}.
-
-{mapping, "tcp_listen_options.exit_on_close", "rabbit.tcp_listen_options.exit_on_close",
-    [{datatype, boolean}]}.
-
-{mapping, "tcp_listen_options.fd", "rabbit.tcp_listen_options.fd",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.high_msgq_watermark", "rabbit.tcp_listen_options.high_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.high_watermark", "rabbit.tcp_listen_options.high_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.keepalive", "rabbit.tcp_listen_options.keepalive",
-    [{datatype, boolean}]}.
-
-{mapping, "tcp_listen_options.low_msgq_watermark", "rabbit.tcp_listen_options.low_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.low_watermark", "rabbit.tcp_listen_options.low_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.port", "rabbit.tcp_listen_options.port",
-    [{datatype, integer}, {validators, ["port"]}]}.
-
-{mapping, "tcp_listen_options.priority", "rabbit.tcp_listen_options.priority",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.recbuf", "rabbit.tcp_listen_options.recbuf",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.send_timeout", "rabbit.tcp_listen_options.send_timeout",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.send_timeout_close", "rabbit.tcp_listen_options.send_timeout_close",
-    [{datatype, boolean}]}.
-
-{mapping, "tcp_listen_options.sndbuf", "rabbit.tcp_listen_options.sndbuf",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.tos", "rabbit.tcp_listen_options.tos",
-    [{datatype, integer}]}.
-
-{mapping, "tcp_listen_options.linger.on", "rabbit.tcp_listen_options.linger",
-    [{datatype, boolean}]}.
-
-{mapping, "tcp_listen_options.linger.timeout", "rabbit.tcp_listen_options.linger",
-    [{datatype, {integer, non_negative}}]}.
-
-{translation, "rabbit.tcp_listen_options.linger",
-fun(Conf) ->
-    LingerOn = cuttlefish:conf_get("tcp_listen_options.linger.on", Conf, false),
-    LingerTimeout = cuttlefish:conf_get("tcp_listen_options.linger.timeout", Conf, 0),
-    {LingerOn, LingerTimeout}
-end}.
+{include_partial, {rabbit, "tcp_listen_options"},
+    [{prefix, "tcp_listen_options"},
+     {app_prefix, "rabbit.tcp_listen_options"},
+     {disable_with, none}]}.
 
 
 %% ==========================================================================

--- a/deps/rabbit/priv/schema/ssl_options.partial
+++ b/deps/rabbit/priv/schema/ssl_options.partial
@@ -1,0 +1,88 @@
+%% Cuttlefish partial: shared TLS options used by every RabbitMQ
+%% schema that exposes an `ssl_options` block — protocol listeners,
+%% peer-discovery backends, the HTTP and LDAP auth backends, the trust
+%% store and shovel. Pair with the include directive:
+%%
+%%   {include_partial, {rabbit, "ssl_options"},
+%%       [{prefix, "<scope>.ssl_options"},
+%%        {app_prefix, "<app>.ssl_options"},
+%%        {disable_with, none}]}.
+%%
+%% Consumers with extras (rabbit's primary listener has CRL sources and
+%% log levels, auth_ldap has honor_cipher_order, etc.) declare those
+%% inline alongside the include.
+
+{mapping, "verify", "verify",
+    [{datatype, {enum, [verify_peer, verify_none]}}]}.
+
+{mapping, "fail_if_no_peer_cert", "fail_if_no_peer_cert",
+    [{datatype, boolean}]}.
+
+{mapping, "cacertfile", "cacertfile",
+    [{datatype, string}, {validators, ["pem_file"]}]}.
+
+{mapping, "certfile", "certfile",
+    [{datatype, string}, {validators, ["pem_file"]}]}.
+
+{mapping, "cert", "cert", [{datatype, string}]}.
+
+{partial_translation, "cert",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        list_to_binary(cuttlefish:conf_get(ConfPrefix ++ ".cert", Conf))
+    end}.
+
+{mapping, "crl_check", "crl_check",
+    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+
+{mapping, "depth", "depth", [{datatype, byte}]}.
+
+{mapping, "dh", "dh", [{datatype, string}]}.
+
+{partial_translation, "dh",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        list_to_binary(cuttlefish:conf_get(ConfPrefix ++ ".dh", Conf))
+    end}.
+
+{mapping, "dhfile", "dhfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+%% `key.RSAPrivateKey` and friends are intentionally left out of the
+%% partial. The pre-migration translations diverged across consumers
+%% (`cuttlefish:unset/0` vs the atom `undefined` for the no-match
+%% branch, plus an upstream bug in non-rabbit consumers where the
+%% `[_,_,Key]` 3-segment pattern never matched their 5+ segment paths)
+%% and the partial cannot preserve both shapes simultaneously. Each
+%% consumer keeps its `key.*` mappings and translation inline so the
+%% generated `app.config` stays byte-identical with the pre-migration version of the schema.
+
+{mapping, "keyfile", "keyfile",
+    [{datatype, string}, {validators, ["pem_file"]}]}.
+
+{mapping, "log_alert", "log_alert", [{datatype, boolean}]}.
+
+{mapping, "password", "password",
+    [{datatype, [tagged_binary, binary]}]}.
+
+{mapping, "psk_identity", "psk_identity", [{datatype, string}]}.
+
+{mapping, "reuse_sessions", "reuse_sessions", [{datatype, boolean}]}.
+
+{mapping, "secure_renegotiate", "secure_renegotiate", [{datatype, boolean}]}.
+
+{mapping, "versions.$version", "versions", [{datatype, atom}]}.
+
+{partial_translation, "versions",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        Settings = cuttlefish_variable:filter_by_prefix(
+                     ConfPrefix ++ ".versions", Conf),
+        [V || {_, V} <- Settings]
+    end}.
+
+{mapping, "ciphers.$cipher", "ciphers", [{datatype, string}]}.
+
+{partial_translation, "ciphers",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        Settings = cuttlefish_variable:filter_by_prefix(
+                     ConfPrefix ++ ".ciphers", Conf),
+        lists:reverse([V || {_, V} <- Settings])
+    end}.

--- a/deps/rabbit/priv/schema/tcp_listen_options.partial
+++ b/deps/rabbit/priv/schema/tcp_listen_options.partial
@@ -1,0 +1,66 @@
+%% Cuttlefish partial: TCP listener options shared by every RabbitMQ
+%% protocol listener (AMQP, MQTT, STOMP, Stream). Included from
+%% rabbit.schema for its own listener and from the per-protocol schemas
+%% with their respective conf and app prefixes.
+%%
+%% Pair with the include directive:
+%%
+%%   {include_partial, {rabbit, "tcp_listen_options"},
+%%       [{prefix, "<protocol>.tcp_listen_options"},
+%%        {app_prefix, "<app>.tcp_listen_options"},
+%%        {disable_with, none}]}.
+%%
+%% `disable_with` emits the historical `<prefix> = none` guard mapping
+%% plus its translation — keeping the user-facing surface unchanged.
+
+{mapping, "backlog", "backlog", [{datatype, integer}]}.
+
+{mapping, "nodelay", "nodelay", [{datatype, boolean}]}.
+
+{mapping, "buffer", "buffer", [{datatype, integer}]}.
+
+{mapping, "delay_send", "delay_send", [{datatype, boolean}]}.
+
+{mapping, "dontroute", "dontroute", [{datatype, boolean}]}.
+
+{mapping, "exit_on_close", "exit_on_close", [{datatype, boolean}]}.
+
+{mapping, "fd", "fd", [{datatype, integer}]}.
+
+{mapping, "high_msgq_watermark", "high_msgq_watermark", [{datatype, integer}]}.
+
+{mapping, "high_watermark", "high_watermark", [{datatype, integer}]}.
+
+{mapping, "keepalive", "keepalive", [{datatype, boolean}]}.
+
+{mapping, "low_msgq_watermark", "low_msgq_watermark", [{datatype, integer}]}.
+
+{mapping, "low_watermark", "low_watermark", [{datatype, integer}]}.
+
+{mapping, "port", "port", [{datatype, integer}, {validators, ["port"]}]}.
+
+{mapping, "priority", "priority", [{datatype, integer}]}.
+
+{mapping, "recbuf", "recbuf", [{datatype, integer}]}.
+
+{mapping, "send_timeout", "send_timeout", [{datatype, integer}]}.
+
+{mapping, "send_timeout_close", "send_timeout_close", [{datatype, boolean}]}.
+
+{mapping, "sndbuf", "sndbuf", [{datatype, integer}]}.
+
+{mapping, "tos", "tos", [{datatype, integer}]}.
+
+{mapping, "linger.on", "linger", [{datatype, boolean}]}.
+
+{mapping, "linger.timeout", "linger",
+    [{datatype, {integer, non_negative}}]}.
+
+{partial_translation, "linger",
+    fun(Conf, ConfPrefix, _AppPrefix) ->
+        LingerOn = cuttlefish:conf_get(ConfPrefix ++ ".linger.on",
+                                       Conf, false),
+        LingerTimeout = cuttlefish:conf_get(ConfPrefix ++ ".linger.timeout",
+                                            Conf, 0),
+        {LingerOn, LingerTimeout}
+    end}.

--- a/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
+++ b/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
@@ -28,116 +28,48 @@
 
 %% TLS options
 
-{mapping, "auth_http.ssl_options", "rabbitmq_auth_backend_http.ssl_options", [
-    {datatype, {enum, [none]}}
-]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "auth_http.ssl_options"},
+     {app_prefix, "rabbitmq_auth_backend_http.ssl_options"},
+     {disable_with, none}]}.
 
-{translation, "rabbitmq_auth_backend_http.ssl_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("auth_http.ssl_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid auth_http.ssl_options")
-    end
-end}.
+%% `key.*` is kept inline so the no-match branch stays the atom
+%% `undefined`, matching the historical (and buggy) translation shape.
 
-{mapping, "auth_http.ssl_options.verify", "rabbitmq_auth_backend_http.ssl_options.verify", [
-    {datatype, {enum, [verify_peer, verify_none]}}]}.
-
-{mapping, "auth_http.ssl_options.fail_if_no_peer_cert", "rabbitmq_auth_backend_http.ssl_options.fail_if_no_peer_cert", [
-    {datatype, boolean}]}.
-
-{mapping, "auth_http.ssl_options.cacertfile", "rabbitmq_auth_backend_http.ssl_options.cacertfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "auth_http.ssl_options.certfile", "rabbitmq_auth_backend_http.ssl_options.certfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "auth_http.ssl_options.cert", "rabbitmq_auth_backend_http.ssl_options.cert",
+{mapping, "auth_http.ssl_options.key.RSAPrivateKey",
+    "rabbitmq_auth_backend_http.ssl_options.key",
     [{datatype, string}]}.
 
-{translation, "rabbitmq_auth_backend_http.ssl_options.cert",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("auth_http.ssl_options.cert", Conf))
-end}.
-
-{mapping, "auth_http.ssl_options.client_renegotiation", "rabbitmq_auth_backend_http.ssl_options.client_renegotiation",
-    [{datatype, boolean}]}.
-
-{mapping, "auth_http.ssl_options.crl_check", "rabbitmq_auth_backend_http.ssl_options.crl_check",
-    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
-
-{mapping, "auth_http.ssl_options.depth", "rabbitmq_auth_backend_http.ssl_options.depth",
-    [{datatype, byte}]}.
-
-{mapping, "auth_http.ssl_options.dh", "rabbitmq_auth_backend_http.ssl_options.dh",
+{mapping, "auth_http.ssl_options.key.DSAPrivateKey",
+    "rabbitmq_auth_backend_http.ssl_options.key",
     [{datatype, string}]}.
 
-{translation, "rabbitmq_auth_backend_http.ssl_options.dh",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("auth_http.ssl_options.dh", Conf))
-end}.
-
-{mapping, "auth_http.ssl_options.dhfile", "rabbitmq_auth_backend_http.ssl_options.dhfile",
-    [{datatype, string}, {validators, ["file_accessible"]}]}.
-
-{mapping, "auth_http.ssl_options.honor_cipher_order", "rabbitmq_auth_backend_http.ssl_options.honor_cipher_order",
-    [{datatype, boolean}]}.
-
-{mapping, "auth_http.ssl_options.honor_ecc_order", "rabbitmq_auth_backend_http.ssl_options.honor_ecc_order",
-    [{datatype, boolean}]}.
-
-{mapping, "auth_http.ssl_options.key.RSAPrivateKey", "rabbitmq_auth_backend_http.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "auth_http.ssl_options.key.DSAPrivateKey", "rabbitmq_auth_backend_http.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "auth_http.ssl_options.key.PrivateKeyInfo", "rabbitmq_auth_backend_http.ssl_options.key",
+{mapping, "auth_http.ssl_options.key.PrivateKeyInfo",
+    "rabbitmq_auth_backend_http.ssl_options.key",
     [{datatype, string}]}.
 
 {translation, "rabbitmq_auth_backend_http.ssl_options.key",
 fun(Conf) ->
-    case cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.key", Conf) of
+    case cuttlefish_variable:filter_by_prefix(
+           "auth_http.ssl_options.key", Conf) of
         [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
         _ -> undefined
     end
 end}.
 
-{mapping, "auth_http.ssl_options.keyfile", "rabbitmq_auth_backend_http.ssl_options.keyfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
+%% auth_http extras on top of the shared partial.
 
-{mapping, "auth_http.ssl_options.log_alert", "rabbitmq_auth_backend_http.ssl_options.log_alert",
+{mapping, "auth_http.ssl_options.client_renegotiation",
+    "rabbitmq_auth_backend_http.ssl_options.client_renegotiation",
     [{datatype, boolean}]}.
 
-{mapping, "auth_http.ssl_options.password", "rabbitmq_auth_backend_http.ssl_options.password",
-    [{datatype, [tagged_binary, binary]}]}.
-
-{mapping, "auth_http.ssl_options.psk_identity", "rabbitmq_auth_backend_http.ssl_options.psk_identity",
-    [{datatype, string}]}.
-
-{mapping, "auth_http.ssl_options.reuse_sessions", "rabbitmq_auth_backend_http.ssl_options.reuse_sessions",
+{mapping, "auth_http.ssl_options.honor_cipher_order",
+    "rabbitmq_auth_backend_http.ssl_options.honor_cipher_order",
     [{datatype, boolean}]}.
 
-{mapping, "auth_http.ssl_options.secure_renegotiate", "rabbitmq_auth_backend_http.ssl_options.secure_renegotiate",
+{mapping, "auth_http.ssl_options.honor_ecc_order",
+    "rabbitmq_auth_backend_http.ssl_options.honor_ecc_order",
     [{datatype, boolean}]}.
-
-{mapping, "auth_http.ssl_options.versions.$version", "rabbitmq_auth_backend_http.ssl_options.versions",
-    [{datatype, atom}]}.
-
-{translation, "rabbitmq_auth_backend_http.ssl_options.versions",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.versions", Conf),
-    [ V || {_, V} <- Settings ]
-end}.
-
-{mapping, "auth_http.ssl_options.ciphers.$cipher", "rabbitmq_auth_backend_http.ssl_options.ciphers",
-    [{datatype, string}]}.
-
-{translation, "rabbitmq_auth_backend_http.ssl_options.ciphers",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("auth_http.ssl_options.ciphers", Conf),
-    lists:reverse([V || {_, V} <- Settings])
-end}.
 
 {mapping, "auth_http.ssl_options.sni", "rabbitmq_auth_backend_http.ssl_options.server_name_indication",
     [{datatype, [{enum, [none]}, string]}]}.

--- a/deps/rabbitmq_auth_backend_ldap/priv/schema/rabbitmq_auth_backend_ldap.schema
+++ b/deps/rabbitmq_auth_backend_ldap/priv/schema/rabbitmq_auth_backend_ldap.schema
@@ -208,116 +208,48 @@ end}.
 
 %% TLS options
 
-{mapping, "auth_ldap.ssl_options", "rabbitmq_auth_backend_ldap.ssl_options", [
-    {datatype, {enum, [none]}}
-]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "auth_ldap.ssl_options"},
+     {app_prefix, "rabbitmq_auth_backend_ldap.ssl_options"},
+     {disable_with, none}]}.
 
-{translation, "rabbitmq_auth_backend_ldap.ssl_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("auth_ldap.ssl_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid auth_ldap.ssl_options")
-    end
-end}.
+%% `key.*` is kept inline so the no-match branch stays the atom
+%% `undefined`, matching the historical (and buggy) translation shape.
 
-{mapping, "auth_ldap.ssl_options.verify", "rabbitmq_auth_backend_ldap.ssl_options.verify", [
-    {datatype, {enum, [verify_peer, verify_none]}}]}.
-
-{mapping, "auth_ldap.ssl_options.fail_if_no_peer_cert", "rabbitmq_auth_backend_ldap.ssl_options.fail_if_no_peer_cert", [
-    {datatype, boolean}]}.
-
-{mapping, "auth_ldap.ssl_options.cacertfile", "rabbitmq_auth_backend_ldap.ssl_options.cacertfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "auth_ldap.ssl_options.certfile", "rabbitmq_auth_backend_ldap.ssl_options.certfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "auth_ldap.ssl_options.cert", "rabbitmq_auth_backend_ldap.ssl_options.cert",
+{mapping, "auth_ldap.ssl_options.key.RSAPrivateKey",
+    "rabbitmq_auth_backend_ldap.ssl_options.key",
     [{datatype, string}]}.
 
-{translation, "rabbitmq_auth_backend_ldap.ssl_options.cert",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("auth_ldap.ssl_options.cert", Conf))
-end}.
-
-{mapping, "auth_ldap.ssl_options.client_renegotiation", "rabbitmq_auth_backend_ldap.ssl_options.client_renegotiation",
-    [{datatype, boolean}]}.
-
-{mapping, "auth_ldap.ssl_options.crl_check", "rabbitmq_auth_backend_ldap.ssl_options.crl_check",
-    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
-
-{mapping, "auth_ldap.ssl_options.depth", "rabbitmq_auth_backend_ldap.ssl_options.depth",
-    [{datatype, byte}]}.
-
-{mapping, "auth_ldap.ssl_options.dh", "rabbitmq_auth_backend_ldap.ssl_options.dh",
+{mapping, "auth_ldap.ssl_options.key.DSAPrivateKey",
+    "rabbitmq_auth_backend_ldap.ssl_options.key",
     [{datatype, string}]}.
 
-{translation, "rabbitmq_auth_backend_ldap.ssl_options.dh",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("auth_ldap.ssl_options.dh", Conf))
-end}.
-
-{mapping, "auth_ldap.ssl_options.dhfile", "rabbitmq_auth_backend_ldap.ssl_options.dhfile",
-    [{datatype, string}, {validators, ["file_accessible"]}]}.
-
-{mapping, "auth_ldap.ssl_options.honor_cipher_order", "rabbitmq_auth_backend_ldap.ssl_options.honor_cipher_order",
-    [{datatype, boolean}]}.
-
-{mapping, "auth_ldap.ssl_options.honor_ecc_order", "rabbitmq_auth_backend_ldap.ssl_options.honor_ecc_order",
-    [{datatype, boolean}]}.
-
-{mapping, "auth_ldap.ssl_options.key.RSAPrivateKey", "rabbitmq_auth_backend_ldap.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "auth_ldap.ssl_options.key.DSAPrivateKey", "rabbitmq_auth_backend_ldap.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "auth_ldap.ssl_options.key.PrivateKeyInfo", "rabbitmq_auth_backend_ldap.ssl_options.key",
+{mapping, "auth_ldap.ssl_options.key.PrivateKeyInfo",
+    "rabbitmq_auth_backend_ldap.ssl_options.key",
     [{datatype, string}]}.
 
 {translation, "rabbitmq_auth_backend_ldap.ssl_options.key",
 fun(Conf) ->
-    case cuttlefish_variable:filter_by_prefix("auth_ldap.ssl_options.key", Conf) of
+    case cuttlefish_variable:filter_by_prefix(
+           "auth_ldap.ssl_options.key", Conf) of
         [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
         _ -> undefined
     end
 end}.
 
-{mapping, "auth_ldap.ssl_options.keyfile", "rabbitmq_auth_backend_ldap.ssl_options.keyfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
+%% auth_ldap extras on top of the shared partial.
 
-{mapping, "auth_ldap.ssl_options.log_alert", "rabbitmq_auth_backend_ldap.ssl_options.log_alert",
+{mapping, "auth_ldap.ssl_options.client_renegotiation",
+    "rabbitmq_auth_backend_ldap.ssl_options.client_renegotiation",
     [{datatype, boolean}]}.
 
-{mapping, "auth_ldap.ssl_options.password", "rabbitmq_auth_backend_ldap.ssl_options.password",
-    [{datatype, [tagged_binary, binary]}]}.
-
-{mapping, "auth_ldap.ssl_options.psk_identity", "rabbitmq_auth_backend_ldap.ssl_options.psk_identity",
-    [{datatype, string}]}.
-
-{mapping, "auth_ldap.ssl_options.reuse_sessions", "rabbitmq_auth_backend_ldap.ssl_options.reuse_sessions",
+{mapping, "auth_ldap.ssl_options.honor_cipher_order",
+    "rabbitmq_auth_backend_ldap.ssl_options.honor_cipher_order",
     [{datatype, boolean}]}.
 
-{mapping, "auth_ldap.ssl_options.secure_renegotiate", "rabbitmq_auth_backend_ldap.ssl_options.secure_renegotiate",
+{mapping, "auth_ldap.ssl_options.honor_ecc_order",
+    "rabbitmq_auth_backend_ldap.ssl_options.honor_ecc_order",
     [{datatype, boolean}]}.
-
-{mapping, "auth_ldap.ssl_options.versions.$version", "rabbitmq_auth_backend_ldap.ssl_options.versions",
-    [{datatype, atom}]}.
-
-{translation, "rabbitmq_auth_backend_ldap.ssl_options.versions",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("auth_ldap.ssl_options.versions", Conf),
-    [ V || {_, V} <- Settings ]
-end}.
-
-{mapping, "auth_ldap.ssl_options.ciphers.$cipher", "rabbitmq_auth_backend_ldap.ssl_options.ciphers",
-    [{datatype, string}]}.
-
-{translation, "rabbitmq_auth_backend_ldap.ssl_options.ciphers",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("auth_ldap.ssl_options.ciphers", Conf),
-    lists:reverse([V || {_, V} <- Settings])
-end}.
 
 {mapping, "auth_ldap.ssl_options.sni", "rabbitmq_auth_backend_ldap.ssl_options.server_name_indication",
     [{datatype, [{enum, [none]}, string]}]}.

--- a/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
+++ b/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
@@ -199,88 +199,10 @@ end}.
 
 %% TCP listener section ======================================================
 
-{mapping, "mqtt.tcp_listen_options", "rabbitmq_mqtt.tcp_listen_options", [
-    {datatype, {enum, [none]}}]}.
-
-{translation, "rabbitmq_mqtt.tcp_listen_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("mqtt.tcp_listen_options", Conf) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid mqtt.tcp_listen_options")
-    end
-end}.
-
-{mapping, "mqtt.tcp_listen_options.backlog", "rabbitmq_mqtt.tcp_listen_options.backlog", [
-    {datatype, integer}
-]}.
-
-{mapping, "mqtt.tcp_listen_options.nodelay", "rabbitmq_mqtt.tcp_listen_options.nodelay", [
-    {datatype, boolean}
-]}.
-
-{mapping, "mqtt.tcp_listen_options.buffer", "rabbitmq_mqtt.tcp_listen_options.buffer",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.delay_send", "rabbitmq_mqtt.tcp_listen_options.delay_send",
-    [{datatype, boolean}]}.
-
-{mapping, "mqtt.tcp_listen_options.dontroute", "rabbitmq_mqtt.tcp_listen_options.dontroute",
-    [{datatype, boolean}]}.
-
-{mapping, "mqtt.tcp_listen_options.exit_on_close", "rabbitmq_mqtt.tcp_listen_options.exit_on_close",
-    [{datatype, boolean}]}.
-
-{mapping, "mqtt.tcp_listen_options.fd", "rabbitmq_mqtt.tcp_listen_options.fd",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.high_msgq_watermark", "rabbitmq_mqtt.tcp_listen_options.high_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.high_watermark", "rabbitmq_mqtt.tcp_listen_options.high_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.keepalive", "rabbitmq_mqtt.tcp_listen_options.keepalive",
-    [{datatype, boolean}]}.
-
-{mapping, "mqtt.tcp_listen_options.low_msgq_watermark", "rabbitmq_mqtt.tcp_listen_options.low_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.low_watermark", "rabbitmq_mqtt.tcp_listen_options.low_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.port", "rabbitmq_mqtt.tcp_listen_options.port",
-    [{datatype, integer}, {validators, ["port"]}]}.
-
-{mapping, "mqtt.tcp_listen_options.priority", "rabbitmq_mqtt.tcp_listen_options.priority",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.recbuf", "rabbitmq_mqtt.tcp_listen_options.recbuf",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.send_timeout", "rabbitmq_mqtt.tcp_listen_options.send_timeout",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.send_timeout_close", "rabbitmq_mqtt.tcp_listen_options.send_timeout_close",
-    [{datatype, boolean}]}.
-
-{mapping, "mqtt.tcp_listen_options.sndbuf", "rabbitmq_mqtt.tcp_listen_options.sndbuf",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.tos", "rabbitmq_mqtt.tcp_listen_options.tos",
-    [{datatype, integer}]}.
-
-{mapping, "mqtt.tcp_listen_options.linger.on", "rabbitmq_mqtt.tcp_listen_options.linger",
-    [{datatype, boolean}]}.
-
-{mapping, "mqtt.tcp_listen_options.linger.timeout", "rabbitmq_mqtt.tcp_listen_options.linger",
-    [{datatype, {integer, non_negative}}]}.
-
-{translation, "rabbitmq_mqtt.tcp_listen_options.linger",
-fun(Conf) ->
-    LingerOn = cuttlefish:conf_get("mqtt.tcp_listen_options.linger.on", Conf, false),
-    LingerTimeout = cuttlefish:conf_get("mqtt.tcp_listen_options.linger.timeout", Conf, 0),
-    {LingerOn, LingerTimeout}
-end}.
+{include_partial, {rabbit, "tcp_listen_options"},
+    [{prefix, "mqtt.tcp_listen_options"},
+     {app_prefix, "rabbitmq_mqtt.tcp_listen_options"},
+     {disable_with, none}]}.
 
 %% Durable queue type to be used for QoS 1 subscriptions
 %%

--- a/deps/rabbitmq_peer_discovery_consul/priv/schema/rabbitmq_peer_discovery_consul.schema
+++ b/deps/rabbitmq_peer_discovery_consul/priv/schema/rabbitmq_peer_discovery_consul.schema
@@ -343,104 +343,33 @@ end}.
 %% TLS client options
 %%
 
-{mapping, "cluster_formation.consul.ssl_options", "rabbit.cluster_formation.peer_discovery_consul.ssl_options", [
-    {datatype, {enum, [none]}}
-]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "cluster_formation.consul.ssl_options"},
+     {app_prefix, "rabbit.cluster_formation.peer_discovery_consul.ssl_options"},
+     {disable_with, none}]}.
 
-{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options",
-fun(Conf) ->
-case cuttlefish:conf_get("cluster_formation.consul.ssl_options", Conf, undefined) of
-    none -> [];
-    _    -> cuttlefish:invalid("Invalid cluster_formation.consul.ssl_options")
-end
-end}.
+%% `key.*` is kept inline so the no-match branch stays the atom
+%% `undefined` — the historical (and buggy) translation shape on
+%% consul's deeper conf-key prefix. Preserving it keeps the generated
+%% app.config byte-identical for users who never set these keys.
 
-{mapping, "cluster_formation.consul.ssl_options.verify", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.verify", [
-{datatype, {enum, [verify_peer, verify_none]}}]}.
+{mapping, "cluster_formation.consul.ssl_options.key.RSAPrivateKey",
+    "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
+    [{datatype, string}]}.
 
-{mapping, "cluster_formation.consul.ssl_options.fail_if_no_peer_cert", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.fail_if_no_peer_cert", [
-{datatype, boolean}]}.
+{mapping, "cluster_formation.consul.ssl_options.key.DSAPrivateKey",
+    "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
+    [{datatype, string}]}.
 
-{mapping, "cluster_formation.consul.ssl_options.cacertfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cacertfile",
-[{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.certfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.certfile",
-[{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.cert", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cert",
-[{datatype, string}]}.
-
-{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cert",
-fun(Conf) ->
-list_to_binary(cuttlefish:conf_get("cluster_formation.consul.ssl_options.cert", Conf))
-end}.
-
-{mapping, "cluster_formation.consul.ssl_options.crl_check", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.crl_check",
-[{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.depth", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.depth",
-[{datatype, byte}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.dh", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.dh",
-[{datatype, string}]}.
-
-{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.dh",
-fun(Conf) ->
-list_to_binary(cuttlefish:conf_get("cluster_formation.consul.ssl_options.dh", Conf))
-end}.
-
-{mapping, "cluster_formation.consul.ssl_options.dhfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.dhfile",
-[{datatype, string}, {validators, ["file_accessible"]}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.key.RSAPrivateKey", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
-[{datatype, string}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.key.DSAPrivateKey", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
-[{datatype, string}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.key.PrivateKeyInfo", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
-[{datatype, string}]}.
+{mapping, "cluster_formation.consul.ssl_options.key.PrivateKeyInfo",
+    "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
+    [{datatype, string}]}.
 
 {translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
 fun(Conf) ->
-case cuttlefish_variable:filter_by_prefix("cluster_formation.consul.ssl_options.key", Conf) of
-    [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
-    _ -> undefined
-end
-end}.
-
-{mapping, "cluster_formation.consul.ssl_options.keyfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.keyfile",
-[{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.log_alert", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.log_alert",
-[{datatype, boolean}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.password", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.password",
-[{datatype, [tagged_binary, binary]}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.psk_identity", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.psk_identity",
-[{datatype, string}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.reuse_sessions", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.reuse_sessions",
-[{datatype, boolean}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.secure_renegotiate", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.secure_renegotiate",
-[{datatype, boolean}]}.
-
-{mapping, "cluster_formation.consul.ssl_options.versions.$version", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.versions",
-[{datatype, atom}]}.
-
-{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.versions",
-fun(Conf) ->
-Settings = cuttlefish_variable:filter_by_prefix("cluster_formation.consul.ssl_options.versions", Conf),
-[V || {_, V} <- Settings]
-end}.
-
-{mapping, "cluster_formation.consul.ssl_options.ciphers.$cipher", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.ciphers",
-[{datatype, string}]}.
-
-{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.ciphers",
-fun(Conf) ->
-Settings = cuttlefish_variable:filter_by_prefix("cluster_formation.consul.ssl_options.ciphers", Conf),
-lists:reverse([V || {_, V} <- Settings])
+    case cuttlefish_variable:filter_by_prefix(
+           "cluster_formation.consul.ssl_options.key", Conf) of
+        [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
+        _ -> undefined
+    end
 end}.

--- a/deps/rabbitmq_peer_discovery_etcd/priv/schema/rabbitmq_peer_discovery_etcd.schema
+++ b/deps/rabbitmq_peer_discovery_etcd/priv/schema/rabbitmq_peer_discovery_etcd.schema
@@ -163,90 +163,32 @@ end}.
 %% TLS client options
 %%
 
-{mapping, "cluster_formation.etcd.ssl_options", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options", [
-    {datatype, {enum, [none]}}
-]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "cluster_formation.etcd.ssl_options"},
+     {app_prefix, "rabbit.cluster_formation.peer_discovery_etcd.ssl_options"},
+     {disable_with, none},
+     {exclude, ["fail_if_no_peer_cert", "dh", "dhfile"]}]}.
 
-{translation, "rabbit.cluster_formation.peer_discovery_etcd.ssl_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("cluster_formation.etcd.ssl_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid cluster_formation.etcd.ssl_options")
-    end
-end}.
+%% `key.*` is kept inline so the no-match branch stays the atom
+%% `undefined`, matching the historical (and buggy) translation shape.
 
-{mapping, "cluster_formation.etcd.ssl_options.verify", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.verify", [
-    {datatype, {enum, [verify_peer, verify_none]}}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.cacertfile", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.cacertfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.certfile", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.certfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.cert", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.cert",
+{mapping, "cluster_formation.etcd.ssl_options.key.RSAPrivateKey",
+    "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
     [{datatype, string}]}.
 
-{translation, "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.cert",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("cluster_formation.etcd.ssl_options.cert", Conf))
-end}.
-
-{mapping, "cluster_formation.etcd.ssl_options.crl_check", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.crl_check",
-    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.depth", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.depth",
-    [{datatype, byte}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.key.RSAPrivateKey", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
+{mapping, "cluster_formation.etcd.ssl_options.key.DSAPrivateKey",
+    "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
     [{datatype, string}]}.
 
-{mapping, "cluster_formation.etcd.ssl_options.key.DSAPrivateKey", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.key.PrivateKeyInfo", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
+{mapping, "cluster_formation.etcd.ssl_options.key.PrivateKeyInfo",
+    "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
     [{datatype, string}]}.
 
 {translation, "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
 fun(Conf) ->
-    case cuttlefish_variable:filter_by_prefix("cluster_formation.etcd.ssl_options.key", Conf) of
+    case cuttlefish_variable:filter_by_prefix(
+           "cluster_formation.etcd.ssl_options.key", Conf) of
         [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
         _ -> undefined
     end
-end}.
-
-{mapping, "cluster_formation.etcd.ssl_options.keyfile", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.keyfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.log_alert", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.log_alert",
-    [{datatype, boolean}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.password", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.password",
-    [{datatype, [tagged_binary, binary]}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.psk_identity", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.psk_identity",
-    [{datatype, string}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.reuse_sessions", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.reuse_sessions",
-    [{datatype, boolean}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.secure_renegotiate", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.secure_renegotiate",
-    [{datatype, boolean}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.versions.$version", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.versions",
-    [{datatype, atom}]}.
-
-{translation, "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.versions",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("cluster_formation.etcd.ssl_options.versions", Conf),
-    [V || {_, V} <- Settings]
-end}.
-
-{mapping, "cluster_formation.etcd.ssl_options.ciphers.$cipher", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.ciphers",
-    [{datatype, string}]}.
-
-{translation, "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.ciphers",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("cluster_formation.etcd.ssl_options.ciphers", Conf),
-    lists:reverse([V || {_, V} <- Settings])
 end}.

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -402,9 +402,13 @@ do_list_schemas_in_app(App, SchemaDir) ->
         {ok, Files} ->
             ?LOG_DEBUG("  [x] ~ts", [App],
                        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
+            %% Match `.schema` exactly so cuttlefish 3.8.0+ partial files
+            %% (`.partial`) and other sidecars (editor swapfiles, OS
+            %% metadata) stay out of `cuttlefish_schema:files/1`.
             [filename:join(SchemaDir, File)
              || [C | _] = File <- Files,
-                C =/= $.];
+                C =/= $.,
+                filename:extension(File) =:= ".schema"];
         error ->
             ?LOG_DEBUG(
               "  [ ] ~ts (no readable schema dir)", [App],

--- a/deps/rabbitmq_stomp/priv/schema/rabbitmq_stomp.schema
+++ b/deps/rabbitmq_stomp/priv/schema/rabbitmq_stomp.schema
@@ -37,88 +37,10 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "stomp.tcp_listen_options", "rabbitmq_stomp.tcp_listen_options", [
-    {datatype, {enum, [none]}}]}.
-
-{translation, "rabbitmq_stomp.tcp_listen_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("stomp.tcp_listen_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid stomp.tcp_listen_options")
-    end
-end}.
-
-{mapping, "stomp.tcp_listen_options.backlog", "rabbitmq_stomp.tcp_listen_options.backlog", [
-    {datatype, integer}
-]}.
-
-{mapping, "stomp.tcp_listen_options.nodelay", "rabbitmq_stomp.tcp_listen_options.nodelay", [
-    {datatype, boolean}
-]}.
-
-{mapping, "stomp.tcp_listen_options.buffer", "rabbitmq_stomp.tcp_listen_options.buffer",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.delay_send", "rabbitmq_stomp.tcp_listen_options.delay_send",
-    [{datatype, boolean}]}.
-
-{mapping, "stomp.tcp_listen_options.dontroute", "rabbitmq_stomp.tcp_listen_options.dontroute",
-    [{datatype, boolean}]}.
-
-{mapping, "stomp.tcp_listen_options.exit_on_close", "rabbitmq_stomp.tcp_listen_options.exit_on_close",
-    [{datatype, boolean}]}.
-
-{mapping, "stomp.tcp_listen_options.fd", "rabbitmq_stomp.tcp_listen_options.fd",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.high_msgq_watermark", "rabbitmq_stomp.tcp_listen_options.high_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.high_watermark", "rabbitmq_stomp.tcp_listen_options.high_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.keepalive", "rabbitmq_stomp.tcp_listen_options.keepalive",
-    [{datatype, boolean}]}.
-
-{mapping, "stomp.tcp_listen_options.low_msgq_watermark", "rabbitmq_stomp.tcp_listen_options.low_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.low_watermark", "rabbitmq_stomp.tcp_listen_options.low_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.port", "rabbitmq_stomp.tcp_listen_options.port",
-    [{datatype, integer}, {validators, ["port"]}]}.
-
-{mapping, "stomp.tcp_listen_options.priority", "rabbitmq_stomp.tcp_listen_options.priority",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.recbuf", "rabbitmq_stomp.tcp_listen_options.recbuf",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.send_timeout", "rabbitmq_stomp.tcp_listen_options.send_timeout",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.send_timeout_close", "rabbitmq_stomp.tcp_listen_options.send_timeout_close",
-    [{datatype, boolean}]}.
-
-{mapping, "stomp.tcp_listen_options.sndbuf", "rabbitmq_stomp.tcp_listen_options.sndbuf",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.tos", "rabbitmq_stomp.tcp_listen_options.tos",
-    [{datatype, integer}]}.
-
-{mapping, "stomp.tcp_listen_options.linger.on", "rabbitmq_stomp.tcp_listen_options.linger",
-    [{datatype, boolean}]}.
-
-{mapping, "stomp.tcp_listen_options.linger.timeout", "rabbitmq_stomp.tcp_listen_options.linger",
-    [{datatype, {integer, non_negative}}]}.
-
-{translation, "rabbitmq_stomp.tcp_listen_options.linger",
-fun(Conf) ->
-    LingerOn = cuttlefish:conf_get("stomp.tcp_listen_options.linger.on", Conf, false),
-    LingerTimeout = cuttlefish:conf_get("stomp.tcp_listen_options.linger.timeout", Conf, 0),
-    {LingerOn, LingerTimeout}
-end}.
+{include_partial, {rabbit, "tcp_listen_options"},
+    [{prefix, "stomp.tcp_listen_options"},
+     {app_prefix, "rabbitmq_stomp.tcp_listen_options"},
+     {disable_with, none}]}.
 
 
 %%

--- a/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
+++ b/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
@@ -37,88 +37,10 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "stream.tcp_listen_options", "rabbitmq_stream.tcp_listen_options", [
-    {datatype, {enum, [none]}}]}.
-
-{translation, "rabbitmq_stream.tcp_listen_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("stream.tcp_listen_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid stream.tcp_listen_options")
-    end
-end}.
-
-{mapping, "stream.tcp_listen_options.backlog", "rabbitmq_stream.tcp_listen_options.backlog", [
-    {datatype, integer}
-]}.
-
-{mapping, "stream.tcp_listen_options.nodelay", "rabbitmq_stream.tcp_listen_options.nodelay", [
-    {datatype, boolean}
-]}.
-
-{mapping, "stream.tcp_listen_options.buffer", "rabbitmq_stream.tcp_listen_options.buffer",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.delay_send", "rabbitmq_stream.tcp_listen_options.delay_send",
-    [{datatype, boolean}]}.
-
-{mapping, "stream.tcp_listen_options.dontroute", "rabbitmq_stream.tcp_listen_options.dontroute",
-    [{datatype, boolean}]}.
-
-{mapping, "stream.tcp_listen_options.exit_on_close", "rabbitmq_stream.tcp_listen_options.exit_on_close",
-    [{datatype, boolean}]}.
-
-{mapping, "stream.tcp_listen_options.fd", "rabbitmq_stream.tcp_listen_options.fd",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.high_msgq_watermark", "rabbitmq_stream.tcp_listen_options.high_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.high_watermark", "rabbitmq_stream.tcp_listen_options.high_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.keepalive", "rabbitmq_stream.tcp_listen_options.keepalive",
-    [{datatype, boolean}]}.
-
-{mapping, "stream.tcp_listen_options.low_msgq_watermark", "rabbitmq_stream.tcp_listen_options.low_msgq_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.low_watermark", "rabbitmq_stream.tcp_listen_options.low_watermark",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.port", "rabbitmq_stream.tcp_listen_options.port",
-    [{datatype, integer}, {validators, ["port"]}]}.
-
-{mapping, "stream.tcp_listen_options.priority", "rabbitmq_stream.tcp_listen_options.priority",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.recbuf", "rabbitmq_stream.tcp_listen_options.recbuf",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.send_timeout", "rabbitmq_stream.tcp_listen_options.send_timeout",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.send_timeout_close", "rabbitmq_stream.tcp_listen_options.send_timeout_close",
-    [{datatype, boolean}]}.
-
-{mapping, "stream.tcp_listen_options.sndbuf", "rabbitmq_stream.tcp_listen_options.sndbuf",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.tos", "rabbitmq_stream.tcp_listen_options.tos",
-    [{datatype, integer}]}.
-
-{mapping, "stream.tcp_listen_options.linger.on", "rabbitmq_stream.tcp_listen_options.linger",
-    [{datatype, boolean}]}.
-
-{mapping, "stream.tcp_listen_options.linger.timeout", "rabbitmq_stream.tcp_listen_options.linger",
-    [{datatype, {integer, non_negative}}]}.
-
-{translation, "rabbitmq_stream.tcp_listen_options.linger",
-fun(Conf) ->
-    LingerOn = cuttlefish:conf_get("stream.tcp_listen_options.linger.on", Conf, false),
-    LingerTimeout = cuttlefish:conf_get("stream.tcp_listen_options.linger.timeout", Conf, 0),
-    {LingerOn, LingerTimeout}
-end}.
+{include_partial, {rabbit, "tcp_listen_options"},
+    [{prefix, "stream.tcp_listen_options"},
+     {app_prefix, "rabbitmq_stream.tcp_listen_options"},
+     {disable_with, none}]}.
 
 %% Number of Erlang processes that will accept connections for the TCP listener
 %%

--- a/deps/rabbitmq_trust_store/priv/schema/rabbitmq_trust_store.schema
+++ b/deps/rabbitmq_trust_store/priv/schema/rabbitmq_trust_store.schema
@@ -48,110 +48,41 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "trust_store.ssl_options", "rabbitmq_trust_store.ssl_options", [
-    {datatype, {enum, [none]}}
-]}.
+{include_partial, {rabbit, "ssl_options"},
+    [{prefix, "trust_store.ssl_options"},
+     {app_prefix, "rabbitmq_trust_store.ssl_options"},
+     {disable_with, none}]}.
 
-{translation, "rabbitmq_trust_store.ssl_options",
-fun(Conf) ->
-    case cuttlefish:conf_get("trust_store.ssl_options", Conf, undefined) of
-        none -> [];
-        _    -> cuttlefish:invalid("Invalid ssl_options")
-    end
-end}.
+%% `key.*` is kept inline so the no-match branch stays the atom
+%% `undefined`, matching the historical (and buggy) translation shape.
 
-{mapping, "trust_store.ssl_options.verify", "rabbitmq_trust_store.ssl_options.verify", [
-    {datatype, {enum, [verify_peer, verify_none]}}]}.
-
-{mapping, "trust_store.ssl_options.fail_if_no_peer_cert", "rabbitmq_trust_store.ssl_options.fail_if_no_peer_cert", [
-    {datatype, boolean}]}.
-
-{mapping, "trust_store.ssl_options.cacertfile", "rabbitmq_trust_store.ssl_options.cacertfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "trust_store.ssl_options.certfile", "rabbitmq_trust_store.ssl_options.certfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
-
-{mapping, "trust_store.ssl_options.cert", "rabbitmq_trust_store.ssl_options.cert",
+{mapping, "trust_store.ssl_options.key.RSAPrivateKey",
+    "rabbitmq_trust_store.ssl_options.key",
     [{datatype, string}]}.
 
-{translation, "rabbitmq_trust_store.ssl_options.cert",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("trust_store.ssl_options.cert", Conf))
-end}.
-
-{mapping, "trust_store.ssl_options.client_renegotiation", "rabbitmq_trust_store.ssl_options.client_renegotiation",
-    [{datatype, boolean}]}.
-
-{mapping, "trust_store.ssl_options.crl_check", "rabbitmq_trust_store.ssl_options.crl_check",
-    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
-
-{mapping, "trust_store.ssl_options.depth", "rabbitmq_trust_store.ssl_options.depth",
-    [{datatype, byte}]}.
-
-{mapping, "trust_store.ssl_options.dh", "rabbitmq_trust_store.ssl_options.dh",
+{mapping, "trust_store.ssl_options.key.DSAPrivateKey",
+    "rabbitmq_trust_store.ssl_options.key",
     [{datatype, string}]}.
 
-{translation, "rabbitmq_trust_store.ssl_options.dh",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("trust_store.ssl_options.dh", Conf))
-end}.
-
-{mapping, "trust_store.ssl_options.dhfile", "rabbitmq_trust_store.ssl_options.dhfile",
-    [{datatype, string}, {validators, ["file_accessible"]}]}.
-
-{mapping, "trust_store.ssl_options.honor_cipher_order", "rabbitmq_trust_store.ssl_options.honor_cipher_order",
-    [{datatype, boolean}]}.
-
-{mapping, "trust_store.ssl_options.key.RSAPrivateKey", "rabbitmq_trust_store.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "trust_store.ssl_options.key.DSAPrivateKey", "rabbitmq_trust_store.ssl_options.key",
-    [{datatype, string}]}.
-
-{mapping, "trust_store.ssl_options.key.PrivateKeyInfo", "rabbitmq_trust_store.ssl_options.key",
+{mapping, "trust_store.ssl_options.key.PrivateKeyInfo",
+    "rabbitmq_trust_store.ssl_options.key",
     [{datatype, string}]}.
 
 {translation, "rabbitmq_trust_store.ssl_options.key",
 fun(Conf) ->
-    case cuttlefish_variable:filter_by_prefix("trust_store.ssl_options.key", Conf) of
+    case cuttlefish_variable:filter_by_prefix(
+           "trust_store.ssl_options.key", Conf) of
         [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
         _ -> undefined
     end
 end}.
 
-{mapping, "trust_store.ssl_options.keyfile", "rabbitmq_trust_store.ssl_options.keyfile",
-    [{datatype, string}, {validators, ["pem_file"]}]}.
+%% trust_store additions on top of the shared partial.
 
-{mapping, "trust_store.ssl_options.log_alert", "rabbitmq_trust_store.ssl_options.log_alert",
+{mapping, "trust_store.ssl_options.client_renegotiation",
+    "rabbitmq_trust_store.ssl_options.client_renegotiation",
     [{datatype, boolean}]}.
 
-{mapping, "trust_store.ssl_options.password", "rabbitmq_trust_store.ssl_options.password",
-    [{datatype, [tagged_binary, binary]}]}.
-
-{mapping, "trust_store.ssl_options.psk_identity", "rabbitmq_trust_store.ssl_options.psk_identity",
-    [{datatype, string}]}.
-
-{mapping, "trust_store.ssl_options.reuse_sessions", "rabbitmq_trust_store.ssl_options.reuse_sessions",
+{mapping, "trust_store.ssl_options.honor_cipher_order",
+    "rabbitmq_trust_store.ssl_options.honor_cipher_order",
     [{datatype, boolean}]}.
-
-{mapping, "trust_store.ssl_options.secure_renegotiate", "rabbitmq_trust_store.ssl_options.secure_renegotiate",
-    [{datatype, boolean}]}.
-
-{mapping, "trust_store.ssl_options.versions.$version", "rabbitmq_trust_store.ssl_options.versions",
-    [{datatype, atom}]}.
-
-{translation, "rabbitmq_trust_store.ssl_options.versions",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("trust_store.ssl_options.versions", Conf),
-    [ V || {_, V} <- Settings ]
-end}.
-
-{mapping, "trust_store.ssl_options.ciphers.$cipher", "rabbitmq_trust_store.ssl_options.ciphers",
-    [{datatype, string}]}.
-
-{translation, "rabbitmq_trust_store.ssl_options.ciphers",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("trust_store.ssl_options.ciphers", Conf),
-    lists:reverse([V || {_, V} <- Settings])
-end}.

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -46,7 +46,7 @@ endif
 dep_cowboy = hex 2.15.0
 dep_cowlib = hex 2.16.1
 dep_credentials_obfuscation = hex 3.5.0
-dep_cuttlefish = hex 3.8.0
+dep_cuttlefish = hex 3.9.1
 dep_gen_batch_server = hex 0.10.0
 dep_gun = hex 2.3.0
 dep_jose = hex 1.11.12


### PR DESCRIPTION
All changes are backwards compatible and meant to
reduce `*.schema` file duplication using Cuttlefish 3.8 and 3.9's features.

`main` and `v4.2.x` versions will be submitted as separate PRs. In this case it was easier
to do it this way instead of tranditional backporting:

 * [`main`](https://github.com/rabbitmq/rabbitmq-server/pull/16576)
 * [`v4.2.x`](https://github.com/rabbitmq/rabbitmq-server/pull/16578)