### PR TITLE
docker-image: skip macOS-specific files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ PROJECT_DESCRIPTION = RabbitMQ Server
 # value from rabbitmq-components.mk.
 export RABBITMQ_VERSION := $(PROJECT_VERSION)
 
+# Avoid creating macOS AppleDouble/resource fork files in tarballs.
+export COPYFILE_DISABLE = 1
+
 # Release artifacts are put in $(PACKAGES_DIR).
 PACKAGES_DIR ?= $(abspath PACKAGES)
 
@@ -96,6 +99,7 @@ RSYNC_V = $(RSYNC_V_$(V))
 BASE_RSYNC_FLAGS += -a $(RSYNC_V) \
 	       --delete					\
 	       --delete-excluded			\
+	       --exclude '._*'				\
 	       --exclude '.sw?' --exclude '.*.sw?'	\
 	       --exclude '*.beam'			\
 	       --exclude '*.d'				\

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,6 +1,9 @@
 all: package-generic-unix
 	@:
 
+# Avoid creating macOS AppleDouble/resource fork files in tarballs.
+export COPYFILE_DISABLE = 1
+
 # --------------------------------------------------------------------
 # Packaging.
 # --------------------------------------------------------------------

--- a/packaging/generic-unix/Makefile
+++ b/packaging/generic-unix/Makefile
@@ -1,5 +1,8 @@
 SOURCE_DIST_FILE ?= $(wildcard ../../../rabbitmq-server-*.tar.xz)
 
+# Avoid creating macOS AppleDouble/resource fork files in tarballs.
+export COPYFILE_DISABLE = 1
+
 ifneq ($(filter-out clean,$(MAKECMDGOALS)),)
 ifeq ($(SOURCE_DIST_FILE),)
 $(error Cannot find source archive; please specify SOURCE_DIST_FILE)


### PR DESCRIPTION
when building the image on macOS, some files
are generated with `._` prefix. Setting
`COPYFILE_DISABLE=1` prevents these files
from being created. Additionally, we exclude
them from `rsync` in case they already exist.
