### PR TITLE
By @michaelklishin: fix a `tiie_binding_to_dest_with_keep_while_cond`-specific crash on data-less Khepri tree nodes

### DIFF
--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -1016,9 +1016,10 @@ tie_binding_to_dest_with_keep_while_cond_enable(
                        "auto-delete exchanges",
                        [FeatureName],
                        #{domain => ?RMQLOG_DOMAIN_DB}),
+                    %% `#if_has_data{}' skips data-less intermediate nodes.
                     ExchangePattern = rabbit_db_exchange:khepri_exchange_path(
                                         ?KHEPRI_WILDCARD_STAR,
-                                        ?KHEPRI_WILDCARD_STAR),
+                                        #if_has_data{}),
                     ok = khepri_tx:foreach(
                            ExchangePattern,
                            fun(ExchangePath, #{data := Exchange}) ->
@@ -1040,12 +1041,13 @@ tie_binding_to_dest_with_keep_while_cond_enable(
                        "bindings",
                        [FeatureName],
                        #{domain => ?RMQLOG_DOMAIN_DB}),
+                    %% Same `#if_has_data{}' guard as above.
                     BindingPattern = rabbit_db_binding:khepri_route_path(
                                        ?KHEPRI_WILDCARD_STAR,
                                        ?KHEPRI_WILDCARD_STAR,
                                        ?KHEPRI_WILDCARD_STAR,
                                        ?KHEPRI_WILDCARD_STAR,
-                                       ?KHEPRI_WILDCARD_STAR),
+                                       #if_has_data{}),
                     ok = khepri_tx:foreach(
                            BindingPattern,
                            fun(BindingPath, #{data := Set}) ->

--- a/deps/rabbit/test/rabbit_db_binding_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_binding_SUITE.erl
@@ -36,7 +36,11 @@
          match/1, match1/1,
          match_routing_key/1, match_routing_key1/1,
          tie_binding_to_dest_with_keep_while_cond/1,
-         tie_binding_to_dest_with_keep_while_cond1/1
+         tie_binding_to_dest_with_keep_while_cond1/1,
+         tie_binding_to_dest_with_keep_while_cond_orphan_nodes/1,
+         tie_binding_to_dest_with_keep_while_cond_orphan_nodes1/1,
+         tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission/1,
+         tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission1/1
         ]).
 
 -define(VHOST, <<"/">>).
@@ -55,7 +59,9 @@ groups() ->
        delete_v2,
        auto_delete_v1,
        auto_delete_v2,
-       tie_binding_to_dest_with_keep_while_cond]}
+       tie_binding_to_dest_with_keep_while_cond,
+       tie_binding_to_dest_with_keep_while_cond_orphan_nodes,
+       tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission]}
     ].
 
 all_tests() ->
@@ -566,5 +572,88 @@ tie_binding_to_dest_with_keep_while_cond1(_Config) ->
     ?assert(rabbit_khepri:exists(XPath2)),
     ?assertNot(rabbit_khepri:exists(BPath1)),
     ?assertNot(rabbit_khepri:exists(BPath2)),
+
+    passed.
+
+tie_binding_to_dest_with_keep_while_cond_orphan_nodes(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0,
+               ?MODULE,
+               tie_binding_to_dest_with_keep_while_cond_orphan_nodes1,
+               [Config]).
+
+tie_binding_to_dest_with_keep_while_cond_orphan_nodes1(_Config) ->
+    %% Regression test: an orphan exchange-level tree node (with bindings
+    %% underneath but no exchange record of its own) used to crash the
+    %% migration with `function_clause'.
+
+    ?assertNot(
+       rabbit_feature_flags:is_enabled(
+         tie_binding_to_dest_with_keep_while_cond)),
+
+    NamePrefix = atom_to_binary(?FUNCTION_NAME),
+    XName = rabbit_misc:r(?VHOST, exchange, <<NamePrefix/binary, "-x">>),
+    Exchange = #exchange{
+                  name = XName,
+                  durable = true, auto_delete = false, decorators = {[], []}},
+    ?assertMatch(
+       {new, #exchange{}},
+       rabbit_db_exchange:create_or_get(Exchange)),
+
+    %% A leaf below a non-existent source exchange leaves the intermediate
+    %% exchange-level node without a payload. Reuse `XName' as the
+    %% destination so the migration's `keep_while' holds.
+    SrcName = <<".*">>,
+    BindingPath = rabbit_db_binding:khepri_route_path(
+                    ?VHOST,
+                    SrcName,
+                    exchange,
+                    XName#resource.name,
+                    <<"">>),
+    OrphanExchangePath = rabbit_db_exchange:khepri_exchange_path(
+                           ?VHOST, SrcName),
+    ?assertEqual(ok, rabbit_khepri:put(BindingPath, sets:new())),
+    ?assert(rabbit_khepri:exists(BindingPath)),
+    ?assert(rabbit_khepri:exists(OrphanExchangePath)),
+
+    ?assertEqual(
+       ok,
+       rabbit_feature_flags:enable(
+         tie_binding_to_dest_with_keep_while_cond)),
+
+    passed.
+
+tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0,
+               ?MODULE,
+               tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission1,
+               [Config]).
+
+tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission1(_Config) ->
+    %% Same regression as `tie_binding_to_dest_with_keep_while_cond_orphan_nodes',
+    %% but the orphan is left by a topic permission whose `exchange' field
+    %% does not match any real exchange (e.g. `.*').
+
+    ?assertNot(
+       rabbit_feature_flags:is_enabled(
+         tie_binding_to_dest_with_keep_while_cond)),
+
+    ExchangeName = <<".*">>,
+    TopicPermissionPath = rabbit_db_user:khepri_topic_permission_path(
+                            <<"a-user">>,
+                            ?VHOST,
+                            ExchangeName),
+    OrphanExchangePath = rabbit_db_exchange:khepri_exchange_path(
+                           ?VHOST, ExchangeName),
+    ?assertEqual(
+       ok, rabbit_khepri:put(TopicPermissionPath, #topic_permission{})),
+    ?assert(rabbit_khepri:exists(TopicPermissionPath)),
+    ?assert(rabbit_khepri:exists(OrphanExchangePath)),
+
+    ?assertEqual(
+       ok,
+       rabbit_feature_flags:enable(
+         tie_binding_to_dest_with_keep_while_cond)),
 
     passed.


### PR DESCRIPTION
References #16590 #16587 #14902 #15954.
Closes #16587.

(cherry picked from commit 83b19ec26b6f9662c2d2bcc46aa39a1adcef28a8)

Forward-porting the correct commit to main. No backport necessary.