### PR TITLE
By @AyandaDube: Safely handle channel creation errors on initiating connections and top-level supervisors

### DIFF
--- a/deps/amqp_client/src/amqp_channel_sup.erl
+++ b/deps/amqp_client/src/amqp_channel_sup.erl
@@ -39,6 +39,7 @@ start_link(Type, Connection, ConnName, InfraArgs, ChNumber,
             {ok, AState} = init_command_assembler(Type),
             {ok, Sup, {ChPid, AState}};
         {error, _}=Error ->
+            rabbit_misc:shutdown_supervisor(Sup),
             Error
     end.
 

--- a/deps/amqp_client/src/amqp_channels_manager.erl
+++ b/deps/amqp_client/src/amqp_channels_manager.erl
@@ -105,12 +105,15 @@ handle_open_channel(ProposedNumber, Consumer, InfraArgs,
                     State = #state{channel_sup_sup = ChSupSup}) ->
     case new_number(ProposedNumber, State) of
         {ok, Number} ->
-            {ok, _ChSup, {Ch, AState}} =
-                amqp_channel_sup_sup:start_channel_sup(ChSupSup, InfraArgs,
-                                                       Number, Consumer),
-            NewState = internal_register(Number, Ch, AState, State),
-            erlang:monitor(process, Ch),
-            {reply, {ok, Ch}, NewState};
+            case amqp_channel_sup_sup:start_channel_sup(ChSupSup, InfraArgs,
+                                                        Number, Consumer) of
+                {ok, _ChSup, {Ch, AState}} ->
+                    NewState = internal_register(Number, Ch, AState, State),
+                    erlang:monitor(process, Ch),
+                    {reply, {ok, Ch}, NewState};
+                {error, _} = Error ->
+                    {reply, Error, State}
+            end;
         {error, _} = Error ->
             {reply, Error, State}
     end.

--- a/deps/rabbit/src/rabbit_channel_sup.erl
+++ b/deps/rabbit/src/rabbit_channel_sup.erl
@@ -38,8 +38,6 @@
          rabbit_types:user(), rabbit_types:vhost(),
          rabbit_framing:amqp_table(), pid()}.
 
--define(FAIR_WAIT, 70000).
-
 %%----------------------------------------------------------------------------
 
 -spec start_link(start_link_args()) ->
@@ -63,6 +61,8 @@ start_link({tcp, Sock, Channel, FrameMax, ReaderPid, ConnName, User,
                   shutdown => ?FAIR_WAIT,
                   type => worker,
                   modules => [rabbit_channel]},
+    %% For potential backports to 4.1: this call site will need adjustment compared to 4.2 and newer series.
+    %% Thread `Protocol` through `start_link_args/0` and `rabbit_command_assembler:init/1`.
     case supervisor:start_child(SupPid, ChildSpec) of
         {ok, ChannelPid} ->
             {ok, AState} = rabbit_command_assembler:init(),

--- a/deps/rabbit/src/rabbit_channel_sup.erl
+++ b/deps/rabbit/src/rabbit_channel_sup.erl
@@ -42,7 +42,8 @@
 
 %%----------------------------------------------------------------------------
 
--spec start_link(start_link_args()) -> {'ok', pid(), {pid(), any()}}.
+-spec start_link(start_link_args()) ->
+    {'ok', pid(), {pid(), any()}} | {'error', any()}.
 
 start_link({tcp, Sock, Channel, FrameMax, ReaderPid, ConnName, User,
             VHost, Capabilities, Collector}) ->
@@ -62,9 +63,14 @@ start_link({tcp, Sock, Channel, FrameMax, ReaderPid, ConnName, User,
                   shutdown => ?FAIR_WAIT,
                   type => worker,
                   modules => [rabbit_channel]},
-    {ok, ChannelPid} = supervisor:start_child(SupPid, ChildSpec),
-    {ok, AState} = rabbit_command_assembler:init(),
-    {ok, SupPid, {ChannelPid, AState}};
+    case supervisor:start_child(SupPid, ChildSpec) of
+        {ok, ChannelPid} ->
+            {ok, AState} = rabbit_command_assembler:init(),
+            {ok, SupPid, {ChannelPid, AState}};
+        {error, Reason} ->
+            rabbit_misc:shutdown_supervisor(SupPid),
+            {error, Reason}
+    end;
 start_link({direct, Channel, ClientChannelPid, ConnPid, ConnName,
             User, VHost, Capabilities, Collector, AmqpParams}) ->
     {ok, SupPid} = supervisor:start_link(
@@ -81,8 +87,13 @@ start_link({direct, Channel, ClientChannelPid, ConnPid, ConnName,
                   shutdown => ?FAIR_WAIT,
                   type => worker,
                   modules => [rabbit_channel]},
-    {ok, ChannelPid} = supervisor:start_child(SupPid, ChildSpec),
-    {ok, SupPid, {ChannelPid, none}}.
+    case supervisor:start_child(SupPid, ChildSpec) of
+        {ok, ChannelPid} ->
+            {ok, SupPid, {ChannelPid, none}};
+        {error, Reason} ->
+            rabbit_misc:shutdown_supervisor(SupPid),
+            {error, Reason}
+    end.
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbit/src/rabbit_channel_sup_sup.erl
+++ b/deps/rabbit/src/rabbit_channel_sup_sup.erl
@@ -28,7 +28,7 @@ start_link() ->
     supervisor:start_link(?MODULE, []).
 
 -spec start_channel(pid(), rabbit_channel_sup:start_link_args()) ->
-          {'ok', pid(), {pid(), any()}}.
+          {'ok', pid(), {pid(), any()}} | {'error', any()}.
 
 start_channel(Pid, Args) ->
     supervisor:start_child(Pid, [Args]).

--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -229,41 +229,52 @@ start_channel(Number, ClientChannelPid, ConnPid, ConnName,
               Collector, AmqpParams) ->
     case rabbit_auth_backend_internal:is_over_channel_limit(Username) of
         false ->
-            case supervisor:start_child(
-                   rabbit_direct_client_sup,
-                   [{direct, Number, ClientChannelPid, ConnPid, ConnName,
-                     User, VHost, Capabilities, Collector, AmqpParams}]) of
-                {ok, _, {ChannelPid, _}} ->
-                    {ok, ChannelPid};
-                {error, Reason} ->
-                    ?LOG_ERROR(
-                        "Error on direct connection ~tp~n"
-                        "failed to open channel: ~tp",
-                        [ConnPid, Reason]),
-                    {error, channel_open_failed}
+            case rabbit_reader:is_over_node_channel_limit() of
+                false ->
+                    case supervisor:start_child(
+                           rabbit_direct_client_sup,
+                           [{direct, Number, ClientChannelPid, ConnPid, ConnName,
+                             User, VHost, Capabilities, Collector, AmqpParams}]) of
+                        {ok, _, {ChannelPid, _}} ->
+                            {ok, ChannelPid};
+                        {error, Reason} ->
+                            ?LOG_ERROR(
+                                "Error on direct connection ~tp~n"
+                                "failed to open channel: ~tp",
+                                [ConnPid, Reason]),
+                            {error, channel_open_failed}
+                    end;
+                {true, NodeLimit} ->
+                    Text = rabbit_misc:format(
+                            "number of channels opened on node '~ts' has "
+                            "reached the maximum allowed limit of (~w)",
+                            [node(), NodeLimit]),
+                    ?LOG_ERROR("Error on direct connection ~tp~n~ts",
+                               [ConnPid, Text]),
+                    cast_server_close(ConnPid, Text),
+                    {error, not_allowed}
             end;
         {true, Limit} ->
-            ?LOG_ERROR(
-                "Error on direct connection ~tp~n"
-                "number of channels opened for user '~ts' has reached the "
-                "maximum allowed limit of (~w)",
-                [ConnPid, Username, Limit]),
-            %% Mirror `rabbit_reader:handle_exception/3` for the network case:
-            %% a per-user channel-limit error is connection-level, so signal
-            %% the direct connection to terminate with a server-initiated close.
-            ReplyText = rabbit_data_coercion:to_binary(
-                          rabbit_misc:format(
-                            "number of channels opened for user '~ts' "
-                            "has reached the maximum allowed limit of (~w)",
-                            [Username, Limit])),
-            gen_server:cast(ConnPid,
-                {server_close,
-                 #'connection.close'{reply_code = ?NOT_ALLOWED,
-                                     reply_text = ReplyText,
-                                     class_id = 0,
-                                     method_id = 0}}),
+            Text = rabbit_misc:format(
+                    "number of channels opened for user '~ts' has "
+                    "reached the maximum allowed limit of (~w)",
+                    [Username, Limit]),
+            ?LOG_ERROR("Error on direct connection ~tp~n~ts",
+                       [ConnPid, Text]),
+            cast_server_close(ConnPid, Text),
             {error, not_allowed}
     end.
+
+%% Mirror `rabbit_reader:handle_exception/3` for the network case: a
+%% channel-limit error is connection-level, so signal the direct
+%% connection to terminate with a server-initiated close.
+cast_server_close(ConnPid, Text) ->
+    gen_server:cast(ConnPid,
+        {server_close,
+         #'connection.close'{reply_code = ?NOT_ALLOWED,
+                             reply_text = rabbit_data_coercion:to_binary(Text),
+                             class_id = 0,
+                             method_id = 0}}).
 
 -spec disconnect(pid(), rabbit_event:event_props()) -> 'ok'.
 

--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -209,7 +209,7 @@ connect1(User = #user{username = Username}, VHost, Pid, Infos) ->
         (rabbit_channel:channel_number(), pid(), pid(), string(),
          rabbit_types:protocol(), rabbit_types:user(), rabbit_types:vhost(),
          rabbit_framing:amqp_table(), pid(), any()) ->
-            {'ok', pid()}.
+            {'ok', pid()} | {'error', any()}.
 
 %% Kept for compatibility with older amqp_client versions (rpc:call).
 start_channel(Number, ClientChannelPid, ConnPid, ConnName, _Protocol,
@@ -221,19 +221,26 @@ start_channel(Number, ClientChannelPid, ConnPid, ConnName, _Protocol,
         (rabbit_channel:channel_number(), pid(), pid(), string(),
          rabbit_types:user(), rabbit_types:vhost(),
          rabbit_framing:amqp_table(), pid(), any()) ->
-            {'ok', pid()}.
+            {'ok', pid()} | {'error', any()}.
 
 start_channel(Number, ClientChannelPid, ConnPid, ConnName,
               User = #user{username = Username}, VHost, Capabilities,
               Collector, AmqpParams) ->
     case rabbit_auth_backend_internal:is_over_channel_limit(Username) of
         false ->
-            {ok, _, {ChannelPid, _}} =
-                supervisor:start_child(
-                  rabbit_direct_client_sup,
-                  [{direct, Number, ClientChannelPid, ConnPid, ConnName,
-                    User, VHost, Capabilities, Collector, AmqpParams}]),
-            {ok, ChannelPid};
+            case supervisor:start_child(
+                   rabbit_direct_client_sup,
+                   [{direct, Number, ClientChannelPid, ConnPid, ConnName,
+                     User, VHost, Capabilities, Collector, AmqpParams}]) of
+                {ok, _, {ChannelPid, _}} ->
+                    {ok, ChannelPid};
+                {error, Reason} ->
+                    ?LOG_ERROR(
+                        "Error on direct connection ~tp~n"
+                        "failed to open channel: ~tp",
+                        [ConnPid, Reason]),
+                    {error, channel_open_failed}
+            end;
         {true, Limit} ->
             ?LOG_ERROR(
                 "Error on direct connection ~tp~n"

--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -17,6 +17,7 @@
          conserve_resources/3]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit_framing.hrl").
 -include_lib("rabbit_common/include/rabbit_misc.hrl").
 -include_lib("kernel/include/logger.hrl").
 
@@ -247,6 +248,20 @@ start_channel(Number, ClientChannelPid, ConnPid, ConnName,
                 "number of channels opened for user '~ts' has reached the "
                 "maximum allowed limit of (~w)",
                 [ConnPid, Username, Limit]),
+            %% Mirror `rabbit_reader:handle_exception/3` for the network case:
+            %% a per-user channel-limit error is connection-level, so signal
+            %% the direct connection to terminate with a server-initiated close.
+            ReplyText = rabbit_data_coercion:to_binary(
+                          rabbit_misc:format(
+                            "number of channels opened for user '~ts' "
+                            "has reached the maximum allowed limit of (~w)",
+                            [Username, Limit])),
+            gen_server:cast(ConnPid,
+                {server_close,
+                 #'connection.close'{reply_code = ?NOT_ALLOWED,
+                                     reply_text = ReplyText,
+                                     class_id = 0,
+                                     method_id = 0}}),
             {error, not_allowed}
     end.
 

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -55,6 +55,8 @@
 
 -export([conserve_resources/3, server_properties/1]).
 
+-export([is_over_node_channel_limit/0]).
+
 -define(NORMAL_TIMEOUT, 3).
 -define(CLOSING_TIMEOUT, 30).
 -define(CHANNEL_TERMINATION_TIMEOUT, 3).

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -975,15 +975,24 @@ create_channel(Channel,
                    } = State) ->
     case is_over_limits(Username) of
         false ->
-            {ok, _ChSupPid, {ChPid, AState}} =
-                rabbit_channel_sup_sup:start_channel(
-                  ChanSupSup, {tcp, Sock, Channel, FrameMax, self(), Name,
-                               User, VHost, Capabilities,
-                               Collector}),
-            MRef = erlang:monitor(process, ChPid),
-            put({ch_pid, ChPid}, {Channel, MRef}),
-            put({channel, Channel}, {ChPid, AState}),
-            {ok, {ChPid, AState}, State#v1{channel_count = ChannelCount + 1}};
+            case rabbit_channel_sup_sup:start_channel(
+                   ChanSupSup, {tcp, Sock, Channel, FrameMax, self(), Name,
+                                User, VHost, Capabilities,
+                                Collector}) of
+                {ok, _ChSupPid, {ChPid, AState}} ->
+                    MRef = erlang:monitor(process, ChPid),
+                    put({ch_pid, ChPid}, {Channel, MRef}),
+                    put({channel, Channel}, {ChPid, AState}),
+                    {ok, {ChPid, AState}, State#v1{channel_count = ChannelCount + 1}};
+                {error, Reason} ->
+                    ?LOG_ERROR(
+                        "Connection ~ts failed to open channel ~tp: ~tp",
+                        [Name, Channel, Reason]),
+                    {error, rabbit_misc:amqp_error(
+                              internal_error,
+                              "failed to open channel ~tp",
+                              [Channel], none)}
+            end;
         {true, Limit, Fmt, FmtArg} ->
             {error, rabbit_misc:amqp_error(
                       not_allowed,

--- a/deps/rabbit/test/channel_interceptor_SUITE.erl
+++ b/deps/rabbit/test/channel_interceptor_SUITE.erl
@@ -225,7 +225,7 @@ conflicting_interceptors_close_network_connections_gracefully1(Config) ->
                                   dummy_interceptor),
     ok = rabbit_registry:register(channel_interceptor,
                                   <<"conflicting dummy interceptor">>,
-                                  conflicting_dummy_interceptor),
+                                  dummy_interceptor_conflicting),
     try
         Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0),
         ?assert(is_pid(Conn)),
@@ -267,7 +267,7 @@ conflicting_interceptors_close_direct_connections_gracefully1(Config) ->
                                   dummy_interceptor),
     ok = rabbit_registry:register(channel_interceptor,
                                   <<"conflicting dummy interceptor">>,
-                                  conflicting_dummy_interceptor),
+                                  dummy_interceptor_conflicting),
     try
         Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
         Params = #amqp_params_direct{node = Node,

--- a/deps/rabbit/test/channel_interceptor_SUITE.erl
+++ b/deps/rabbit/test/channel_interceptor_SUITE.erl
@@ -24,7 +24,9 @@ groups() ->
           register_interceptor,
           register_interceptor_failing_with_amqp_error,
           register_interceptor_crashing_with_amqp_error_exception,
-          register_failing_interceptors
+          register_failing_interceptors,
+          conflicting_interceptors_close_network_connections_gracefully,
+          conflicting_interceptors_close_direct_connections_gracefully
         ]}
     ].
 
