### PR TITLE
Federation and shovel: better network partition handling

### DIFF
--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -7,7 +7,12 @@
 
 -module(mirrored_supervisor).
 
+-compile(nowarn_deprecated_catch).
+
+-include_lib("khepri/include/khepri.hrl").
+-include("include/rabbit_khepri.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include("mirrored_supervisor.hrl").
 
 %% Mirrored Supervisor
 %% ===================
@@ -273,7 +278,9 @@ handle_call({init, Overall}, _From,
     Results = [maybe_start(Group, Overall, Delegate, S) || S <- ChildSpecs],
     mirrored_supervisor_locks:unlock(LockId),
     case errors(Results) of
-        []     -> {reply, ok, State1};
+        []     ->
+            erlang:send_after(10000, self(), reconcile),
+            {reply, ok, State1};
         Errors -> {stop, {shutdown, Errors}, State1}
     end;
 
@@ -363,8 +370,87 @@ handle_info({'DOWN', _Ref, process, Pid, _Reason},
         Errors -> {stop, {shutdown, Errors}, State}
     end;
 
+handle_info(reconcile, State = #state{overall  = Overall,
+                                      delegate = Delegate,
+                                      group    = Group}) when Overall =/= undefined ->
+    reconcile_children(Group, Overall, Delegate),
+    erlang:send_after(30000, self(), reconcile),
+    {noreply, State};
+
 handle_info(Info, State) ->
     {stop, {unexpected_info, Info}, State}.
+
+reconcile_children(Group, Overall, Delegate) ->
+    %% This runs periodically on every node, so it must tolerate Khepri being
+    %% temporarily unavailable (for example during a leader election or a
+    %% partition), which is precisely when this code is most needed. Any error
+    %% is logged and swallowed; the next reconcile tick retries.
+    try
+        do_reconcile_children(Group, Overall, Delegate)
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_WARNING("Mirrored supervisor: reconciliation of group ~tp failed, will retry on the next tick: ~tp:~tp~n~tp",
+                         [Group, Class, Reason, Stacktrace]),
+            ok
+    end.
+
+do_reconcile_children(Group, Overall, Delegate) ->
+    case ?SUPERVISOR:which_children(Delegate) of
+        Children when is_list(Children) ->
+            %% Stop any local child the metadata store says is owned by another
+            %% node, so that exactly one node runs each child.
+            [case rabbit_db_msup:find_mirror(Group, Id) of
+                 {ok, Owner} when Owner =/= Overall ->
+                     ?LOG_WARNING("Mirrored supervisor: child ~tp in group ~tp is owned by another node ~tp (we are ~tp), stopping local instance",
+                                  [Id, Group, node(Owner), node()]),
+                     catch ?SUPERVISOR:terminate_child(Delegate, Id),
+                     catch ?SUPERVISOR:delete_child(Delegate, Id);
+                 _ ->
+                     ok
+             end
+             || {Id, Pid, _, _} <- Children, is_pid(Pid)],
+            reclaim_orphans(Group, Overall, Delegate);
+        _ ->
+            ok
+    end.
+
+reclaim_orphans(Group, Overall, Delegate) ->
+    ActiveMembers = pg:get_members(Group),
+    case lists:sort(ActiveMembers) of
+        [Overall | _] ->
+            Pattern = #mirrored_sup_childspec{key = {Group, '_'}, _ = '_'},
+            Conditions = [?KHEPRI_WILDCARD_STAR_STAR, #if_data_matches{pattern = Pattern}],
+            PathPattern = rabbit_db_msup:khepri_mirrored_supervisor_path(
+                            ?KHEPRI_WILDCARD_STAR,
+                            #if_all{conditions = Conditions}),
+            case rabbit_khepri:get_many(PathPattern) of
+                {ok, Map} ->
+                    [case S0 of
+                         #mirrored_sup_childspec{mirroring_pid = OwnerPid, childspec = ChildSpec, key = {Group, Id}} ->
+                             case lists:member(OwnerPid, ActiveMembers) of
+                                 false ->
+                                     ?LOG_NOTICE("Mirrored supervisor: reclaiming orphan child ~tp in group ~tp (previous owner ~tp was dead/unreachable)",
+                                                 [Id, Group, OwnerPid]),
+                                     NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
+                                     case rabbit_khepri:put(Path, NewS) of
+                                         ok ->
+                                             catch ?SUPERVISOR:start_child(Delegate, ChildSpec);
+                                         _ ->
+                                             ok
+                                     end;
+                                 true ->
+                                     ok
+                             end;
+                         _ ->
+                             ok
+                     end
+                     || {Path, S0} <- maps:to_list(Map)];
+                _ ->
+                    ok
+            end;
+        _ ->
+            ok
+    end.
 
 terminate(_Reason, _State) ->
     ok.

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -564,21 +564,16 @@ reclaim_orphans(Group, Overall, Delegate) ->
               fun({Path, #mirrored_sup_childspec{mirroring_pid = OwnerPid,
                                                  childspec = ChildSpec,
                                                  key = {_, Id}} = S0}) ->
-                      case lists:member(OwnerPid, ActiveMembers) of
-                          false ->
-                              ?LOG_NOTICE("Mirrored supervisor: reclaiming orphan child ~tp in group ~tp (previous owner ~tp was dead/unreachable)",
-                                          [Id, Group, OwnerPid]),
-                              NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
-                              case rabbit_khepri:put(Path, NewS) of
-                                  ok ->
-                                      try ?SUPERVISOR:start_child(Delegate, ChildSpec) catch _:_ -> ok end,
-                                      ok;
-                                  _ ->
-                                      ok
-                              end;
-                          true ->
-                              ok
-                      end
+                  maybe
+                      false ?= lists:member(OwnerPid, ActiveMembers),
+                      ?LOG_NOTICE("Mirrored supervisor: reclaiming orphan child ~tp in group ~tp (previous owner ~tp was dead/unreachable)",
+                                  [Id, Group, OwnerPid]),
+                      NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
+                      ok ?= rabbit_khepri:put(Path, NewS),
+                      try ?SUPERVISOR:start_child(Delegate, ChildSpec) catch _:_ -> ok end
+                  else
+                      _ -> ok
+                  end
               end, group_childspecs(Group));
         _ ->
             ok

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -103,6 +103,11 @@
 -define(GEN_SERVER, gen_server2).
 -define(SUP_MODULE, mirrored_supervisor_sups).
 
+%% Periodic reconciliation interval, and a short debounce used to coalesce
+%% reconciliations triggered by process group membership changes.
+-define(RECONCILE_INTERVAL, 30000).
+-define(RECONCILE_DEBOUNCE, 2000).
+
 -export([start_link/3, start_link/4,
          start_child/2, restart_child/2,
          delete_child/2, terminate_child/2,
@@ -121,7 +126,12 @@
                 group,
                 tx_fun,
                 initial_childspecs,
-                child_order}).
+                child_order,
+                %% Reference returned by pg:monitor/1 for the group.
+                pg_ref,
+                %% Whether a debounced, membership-triggered reconciliation is
+                %% already scheduled, to coalesce bursts of pg events.
+                reconcile_scheduled = false}).
 
 %%--------------------------------------------------------------------------
 %% Callback behaviour
