### PR TITLE
Await stream sync on await_online_quorum_plus_one

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -56,7 +56,9 @@
          ra_local_query/1]).
 
 -export([log_overview/1,
-         key_metrics_rpc/1]).
+         key_metrics_rpc/1,
+         is_replica_fresh/2,
+         is_replication_stale/2]).
 
 %% for SAC coordinator
 -export([sac_state/1,
@@ -214,11 +216,7 @@ add_replica(Q, Node) when ?is_amqqueue(Q) ->
     Pid = amqqueue:get_pid(Q),
     try
         ReplState0 = osiris_writer:query_replication_state(Pid),
-        {{_, InitTs}, ReplState} = maps:take(node(Pid), ReplState0),
-        {MaxTs, MinTs} = maps:fold(fun (_, {_, Ts}, {Max, Min}) ->
-                                           {max(Ts, Max), min(Ts, Min)}
-                                   end, {InitTs, InitTs}, ReplState),
-        case (MaxTs - MinTs) > ?REPLICA_FRESHNESS_LIMIT_MS of
+        case is_replication_stale(node(Pid), ReplState0) of
             true ->
                 {error, {disallowed, out_of_sync_replica}};
             false ->
@@ -237,6 +235,24 @@ add_replica(Q, Node) when ?is_amqqueue(Q) ->
         _:Error ->
             {error, Error}
     end.
+
+-spec is_replication_stale(node(), map()) -> boolean().
+is_replication_stale(LeaderNode, ReplState0) ->
+    case maps:take(LeaderNode, ReplState0) of
+        {{_, LeaderTs}, ReplState} ->
+            maps:fold(fun(_, {_, Ts}, Acc) ->
+                              Acc orelse not is_replica_fresh(LeaderTs, Ts)
+                      end, false, ReplState);
+        error ->
+            true
+    end.
+
+-spec is_replica_fresh(integer(), integer()) -> boolean().
+is_replica_fresh(LeaderTs, ReplicaTs)
+  when is_integer(LeaderTs) andalso is_integer(ReplicaTs) ->
+    (LeaderTs - ReplicaTs) =< (?REPLICA_FRESHNESS_LIMIT_MS);
+is_replica_fresh(_, _) ->
+    false.
 
 delete_replica(StreamId, Node) ->
     process_command({delete_replica, StreamId, #{node => Node}}).

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -905,9 +905,17 @@ status(Vhost, QueueName) ->
         {ok, Q} when ?amqqueue_is_quorum(Q) ->
             {error, quorum_queue_not_supported};
         {ok, Q} when ?amqqueue_is_stream(Q) ->
+            FreshnessMap = case amqqueue:get_pid(Q) of
+                               none -> #{};
+                               LeaderPid -> replica_freshness(LeaderPid)
+                           end,
             [begin
+                 Node = maps:get(node, C),
+                 FreshnessVal = maps:get(Node, FreshnessMap, {false, undefined, undefined}),
+                 SyncStatus = format_sync_status(maps:is_key(epoch, C), FreshnessVal),
                  [get_key(role, C),
                   get_key(node, C),
+                  {synchronized, SyncStatus},
                   get_key(epoch, C),
                   get_key(offset, C),
                   get_key(committed_offset, C),
@@ -924,6 +932,29 @@ status(Vhost, QueueName) ->
 
 get_key(Key, Cnt) ->
     {Key, maps:get(Key, Cnt, undefined)}.
+
+format_sync_status(false, _) ->
+    <<"unknown">>;
+format_sync_status(true, {IsFresh, TimeLag, OffsetLag}) ->
+    IsFreshStr = format_boolean(IsFresh),
+    TimeLagStr =
+        case TimeLag of
+            undefined -> <<"unknown">>;
+            _         -> list_to_binary(integer_to_list(TimeLag) ++ "ms")
+        end,
+    OffsetLagStr =
+        case OffsetLag of
+            undefined -> <<"unknown">>;
+            _         ->
+                list_to_binary(integer_to_list(OffsetLag) ++ " msgs")
+        end,
+    <<IsFreshStr/binary, " (", TimeLagStr/binary, ", ",
+      OffsetLagStr/binary, " behind)">>;
+format_sync_status(true, _) ->
+    <<"unknown">>.
+
+format_boolean(true)  -> <<"yes">>;
+format_boolean(false) -> <<"no">>.
 
 -spec get_role({pid() | undefined, writer | replica}) -> writer | replica.
 get_role({_, Role}) -> Role.
@@ -1566,19 +1597,23 @@ up_to_date_running_members(Q, RunningMembers) ->
 
 %% Returns whether a given node is considered fresh based on the freshness map status.
 is_fresh_member(Node, FreshnessMap) ->
-    maps:get(Node, FreshnessMap, false).
+    {IsFresh, _, _} = maps:get(Node, FreshnessMap, {false, undefined, undefined}),
+    IsFresh.
 
 %% Queries the leader replica of the stream to construct a map of nodes to their lag status.
 replica_freshness(LeaderPid) ->
     try osiris_writer:query_replication_state(LeaderPid) of
         ReplState0 ->
             case maps:take(node(LeaderPid), ReplState0) of
-                {{_, LeaderTs}, ReplState} ->
+                {{LeaderOffset, LeaderTs}, ReplState} ->
                     FreshnessMap = maps:map(
-                        fun(_, {_, ReplicaTs}) ->
-                            rabbit_stream_coordinator:is_replica_fresh(LeaderTs, ReplicaTs)
+                        fun(_, {ReplicaOffset, ReplicaTs}) ->
+                            IsFresh = rabbit_stream_coordinator:is_replica_fresh(LeaderTs, ReplicaTs),
+                            TimeLag = LeaderTs - ReplicaTs,
+                            OffsetLag = LeaderOffset - ReplicaOffset,
+                            {IsFresh, TimeLag, OffsetLag}
                         end, ReplState),
-                    FreshnessMap#{node(LeaderPid) => true};
+                    FreshnessMap#{node(LeaderPid) => {true, 0, 0}};
                 error ->
                     #{}
             end

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1548,8 +1548,44 @@ list_with_minimum_quorum() ->
                          StreamId = maps:get(name, amqqueue:get_type_state(Q)),
                          {ok, Members} = rabbit_stream_coordinator:members(StreamId),
                          RunningMembers = maps:filter(fun(_, {State, _}) -> State =/= undefined end, Members),
-                         map_size(RunningMembers) =< map_size(Members) div 2 + 1
+                         UpToDateRunningMembers = up_to_date_running_members(Q, RunningMembers),
+                         map_size(UpToDateRunningMembers) =< map_size(Members) div 2 + 1
                  end, rabbit_amqqueue:list_local_stream_queues()).
+
+%% Filters running stream members returning only those that are sufficiently up to date.
+up_to_date_running_members(Q, RunningMembers) ->
+    case amqqueue:get_pid(Q) of
+        none ->
+            #{};
+        LeaderPid ->
+            FreshnessMap = replica_freshness(LeaderPid),
+            maps:filter(fun(Node, _) ->
+                                is_fresh_member(Node, FreshnessMap)
+                        end, RunningMembers)
+    end.
+
+%% Returns whether a given node is considered fresh based on the freshness map status.
+is_fresh_member(Node, FreshnessMap) ->
+    maps:get(Node, FreshnessMap, false).
+
+%% Queries the leader replica of the stream to construct a map of nodes to their lag status.
+replica_freshness(LeaderPid) ->
+    try osiris_writer:query_replication_state(LeaderPid) of
+        ReplState0 ->
+            case maps:take(node(LeaderPid), ReplState0) of
+                {{_, LeaderTs}, ReplState} ->
+                    FreshnessMap = maps:map(
+                        fun(_, {_, ReplicaTs}) ->
+                            rabbit_stream_coordinator:is_replica_fresh(LeaderTs, ReplicaTs)
+                        end, ReplState),
+                    FreshnessMap#{node(LeaderPid) => true};
+                error ->
+                    #{}
+            end
+    catch
+        _:_ ->
+            #{}
+    end.
 
 get_nodes(Q) when ?is_amqqueue(Q) ->
     #{nodes := Nodes} = amqqueue:get_type_state(Q),


### PR DESCRIPTION
When calling `rabbitmq-upgrade await_online_quorum_plus_one`, wait for the stream replicas to not only be running, but also to be sufficiently up to date (max 10s behind right now). Otherwise we may restart the next node in a rolling restart process and end up with a degraded stream.

Additionally, report the replication lag in `rabbitmq-streams stream_status`