@@ -212,6 +214,94 @@ register_interceptor_crashing_with_amqp_error_exception1(Config, Interceptor) ->
 register_failing_interceptors(Config) ->
     passed = rabbit_ct_broker_helpers:rpc(Config, 0,
       ?MODULE, register_interceptor1, [Config, failing_dummy_interceptor]).
+
+conflicting_interceptors_close_network_connections_gracefully(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, conflicting_interceptors_close_network_connections_gracefully1, [Config]).
+
+conflicting_interceptors_close_network_connections_gracefully1(Config) ->
+    ok = rabbit_registry:register(channel_interceptor,
+                                  <<"dummy interceptor">>,
+                                  dummy_interceptor),
+    ok = rabbit_registry:register(channel_interceptor,
+                                  <<"conflicting dummy interceptor">>,
+                                  conflicting_dummy_interceptor),
+    try
+        Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0),
+        ?assert(is_pid(Conn)),
+        ?assert(is_process_alive(Conn)),
+        ConnMRef = erlang:monitor(process, Conn),
+        Result = try amqp_connection:open_channel(Conn)
+                 catch _:_ -> {error, channel_open_failed}
+                 end,
+        ?assertMatch({error, _}, Result),
+        receive
+            {'DOWN', ConnMRef, process, Conn, ConnExitReason} ->
+                ?assertMatch(
+                    {shutdown, {server_initiated_close, _, _}},
+                    ConnExitReason)
+        after 10000 ->
+            ct:fail("Connection process did not terminate")
+        end
+    after
+        ok = rabbit_registry:unregister(channel_interceptor,
+                                        <<"dummy interceptor">>),
+        ok = rabbit_registry:unregister(channel_interceptor,
+                                        <<"conflicting dummy interceptor">>)
+    end,
+    %% Verify the server still accepts new connections and channels
+    Conn2 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0),
+    ?assert(is_pid(Conn2)),
+    {ok, Ch} = amqp_connection:open_channel(Conn2),
+    ?assert(is_pid(Ch)),
+    ok = amqp_connection:close(Conn2),
+    passed.
+
+conflicting_interceptors_close_direct_connections_gracefully(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, conflicting_interceptors_close_direct_connections_gracefully1, [Config]).
+
+conflicting_interceptors_close_direct_connections_gracefully1(Config) ->
+    ok = rabbit_registry:register(channel_interceptor,
+                                  <<"dummy interceptor">>,
+                                  dummy_interceptor),
+    ok = rabbit_registry:register(channel_interceptor,
+                                  <<"conflicting dummy interceptor">>,
+                                  conflicting_dummy_interceptor),
+    try
+        Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+        Params = #amqp_params_direct{node = Node,
+                                     virtual_host = <<"/">>,
+                                     username = <<"guest">>,
+                                     password = <<"guest">>},
+        {ok, Conn} = amqp_connection:start(Params),
+        ?assert(is_pid(Conn)),
+        ?assert(is_process_alive(Conn)),
+        %% open_channel must return {error, _} gracefully, not crash.
+        %% If the connection process crashes (e.g. badmatch in
+        %% amqp_channels_manager), this call will throw and fail the test.
+        Result = amqp_connection:open_channel(Conn),
+        ?assertMatch({error, _}, Result),
+        ?assert(is_process_alive(Conn)),
+        ok = amqp_connection:close(Conn)
+    after
+        ok = rabbit_registry:unregister(channel_interceptor,
+                                        <<"dummy interceptor">>),
+        ok = rabbit_registry:unregister(channel_interceptor,
+                                        <<"conflicting dummy interceptor">>)
+    end,
+    %% Verify the server still accepts new direct connections and channels
+    Node2 = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Params2 = #amqp_params_direct{node = Node2,
+                                  virtual_host = <<"/">>,
+                                  username = <<"guest">>,
+                                  password = <<"guest">>},
+    {ok, Conn2} = amqp_connection:start(Params2),
+    ?assert(is_pid(Conn2)),
+    {ok, Ch} = amqp_connection:open_channel(Conn2),
+    ?assert(is_pid(Ch)),
+    ok = amqp_connection:close(Conn2),
+    passed.
 
 check_send_receive(Ch1, QName, Send, Receive) ->
     amqp_channel:call(Ch1,

--- a/deps/rabbit/test/channel_interceptor_SUITE.erl
+++ b/deps/rabbit/test/channel_interceptor_SUITE.erl
@@ -277,9 +277,9 @@ conflicting_interceptors_close_direct_connections_gracefully1(Config) ->
         {ok, Conn} = amqp_connection:start(Params),
         ?assert(is_pid(Conn)),
         ?assert(is_process_alive(Conn)),
-        %% open_channel must return {error, _} gracefully, not crash.
+        %% `open_channel` must return `{error, _}` gracefully, not crash.
         %% If the connection process crashes (e.g. badmatch in
-        %% amqp_channels_manager), this call will throw and fail the test.
+        %% `amqp_channels_manager`), this call will throw and fail the test.
         Result = amqp_connection:open_channel(Conn),
         ?assertMatch({error, _}, Result),
         ?assert(is_process_alive(Conn)),

