### PR TITLE
Support encrypted values for `definitions.https.url`

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -161,9 +161,22 @@ end}.
     {datatype, {enum, [sha, sha224, sha256, sha384, sha512]}}]}.
 
 %% Load definitions from a remote URL over HTTPS. See
-%% https://www.rabbitmq.com/docs/management#load-definitions
+%% https://www.rabbitmq.com/docs/management#load-definitions.
 {mapping, "definitions.https.url", "rabbit.definitions.url",
-    [{datatype, string}]}.
+    [{datatype, [tagged_string, string]}]}.
+
+%% The tagged_string datatype matches any alphanumeric prefix followed by `:`,
+%% which includes URL schemes like `https:`. Treat the `encrypted` tag as a
+%% tagged value to be decrypted later; reconstruct the URL for any other tag.
+{translation, "rabbit.definitions.url",
+fun(Conf) ->
+    case cuttlefish:conf_get("definitions.https.url", Conf, undefined) of
+        undefined                                -> cuttlefish:unset();
+        {encrypted, Rest}                        -> {encrypted, Rest};
+        {Scheme, Rest} when is_atom(Scheme)      -> atom_to_list(Scheme) ++ ":" ++ Rest;
+        Str                                      -> Str
+    end
+end}.
 
 %% Client-side TLS settings used by e.g. HTTPS definition loading mechanism.
 %% These can be reused by other clients.

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1091,6 +1091,42 @@ credential_validator.regexp = ^abc\\d+",
     ]}]}],
   []},
 
+  %% modern configuration key, HTTPS source with a tagged (encrypted) URL
+ {definition_files_encrypted_url,
+  "definitions.import_backend = https
+                     definitions.https.url = encrypted:GhC4J5lh2DUkbdyKO0aMI8aYJ54mwe4eEWzou4yRFAHMF82IbD6cRiYAiBa8UIzR",
+  [{rabbit, [
+    {definitions, [
+      {import_backend, rabbit_definitions_import_https},
+      {url, {encrypted, "GhC4J5lh2DUkbdyKO0aMI8aYJ54mwe4eEWzou4yRFAHMF82IbD6cRiYAiBa8UIzR"}}
+    ]}]}],
+  []},
+
+  %% HTTPS URL with a non-default port and userinfo. Exercises URL
+  %% reconstruction when cuttlefish's tagged_string parser splits at the
+  %% first colon and leaves multiple colons in the remainder.
+ {definition_files_https_url_with_port_and_userinfo,
+  "definitions.import_backend = https
+                     definitions.https.url = https://admin:s3cret@rabbitmq.example.com:8443/env-1/case1.json",
+  [{rabbit, [
+    {definitions, [
+      {import_backend, rabbit_definitions_import_https},
+      {url, "https://admin:s3cret@rabbitmq.example.com:8443/env-1/case1.json"}
+    ]}]}],
+  []},
+
+  %% Plain HTTP URL (different scheme than the key name suggests). Exercises
+  %% URL reconstruction for a non-https scheme.
+ {definition_files_http_url,
+  "definitions.import_backend = https
+                     definitions.https.url = http://rabbitmq.example.com/case1.json",
+  [{rabbit, [
+    {definitions, [
+      {import_backend, rabbit_definitions_import_https},
+      {url, "http://rabbitmq.example.com/case1.json"}
+    ]}]}],
+  []},
+
   %%
   %% Raft
   %%

--- a/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
+++ b/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
@@ -112,11 +112,11 @@ end}.
 {mapping, "prometheus.ssl.cacertfile", "rabbitmq_prometheus.ssl_config.ssl_opts.cacertfile",
     [{datatype, string}, {validators, ["pem_file"]}]}.
 {mapping, "prometheus.ssl.password", "rabbitmq_prometheus.ssl_config.ssl_opts.password",
-    [{datatype, [tagged_string, string]}]}.
+    [{datatype, [tagged_binary, binary]}]}.
 
 {translation, "rabbitmq_prometheus.ssl_config.ssl_opts.password",
 fun(Conf) ->
-    rabbit_cuttlefish:optionally_tagged_string("prometheus.ssl.password", Conf)
+    rabbit_cuttlefish:optionally_tagged_binary("prometheus.ssl.password", Conf)
 end}.
 
 {mapping, "prometheus.ssl.verify", "rabbitmq_prometheus.ssl_config.ssl_opts.verify", [

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
@@ -348,7 +348,7 @@
     [{rabbitmq_prometheus,[
                            {ssl_config,[
                                         {ssl_opts, [
-                                          {password, "t0p$3cr3t"}
+                                          {password, <<"t0p$3cr3t">>}
                                         ]}
                                        ]}
                           ]}],
@@ -359,7 +359,7 @@
     [{rabbitmq_prometheus,[
                            {ssl_config,[
                                         {ssl_opts, [
-                                          {password, {encrypted, "GhC4J5lh2DUkbdyKO0aMI8aYJ54mwe4eEWzou4yRFAHMF82IbD6cRiYAiBa8UIzR"}}
+                                          {password, {encrypted, <<"GhC4J5lh2DUkbdyKO0aMI8aYJ54mwe4eEWzou4yRFAHMF82IbD6cRiYAiBa8UIzR">>}}
                                         ]}
                                        ]}
                           ]}],


### PR DESCRIPTION
Note that this key is a tricky one: it includes
colon-prefixed values that are NOT encrypted
since that's the typical URI, URL format.

This is a continuation to #16541, including one
backwards-compatible internal data type change
from a tagged string to a tagged binary, for
consistency with the rest of the comparable keys
across the entire codebase.
