### PR TITLE
Extract `rabbit_re`, use it in more places

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_filter_sql.erl
+++ b/deps/rabbit/src/rabbit_amqp_filter_sql.erl
@@ -255,16 +255,12 @@ like(Subject,{{prefix, PrefixSize, _} = Prefix,
     like(Subject, Suffix);
 like(Subject, CompiledRe)
   when element(1, CompiledRe) =:= re_pattern ->
-    try re:run(Subject, CompiledRe, [{capture, none},
-                                     {match_limit, 50_000},
-                                     {match_limit_recursion, 50_000}]) of
-        match ->
-            true;
-        _ ->
-            false
-    catch error:badarg ->
-              %% This branch is hit if Subject is not a UTF-8 string.
-              undefined
+    case rabbit_re:run(Subject, CompiledRe) of
+        match           -> true;
+        nomatch         -> false;
+        %% Subject is not a UTF-8 string.
+        {error, badarg} -> undefined;
+        {error, _}      -> false
     end.
 
 get_field_value(priority, Msg) ->

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -493,7 +493,7 @@ get_resource_vhost_name(#resource{virtual_host = VHostName}) ->
     VHostName.
 
 is_match(Subj, RegEx) ->
-   nomatch /= re:run(Subj, RegEx).
+   rabbit_re:matches(Subj, RegEx).
 
 iterative_rebalance(ByNode, MaxQueuesDesired) ->
     case maybe_migrate(ByNode, MaxQueuesDesired) of

--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -155,9 +155,11 @@ check_resource_access(#auth_user{username = Username},
                              <<"">> -> <<$^, $$>>;
                              RE     -> RE
                          end,
-            case re:run(Name, PermRegexp, [{capture, none}]) of
-                match    -> true;
-                nomatch  -> false
+            case rabbit_re:run(Name, PermRegexp) of
+                match   -> true;
+                nomatch -> false;
+                %% Deny on regex error.
+                _Error  -> false
             end
     end.
 
@@ -180,9 +182,11 @@ check_topic_access(#auth_user{username = Username},
                 PermRegexp,
                 maps:get(variable_map, Context, undefined)
             ),
-            case re:run(maps:get(routing_key, Context), PermRegexpExpanded, [{capture, none}]) of
-                match    -> true;
-                nomatch  -> false
+            case rabbit_re:run(maps:get(routing_key, Context),
+                               PermRegexpExpanded) of
+                match   -> true;
+                nomatch -> false;
+                _Error  -> false
             end
     end.
 
@@ -497,7 +501,7 @@ set_permissions(Username, VirtualHost, ConfigurePerm, WritePerm, ReadPerm, Actin
     _ = lists:map(
       fun (RegexpBin) ->
               Regexp = binary_to_list(RegexpBin),
-              case re:compile(Regexp) of
+              case rabbit_re:compile(Regexp) of
                   {ok, _}         -> ok;
                   {error, Reason} ->
                       ?LOG_WARNING("Failed to set permissions for user '~ts' in virtual host '~ts': "
@@ -605,7 +609,7 @@ set_topic_permissions(Username, VirtualHost, Exchange, WritePerm, ReadPerm, Acti
     ReadPermRegex = rabbit_data_coercion:to_binary(ReadPerm),
     lists:foreach(
       fun (RegexpBin) ->
-              case re:compile(RegexpBin) of
+              case rabbit_re:compile(RegexpBin) of
                   {ok, _}         -> ok;
                   {error, Reason} ->
                       ?LOG_WARNING("Failed to set topic permissions on exchange '~ts' for user "

--- a/deps/rabbit/src/rabbit_event_consumer.erl
+++ b/deps/rabbit/src/rabbit_event_consumer.erl
@@ -47,7 +47,7 @@ handle_event(#event{type      = Type,
                                               pattern = Pattern} = State) ->
     _ = case key(Type) of
         ignore -> ok;
-        Key    -> case re:run(Key, Pattern, [{capture, none}]) of
+        Key    -> case rabbit_re:run(Key, Pattern) of
                       match ->
                           Data = [{'event', Key}] ++
                               fmt_proplist([{'timestamp_in_ms', TS} | Props]),

--- a/deps/rabbit/src/rabbit_parameter_validation.erl
+++ b/deps/rabbit/src/rabbit_parameter_validation.erl
@@ -50,10 +50,14 @@ list(Name, Term) ->
     {error, "~ts should be list, actually was ~tp", [Name, Term]}.
 
 regex(Name, Term) when is_binary(Term) ->
-    case re:compile(Term) of
-        {ok, _}         -> ok;
-        {error, Reason} -> {error, "~ts should be regular expression "
-                                   "but is invalid: ~tp", [Name, Reason]}
+    case rabbit_re:compile(Term) of
+        {ok, _}                  -> ok;
+        {error, pattern_too_long} ->
+            {error, "~ts must not exceed ~b bytes",
+             [Name, rabbit_re:max_pattern_length()]};
+        {error, Reason}          ->
+            {error, "~ts should be regular expression "
+                    "but is invalid: ~tp", [Name, Reason]}
     end;
 regex(Name, Term) ->
     {error, "~ts should be a binary but was ~tp", [Name, Term]}.

--- a/deps/rabbit/src/rabbit_policy.erl
+++ b/deps/rabbit/src/rabbit_policy.erl
@@ -210,7 +210,7 @@ matches(Q, Policy, Function) when ?is_amqqueue(Q) ->
     #resource{name = Name, virtual_host = VHost} = amqqueue:get_name(Q),
     matches_queue_type(queue, amqqueue:get_type(Q), pget('apply-to', Policy)) andalso
         is_applicable(Q, pget(definition, Policy), Function) andalso
-        match =:= re:run(Name, pget(pattern, Policy), [{capture, none}]) andalso
+        match =:= rabbit_re:run(Name, pget(pattern, Policy)) andalso
         VHost =:= pget(vhost, Policy);
 matches(#resource{kind = queue} = Resource, Policy, Function) ->
     {ok, Q} = rabbit_amqqueue:lookup(Resource),
@@ -218,7 +218,7 @@ matches(#resource{kind = queue} = Resource, Policy, Function) ->
 matches(#resource{name = Name, kind = Kind, virtual_host = VHost} = Resource, Policy, Function) ->
     matches_type(Kind, pget('apply-to', Policy)) andalso
         is_applicable(Resource, pget(definition, Policy), Function) andalso
-        match =:= re:run(Name, pget(pattern, Policy), [{capture, none}]) andalso
+        match =:= rabbit_re:run(Name, pget(pattern, Policy)) andalso
         VHost =:= pget(vhost, Policy).
 
 get0(_Name, undefined, undefined) -> undefined;

--- a/deps/rabbit/src/rabbit_queue_type_ra.erl
+++ b/deps/rabbit/src/rabbit_queue_type_ra.erl
@@ -208,7 +208,7 @@ matches_strategy(even, Members) ->
     length(Members) rem 2 =:= 0.
 
 is_match(Subject, RE) ->
-    match =:= re:run(Subject, RE, [{capture, none}]).
+    rabbit_re:matches(Subject, RE).
 
 get_resource_name(#resource{name = Name}) ->
     Name.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1912,7 +1912,7 @@ matches_strategy(even, Members) ->
     length(Members) rem 2 == 0.
 
 is_match(Subj, E) ->
-   nomatch /= re:run(Subj, E).
+   rabbit_re:matches(Subj, E).
 
 -spec reclaim_memory(rabbit_types:r(queue)) -> ok | {error, term()}.
 reclaim_memory(#resource{virtual_host = Vhost, name = QueueName}) ->
@@ -2700,7 +2700,7 @@ leader_health_check(QueueNameOrRegEx, VHost, ProcessLimitThreshold) ->
         lists:flatten(
             [begin
                 {resource, _VHostN, queue, QueueName} = QResource = amqqueue:get_name(Q),
-                case re:run(QueueName, QueueNameOrRegEx, [{capture, none}]) of
+                case rabbit_re:run(QueueName, QueueNameOrRegEx) of
                     match ->
                         {ClusterName, _} = rabbit_amqqueue:pid_of(Q),
                         _Pid = spawn(fun() -> run_leader_health_check(ClusterName, QResource, HealthCheckRef, ParentPID) end);

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1215,7 +1215,7 @@ matches_strategy(even, Members) ->
     length(Members) rem 2 == 0.
 
 is_match(Subj, E) ->
-    nomatch /= re:run(Subj, E).
+    rabbit_re:matches(Subj, E).
 
 get_resource_name(#resource{name = Name}) ->
     Name.

--- a/deps/rabbit_common/src/rabbit_re.erl
+++ b/deps/rabbit_common/src/rabbit_re.erl
@@ -1,0 +1,78 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_re).
+
+-export([run/2, run/3,
+         matches/2, matches/3,
+         compile/1, compile/2,
+         match_limit/0,
+         max_pattern_length/0]).
+
+-define(MATCH_LIMIT, 50_000).
+-define(MAX_PATTERN_LENGTH, 1024).
+
+-spec match_limit() -> pos_integer().
+match_limit() -> ?MATCH_LIMIT.
+
+-spec max_pattern_length() -> pos_integer().
+max_pattern_length() -> ?MAX_PATTERN_LENGTH.
+
+-spec run(iodata() | unicode:charlist(), re:mp() | iodata()) ->
+    match | nomatch | {error, term()}.
+run(Subject, Pattern) ->
+    run(Subject, Pattern, [{capture, none}]).
+
+-spec run(iodata() | unicode:charlist(),
+          re:mp() | iodata(),
+          re:options()) ->
+    {match, [{integer(), integer()} | binary() | string()]}
+  | match
+  | nomatch
+  | {error, term()}.
+run(Subject, Pattern, Opts) ->
+    try
+        re:run(Subject, Pattern,
+               [{match_limit, ?MATCH_LIMIT},
+                {match_limit_recursion, ?MATCH_LIMIT}
+                | Opts])
+    catch
+        %% `re:run/3` raises on malformed patterns and other shape errors.
+        %% Surface them as a safe error tuple so callers do not need to
+        %% wrap every call in `try`.
+        error:Reason -> {error, Reason}
+    end.
+
+-spec matches(iodata() | unicode:charlist(), re:mp() | iodata()) -> boolean().
+matches(Subject, Pattern) ->
+    matches(Subject, Pattern, []).
+
+-spec matches(iodata() | unicode:charlist(),
+              re:mp() | iodata(),
+              re:options()) -> boolean().
+matches(Subject, Pattern, Opts) ->
+    %% `{capture, none}` must come last because `re:run/3` resolves
+    %% repeated capture options with last-wins precedence.
+    case run(Subject, Pattern, Opts ++ [{capture, none}]) of
+        match -> true;
+        _     -> false
+    end.
+
+-spec compile(iodata()) -> {ok, re:mp()} | {error, term()}.
+compile(Pattern) ->
+    compile(Pattern, []).
+
+-spec compile(iodata(), re:compile_options()) ->
+    {ok, re:mp()} | {error, term()}.
+compile(Pattern, _Opts) when is_binary(Pattern),
+                             byte_size(Pattern) > ?MAX_PATTERN_LENGTH ->
+    {error, pattern_too_long};
+compile(Pattern, _Opts) when is_list(Pattern),
+                             length(Pattern) > ?MAX_PATTERN_LENGTH ->
+    {error, pattern_too_long};
+compile(Pattern, Opts) ->
+    re:compile(Pattern, Opts).

--- a/deps/rabbit_common/test/rabbit_re_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_re_SUITE.erl
@@ -1,0 +1,223 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_re_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-define(NUM_TESTS, 256).
+-define(PROPER_OPTS, [{numtests, ?NUM_TESTS}, {to_file, user}]).
+
+all() ->
+    [{group, units}, {group, properties}].
+
+groups() ->
+    [{units, [parallel],
+      [match_ascii_substring,
+       no_match_returns_nomatch,
+       match_returns_atom_match_with_capture_none,
+       run_with_compiled_pattern,
+       run_with_extra_capture_option,
+       run_bounded_by_match_limit,
+       run_converts_re_badarg_to_error_tuple,
+       matches_returns_true_for_match,
+       matches_returns_false_for_nomatch,
+       matches_returns_false_for_malformed_pattern,
+       matches_bounded_by_match_limit,
+       matches_ignores_caller_capture_option,
+       compile_accepts_ascii_pattern,
+       compile_accepts_binary_at_cap,
+       compile_rejects_binary_just_over_cap,
+       compile_rejects_charlist_just_over_cap,
+       compile_returns_re_error_for_invalid_pattern,
+       compile_with_options_passes_them_through,
+       match_limit_constant,
+       max_pattern_length_constant]},
+     {properties, [parallel],
+      [run_agrees_with_re_for_short_inputs_prop,
+       compile_returns_too_long_for_overlong_input_prop,
+       run_returns_safe_atom_or_error_prop,
+       matches_always_returns_boolean_prop]}].
+
+%% Tests
+
+match_ascii_substring(_Config) ->
+    match = rabbit_re:run(<<"hello world">>, <<"world">>),
+    ok.
+
+no_match_returns_nomatch(_Config) ->
+    nomatch = rabbit_re:run(<<"hello">>, <<"^world$">>),
+    ok.
+
+match_returns_atom_match_with_capture_none(_Config) ->
+    match = rabbit_re:run(<<"queue-prod-001">>, <<"^queue-prod-">>),
+    ok.
+
+run_with_compiled_pattern(_Config) ->
+    {ok, MP} = rabbit_re:compile(<<"^queue-">>),
+    match = rabbit_re:run(<<"queue-prod-001">>, MP),
+    ok.
+
+run_with_extra_capture_option(_Config) ->
+    {match, [<<"prod">>]} =
+        rabbit_re:run(<<"queue-prod-001">>,
+                      <<"queue-(\\w+)-\\d+">>,
+                      [{capture, all_but_first, binary}]),
+    ok.
+
+run_converts_re_badarg_to_error_tuple(_Config) ->
+    %% `re:run/3` raises `badarg` on some inputs; the helper surfaces this
+    %% as `{error, _}` so callers do not need a `try`.
+    {error, _} = rabbit_re:run(<<>>, <<"(">>),
+    ok.
+
+matches_returns_true_for_match(_Config) ->
+    true = rabbit_re:matches(<<"queue-prod-001">>, <<"^queue-prod-">>),
+    ok.
+
+matches_returns_false_for_nomatch(_Config) ->
+    false = rabbit_re:matches(<<"hello">>, <<"^world$">>),
+    ok.
+
+matches_returns_false_for_malformed_pattern(_Config) ->
+    false = rabbit_re:matches(<<"anything">>, <<"(">>),
+    ok.
+
+matches_bounded_by_match_limit(_Config) ->
+    Pat   = <<"^(a+)+$">>,
+    Input = <<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab">>,
+    {Time, Result} = timer:tc(fun() -> rabbit_re:matches(Input, Pat) end),
+    true = Time < 1_000_000,
+    true = is_boolean(Result),
+    ok.
+
+matches_ignores_caller_capture_option(_Config) ->
+    %% A caller-supplied capture option must not change the boolean result.
+    true  = rabbit_re:matches(<<"queue-prod-001">>,
+                              <<"queue-(\\w+)-\\d+">>,
+                              [{capture, all_but_first, binary}]),
+    false = rabbit_re:matches(<<"hello">>,
+                              <<"^world">>,
+                              [{capture, all_but_first, binary}]),
+    ok.
+
+run_bounded_by_match_limit(_Config) ->
+    Pat   = <<"^(a+)+$">>,
+    Input = <<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab">>,
+    {Time, Result} = timer:tc(fun() -> rabbit_re:run(Input, Pat) end),
+    true = Time < 1_000_000,
+    true = case Result of
+               match      -> true;
+               nomatch    -> true;
+               {match, _} -> true;
+               {error, _} -> true;
+               _          -> false
+           end,
+    ok.
+
+compile_accepts_ascii_pattern(_Config) ->
+    {ok, _} = rabbit_re:compile(<<"^queue-[a-z]+-\\d+$">>),
+    ok.
+
+compile_accepts_binary_at_cap(_Config) ->
+    Pat = binary:copy(<<"a">>, rabbit_re:max_pattern_length()),
+    {ok, _} = rabbit_re:compile(Pat),
+    ok.
+
+compile_rejects_binary_just_over_cap(_Config) ->
+    Pat = binary:copy(<<"a">>, rabbit_re:max_pattern_length() + 1),
+    {error, pattern_too_long} = rabbit_re:compile(Pat),
+    ok.
+
+compile_rejects_charlist_just_over_cap(_Config) ->
+    Pat = lists:duplicate(rabbit_re:max_pattern_length() + 1, $a),
+    {error, pattern_too_long} = rabbit_re:compile(Pat),
+    ok.
+
+compile_returns_re_error_for_invalid_pattern(_Config) ->
+    {error, _} = rabbit_re:compile(<<"(unclosed">>),
+    ok.
+
+compile_with_options_passes_them_through(_Config) ->
+    {ok, MP1} = rabbit_re:compile(<<"abc">>, [caseless]),
+    match = rabbit_re:run(<<"ABC">>, MP1),
+    ok.
+
+match_limit_constant(_Config) ->
+    Limit = rabbit_re:match_limit(),
+    true = is_integer(Limit) andalso Limit > 0,
+    ok.
+
+max_pattern_length_constant(_Config) ->
+    Len = rabbit_re:max_pattern_length(),
+    true = is_integer(Len) andalso Len > 0,
+    ok.
+
+%% Property runners
+
+run_agrees_with_re_for_short_inputs_prop(_Config) ->
+    true = proper:quickcheck(run_agrees_with_re_for_short_inputs(),
+                             ?PROPER_OPTS).
+
+compile_returns_too_long_for_overlong_input_prop(_Config) ->
+    true = proper:quickcheck(compile_returns_too_long_for_overlong_input(),
+                             ?PROPER_OPTS).
+
+run_returns_safe_atom_or_error_prop(_Config) ->
+    true = proper:quickcheck(run_returns_safe_atom_or_error(),
+                             ?PROPER_OPTS).
+
+matches_always_returns_boolean_prop(_Config) ->
+    true = proper:quickcheck(matches_always_returns_boolean(),
+                             ?PROPER_OPTS).
+
+%% Properties
+
+run_agrees_with_re_for_short_inputs() ->
+    %% On short alphanumeric inputs the helper agrees with plain `re:run/3`.
+    ?FORALL({Subject, Pattern}, {short_alpha_binary(), short_alpha_binary()},
+            begin
+                Bare = case re:run(Subject, Pattern, [{capture, none}]) of
+                           match   -> match;
+                           nomatch -> nomatch
+                       end,
+                Helper = rabbit_re:run(Subject, Pattern),
+                Bare =:= Helper
+            end).
+
+compile_returns_too_long_for_overlong_input() ->
+    ?FORALL(Extra, non_neg_integer(),
+            begin
+                Len = rabbit_re:max_pattern_length() + Extra + 1,
+                Pat = binary:copy(<<"a">>, Len),
+                {error, pattern_too_long} =:= rabbit_re:compile(Pat)
+            end).
+
+run_returns_safe_atom_or_error() ->
+    %% The helper returns one of the documented shapes for any binary input.
+    ?FORALL({Subject, Pattern}, {binary(), binary()},
+            case rabbit_re:run(Subject, Pattern) of
+                match           -> true;
+                nomatch         -> true;
+                {match, _}      -> true;
+                {error, _}      -> true;
+                _Other          -> false
+            end).
+
+matches_always_returns_boolean() ->
+    ?FORALL({Subject, Pattern}, {binary(), binary()},
+            is_boolean(rabbit_re:matches(Subject, Pattern))).
+
+%% Generators
+
+short_alpha_binary() ->
+    ?LET(L,
+         list(oneof([integer($a, $z), integer($0, $9), $-])),
+         list_to_binary(lists:sublist(L, 30))).

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_scope.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_scope.erl
@@ -127,12 +127,18 @@ regex_full_string_match(_, _) ->
 do_regex_full_string_match(Subject, Pattern) ->
     Wrapped = <<"\\A(?:", Pattern/binary, ")\\z">>,
     try
+        %% OAuth 2 enforces its own pattern length limit
+        %% (`?MAX_REGEX_PATTERN_BYTES`), which is higher than
+        %% `rabbit_re:compile/2`'s.
         case re:compile(Wrapped, [unicode, anchored, ucp]) of
             {ok, MP} ->
+                %% Caller-supplied `match_limit` and `match_limit_recursion`
+                %% override `rabbit_re`'s defaults via `re:run/3`'s last-wins
+                %% rule, keeping OAuth 2's tighter bounds.
                 Opts = [{capture, none},
                         {match_limit, ?REGEX_MATCH_LIMIT},
                         {match_limit_recursion, ?REGEX_MATCH_LIMIT_RECURSION}],
-                case re:run(Subject, MP, Opts) of
+                case rabbit_re:run(Subject, MP, Opts) of
                     match ->
                         true;
                     nomatch ->

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_parameters.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_parameters.erl
@@ -124,10 +124,14 @@ validate_policy([{<<"federation-upstream-set">>, Value}]) ->
 
 validate_policy([{<<"federation-upstream-pattern">>, Value}])
   when is_binary(Value) ->
-    case re:compile(Value) of
-        {ok, _}         -> ok;
-        {error, Reason} -> {error, "could not compile pattern ~ts to a regular expression. "
-                                   "Error: ~tp", [Value, Reason]}
+    case rabbit_re:compile(Value) of
+        {ok, _}                  -> ok;
+        {error, pattern_too_long} ->
+            {error, "federation-upstream-pattern must not exceed ~b bytes",
+             [rabbit_re:max_pattern_length()]};
+        {error, Reason}          ->
+            {error, "could not compile pattern ~ts to a regular expression. "
+                    "Error: ~tp", [Value, Reason]}
     end;
 validate_policy([{<<"federation-upstream-pattern">>, Value}]) ->
     {error, "~tp is not a valid federation upstream pattern name", [Value]};

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -102,7 +102,7 @@ find_contents(RegExp, VHost) ->
     Upstreams0 = rabbit_runtime_parameters:list(
                     VHost, <<"federation-upstream">>),
     Upstreams  = [rabbit_data_coercion:to_list(U) || U <- Upstreams0,
-                    re:run(pget(name, U), RegExp) =/= nomatch],
+                    rabbit_re:matches(pget(name, U), RegExp)],
     [[{<<"upstream">>, pget(name, U)}] || U <- Upstreams].
 
 from_set_contents(Set, XorQ) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -512,9 +512,7 @@ maybe_filter_context(List, _) ->
 
 
 match_value({_, Value}, ValueTag, UseRegex) when UseRegex =:= "true" ->
-    case re:run(Value, ValueTag, [caseless,
-                                  {match_limit, 50_000},
-                                  {match_limit_recursion, 50_000}]) of
+    case rabbit_re:run(Value, ValueTag, [caseless]) of
         {match, _} -> true;
         {error, _} -> false;
         nomatch -> false

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -962,9 +962,7 @@ queue_filter_from_pdict() ->
 matches_queue_filter(_QName, false) ->
     true;
 matches_queue_filter(QName, MP) ->
-    re:run(QName, MP, [{capture, none},
-                       {match_limit, 50_000},
-                       {match_limit_recursion, 50_000}]) =:= match.
+    rabbit_re:matches(QName, MP).
 
 filter_by_queue_name(Rows, false) ->
     Rows;

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
@@ -104,10 +104,7 @@ build_filter_fun(VHostFilterFun, undefined) ->
     VHostFilterFun;
 build_filter_fun(VHostFilterFun, QueueFilter) ->
     fun(#{queue := Q} = Labels) ->
-            VHostFilterFun(Labels) andalso re:run(Q, QueueFilter,
-                                                  [{capture, none},
-                                                   {match_limit, 50_000},
-                                                   {match_limit_recursion, 50_000}]) =:= match;
+            VHostFilterFun(Labels) andalso rabbit_re:matches(Q, QueueFilter);
        (_) ->
             false
     end.


### PR DESCRIPTION
To avoid repetition of a few defensive settings at every call site.

The OAuth 2 plugin is an exception because it matches on a JWT token value which can be longer that the limit `rabbit_re` enforces.