--- a/deps/rabbit/test/conflicting_dummy_interceptor.erl
+++ b/deps/rabbit/test/conflicting_dummy_interceptor.erl
@@ -1,0 +1,21 @@
+-module(conflicting_dummy_interceptor).
+
+-behaviour(rabbit_channel_interceptor).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit_framing.hrl").
+
+-compile(export_all).
+
+init(_Ch) ->
+    undefined.
+
+description() ->
+    [{description,
+      <<"Interceptor that conflicts with dummy_interceptor on queue.declare">>}].
+
+intercept(Method, Content, _IState) ->
+    {Method, Content}.
+
+applies_to() ->
+    ['queue.declare'].

--- a/deps/rabbit/test/dummy_interceptor_conflicting.erl
+++ b/deps/rabbit/test/dummy_interceptor_conflicting.erl
@@ -1,4 +1,11 @@
--module(conflicting_dummy_interceptor).
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(dummy_interceptor_conflicting).
 
 -behaviour(rabbit_channel_interceptor).
 

--- a/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
+++ b/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
@@ -1617,11 +1617,23 @@ await_user_limit_visible(Config, Username, LimitType, Value) ->
       fun(I) ->
               ?awaitMatch(
                  Expected,
-                 rabbit_ct_broker_helpers:rpc(
-                   Config, I, rabbit_auth_backend_internal, get_user_limit,
-                   [Username, LimitType]),
+                 lookup_user_limit(Config, I, Username, LimitType),
                  ?AWAIT, ?INTERVAL)
       end, lists:seq(0, length(Nodenames) - 1)).
