### PR TITLE
Minor channel limit violation log message improvement

### DIFF
--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -247,7 +247,7 @@ start_channel(Number, ClientChannelPid, ConnPid, ConnName,
                 {true, NodeLimit} ->
                     Text = rabbit_misc:format(
                             "number of channels opened on node '~ts' has "
-                            "reached the maximum allowed limit of (~w)",
+                            "reached the maximum allowed limit of ~w",
                             [node(), NodeLimit]),
                     ?LOG_ERROR("Error on direct connection ~tp~n~ts",
                                [ConnPid, Text]),
@@ -257,7 +257,7 @@ start_channel(Number, ClientChannelPid, ConnPid, ConnName,
         {true, Limit} ->
             Text = rabbit_misc:format(
                     "number of channels opened for user '~ts' has "
-                    "reached the maximum allowed limit of (~w)",
+                    "reached the maximum allowed limit of ~w",
                     [Username, Limit]),
             ?LOG_ERROR("Error on direct connection ~tp~n~ts",
                        [ConnPid, Text]),

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -1011,13 +1011,13 @@ is_over_limits(Username) ->
                 {true, Limit} ->
                     Fmt =
                         "number of channels opened on node '~ts' has reached "
-                        "the maximum allowed limit of (~w)",
+                        "the maximum allowed limit of ~w",
                     {true, Limit, Fmt, node()}
             end;
         {true, Limit} ->
             Fmt =
                 "number of channels opened for user '~ts' has reached "
-                "the maximum allowed user limit of (~w)",
+                "the maximum allowed user limit of ~w",
             {true, Limit, Fmt, Username}
     end.
 


### PR DESCRIPTION
The parentheses around the numerical limit look weird, let's drop them.