@@ -258,6 +268,11 @@ handle_call({init, Overall}, _From,
     LockId = mirrored_supervisor_locks:lock(Group),
     maybe_log_lock_acquisition_failure(LockId, Group),
     ok = pg:join(Group, Overall),
+    %% Watch group membership so that partitions and heals trigger a prompt
+    %% reconciliation instead of waiting for the next periodic tick. This
+    %% shrinks the window during which a child runs (and is reported) on more
+    %% than one node after a partition heals.
+    {PgRef, _} = pg:monitor(Group),
     ?LOG_DEBUG("Mirrored supervisor: initializing, overall supervisor ~tp joined group ~tp", [Overall, Group]),
     Rest = pg:get_members(Group) -- [Overall],
     Nodes = [node(M) || M <- Rest],
@@ -281,7 +296,7 @@ handle_call({init, Overall}, _From,
      end || Pid <- Rest],
     Delegate = delegate(Overall),
     erlang:monitor(process, Delegate),
-    State1 = State#state{overall = Overall, delegate = Delegate},
+    State1 = State#state{overall = Overall, delegate = Delegate, pg_ref = PgRef},
     Results = [maybe_start(Group, Overall, Delegate, S) || S <- ChildSpecs],
     mirrored_supervisor_locks:unlock(LockId),
     case errors(Results) of
@@ -400,8 +415,33 @@ handle_info(reconcile, State = #state{overall  = Overall,
                                       delegate = Delegate,
                                       group    = Group}) when Overall =/= undefined ->
     reconcile_children(Group, Overall, Delegate),
-    erlang:send_after(30000, self(), reconcile),
+    erlang:send_after(?RECONCILE_INTERVAL, self(), reconcile),
     {noreply, State};
