### PR TITLE
Test flake chase: address a hard to reproduce flake (Jun 3, 2026) (round 2)

### DIFF
--- a/deps/rabbit/test/consumer_timeout_SUITE.erl
+++ b/deps/rabbit/test/consumer_timeout_SUITE.erl
@@ -149,7 +149,12 @@ consumer_timeout_with_basic_cancel_capability(Config) ->
     {Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
     QName = ?config(queue_name, Config),
     declare_queue(Ch, Config, QName),
+    amqp_channel:call(Ch, #'confirm.select'{}),
     publish(Ch, QName, [<<"msg1">>]),
+    %% Settle the publish before polling `list_queues/0`: on a freshly-declared
+    %% quorum queue the local node's view of the message count can lag
+    %% the actual write by enough for `wait_for_messages/2` to time out at 0/0/0.
+    amqp_channel:wait_for_confirms_or_die(Ch, 30),
     wait_for_messages(Config, [[QName, <<"1">>, <<"1">>, <<"0">>]]),
     Ctag = <<"ctag">>,
     subscribe(Ch, QName, false, Ctag),
@@ -200,7 +205,9 @@ consumer_timeout_basic_get(Config) ->
     {Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
     QName = ?config(queue_name, Config),
     declare_queue(Ch, Config, QName),
+    amqp_channel:call(Ch, #'confirm.select'{}),
     publish(Ch, QName, [<<"msg1">>]),
+    amqp_channel:wait_for_confirms_or_die(Ch, 30),
     wait_for_messages(Config, [[QName, <<"1">>, <<"1">>, <<"0">>]]),
     %% Fetch message via basic.get without acknowledging
     [_DelTag] = consume(Ch, QName, [<<"msg1">>]),
@@ -247,7 +254,9 @@ consumer_timeout_no_basic_cancel_capability(Config) ->
     {ok, Ch} = amqp_connection:open_channel(Conn),
     QName = ?config(queue_name, Config),
     declare_queue(Ch, Config, QName),
+    amqp_channel:call(Ch, #'confirm.select'{}),
     publish(Ch, QName, [<<"msg1">>]),
+    amqp_channel:wait_for_confirms_or_die(Ch, 30),
     wait_for_messages(Config, [[QName, <<"1">>, <<"1">>, <<"0">>]]),
     erlang:monitor(process, Conn),
     erlang:monitor(process, Ch),

--- a/deps/rabbit/test/publisher_confirms_parallel_SUITE.erl
+++ b/deps/rabbit/test/publisher_confirms_parallel_SUITE.erl
@@ -112,8 +112,12 @@ publisher_confirms(Config) ->
     amqp_channel:call(Ch, #'confirm.select'{}),
     amqp_channel:register_confirm_handler(Ch, self()),
     publish(Ch, QName, [<<"msg1">>]),
+    %% Wait for the publish to be confirmed before polling `list_queues/0`:
+    %% on a freshly-declared quorum queue, the local node's view of the
+    %% message count can lag the actual write by enough for the 30 s
+    %% `wait_for_messages/2` poll to time out at 0/0/0.
+    amqp_channel:wait_for_confirms_or_die(Ch, 30),
     wait_for_messages(Config, [[QName, <<"1">>, <<"1">>, <<"0">>]]),
-    amqp_channel:wait_for_confirms(Ch, 5),
     amqp_channel:unregister_confirm_handler(Ch),
     ok.
 


### PR DESCRIPTION
Settle the publish before `wait_for_messages` to avoid a queue [process] startup race.

This is a speculative fix in the sense that I could never reproduce the failure locally, even after a double digit number of runs.