+
+lookup_user_limit(Config, NodeIndex, Username, LimitType) ->
+    case rabbit_ct_broker_helpers:rpc(
+           Config, NodeIndex, rabbit_auth_backend_internal, get_user_limits,
+           [Username]) of
+        undefined ->
+            undefined;
+        Limits when is_map(Limits) ->
+            case maps:get(LimitType, Limits, undefined) of
+                N when is_integer(N), N < 0 -> undefined;
+                N when is_integer(N), N >= 0 -> {ok, N};
+                undefined -> undefined
+            end
+    end.
 
 clear_all_user_limits(Config, Username) ->
     clear_all_user_limits(Config, 0, Username).

--- a/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
+++ b/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
@@ -12,6 +12,9 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 
+-define(AWAIT, 30000).
+-define(INTERVAL, 250).
+
 -compile(nowarn_export_all).
 -compile(export_all).
 
@@ -1577,7 +1580,9 @@ set_user_connection_and_channel_limit(Config, NodeIndex, Username, ConnLimit, Ch
     ok = rabbit_ct_broker_helpers:control_action(
       set_user_limits, Node, [rabbit_data_coercion:to_list(Username)] ++
       ["{\"max-connections\": " ++ integer_to_list(ConnLimit) ++ "," ++
-       " \"max-channels\": " ++ integer_to_list(ChLimit) ++ "}"]).
+       " \"max-channels\": " ++ integer_to_list(ChLimit) ++ "}"]),
+    await_user_limit_visible(Config, Username, <<"max-connections">>, ConnLimit),
+    await_user_limit_visible(Config, Username, <<"max-channels">>, ChLimit).
 
 set_user_connection_limit_only(Config, Username, ConnLimit) ->
     set_user_connection_limit_only(Config, 0, Username, ConnLimit).