+
+%% A debounced reconciliation triggered by a group membership change. Unlike
+%% the periodic 'reconcile' it does not reschedule the periodic timer; it just
+%% reconciles once and clears the debounce flag.
+handle_info(reconcile_now, State = #state{overall  = Overall,
+                                          delegate = Delegate,
+                                          group    = Group}) when Overall =/= undefined ->
+    reconcile_children(Group, Overall, Delegate),
+    {noreply, State#state{reconcile_scheduled = false}};
+
+%% Group membership changed (a peer joined on partition heal, or left on
+%% partition). Schedule a single debounced reconciliation so that the minority
+%% side sheds its children promptly and the majority side stops any duplicate
+%% it has taken over, instead of waiting for the next periodic tick.
+handle_info({PgRef, Event, _Group, _Pids},
+            State = #state{pg_ref = PgRef, overall = Overall,
+                           reconcile_scheduled = Scheduled})
+  when (Event =:= join orelse Event =:= leave) ->
+    case Overall =/= undefined andalso not Scheduled of
+        true ->
+            erlang:send_after(?RECONCILE_DEBOUNCE, self(), reconcile_now),
+            {noreply, State#state{reconcile_scheduled = true}};
+        false ->
+            {noreply, State}
+    end;
 
 handle_info(Info, State) ->
     {stop, {unexpected_info, Info}, State}.

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -421,42 +421,41 @@ reconcile_children(Group, Overall, Delegate) ->
     end.
 
 do_reconcile_children(Group, Overall, Delegate) ->
-    case ?SUPERVISOR:which_children(Delegate) of
-        Children when is_list(Children) ->
-            Members = rabbit_nodes:list_members(),
-            TotalSize = length(Members),
-            Reachable = rabbit_nodes:list_reachable(),
-            %% A strict majority of cluster members must be reachable to keep
-            %% children running locally. On an even split (for example 2|2 of
-            %% four nodes) neither side reaches the majority, so both sides stop
-            %% their children; the majority side, once one exists again, reclaims
-            %% them on partition heal. Clusters with fewer than three members
-            %% never stop children this way, since they cannot have a majority.
-            IsMinority = (TotalSize >= 3) andalso (length(Reachable) < (TotalSize div 2) + 1),
-            case IsMinority of
-                true ->
-                    [begin
-                         ?LOG_WARNING("Mirrored supervisor: node is in a minority partition (~tp/~tp nodes reachable), stopping local instance of child ~tp in group ~tp",
-                                      [length(Reachable), TotalSize, Id, Group]),
-                         catch ?SUPERVISOR:terminate_child(Delegate, Id),
-                         catch ?SUPERVISOR:delete_child(Delegate, Id)
-                     end
-                     || {Id, Pid, _, _} <- Children, is_pid(Pid)];
-                false ->
-                    [case rabbit_db_msup:find_mirror(Group, Id) of
-                         {ok, Owner} when Owner =/= Overall ->
-                             ?LOG_WARNING("Mirrored supervisor: child ~tp in group ~tp is owned by another node ~tp (we are ~tp), stopping local instance",
-                                          [Id, Group, node(Owner), node()]),
-                             catch ?SUPERVISOR:terminate_child(Delegate, Id),
-                             catch ?SUPERVISOR:delete_child(Delegate, Id);
-                         _ ->
-                             ok
-                     end
-                     || {Id, Pid, _, _} <- Children, is_pid(Pid)],
-                    reclaim_orphans(Group, Overall, Delegate)
-            end;
-        _ ->
-            ok
+    Children = ?SUPERVISOR:which_children(Delegate),
+    RunningIds = [Id || {Id, Pid, _, _} <- Children, is_pid(Pid)],
+    Members = rabbit_nodes:list_members(),
+    TotalSize = length(Members),
+    Reachable = rabbit_nodes:list_reachable(),
+    %% A strict majority of cluster members must be reachable to keep children
+    %% running locally. On an even split (for example 2|2 of four nodes) neither
+    %% side reaches the majority, so both sides stop their children; the
+    %% majority side, once one exists again, reclaims them on partition heal.
+    %% Clusters with fewer than three members never stop children this way,
+    %% since they cannot have a majority.
+    IsMinority = (TotalSize >= 3) andalso (length(Reachable) < (TotalSize div 2) + 1),
+    case IsMinority of
+        true ->
+            lists:foreach(
+              fun(Id) ->
+                      ?LOG_WARNING("Mirrored supervisor: node is in a minority partition (~tp/~tp nodes reachable), stopping local instance of child ~tp in group ~tp",
+                                   [length(Reachable), TotalSize, Id, Group]),
+                      catch ?SUPERVISOR:terminate_child(Delegate, Id),
+                      catch ?SUPERVISOR:delete_child(Delegate, Id)
+              end, RunningIds);
+        false ->
+            lists:foreach(
+              fun(Id) ->
+                      case rabbit_db_msup:find_mirror(Group, Id) of
+                          {ok, Owner} when Owner =/= Overall ->
+                              ?LOG_WARNING("Mirrored supervisor: child ~tp in group ~tp is owned by another node ~tp (we are ~tp), stopping local instance",
+                                           [Id, Group, node(Owner), node()]),
+                              catch ?SUPERVISOR:terminate_child(Delegate, Id),
+                              catch ?SUPERVISOR:delete_child(Delegate, Id);
+                          _ ->
+                              ok
+                      end
+              end, RunningIds),
+            reclaim_orphans(Group, Overall, Delegate)
     end.
 
 reclaim_orphans(Group, Overall, Delegate) ->
@@ -470,26 +469,31 @@ reclaim_orphans(Group, Overall, Delegate) ->
                             #if_all{conditions = Conditions}),
             case rabbit_khepri:get_many(PathPattern) of
                 {ok, Map} ->
-                    [case S0 of
-                         #mirrored_sup_childspec{mirroring_pid = OwnerPid, childspec = ChildSpec, key = {Group, Id}} ->
-                             case lists:member(OwnerPid, ActiveMembers) of
-                                 false ->
-                                     ?LOG_NOTICE("Mirrored supervisor: reclaiming orphan child ~tp in group ~tp (previous owner ~tp was dead/unreachable)",
-                                                 [Id, Group, OwnerPid]),
-                                     NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
-                                     case rabbit_khepri:put(Path, NewS) of
-                                         ok ->
-                                             catch ?SUPERVISOR:start_child(Delegate, ChildSpec);
-                                         _ ->
-                                             ok
-                                     end;
-                                 true ->
-                                     ok
-                             end;
-                         _ ->
-                             ok
-                     end
-                     || {Path, S0} <- maps:to_list(Map)];
+                    lists:foreach(
+                      %% get_many already restricts results to this group via
+                      %% the #if_data_matches condition, so the key's group
+                      %% element is always Group here.
+                      fun({Path, #mirrored_sup_childspec{mirroring_pid = OwnerPid,
+                                                         childspec = ChildSpec,
+                                                         key = {_, Id}} = S0}) ->
+                              case lists:member(OwnerPid, ActiveMembers) of
+                                  false ->
+                                      ?LOG_NOTICE("Mirrored supervisor: reclaiming orphan child ~tp in group ~tp (previous owner ~tp was dead/unreachable)",
+                                                  [Id, Group, OwnerPid]),
+                                      NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
+                                      case rabbit_khepri:put(Path, NewS) of
+                                          ok ->
+                                              catch ?SUPERVISOR:start_child(Delegate, ChildSpec),
+                                              ok;
+                                          _ ->
+                                              ok
+                                      end;
+                                  true ->
+                                      ok
+                              end;
+                         (_) ->
+                              ok
+                      end, maps:to_list(Map));
                 _ ->
                     ok
             end;

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -358,24 +358,43 @@ handle_info({'DOWN', _Ref, process, Pid, _Reason},
                            group    = Group,
                            overall  = O,
                            child_order = ChildOrder}) ->
