### PR TITLE
By @Ayanda-D: Don't stop worker-pool worker processes when they receive unexpected messages

### DIFF
--- a/deps/rabbit_common/src/worker_pool_worker.erl
+++ b/deps/rabbit_common/src/worker_pool_worker.erl
@@ -113,7 +113,8 @@ handle_cast({submit_async, Fun, CPid}, {from, CPid, MRef}) ->
     {noreply, undefined, hibernate};
 
 handle_cast(Msg, State) ->
-    {stop, {unexpected_cast, Msg}, State}.
+    rabbit_log:warning("worker_pool_worker received unexpected cast: ~tp", [Msg]),
+    {noreply, State, hibernate}.
 
 handle_info({'DOWN', MRef, process, CPid, _Reason}, {from, CPid, MRef}) ->
     ok = worker_pool:idle(get(worker_pool_name), self()),
@@ -128,7 +129,8 @@ handle_info({timeout, Key, Fun}, State) ->
     {noreply, State, hibernate};
 
 handle_info(Msg, State) ->
-    {stop, {unexpected_info, Msg}, State}.
+    rabbit_log:warning("worker_pool_worker received unexpected message: ~tp", [Msg]),
+    {noreply, State, hibernate}.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/deps/rabbit_common/src/worker_pool_worker.erl
+++ b/deps/rabbit_common/src/worker_pool_worker.erl
@@ -113,7 +113,8 @@ handle_cast({submit_async, Fun, CPid}, {from, CPid, MRef}) ->
     {noreply, undefined, hibernate};
 
 handle_cast(Msg, State) ->
-    rabbit_log:warning("worker_pool_worker received unexpected cast: ~tp", [Msg]),
+    rabbit_log:warning("worker_pool_worker (~ts) received unexpected cast: ~256P",
+                       [get(worker_pool_name), Msg, 7]),
     {noreply, State, hibernate}.
 
 handle_info({'DOWN', MRef, process, CPid, _Reason}, {from, CPid, MRef}) ->
@@ -129,7 +130,8 @@ handle_info({timeout, Key, Fun}, State) ->
     {noreply, State, hibernate};
 
 handle_info(Msg, State) ->
-    rabbit_log:warning("worker_pool_worker received unexpected message: ~tp", [Msg]),
+    rabbit_log:warning("worker_pool_worker (~ts) received unexpected info message: ~256P",
+                       [get(worker_pool_name), Msg, 7]),
     {noreply, State, hibernate}.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/deps/rabbit_common/test/worker_pool_SUITE.erl
+++ b/deps/rabbit_common/test/worker_pool_SUITE.erl
@@ -22,7 +22,9 @@ all() ->
     set_timeout,
     cancel_timeout,
     cancel_timeout_by_setting,
-    dispatch_async_blocks_until_task_begins
+    dispatch_async_blocks_until_task_begins,
+    unexpected_cast_does_not_terminate_worker,
+    unexpected_info_does_not_terminate_worker
     ].
 
 init_per_testcase(_, Config) ->
@@ -218,3 +220,41 @@ dispatch_async_blocks_until_task_begins(_) ->
                         false
                 end,
     ?assert(DidFinish, "appearance of a free worker should unblock the dispatcher").
+
+unexpected_cast_does_not_terminate_worker(_) ->
+    Worker = worker_pool:submit(?POOL_NAME,
+        fun() -> self() end,
+        reuse),
+    ?assert(is_process_alive(Worker)),
+    gen_server2:cast(Worker, {bogus_unknown_cast, make_ref()}),
+    timer:sleep(100),
+    ?assert(is_process_alive(Worker)),
+    %% Verify the worker can still execute jobs
+    Self = self(),
+    Ref = make_ref(),
+    worker_pool_worker:next_job_from(Worker, Self),
+    worker_pool_worker:submit(Worker,
+        fun() -> Self ! {done, Ref} end,
+        reuse),
+    receive {done, Ref} -> ok
+    after 1000 -> error(worker_terminated_after_unexpected_cast)
+    end.
+
+unexpected_info_does_not_terminate_worker(_) ->
+    Worker = worker_pool:submit(?POOL_NAME,
+        fun() -> self() end,
+        reuse),
+    ?assert(is_process_alive(Worker)),
+    Worker ! {bogus_unknown_message, make_ref()},
+    timer:sleep(100),
+    ?assert(is_process_alive(Worker)),
+    %% Verify the worker can still execute jobs
+    Self = self(),
+    Ref = make_ref(),
+    worker_pool_worker:next_job_from(Worker, Self),
+    worker_pool_worker:submit(Worker,
+        fun() -> Self ! {done, Ref} end,
+        reuse),
+    receive {done, Ref} -> ok
+    after 1000 -> error(worker_terminated_after_unexpected_info)
+    end.

--- a/deps/rabbit_common/test/worker_pool_SUITE.erl
+++ b/deps/rabbit_common/test/worker_pool_SUITE.erl
@@ -227,7 +227,9 @@ unexpected_cast_does_not_terminate_worker(_) ->
         reuse),
     ?assert(is_process_alive(Worker)),
     gen_server2:cast(Worker, {bogus_unknown_cast, make_ref()}),
-    timer:sleep(100),
+    %% `sys:get_state/2` is a synchronous barrier: it returns only after
+    %% all prior messages (including the cast above) have been processed.
+    _ = sys:get_state(Worker, 5000),
     ?assert(is_process_alive(Worker)),
     %% Verify the worker can still execute jobs
     Self = self(),
@@ -246,7 +248,9 @@ unexpected_info_does_not_terminate_worker(_) ->
         reuse),
     ?assert(is_process_alive(Worker)),
     Worker ! {bogus_unknown_message, make_ref()},
-    timer:sleep(100),
+    %% `sys:get_state/2` is a synchronous barrier: it returns only after
+    %% all prior messages (including the info message above) have been processed.
+    _ = sys:get_state(Worker, 5000),
     ?assert(is_process_alive(Worker)),
     %% Verify the worker can still execute jobs
     Self = self(),


### PR DESCRIPTION
This is #16663 by @Ayanda-D with a tweak from me.

Closes #16663.