@@ -1587,7 +1592,8 @@ set_user_connection_limit_only(Config, NodeIndex, Username, ConnLimit) ->
              Config, NodeIndex, nodename),
     ok = rabbit_ct_broker_helpers:control_action(
       set_user_limits, Node, [rabbit_data_coercion:to_list(Username)] ++
-      ["{\"max-connections\": " ++ integer_to_list(ConnLimit) ++ "}"]).
+      ["{\"max-connections\": " ++ integer_to_list(ConnLimit) ++ "}"]),
+    await_user_limit_visible(Config, Username, <<"max-connections">>, ConnLimit).
 
 set_user_channel_limit_only(Config, Username, ChLimit) ->
     set_user_channel_limit_only(Config, 0, Username, ChLimit).
@@ -1597,7 +1603,25 @@ set_user_channel_limit_only(Config, NodeIndex, Username, ChLimit) ->
              Config, NodeIndex, nodename),
     ok = rabbit_ct_broker_helpers:control_action(
       set_user_limits, Node, [rabbit_data_coercion:to_list(Username)] ++
-      ["{\"max-channels\": " ++ integer_to_list(ChLimit) ++ "}"]).
+      ["{\"max-channels\": " ++ integer_to_list(ChLimit) ++ "}"]),
+    await_user_limit_visible(Config, Username, <<"max-channels">>, ChLimit).
+
+%% Awaits runtime-parameter propagation to every cluster node.
+await_user_limit_visible(Config, Username, LimitType, Value) ->
+    Expected = case Value of
+                   V when V < 0 -> undefined;
+                   V            -> {ok, V}
+               end,
+    Nodenames = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    lists:foreach(
+      fun(I) ->
+              ?awaitMatch(
+                 Expected,
+                 rabbit_ct_broker_helpers:rpc(
+                   Config, I, rabbit_auth_backend_internal, get_user_limit,
+                   [Username, LimitType]),
+                 ?AWAIT, ?INTERVAL)
+      end, lists:seq(0, length(Nodenames) - 1)).
 
 clear_all_user_limits(Config, Username) ->
     clear_all_user_limits(Config, 0, Username).