+    %% A peer mirroring process went down. If we sort first in the group, take
+    %% over its children. This touches Khepri, which can be temporarily
+    %% unavailable, for example during the leader election triggered by the
+    %% very partition that caused this 'DOWN'. We must not crash here: crashing
+    %% restarts the mirroring process and, on repeated failures, exhausts the
+    %% supervisor's restart intensity and tears down the whole group. Instead
+    %% we log and let the periodic reconciliation loop take over the orphaned
+    %% children once Khepri is reachable again.
+    %%
     %% No guarantee pg will have received the DOWN before us.
-    R = case lists:sort(pg:get_members(Group)) -- [Pid] of
-            [O | _] -> ChildSpecs = update_all(O, Pid),
-                       case ChildSpecs of
-                           _ when is_list(ChildSpecs) ->
-                               [start(Delegate, ChildSpec)
-                                || ChildSpec <- restore_child_order(
-                                                  ChildSpecs,
-                                                  ChildOrder)];
-                           {error, _} ->
-                               [ChildSpecs]
-                       end;
-            _       -> []
-        end,
-    case errors(R) of
-        []     -> {noreply, State};
-        Errors -> {stop, {shutdown, Errors}, State}
-    end;
+    try
+        case lists:sort(pg:get_members(Group)) -- [Pid] of
+            [O | _] ->
+                case update_all(O, Pid) of
+                    ChildSpecs when is_list(ChildSpecs) ->
+                        Results = [start(Delegate, ChildSpec)
+                                   || ChildSpec <- restore_child_order(
+                                                     ChildSpecs, ChildOrder)],
+                        case errors(Results) of
+                            []     -> ok;
+                            Errors ->
+                                ?LOG_WARNING("Mirrored supervisor: failover in group ~tp could not start some children, reconciliation will retry: ~tp",
+                                             [Group, Errors])
+                        end;
+                    {error, UpdateError} ->
+                        ?LOG_WARNING("Mirrored supervisor: failover in group ~tp failed (~tp), reconciliation will retry",
+                                     [Group, UpdateError])
+                end;
+            _ ->
+                ok
+        end
+    catch
+        Class:CatchReason:Stacktrace ->
+            ?LOG_WARNING("Mirrored supervisor: failover in group ~tp raised ~tp:~tp, reconciliation will retry~n~tp",
+                         [Group, Class, CatchReason, Stacktrace])
+    end,
+    {noreply, State};
 
 handle_info(reconcile, State = #state{overall  = Overall,
                                       delegate = Delegate,

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -386,20 +386,33 @@ handle_info({'DOWN', _Ref, process, Pid, _Reason},
     try
         case lists:sort(pg:get_members(Group)) -- [Pid] of
             [O | _] ->
-                case update_all(O, Pid) of
-                    ChildSpecs when is_list(ChildSpecs) ->
-                        Results = [start(Delegate, ChildSpec)
-                                   || ChildSpec <- restore_child_order(
-                                                     ChildSpecs, ChildOrder)],
-                        case errors(Results) of
-                            []     -> ok;
-                            Errors ->
-                                ?LOG_WARNING("Mirrored supervisor: failover in group ~tp could not start some children, reconciliation will retry: ~tp",
-                                             [Group, Errors])
-                        end;
-                    {error, UpdateError} ->
-                        ?LOG_WARNING("Mirrored supervisor: failover in group ~tp failed (~tp), reconciliation will retry",
-                                     [Group, UpdateError])
+                case partition_status() of
+                    {true, _, _} ->
+                        %% We are in a minority partition. We must not take over
+                        %% the children (the majority side owns them), and we
+                        %% cannot: update_all writes to Khepri, which has no
+                        %% quorum here, so it would block this process until it
+                        %% times out - stalling every other message, including
+                        %% the reconciliation that is supposed to stop our local
+                        %% children. Skip the failover; reconciliation handles
+                        %% the minority case.
+                        ok;
+                    {false, _, _} ->
+                        case update_all(O, Pid) of
+                            ChildSpecs when is_list(ChildSpecs) ->
+                                Results = [start(Delegate, ChildSpec)
+                                           || ChildSpec <- restore_child_order(
+                                                             ChildSpecs, ChildOrder)],
+                                case errors(Results) of
+                                    []     -> ok;
+                                    Errors ->
+                                        ?LOG_WARNING("Mirrored supervisor: failover in group ~tp could not start some children, reconciliation will retry: ~tp",
+                                                     [Group, Errors])
+                                end;
+                            {error, UpdateError} ->
+                                ?LOG_WARNING("Mirrored supervisor: failover in group ~tp failed (~tp), reconciliation will retry",
+                                             [Group, UpdateError])
+                        end
                 end;
             _ ->
                 ok
@@ -446,6 +459,20 @@ handle_info({PgRef, Event, _Group, _Pids},
 handle_info(Info, State) ->
     {stop, {unexpected_info, Info}, State}.
 
+%% Determine whether this node is in a minority partition, along with the
+%% reachable and total cluster member counts (for logging). A strict majority
+%% of cluster members must be reachable; clusters smaller than three members
+%% never qualify, since they cannot establish a majority. On an even split
+%% (for example 2|2 of four nodes) neither side reaches the majority, so both
+%% sides treat themselves as minority and stop their children. These counts
+%% come from Erlang distribution and the locally-known cluster membership, both
+%% of which stay available on a partitioned node (unlike Khepri writes).
+partition_status() ->
+    TotalSize = length(rabbit_nodes:list_members()),
+    ReachableCount = length(rabbit_nodes:list_reachable()),
+    IsMinority = (TotalSize >= 3) andalso (ReachableCount < (TotalSize div 2) + 1),
+    {IsMinority, ReachableCount, TotalSize}.
+
 reconcile_children(Group, Overall, Delegate) ->
     %% This runs periodically on every node, so it must tolerate Khepri being
     %% temporarily unavailable (for example during a leader election or a
@@ -463,22 +490,13 @@ reconcile_children(Group, Overall, Delegate) ->
 do_reconcile_children(Group, Overall, Delegate) ->
     Children = ?SUPERVISOR:which_children(Delegate),
     RunningIds = [Id || {Id, Pid, _, _} <- Children, is_pid(Pid)],
-    Members = rabbit_nodes:list_members(),
-    TotalSize = length(Members),
-    Reachable = rabbit_nodes:list_reachable(),
-    %% A strict majority of cluster members must be reachable to keep children
-    %% running locally. On an even split (for example 2|2 of four nodes) neither
-    %% side reaches the majority, so both sides stop their children; the
-    %% majority side, once one exists again, reclaims them on partition heal.
-    %% Clusters with fewer than three members never stop children this way,
-    %% since they cannot have a majority.
-    IsMinority = (TotalSize >= 3) andalso (length(Reachable) < (TotalSize div 2) + 1),
+    {IsMinority, ReachableCount, TotalSize} = partition_status(),
     case IsMinority of
         true ->
             lists:foreach(
               fun(Id) ->
                       ?LOG_WARNING("Mirrored supervisor: node is in a minority partition (~tp/~tp nodes reachable), stopping local instance of child ~tp in group ~tp",
-                                   [length(Reachable), TotalSize, Id, Group]),
+                                   [ReachableCount, TotalSize, Id, Group]),
                       catch ?SUPERVISOR:terminate_child(Delegate, Id),
                       catch ?SUPERVISOR:delete_child(Delegate, Id)
               end, RunningIds);

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -397,19 +397,38 @@ reconcile_children(Group, Overall, Delegate) ->
 do_reconcile_children(Group, Overall, Delegate) ->
     case ?SUPERVISOR:which_children(Delegate) of
         Children when is_list(Children) ->
-            %% Stop any local child the metadata store says is owned by another
-            %% node, so that exactly one node runs each child.
-            [case rabbit_db_msup:find_mirror(Group, Id) of
-                 {ok, Owner} when Owner =/= Overall ->
-                     ?LOG_WARNING("Mirrored supervisor: child ~tp in group ~tp is owned by another node ~tp (we are ~tp), stopping local instance",
-                                  [Id, Group, node(Owner), node()]),
-                     catch ?SUPERVISOR:terminate_child(Delegate, Id),
-                     catch ?SUPERVISOR:delete_child(Delegate, Id);
-                 _ ->
-                     ok
-             end
-             || {Id, Pid, _, _} <- Children, is_pid(Pid)],
-            reclaim_orphans(Group, Overall, Delegate);
+            Members = rabbit_nodes:list_members(),
+            TotalSize = length(Members),
+            Reachable = rabbit_nodes:list_reachable(),
+            %% A strict majority of cluster members must be reachable to keep
+            %% children running locally. On an even split (for example 2|2 of
+            %% four nodes) neither side reaches the majority, so both sides stop
+            %% their children; the majority side, once one exists again, reclaims
+            %% them on partition heal. Clusters with fewer than three members
+            %% never stop children this way, since they cannot have a majority.
+            IsMinority = (TotalSize >= 3) andalso (length(Reachable) < (TotalSize div 2) + 1),
+            case IsMinority of
+                true ->
+                    [begin
+                         ?LOG_WARNING("Mirrored supervisor: node is in a minority partition (~tp/~tp nodes reachable), stopping local instance of child ~tp in group ~tp",
+                                      [length(Reachable), TotalSize, Id, Group]),
+                         catch ?SUPERVISOR:terminate_child(Delegate, Id),
+                         catch ?SUPERVISOR:delete_child(Delegate, Id)
+                     end
+                     || {Id, Pid, _, _} <- Children, is_pid(Pid)];
+                false ->
+                    [case rabbit_db_msup:find_mirror(Group, Id) of
+                         {ok, Owner} when Owner =/= Overall ->
+                             ?LOG_WARNING("Mirrored supervisor: child ~tp in group ~tp is owned by another node ~tp (we are ~tp), stopping local instance",
+                                          [Id, Group, node(Owner), node()]),
+                             catch ?SUPERVISOR:terminate_child(Delegate, Id),
+                             catch ?SUPERVISOR:delete_child(Delegate, Id);
+                         _ ->
+                             ok
+                     end
+                     || {Id, Pid, _, _} <- Children, is_pid(Pid)],
+                    reclaim_orphans(Group, Overall, Delegate)
+            end;
         _ ->
             ok
     end.

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -262,11 +262,18 @@ handle_call({init, Overall}, _From,
     Rest = pg:get_members(Group) -- [Overall],
     Nodes = [node(M) || M <- Rest],
     ?LOG_DEBUG("Mirrored supervisor: known group ~tp members: ~tp on nodes ~tp", [Group, Rest, Nodes]),
-    case Rest of
-        [] ->
-            ?LOG_DEBUG("Mirrored supervisor: no known peer members in group ~tp, will delete all child records for it", [Group]),
+    %% An empty group is not enough to justify deleting all child records: a
+    %% peer's mirroring process may simply not have (re)joined the group yet,
+    %% and the records (owned by other nodes) may back children that are still
+    %% running cluster-wide. Deleting them here would wipe those children's
+    %% records on every node. Only clear the records when this node is the sole
+    %% reachable cluster member, i.e. a genuine single-node (re)start; otherwise
+    %% leave any genuinely orphaned records to the reconciliation loop.
+    case Rest =:= [] andalso rabbit_nodes:list_reachable() =:= [node()] of
+        true ->
+            ?LOG_DEBUG("Mirrored supervisor: no known peer members in group ~tp and no other reachable cluster members, will delete all child records for it", [Group]),
             delete_all(Group);
-        _  -> ok
+        false -> ok
     end,
     [begin
          ?GEN_SERVER:cast(mirroring(Pid), {ensure_monitoring, Overall}),

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -7,8 +7,6 @@
 
 -module(mirrored_supervisor).
 
--compile(nowarn_deprecated_catch).
-
 -include_lib("khepri/include/khepri.hrl").
 -include("include/rabbit_khepri.hrl").
 -include_lib("kernel/include/logger.hrl").
@@ -497,8 +495,8 @@ do_reconcile_children(Group, Overall, Delegate) ->
               fun(Id) ->
                       ?LOG_WARNING("Mirrored supervisor: node is in a minority partition (~tp/~tp nodes reachable), stopping local instance of child ~tp in group ~tp",
                                    [ReachableCount, TotalSize, Id, Group]),
-                      catch ?SUPERVISOR:terminate_child(Delegate, Id),
-                      catch ?SUPERVISOR:delete_child(Delegate, Id)
+                      _ = try ?SUPERVISOR:terminate_child(Delegate, Id) catch _:_ -> ok end,
+                      try ?SUPERVISOR:delete_child(Delegate, Id) catch _:_ -> ok end
               end, RunningIds);
         false ->
             lists:foreach(
@@ -507,8 +505,8 @@ do_reconcile_children(Group, Overall, Delegate) ->
                           {ok, Owner} when Owner =/= Overall ->
                               ?LOG_WARNING("Mirrored supervisor: child ~tp in group ~tp is owned by another node ~tp (we are ~tp), stopping local instance",
                                            [Id, Group, node(Owner), node()]),
-                              catch ?SUPERVISOR:terminate_child(Delegate, Id),
-                              catch ?SUPERVISOR:delete_child(Delegate, Id);
+                              _ = try ?SUPERVISOR:terminate_child(Delegate, Id) catch _:_ -> ok end,
+                              try ?SUPERVISOR:delete_child(Delegate, Id) catch _:_ -> ok end;
                           _ ->
                               ok
                       end
@@ -551,7 +549,7 @@ restart_owned_children(Group, Overall, Delegate, RunningIds) ->
                   true ->
                       ?LOG_NOTICE("Mirrored supervisor: restarting child ~tp in group ~tp which this node owns but is not running locally",
                                   [Id, Group]),
-                      catch ?SUPERVISOR:start_child(Delegate, ChildSpec),
+                      _ = try ?SUPERVISOR:start_child(Delegate, ChildSpec) catch _:_ -> ok end,
                       ok;
                   false ->
                       ok
@@ -573,7 +571,7 @@ reclaim_orphans(Group, Overall, Delegate) ->
                               NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
                               case rabbit_khepri:put(Path, NewS) of
                                   ok ->
-                                      catch ?SUPERVISOR:start_child(Delegate, ChildSpec),
+                                      try ?SUPERVISOR:start_child(Delegate, ChildSpec) catch _:_ -> ok end,
                                       ok;
                                   _ ->
                                       ok

--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -455,48 +455,75 @@ do_reconcile_children(Group, Overall, Delegate) ->
                               ok
                       end
               end, RunningIds),
+            %% Restart children we own but are not running, then reclaim those
+            %% owned by dead or unreachable nodes.
+            restart_owned_children(Group, Overall, Delegate, RunningIds),
             reclaim_orphans(Group, Overall, Delegate)
     end.
+
+%% Reads all child spec records for the group from the store, as {Path, Record}
+%% pairs. The #if_data_matches condition restricts the results to this group, so
+%% the key's group element is always Group.
+group_childspecs(Group) ->
+    Pattern = #mirrored_sup_childspec{key = {Group, '_'}, _ = '_'},
+    Conditions = [?KHEPRI_WILDCARD_STAR_STAR, #if_data_matches{pattern = Pattern}],
+    PathPattern = rabbit_db_msup:khepri_mirrored_supervisor_path(
+                    ?KHEPRI_WILDCARD_STAR,
+                    #if_all{conditions = Conditions}),
+    case rabbit_khepri:get_many(PathPattern) of
+        {ok, Map} ->
+            [{Path, S} || {Path, S} <- maps:to_list(Map),
+                          is_record(S, mirrored_sup_childspec)];
+        _ ->
+            []
+    end.
+
+%% Ensure every child this node owns in the store is actually running locally.
+%% A node can own a child without running it after it has left a minority
+%% partition: while in the minority it stopped its children but could not give
+%% up ownership in the store (it has no quorum), and if no majority node
+%% reclaimed them before the partition healed, the owner is alive again so they
+%% are not orphans and would otherwise never be restarted.
+restart_owned_children(Group, Overall, Delegate, RunningIds) ->
+    lists:foreach(
+      fun({_Path, #mirrored_sup_childspec{mirroring_pid = OwnerPid,
+                                          childspec = ChildSpec,
+                                          key = {_, Id}}}) ->
+              case OwnerPid =:= Overall andalso not lists:member(Id, RunningIds) of
+                  true ->
+                      ?LOG_NOTICE("Mirrored supervisor: restarting child ~tp in group ~tp which this node owns but is not running locally",
+                                  [Id, Group]),
+                      catch ?SUPERVISOR:start_child(Delegate, ChildSpec),
+                      ok;
+                  false ->
+                      ok
+              end
+      end, group_childspecs(Group)).
 
 reclaim_orphans(Group, Overall, Delegate) ->
     ActiveMembers = pg:get_members(Group),
     case lists:sort(ActiveMembers) of
         [Overall | _] ->
-            Pattern = #mirrored_sup_childspec{key = {Group, '_'}, _ = '_'},
-            Conditions = [?KHEPRI_WILDCARD_STAR_STAR, #if_data_matches{pattern = Pattern}],
-            PathPattern = rabbit_db_msup:khepri_mirrored_supervisor_path(
-                            ?KHEPRI_WILDCARD_STAR,
-                            #if_all{conditions = Conditions}),
-            case rabbit_khepri:get_many(PathPattern) of
-                {ok, Map} ->
-                    lists:foreach(
-                      %% get_many already restricts results to this group via
-                      %% the #if_data_matches condition, so the key's group
-                      %% element is always Group here.
-                      fun({Path, #mirrored_sup_childspec{mirroring_pid = OwnerPid,
-                                                         childspec = ChildSpec,
-                                                         key = {_, Id}} = S0}) ->
-                              case lists:member(OwnerPid, ActiveMembers) of
-                                  false ->
-                                      ?LOG_NOTICE("Mirrored supervisor: reclaiming orphan child ~tp in group ~tp (previous owner ~tp was dead/unreachable)",
-                                                  [Id, Group, OwnerPid]),
-                                      NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
-                                      case rabbit_khepri:put(Path, NewS) of
-                                          ok ->
-                                              catch ?SUPERVISOR:start_child(Delegate, ChildSpec),
-                                              ok;
-                                          _ ->
-                                              ok
-                                      end;
-                                  true ->
+            lists:foreach(
+              fun({Path, #mirrored_sup_childspec{mirroring_pid = OwnerPid,
+                                                 childspec = ChildSpec,
+                                                 key = {_, Id}} = S0}) ->
+                      case lists:member(OwnerPid, ActiveMembers) of
+                          false ->
+                              ?LOG_NOTICE("Mirrored supervisor: reclaiming orphan child ~tp in group ~tp (previous owner ~tp was dead/unreachable)",
+                                          [Id, Group, OwnerPid]),
+                              NewS = S0#mirrored_sup_childspec{mirroring_pid = Overall},
+                              case rabbit_khepri:put(Path, NewS) of
+                                  ok ->
+                                      catch ?SUPERVISOR:start_child(Delegate, ChildSpec),
+                                      ok;
+                                  _ ->
                                       ok
                               end;
-                         (_) ->
+                          true ->
                               ok
-                      end, maps:to_list(Map));
-                _ ->
-                    ok
-            end;
+                      end
+              end, group_childspecs(Group));
         _ ->
             ok
     end.

--- a/deps/rabbit/test/mirrored_supervisor_SUITE.erl
+++ b/deps/rabbit/test/mirrored_supervisor_SUITE.erl
@@ -36,7 +36,8 @@ groups() ->
                          start_idempotence,
                          unsupported,
                          ignore,
-                         startup_failure
+                         startup_failure,
+                         reclaim_orphan
                         ]}
     ].
 
@@ -304,6 +305,34 @@ test_startup_failure(Fail, Group) ->
     process_flag(trap_exit, false),
     ok.
 
+%% A dynamic child can be left orphaned in Khepri under a dead mirroring
+%% process, for example when a takeover failed because Khepri was briefly
+%% unavailable. The periodic reconciliation on the sorted-first member must
+%% reclaim such a child and start it locally.
+reclaim_orphan(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE, reclaim_orphan1, [?config(sup_prefix, Config)]).
+
+reclaim_orphan1(Group) ->
+    with_sups(
+      fun([A]) ->
+              ChildSpec = childspec(worker),
+              %% Record the child in Khepri as owned by a dead process, without
+              %% starting it anywhere: this is the orphaned state to recover.
+              DeadPid = dead_pid(),
+              start = rabbit_db_msup:create_or_update(
+                        Group, DeadPid, DeadPid, ChildSpec, id(worker)),
+              %% Trigger reconciliation explicitly rather than waiting for the
+              %% periodic timer.
+              Mirroring = ?MS:child(A, mirroring),
+              Mirroring ! reconcile,
+              %% The orphan is reclaimed, started locally, and its ownership in
+              %% Khepri is transferred to the live member.
+              Pid = pid_of(worker),
+              true = is_pid(Pid),
+              {ok, A} = rabbit_db_msup:find_mirror(Group, id(worker))
+      end, [sup(Group, 1)], Group).
+
 %% ---------------------------------------------------------------------------
 
 with_sups(Fun, Sups, Group) ->
@@ -387,3 +416,9 @@ init({Strategy, ChildSpecs}) ->
 
 sup(Prefix, Number) ->
     rabbit_data_coercion:to_atom(lists:flatten(io_lib:format("~p~p", [Prefix, Number]))).
+
+dead_pid() ->
+    Pid = spawn(fun() -> ok end),
+    Ref = erlang:monitor(process, Pid),
+    receive {'DOWN', Ref, process, Pid, _} -> ok end,
+    Pid.

--- a/deps/rabbitmq_exchange_federation/src/rabbit_exchange_federation_sup.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_exchange_federation_sup.erl
@@ -55,7 +55,7 @@ init([]) ->
     XLinkSupSup = #{
         id       => x_links,
         start    => {rabbit_federation_exchange_link_sup_sup, start_link, []},
-        restart  => transient,
+        restart  => permanent,
         shutdown => ?SUPERVISOR_WAIT,
         type     => supervisor,
         modules  =>[rabbit_federation_exchange_link_sup_sup]

--- a/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
+++ b/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
@@ -89,10 +89,10 @@ status(Chs, ReqData, Context, Filter) ->
 
 status(Node, Chs, Filter) ->
     case rpc:call(Node, rabbit_federation_status, status, [], infinity) of
-        {badrpc, {'EXIT', {undef, _}}}  -> [];
-        {badrpc, {'EXIT', {noproc, _}}} -> [];
-        Status                          -> [format(Node, I, Chs) || I <- Status,
-                                                                    filter_status(I, Filter)]
+        Status when is_list(Status) ->
+            [format(Node, I, Chs) || I <- Status, filter_status(I, Filter)];
+        _Error ->
+            []
     end.
 
 filter_status(_, all) ->

--- a/deps/rabbitmq_queue_federation/src/rabbit_queue_federation_sup.erl
+++ b/deps/rabbitmq_queue_federation/src/rabbit_queue_federation_sup.erl
@@ -55,7 +55,7 @@ init([]) ->
     QLinkSupSup = #{
         id       => q_links,
         start    => {rabbit_federation_queue_link_sup_sup, start_link, []},
-        restart  => transient,
+        restart  => permanent,
         shutdown => ?SUPERVISOR_WAIT,
         type     => supervisor,
         modules  => [rabbit_federation_queue_link_sup_sup]

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_sup.erl
@@ -58,7 +58,7 @@ supervisor_tree_child_specs(standard) ->
         #{
             id => rabbit_shovel_dyn_worker_sup_sup,
             start => {rabbit_shovel_dyn_worker_sup_sup, start_link, []},
-            restart => transient,
+            restart => permanent,
             shutdown => 16#ffffffff,
             type => supervisor,
             modules => [rabbit_shovel_dyn_worker_sup_sup]

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
@@ -38,10 +38,10 @@ status(ReqData, Context) ->
 
 status(Node) ->
     case rpc:call(Node, rabbit_shovel_status, status, [], ?SHOVEL_CALLS_TIMEOUT_MS) of
-        {badrpc, {'EXIT', _}} ->
-            [];
-        Status ->
-            [format(Node, I) || I <- Status]
+        Status when is_list(Status) ->
+            [format(Node, I) || I <- Status];
+        _Error ->
+            []
     end.
 
 format(Node, {Name, Type, Info, Metrics, TS}) ->


### PR DESCRIPTION
This PR resolves a number of issues in shovel and federation in the context of network partition handling.
Issues I could observe, that I can no longer reproduce on this branch include:
* ghost federation links: links that just won't go away, usually in the "starting" status (caused by stale ETS entries if the link terminated abruptly)
* federation links and shovels not running (for different reasons)
* federation linux and shovels still running on the minority side (they should step down and allow the majority side to take over)
* federation links taking longer than necessary to step down on the minority side
* Management UI returning 500 when reporting federation or shovel status