### PR TITLE
`v4.3.x`: `rabbit_direct:start_channel/9`: enforce node channel limit

### DIFF
--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -228,12 +228,22 @@ start_channel(Number, ClientChannelPid, ConnPid, ConnName,
               Collector, AmqpParams) ->
     case rabbit_auth_backend_internal:is_over_channel_limit(Username) of
         false ->
-            {ok, _, {ChannelPid, _}} =
-                supervisor:start_child(
-                  rabbit_direct_client_sup,
-                  [{direct, Number, ClientChannelPid, ConnPid, ConnName,
-                    User, VHost, Capabilities, Collector, AmqpParams}]),
-            {ok, ChannelPid};
+            case rabbit_reader:is_over_node_channel_limit() of
+                false ->
+                    {ok, _, {ChannelPid, _}} =
+                        supervisor:start_child(
+                          rabbit_direct_client_sup,
+                          [{direct, Number, ClientChannelPid, ConnPid, ConnName,
+                            User, VHost, Capabilities, Collector, AmqpParams}]),
+                    {ok, ChannelPid};
+                {true, NodeLimit} ->
+                    ?LOG_ERROR(
+                        "Error on direct connection ~tp~n"
+                        "number of channels opened on node '~ts' has reached "
+                        "the maximum allowed limit of (~w)",
+                        [ConnPid, node(), NodeLimit]),
+                    {error, not_allowed}
+            end;
         {true, Limit} ->
             ?LOG_ERROR(
                 "Error on direct connection ~tp~n"

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -55,6 +55,8 @@
 
 -export([conserve_resources/3, server_properties/1]).
 
+-export([is_over_node_channel_limit/0]).
+
 -define(NORMAL_TIMEOUT, 3).
 -define(CLOSING_TIMEOUT, 30).
 -define(CHANNEL_TERMINATION_TIMEOUT, 3).


### PR DESCRIPTION
This backports a drive-by change from #16610: the `channel_max_per_node` limit was enforced for network connections (in `rabbit_reader:is_over_limits/1`) not not for direct Erlang client connections.

The direct client is primarily used by the (cluster-local) Shovel and Federation plugin connections.