@@ -1605,7 +1629,9 @@ clear_all_user_limits(Config, NodeIndex, Username) ->
     Node  = rabbit_ct_broker_helpers:get_node_config(
               Config, NodeIndex, nodename),
     ok = rabbit_ct_broker_helpers:control_action(
-        clear_user_limits, Node, [rabbit_data_coercion:to_list(Username), "all"]).
+        clear_user_limits, Node, [rabbit_data_coercion:to_list(Username), "all"]),
+    await_user_limit_visible(Config, Username, <<"max-connections">>, -1),
+    await_user_limit_visible(Config, Username, <<"max-channels">>, -1).
 
 expect_that_client_connection_is_rejected(Config) ->
     expect_that_client_connection_is_rejected(Config, 0).

--- a/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
+++ b/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
@@ -1141,6 +1141,8 @@ cluster_single_user_limit(Config) ->
     expect_that_client_connection_is_rejected(Config, 0, Username),
     expect_that_client_connection_is_rejected(Config, 1, Username),
     expect_that_client_channel_is_rejected(Conn1),
+    %% On direct connections, channel rejection does not close the connection.
+    close_connections([Conn1]),
     rabbit_ct_helpers:await_condition(
         fun () ->
             is_process_alive(Conn1) =:= false andalso
@@ -1175,6 +1177,8 @@ cluster_single_user_limit2(Config) ->
     expect_that_client_connection_is_rejected(Config, 0, Username),
     expect_that_client_connection_is_rejected(Config, 1, Username),
     expect_that_client_channel_is_rejected(Conn1),
+    %% On direct connections, channel rejection does not close the connection.
+    close_connections([Conn1]),
     rabbit_ct_helpers:await_condition(
         fun () ->
             is_process_alive(Conn1) =:= false andalso
@@ -1225,6 +1229,8 @@ cluster_single_user_zero_limit(Config) ->
             count_connections_of_user(Config, Username) =:= 1
         end),
     expect_that_client_channel_is_rejected(ConnA),
+    %% On direct connections, channel rejection does not close the connection.
+    close_connections([ConnA]),
     rabbit_ct_helpers:await_condition(
         fun () ->
             count_connections_of_user(Config, Username) =:= 0 andalso
@@ -1268,6 +1274,8 @@ cluster_single_user_clear_limits(Config) ->
     expect_that_client_connection_is_rejected(Config, 0, Username),
     expect_that_client_connection_is_rejected(Config, 1, Username),
     expect_that_client_channel_is_rejected(Conn1),
+    %% On direct connections, channel rejection does not close the connection.
+    close_connections([Conn1]),
     rabbit_ct_helpers:await_condition(
         fun () ->
             is_process_alive(Conn1) =:= false andalso
@@ -1336,6 +1344,8 @@ cluster_multiple_users_clear_limits(Config) ->
             count_connections_of_user(Config, Username2) =:= 1
         end),
     expect_that_client_channel_is_rejected(ConnA),
+    %% On direct connections, channel rejection does not close the connection.
+    close_connections([ConnA]),
 
     rabbit_ct_helpers:await_condition(
         fun () ->
@@ -1420,6 +1430,8 @@ cluster_multiple_users_zero_limit(Config) ->
     [ConnA, ConnB] = open_connections(Config, [{0, Username1}, {1, Username2}]),
 
     expect_that_client_channel_is_rejected(ConnA),
+    %% On direct connections, channel rejection does not close the connection.
+    close_connections([ConnA]),
     rabbit_ct_helpers:await_condition(
         fun () ->
             count_connections_of_user(Config, Username1) =:= 0 andalso

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -226,6 +226,7 @@
 -define(EMPTY_FRAME_SIZE, 8).
 
 -define(MAX_WAIT, 16#ffffffff).
+-define(FAIR_WAIT, 70_000).
 -define(SUPERVISOR_WAIT,
         rabbit_misc:get_env(rabbit, supervisor_shutdown_timeout, infinity)).
 -define(WORKER_WAIT,

--- a/deps/rabbit_common/include/rabbit_misc.hrl
+++ b/deps/rabbit_common/include/rabbit_misc.hrl
@@ -7,4 +7,3 @@
 
 -define(RPC_TIMEOUT, 15_000).
 -define(RPC_INFINITE_TIMEOUT, infinity).
--define(DEFAULT_TIMEOUT, 5_000).

--- a/deps/rabbit_common/include/rabbit_misc.hrl
+++ b/deps/rabbit_common/include/rabbit_misc.hrl
@@ -5,5 +5,6 @@
 %% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--define(RPC_TIMEOUT, 15000).
+-define(RPC_TIMEOUT, 15_000).
 -define(RPC_INFINITE_TIMEOUT, infinity).
+-define(DEFAULT_TIMEOUT, 5_000).

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -1436,14 +1436,20 @@ find_child(Supervisor, Name) ->
     [Pid || {Name1, Pid, _Type, _Modules} <- supervisor:which_children(Supervisor),
             Name1 =:= Name].
 
+%% Must be called by the process that holds the link to SupPid.
+-spec shutdown_supervisor(pid()) -> ok.
 shutdown_supervisor(SupPid) when is_pid(SupPid) ->
     MRef = erlang:monitor(process, SupPid),
     unlink(SupPid),
     exit(SupPid, shutdown),
     receive
         {'DOWN', MRef, process, SupPid, _} -> ok
-    after ?DEFAULT_TIMEOUT ->
-        exit({shutdown_supervisor_timeout, SupPid})
+    after ?FAIR_WAIT ->
+        erlang:demonitor(MRef, [flush]),
+        ?LOG_WARNING(
+            "rabbit_misc:shutdown_supervisor/1 timed out waiting for ~tp to terminate",
+            [SupPid]),
+        ok
     end.
 
 %% -------------------------------------------------------------------------

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -79,6 +79,7 @@
 -export([raw_read_file/1]).
 -export([strip_bom/1]).
 -export([find_child/2]).
+-export([shutdown_supervisor/1]).
 -export([is_regular_file/1]).
 -export([safe_ets_update_counter/3, safe_ets_update_counter/4, safe_ets_update_counter/5,
          safe_ets_update_element/3, safe_ets_update_element/4, safe_ets_update_element/5]).
@@ -1434,6 +1435,16 @@ safe_ets_update_element(Tab, Key, ElementSpec, OnSuccess, OnFailure) ->
 find_child(Supervisor, Name) ->
     [Pid || {Name1, Pid, _Type, _Modules} <- supervisor:which_children(Supervisor),
             Name1 =:= Name].
+
+shutdown_supervisor(SupPid) when is_pid(SupPid) ->
+    MRef = erlang:monitor(process, SupPid),
+    unlink(SupPid),
+    exit(SupPid, shutdown),
+    receive
+        {'DOWN', MRef, process, SupPid, _} -> ok
+    after ?DEFAULT_TIMEOUT ->
+        exit({shutdown_supervisor_timeout, SupPid})
+    end.
 
 %% -------------------------------------------------------------------------
 %% Begin copypasta from gen_server2.erl

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -1052,7 +1052,7 @@ is_mixed_versions(Config) ->
 %% -------------------------------------------------------------------
 
 await_condition(ConditionFun) ->
-    await_condition(ConditionFun, 10_000).
+    await_condition(ConditionFun, 15_000).
 
 await_condition(ConditionFun, Timeout) ->
     Retries = ceil(Timeout / 50),


### PR DESCRIPTION
This is #16598 with one tweak from me: in one unlikely (shutdown timeout) case, we can log without crashing the caller.

That's in line with the goal of #16598.