### PR TITLE
Management UI: add 'Delayed' column to the queue list

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -84,6 +84,7 @@ var ALL_COLUMNS =
                    ['state',                'State',                  true]],
       'Messages': [['msgs-ready',      'Ready',          true],
                    ['msgs-unacked',    'Unacknowledged', true],
+                   ['msgs-delayed',    'Delayed',        false],
                    ['msgs-ram',        'In memory',      false],
                    ['msgs-persistent', 'Persistent',     false],
                    ['msgs-total',      'Total',          true]],

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -69,6 +69,9 @@
 <% if (show_column('queues', 'msgs-unacked')) { %>
     <th><%= fmt_sort('Unacked',      'messages_unacknowledged') %></th>
 <% } %>
+<% if (show_column('queues', 'msgs-delayed')) { %>
+    <th><%= fmt_sort('Delayed',      'messages_delayed') %></th>
+<% } %>
 <% if (show_column('queues', 'msgs-ram')) { %>
     <th><%= fmt_sort('In Memory',    'messages_ram') %></th>
 <% } %>
@@ -167,6 +170,9 @@
 <% } %>
 <% } %>
 <% if(!disable_stats) { %>
+<% if (show_column('queues', 'msgs-delayed')) { %>
+   <td class="r"><%= fmt_num_thousands(queue.messages_delayed) %></td>
+<% } %>
 <% if (show_column('queues', 'msgs-ram')) { %>
    <td class="r"><%= fmt_num_thousands(queue.messages_ram) %></td>
 <% } %>

--- a/selenium/test/queuesAndStreams/list.js
+++ b/selenium/test/queuesAndStreams/list.js
@@ -75,6 +75,7 @@ describe('Queues and Streams management', function () {
       "columns": [
         {"name:":"Ready","id":"checkbox-queues-msgs-ready"},
         {"name:":"Unacknowledged","id":"checkbox-queues-msgs-unacked"},
+        {"name:":"Delayed","id":"checkbox-queues-msgs-delayed"},
         {"name:":"In memory","id":"checkbox-queues-msgs-ram"},
         {"name:":"Persistent","id":"checkbox-queues-msgs-persistent"},
         {"name:":"Total","id":"checkbox-queues-msgs-total"}


### PR DESCRIPTION
## What

Add a 'Delayed' column to the management UI queue list page, in the Messages column group, positioned between Unacked and In Memory.

## Why

RabbitMQ 4.3 introduced a native retry policy for quorum queues, which added a `messages_delayed` counter visible on the queue detail page. However, the main queue list page did not include this counter, making it necessary to open each queue individually to check it.

The 'In Memory' column (`messages_ram`) follows the same pattern — it only applies to classic queues but is included in the list, hidden by default. This change applies the same treatment to 'Delayed'.

## Changes

- `deps/rabbitmq_management/priv/www/js/global.js`: add `msgs-delayed` entry to the Messages column group (hidden by default)
- `deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs`: add the column header and data cell
- `selenium/test/queuesAndStreams/list.js`: update the column picker assertion to include the new entry