### PR TITLE
Don't stop worker-pool worker processes when they receive unexpected messages

### DIFF
--- a/deps/rabbit_common/src/worker_pool_worker.erl
+++ b/deps/rabbit_common/src/worker_pool_worker.erl
@@ -113,7 +113,8 @@ handle_cast({submit_async, Fun, CPid}, {from, CPid, MRef}) ->
     {noreply, undefined, hibernate};
 
 handle_cast(Msg, State) ->
-    {stop, {unexpected_cast, Msg}, State}.
+    rabbit_log:warning("worker_pool_worker received unexpected cast: ~tp", [Msg]),
+    {noreply, State, hibernate}.
 
 handle_info({'DOWN', MRef, process, CPid, _Reason}, {from, CPid, MRef}) ->
     ok = worker_pool:idle(get(worker_pool_name), self()),
@@ -128,7 +129,8 @@ handle_info({timeout, Key, Fun}, State) ->
     {noreply, State, hibernate};
 
 handle_info(Msg, State) ->
-    {stop, {unexpected_info, Msg}, State}.
+    rabbit_log:warning("worker_pool_worker received unexpected message: ~tp", [Msg]),
+    {noreply, State, hibernate}.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/deps/rabbit_common/test/worker_pool_SUITE.erl
+++ b/deps/rabbit_common/test/worker_pool_SUITE.erl
@@ -22,7 +22,9 @@ all() ->
     set_timeout,
     cancel_timeout,
     cancel_timeout_by_setting,
-    dispatch_async_blocks_until_task_begins
+    dispatch_async_blocks_until_task_begins,
+    unexpected_cast_does_not_terminate_worker,
+    unexpected_info_does_not_terminate_worker
     ].
 
 init_per_testcase(_, Config) ->
@@ -218,3 +220,41 @@ dispatch_async_blocks_until_task_begins(_) ->
                         false
                 end,
     ?assert(DidFinish, "appearance of a free worker should unblock the dispatcher").
+
+unexpected_cast_does_not_terminate_worker(_) ->
+    Worker = worker_pool:submit(?POOL_NAME,
+        fun() -> self() end,
+        reuse),
+    ?assert(is_process_alive(Worker)),
+    gen_server2:cast(Worker, {bogus_unknown_cast, make_ref()}),
+    timer:sleep(100),
+    ?assert(is_process_alive(Worker)),
+    %% Verify the worker can still execute jobs
+    Self = self(),
+    Ref = make_ref(),
+    worker_pool_worker:next_job_from(Worker, Self),
+    worker_pool_worker:submit(Worker,
+        fun() -> Self ! {done, Ref} end,
+        reuse),
+    receive {done, Ref} -> ok
+    after 1000 -> error(worker_terminated_after_unexpected_cast)
+    end.
+
+unexpected_info_does_not_terminate_worker(_) ->
+    Worker = worker_pool:submit(?POOL_NAME,
+        fun() -> self() end,
+        reuse),
+    ?assert(is_process_alive(Worker)),
+    Worker ! {bogus_unknown_message, make_ref()},
+    timer:sleep(100),
+    ?assert(is_process_alive(Worker)),
+    %% Verify the worker can still execute jobs
+    Self = self(),
+    Ref = make_ref(),
+    worker_pool_worker:next_job_from(Worker, Self),
+    worker_pool_worker:submit(Worker,
+        fun() -> Self ! {done, Ref} end,
+        reuse),
+    receive {done, Ref} -> ok
+    after 1000 -> error(worker_terminated_after_unexpected_info)
+    end.


### PR DESCRIPTION
## Proposed Changes

Hi Team 👋 

When a `worker_pool_worker` process receives an unexpected/unknown message, currently it stops and terminates with reason `{unexpected_info, Msg}` or `{unexpected_cast, Msg}`. This seems quite strict for such worker pool purposes. We'd rather like to keep the `worker_pool_worker` process running, log the unexpected message and ignore it. This makes the `worker_pool_worker` process available to pick-up a new job/work - without need for termination and restart by `worker_pool_sup` to maintain the pool-size. (Other, more use-case specific processes such as `gatherer` and `mirrored_supervisor` look OK to have this kind of strictness - they terminate when they receive `unexpected_info` | `unexpected_cast`, however `worker_pool_worker` processes are not tied down to any use-case and should be good to ignore these messages and continue running). 

Currently, the `worker_pool_worker` process stops as follows on reception of an unexpected message (simulated termination from ct-tests):

```
=ERROR REPORT==== 11-Jun-2026::13:50:30.363119 ===
** Generic server <0.170.0> terminating
** Last message in was {'$gen_cast',
                           {bogus_unknown_cast,
                               #Ref<0.926999726.1152122881.137236>}}
** When Server state == undefined
** Reason for termination ==
** {unexpected_cast,{bogus_unknown_cast,#Ref<0.926999726.1152122881.137236>}}

=CRASH REPORT==== 11-Jun-2026::13:50:30.363475 ===
  crasher:
    initial call: worker_pool_worker:init/1
    pid: <0.170.0>
    registered_name: []
    exception exit: {unexpected_cast,
                        {bogus_unknown_cast,
                            #Ref<0.926999726.1152122881.137236>}}
      in function  gen_server2:terminate/3 (gen_server2.erl:1174)
    ancestors: [test_pool_sup,<0.166.0>]
    message_queue_len: 0
    messages: []
    links: [<0.168.0>]
    dictionary: [{worker_pool_name,test_pool},
                  {rand_seed,{#{max => 288230376151711743,type => exsplus,
                                next => #Fun<rand.5.71067687>,
                                jump => #Fun<rand.3.71067687>},
                              [234921452127477889|269473728895170764]}},
                  {worker_pool_worker,true}]
    trap_exit: false
    status: running
    heap_size: 2586
    stack_size: 29
    reductions: 3968
  neighbours:

```

In the real environment, we see most of these coming from the `management_worker_pool`, when unexpected (orphaned) stats are received by the `worker_pool_worker` process resulting in the same crash/termination:

```
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0> ** When Server state == undefined
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0> ** Reason for termination ==
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0> ** {unexpected_info,
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0>        {{#Ref<0.1277009612.2070937603.78826>,
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0>          'rabbit@host-xw-111'},
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0>         [{ok,<14374.10801.0>,
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0>              #{'rabbit@host-gh-231' =>
2026-05-16 14:25:55.703170+00:00 [error] <0.10894.0>                    #{node_node_metrics =>
...
...
```

This results in massive crash logs of the handling `worker_pool_worker` process crash (with entire stats being written to the logs - instead we can only just have these logged and keep `worker_pool_worker` running).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
