### PR TITLE
Replace rabbit_fifo_dlx_sup with two-level supervisor hierarchy

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1113,8 +1113,7 @@ state_enter(leader,
                     enqueuers = Enqs,
                     waiting_consumers = WaitingConsumers,
                     cfg = #cfg{resource = QRes,
-                               dead_letter_handler = DLH},
-                    dlx = DlxState}) ->
+                               dead_letter_handler = DLH}}) ->
     % return effects to monitor all current consumers and enqueuers
     Pids = lists:usort(maps:keys(Enqs)
                        ++ [P || ?CONSUMER_PID(P) <- maps:values(Cons)]
@@ -1124,17 +1123,11 @@ state_enter(leader,
     NodeMons = lists:usort([{monitor, node, node(P)} || P <- Pids]),
     NotifyDecs = notify_decorators_startup(QRes),
     Effects = Mons ++ Nots ++ NodeMons ++ [NotifyDecs],
-
-    case DLH of
-        at_least_once ->
-            ensure_worker_started(QRes, DlxState);
-        _ ->
-            ok
-    end,
-    Effects;
+    maybe_add_dlx_effect(DLH, Effects);
 state_enter(eol, #?STATE{enqueuers = Enqs,
                          consumers = Cons0,
-                         waiting_consumers = WaitingConsumers0}) ->
+                         waiting_consumers = WaitingConsumers0} = State) ->
+    ok = maybe_terminate_worker(State),
     Custs = maps:fold(fun(_K, ?CONSUMER_PID(P) = V, S) ->
                               S#{P => V}
                       end, #{}, Cons0),
@@ -1145,15 +1138,8 @@ state_enter(eol, #?STATE{enqueuers = Enqs,
     [{send_msg, P, eol, ra_event}
      || P <- maps:keys(maps:merge(Enqs, AllConsumers))] ++
     [{aux, eol}];
-state_enter(_, #?STATE{cfg = #cfg{dead_letter_handler = DLH,
-                                  resource = _QRes},
-                       dlx = DlxState}) ->
-    case DLH of
-        at_least_once ->
-            ensure_worker_terminated(DlxState);
-        _ ->
-            ok
-    end,
+state_enter(_, State) ->
+    ok = maybe_terminate_worker(State),
     %% catch all as not handling all states
     [].
 
@@ -1506,15 +1492,7 @@ handle_aux(_RaState, _, force_checkpoint,
                                    ReclaimableBytes, true),
     {no_reply, Aux#?AUX{last_checkpoint = Check}, RaAux, Effects};
 handle_aux(leader, _, {dlx, setup}, Aux, RaAux) ->
-    #?STATE{dlx = DlxState,
-            cfg = #cfg{dead_letter_handler = DLH,
-                       resource = QRes}} = ra_aux:machine_state(RaAux),
-    case DLH of
-        at_least_once ->
-            ensure_worker_started(QRes, DlxState);
-        _ ->
-            ok
-    end,
+    ok = maybe_start_dlx_worker(RaAux),
     {no_reply, Aux, RaAux};
 handle_aux(_, _, {dlx, teardown, Pid}, Aux, RaAux) ->
     terminate_dlx_worker(Pid),
@@ -1524,7 +1502,6 @@ handle_aux(_, _, Unhandled, Aux, RaAux) ->
     ?LOG_DEBUG("~ts: rabbit_fifo: unhandled aux command ~P",
                [rabbit_misc:rs(QR), Unhandled, 10]),
     {no_reply, Aux, RaAux}.
-
 
 eval_gc(RaAux, MacState,
         #?AUX{gc = #aux_gc{last_raft_idx = LastGcIdx} = Gc} = AuxState) ->
@@ -3989,16 +3966,7 @@ dlx_apply(_, {dlx, {checkout, ConsumerPid, Prefetch}},
                 discards = Discards0,
                 msg_bytes = Bytes,
                 msg_bytes_checkout = BytesCheckout} = State0) ->
-    %% Since we allow only a single consumer, the new consumer replaces the old consumer.
-    case ConsumerPid of
-        OldConsumerPid ->
-            ok;
-        _ ->
-            ?LOG_DEBUG("Terminating ~p since ~p becomes active rabbit_fifo_dlx_worker",
-                       [OldConsumerPid, ConsumerPid]),
-            %% turn into aux command
-            ensure_worker_terminated(State0)
-    end,
+    ok = ensure_worker_terminated(ConsumerPid, OldConsumerPid, State0),
     %% All checked out messages to the old consumer need to be returned to the discards queue
     %% such that these messages will be re-delivered to the new consumer.
     %% When inserting back into the discards queue, we respect the original order in which messages
@@ -4024,41 +3992,79 @@ dlx_apply(_, Cmd, DLH, State) ->
 %% down: 90 bytes
 %% enqueue overhead 210
 
-ensure_worker_started(QRef, #?DLX{consumer = undefined}) ->
-    start_worker(QRef);
-ensure_worker_started(QRef, #?DLX{consumer = #dlx_consumer{pid = Pid}}) ->
+maybe_add_dlx_effect(at_least_once, Effects) ->
+    Effects ++ [{aux, {dlx, setup}}];
+maybe_add_dlx_effect(_, Effects) ->
+    Effects.
+
+maybe_start_dlx_worker(RaAux) ->
+    #?STATE{dlx = DlxState,
+            cfg = #cfg{dead_letter_handler = DLH,
+                       resource = QRes}} = ra_aux:machine_state(RaAux),
+maybe_start_dlx_worker(DLH, QRes, DlxState).
+
+maybe_start_dlx_worker(at_least_once, QRes, DlxState) ->
+    ensure_dlx_worker_started(QRes, DlxState);
+maybe_start_dlx_worker(_, _QRes, _DlxState) ->
+    ok.
+
+ensure_dlx_worker_started(QRef, #?DLX{consumer = undefined}) ->
+    start_dlx_worker(QRef);
+ensure_dlx_worker_started(QRef, #?DLX{consumer = #dlx_consumer{pid = Pid}}) ->
     case is_local_and_alive(Pid) of
         true ->
             ?LOG_DEBUG("rabbit_fifo_dlx_worker ~tp already started for ~ts",
                              [Pid, rabbit_misc:rs(QRef)]);
         false ->
-            start_worker(QRef)
+            start_dlx_worker(QRef)
     end.
 
 %% Ensure that starting the rabbit_fifo_dlx_worker succeeds.
 %% Therefore, do not use an effect.
 %% Also therefore, if starting the rabbit_fifo_dlx_worker fails, let the
 %% Ra server process crash in which case another Ra node will become leader.
-start_worker(QRef) ->
-    {ok, Pid} = supervisor:start_child(rabbit_fifo_dlx_sup, [QRef]),
+start_dlx_worker(QRef) ->
+    {ok, SupPid} = supervisor:start_child(rabbit_fifo_dlx_sup_sup, [QRef]),
+    [{_, Pid, worker, _}] = supervisor:which_children(SupPid),
     ?LOG_DEBUG("started rabbit_fifo_dlx_worker ~tp for ~ts",
                      [Pid, rabbit_misc:rs(QRef)]).
+
+%% Since we allow only a single consumer, the new consumer replaces the old consumer.
+ensure_worker_terminated(ConsumerPid, ConsumerPid, _State) ->
+    ok;
+ensure_worker_terminated(ConsumerPid, OldConsumerPid, State) ->
+    ?LOG_DEBUG("Terminating ~p since ~p becomes active rabbit_fifo_dlx_worker",
+                [OldConsumerPid, ConsumerPid]),
+    %% turn into aux command
+    ensure_worker_terminated(State).
 
 ensure_worker_terminated(#?DLX{consumer = undefined}) ->
     ok;
 ensure_worker_terminated(#?DLX{consumer = #dlx_consumer{pid = Pid}}) ->
     terminate_dlx_worker(Pid).
 
+maybe_terminate_worker(#?STATE{cfg = #cfg{dead_letter_handler = at_least_once}, dlx = DlxState}) ->
+    ok = ensure_worker_terminated(DlxState);
+maybe_terminate_worker(_State) ->
+    ok.
+
 terminate_dlx_worker(Pid) ->
-    case is_local_and_alive(Pid) of
-        true ->
-            %% Note that we can't return a mod_call effect here
-            %% because mod_call is executed on the leader only.
-            ok = supervisor:terminate_child(rabbit_fifo_dlx_sup, Pid),
-            ?LOG_DEBUG("terminated rabbit_fifo_dlx_worker ~tp", [Pid]);
-        false ->
-            ok
-    end.
+    terminate_dlx_worker(Pid, is_local_and_alive(Pid)).
+
+terminate_dlx_worker(Pid, true) ->
+    %% Note that we can't return a mod_call effect here
+    %% because mod_call is executed on the leader only.
+    %% Terminate the per-worker supervisor (which also stops the worker).
+    %% The worker stores its supervisor pid in the process dictionary at
+    %% startup (see rabbit_fifo_dlx_worker:init/1). We read it here via
+    %% process_info to avoid a blocking gen_server call.
+    {dictionary, Dict} = erlang:process_info(Pid, dictionary),
+    {sup_pid, SupPid} = lists:keyfind(sup_pid, 1, Dict),
+    ok = supervisor:terminate_child(rabbit_fifo_dlx_sup_sup, SupPid),
+    ?LOG_DEBUG("terminated rabbit_fifo_dlx_worker ~tp", [Pid]),
+    ok;
+terminate_dlx_worker(_Pid, false) ->
+    ok.
 
 local_alive_consumer_pid(#?DLX{consumer = undefined}) ->
     undefined;

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1495,7 +1495,7 @@ handle_aux(leader, _, {dlx, setup}, Aux, RaAux) ->
     ok = maybe_start_dlx_worker(RaAux),
     {no_reply, Aux, RaAux};
 handle_aux(_, _, {dlx, teardown, Pid}, Aux, RaAux) ->
-    terminate_dlx_worker(Pid),
+    ok = rabbit_fifo_dlx_worker:terminate_worker(Pid),
     {no_reply, Aux, RaAux};
 handle_aux(_, _, Unhandled, Aux, RaAux) ->
     #?STATE{cfg = #cfg{resource = QR}} = ra_aux:machine_state(RaAux),
@@ -4011,7 +4011,7 @@ maybe_start_dlx_worker(_, _QRes, _DlxState) ->
 ensure_dlx_worker_started(QRef, #?DLX{consumer = undefined}) ->
     start_dlx_worker(QRef);
 ensure_dlx_worker_started(QRef, #?DLX{consumer = #dlx_consumer{pid = Pid}}) ->
-    case is_local_and_alive(Pid) of
+    case rabbit_misc:is_local_process_alive(Pid) of
         true ->
             ?LOG_DEBUG("rabbit_fifo_dlx_worker ~tp already started for ~ts",
                              [Pid, rabbit_misc:rs(QRef)]);
@@ -4040,46 +4040,22 @@ ensure_worker_terminated(ConsumerPid, OldConsumerPid, State) ->
 ensure_worker_terminated(#?DLX{consumer = undefined}) ->
     ok;
 ensure_worker_terminated(#?DLX{consumer = #dlx_consumer{pid = Pid}}) ->
-    terminate_dlx_worker(Pid).
+    ok = rabbit_fifo_dlx_worker:terminate_worker(Pid).
 
 maybe_terminate_worker(#?STATE{cfg = #cfg{dead_letter_handler = at_least_once}, dlx = DlxState}) ->
     ok = ensure_worker_terminated(DlxState);
 maybe_terminate_worker(_State) ->
     ok.
 
-terminate_dlx_worker(Pid) ->
-    terminate_dlx_worker(Pid, is_local_and_alive(Pid)).
-
-terminate_dlx_worker(Pid, true) ->
-    %% Note that we can't return a mod_call effect here
-    %% because mod_call is executed on the leader only.
-    %% Terminate the per-worker supervisor (which also stops the worker).
-    %% The worker stores its supervisor pid in the process dictionary at
-    %% startup (see rabbit_fifo_dlx_worker:init/1). We read it here via
-    %% process_info to avoid a blocking gen_server call.
-    {dictionary, Dict} = erlang:process_info(Pid, dictionary),
-    {sup_pid, SupPid} = lists:keyfind(sup_pid, 1, Dict),
-    ok = supervisor:terminate_child(rabbit_fifo_dlx_sup_sup, SupPid),
-    ?LOG_DEBUG("terminated rabbit_fifo_dlx_worker ~tp", [Pid]),
-    ok;
-terminate_dlx_worker(_Pid, false) ->
-    ok.
-
 local_alive_consumer_pid(#?DLX{consumer = undefined}) ->
     undefined;
 local_alive_consumer_pid(#?DLX{consumer = #dlx_consumer{pid = Pid}}) ->
-    case is_local_and_alive(Pid) of
+    case rabbit_misc:is_local_process_alive(Pid) of
         true ->
             Pid;
         false ->
             undefined
     end.
-
-is_local_and_alive(Pid)
-  when node(Pid) =:= node() ->
-    is_process_alive(Pid);
-is_local_and_alive(_) ->
-    false.
 
 update_config(at_least_once, at_least_once, _, State) ->
     case local_alive_consumer_pid(State) of

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -3993,7 +3993,7 @@ dlx_apply(_, Cmd, DLH, State) ->
 %% enqueue overhead 210
 
 maybe_add_dlx_effect(at_least_once, Effects) ->
-    Effects ++ [{aux, {dlx, setup}}];
+    [{aux, {dlx, setup}} | Effects];
 maybe_add_dlx_effect(_, Effects) ->
     Effects.
 

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -4001,7 +4001,7 @@ maybe_start_dlx_worker(RaAux) ->
     #?STATE{dlx = DlxState,
             cfg = #cfg{dead_letter_handler = DLH,
                        resource = QRes}} = ra_aux:machine_state(RaAux),
-maybe_start_dlx_worker(DLH, QRes, DlxState).
+    maybe_start_dlx_worker(DLH, QRes, DlxState).
 
 maybe_start_dlx_worker(at_least_once, QRes, DlxState) ->
     ensure_dlx_worker_started(QRes, DlxState);

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -4024,8 +4024,7 @@ ensure_dlx_worker_started(QRef, #?DLX{consumer = #dlx_consumer{pid = Pid}}) ->
 %% Also therefore, if starting the rabbit_fifo_dlx_worker fails, let the
 %% Ra server process crash in which case another Ra node will become leader.
 start_dlx_worker(QRef) ->
-    {ok, SupPid} = supervisor:start_child(rabbit_fifo_dlx_sup_sup, [QRef]),
-    [{_, Pid, worker, _}] = supervisor:which_children(SupPid),
+    {ok, Pid} = rabbit_fifo_dlx_sup_sup:start_worker(QRef),
     ?LOG_DEBUG("started rabbit_fifo_dlx_worker ~tp for ~ts",
                      [Pid, rabbit_misc:rs(QRef)]).
 

--- a/deps/rabbit/src/rabbit_fifo_dlx.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx.erl
@@ -276,7 +276,7 @@ start_worker(QRef) ->
 ensure_worker_terminated(#?MODULE{consumer = undefined}) ->
     ok;
 ensure_worker_terminated(#?MODULE{consumer = #dlx_consumer{pid = Pid}}) ->
-    rabbit_fifo_dlx_worker:terminate_worker(Pid).
+    ok = rabbit_fifo_dlx_worker:terminate_worker(Pid).
 
 local_alive_consumer_pid(#?MODULE{consumer = undefined}) ->
     undefined;

--- a/deps/rabbit/src/rabbit_fifo_dlx.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx.erl
@@ -256,7 +256,7 @@ state_enter(_, _, _, _) ->
 ensure_worker_started(QRef, #?MODULE{consumer = undefined}) ->
     start_worker(QRef);
 ensure_worker_started(QRef, #?MODULE{consumer = #dlx_consumer{pid = Pid}}) ->
-    case is_local_and_alive(Pid) of
+    case rabbit_misc:is_local_process_alive(Pid) of
         true ->
             ?LOG_DEBUG("rabbit_fifo_dlx_worker ~tp already started for ~ts",
                              [Pid, rabbit_misc:rs(QRef)]);
@@ -276,41 +276,17 @@ start_worker(QRef) ->
 ensure_worker_terminated(#?MODULE{consumer = undefined}) ->
     ok;
 ensure_worker_terminated(#?MODULE{consumer = #dlx_consumer{pid = Pid}}) ->
-    terminate_dlx_worker(Pid).
-
-terminate_dlx_worker(Pid) ->
-    terminate_dlx_worker(Pid, is_local_and_alive(Pid)).
-
-terminate_dlx_worker(Pid, true) ->
-    %% Note that we can't return a mod_call effect here
-    %% because mod_call is executed on the leader only.
-    %% Terminate the per-worker supervisor (which also stops the worker).
-    %% The worker stores its supervisor pid in the process dictionary at
-    %% startup (see rabbit_fifo_dlx_worker:init/1). We read it here via
-    %% process_info to avoid a blocking gen_server call.
-    {dictionary, Dict} = erlang:process_info(Pid, dictionary),
-    {sup_pid, SupPid} = lists:keyfind(sup_pid, 1, Dict),
-    ok = supervisor:terminate_child(rabbit_fifo_dlx_sup_sup, SupPid),
-    ?LOG_DEBUG("terminated rabbit_fifo_dlx_worker ~tp", [Pid]),
-    ok;
-terminate_dlx_worker(_Pid, false) ->
-    ok.
+    rabbit_fifo_dlx_worker:terminate_worker(Pid).
 
 local_alive_consumer_pid(#?MODULE{consumer = undefined}) ->
     undefined;
 local_alive_consumer_pid(#?MODULE{consumer = #dlx_consumer{pid = Pid}}) ->
-    case is_local_and_alive(Pid) of
+    case rabbit_misc:is_local_process_alive(Pid) of
         true ->
             Pid;
         false ->
             undefined
     end.
-
-is_local_and_alive(Pid)
-  when node(Pid) =:= node() ->
-    is_process_alive(Pid);
-is_local_and_alive(_) ->
-    false.
 
 -spec update_config(Old :: dead_letter_handler(), New :: dead_letter_handler(),
                     rabbit_types:r('queue'), state()) ->

--- a/deps/rabbit/src/rabbit_fifo_dlx.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx.erl
@@ -245,9 +245,8 @@ delivery_effects(CPid, Msgs0) ->
 
 -spec state_enter(ra_server:ra_state() | eol, rabbit_types:r('queue'), dead_letter_handler(), state()) ->
     ra_machine:effects().
-state_enter(leader, QRes, at_least_once, State) ->
-    ensure_worker_started(QRes, State),
-    [];
+state_enter(leader, _QRes, at_least_once, _State) ->
+    [{aux, {dlx, setup}}];
 state_enter(_, _, at_least_once, State) ->
     ensure_worker_terminated(State),
     [];
@@ -270,22 +269,33 @@ ensure_worker_started(QRef, #?MODULE{consumer = #dlx_consumer{pid = Pid}}) ->
 %% Also therefore, if starting the rabbit_fifo_dlx_worker fails, let the
 %% Ra server process crash in which case another Ra node will become leader.
 start_worker(QRef) ->
-    {ok, Pid} = supervisor:start_child(rabbit_fifo_dlx_sup, [QRef]),
+    {ok, SupPid} = supervisor:start_child(rabbit_fifo_dlx_sup_sup, [QRef]),
+    [{_, Pid, worker, _}] = supervisor:which_children(SupPid),
     ?LOG_DEBUG("started rabbit_fifo_dlx_worker ~tp for ~ts",
                      [Pid, rabbit_misc:rs(QRef)]).
 
 ensure_worker_terminated(#?MODULE{consumer = undefined}) ->
     ok;
 ensure_worker_terminated(#?MODULE{consumer = #dlx_consumer{pid = Pid}}) ->
-    case is_local_and_alive(Pid) of
-        true ->
-            %% Note that we can't return a mod_call effect here
-            %% because mod_call is executed on the leader only.
-            ok = supervisor:terminate_child(rabbit_fifo_dlx_sup, Pid),
-            ?LOG_DEBUG("terminated rabbit_fifo_dlx_worker ~tp", [Pid]);
-        false ->
-            ok
-    end.
+    terminate_dlx_worker(Pid).
+
+terminate_dlx_worker(Pid) ->
+    terminate_dlx_worker(Pid, is_local_and_alive(Pid)).
+
+terminate_dlx_worker(Pid, true) ->
+    %% Note that we can't return a mod_call effect here
+    %% because mod_call is executed on the leader only.
+    %% Terminate the per-worker supervisor (which also stops the worker).
+    %% The worker stores its supervisor pid in the process dictionary at
+    %% startup (see rabbit_fifo_dlx_worker:init/1). We read it here via
+    %% process_info to avoid a blocking gen_server call.
+    {dictionary, Dict} = erlang:process_info(Pid, dictionary),
+    {sup_pid, SupPid} = lists:keyfind(sup_pid, 1, Dict),
+    ok = supervisor:terminate_child(rabbit_fifo_dlx_sup_sup, SupPid),
+    ?LOG_DEBUG("terminated rabbit_fifo_dlx_worker ~tp", [Pid]),
+    ok;
+terminate_dlx_worker(_Pid, false) ->
+    ok.
 
 local_alive_consumer_pid(#?MODULE{consumer = undefined}) ->
     undefined;

--- a/deps/rabbit/src/rabbit_fifo_dlx.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx.erl
@@ -269,8 +269,7 @@ ensure_worker_started(QRef, #?MODULE{consumer = #dlx_consumer{pid = Pid}}) ->
 %% Also therefore, if starting the rabbit_fifo_dlx_worker fails, let the
 %% Ra server process crash in which case another Ra node will become leader.
 start_worker(QRef) ->
-    {ok, SupPid} = supervisor:start_child(rabbit_fifo_dlx_sup_sup, [QRef]),
-    [{_, Pid, worker, _}] = supervisor:which_children(SupPid),
+    {ok, Pid} = rabbit_fifo_dlx_sup_sup:start_worker(QRef),
     ?LOG_DEBUG("started rabbit_fifo_dlx_worker ~tp for ~ts",
                      [Pid, rabbit_misc:rs(QRef)]).
 

--- a/deps/rabbit/src/rabbit_fifo_dlx_sup_sup.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_sup_sup.erl
@@ -2,9 +2,9 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 
--module(rabbit_fifo_dlx_sup).
+-module(rabbit_fifo_dlx_sup_sup).
 
 -behaviour(supervisor).
 
@@ -24,13 +24,9 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    SupFlags = #{strategy => simple_one_for_one,
-                 intensity => 100,
-                 period => 1},
-    Worker = rabbit_fifo_dlx_worker,
-    ChildSpec = #{id => Worker,
-                  start => {Worker, start_link, []},
-                  type => worker,
-                  restart => transient,
-                  modules => [Worker]},
+    SupFlags = #{strategy => simple_one_for_one},
+    ChildSpec = #{id => rabbit_fifo_dlx_worker_sup,
+                  start => {rabbit_fifo_dlx_worker_sup, start_link, []},
+                  type => supervisor,
+                  restart => temporary},
     {ok, {SupFlags, [ChildSpec]}}.

--- a/deps/rabbit/src/rabbit_fifo_dlx_sup_sup.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_sup_sup.erl
@@ -18,10 +18,16 @@
 %% supervisor callback
 -export([init/1]).
 %% client API
--export([start_link/0]).
+-export([start_link/0, start_worker/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-spec start_worker(rabbit_amqqueue:name()) -> {ok, pid()}.
+start_worker(QRef) ->
+    {ok, SupPid} = supervisor:start_child(?MODULE, [QRef]),
+    [{_, Pid, worker, _}] = supervisor:which_children(SupPid),
+    {ok, Pid}.
 
 init([]) ->
     SupFlags = #{strategy => simple_one_for_one},

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
@@ -35,7 +35,10 @@
          handle_cast/2, handle_call/3, handle_info/2,
          code_change/3, format_status/1]).
 
+-export([terminate_worker/1]).
+
 -define(HIBERNATE_AFTER, 4*60*1000).
+-define(DLX_WORKER_SUP_PID_KEY, dlx_worker_sup_pid).
 
 -record(pending, {
           %% consumed_msg_id is not to be confused with consumer delivery tag.
@@ -106,11 +109,31 @@ start_link(QRef, SupPid) ->
 -spec init({rabbit_amqqueue:name(), pid()}) ->
     {ok, undefined, {continue, rabbit_amqqueue:name()}}.
 init({QRef, SupPid}) ->
+    ok = put_sup_pid(SupPid),
+    {ok, undefined, {continue, QRef}}.
+
+-spec put_sup_pid(DlxWorkerSupPid :: pid()) -> ok.
+put_sup_pid(DlxWorkerSupPid) ->
     %% Stored in the process dictionary so that terminate_dlx_worker/2 can
     %% retrieve it via process_info(WorkerPid, dictionary) without blocking
     %% on a gen_server call. Same pattern as rabbit_misc:store_proc_name/1.
-    put(sup_pid, SupPid),
-    {ok, undefined, {continue, QRef}}.
+    put(?DLX_WORKER_SUP_PID_KEY, DlxWorkerSupPid),
+    ok.
+
+-spec terminate_worker(DlxWorkerPid :: pid()) -> ok.
+terminate_worker(DlxWorkerPid) ->
+    terminate_worker(DlxWorkerPid, rabbit_misc:is_local_process_alive(DlxWorkerPid)).
+
+-spec terminate_worker(DlxWorkerPid :: pid(), boolean()) -> ok.
+terminate_worker(DlxWorkerPid, true) ->
+    %% Terminate the per-worker supervisor (which also stops the worker).
+    {dictionary, Dict} = erlang:process_info(DlxWorkerPid, dictionary),
+    {?DLX_WORKER_SUP_PID_KEY, SupPid} = lists:keyfind(?DLX_WORKER_SUP_PID_KEY, 1, Dict),
+    ok = supervisor:terminate_child(rabbit_fifo_dlx_sup_sup, SupPid),
+    ?LOG_DEBUG("terminated rabbit_fifo_dlx_worker ~tp", [DlxWorkerPid]),
+    ok;
+terminate_worker(_DlxWorkerPid, _) ->
+    ok.
 
 -spec handle_continue(rabbit_amqqueue:name(), undefined) ->
     {noreply, state()} | {stop, term(), undefined}.

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
@@ -29,7 +29,7 @@
 
 -behaviour(gen_server).
 
--export([start_link/1]).
+-export([start_link/2]).
 %% gen_server callbacks
 -export([init/1, terminate/2, handle_continue/2,
          handle_cast/2, handle_call/3, handle_info/2,
@@ -100,12 +100,16 @@
 
 -type state() :: #state{}.
 
-start_link(QRef) ->
-    gen_server:start_link(?MODULE, QRef, [{hibernate_after, ?HIBERNATE_AFTER}]).
+start_link(QRef, SupPid) ->
+    gen_server:start_link(?MODULE, {QRef, SupPid}, [{hibernate_after, ?HIBERNATE_AFTER}]).
 
--spec init(rabbit_amqqueue:name()) ->
+-spec init({rabbit_amqqueue:name(), pid()}) ->
     {ok, undefined, {continue, rabbit_amqqueue:name()}}.
-init(QRef) ->
+init({QRef, SupPid}) ->
+    %% Stored in the process dictionary so that terminate_dlx_worker/2 can
+    %% retrieve it via process_info(WorkerPid, dictionary) without blocking
+    %% on a gen_server call. Same pattern as rabbit_misc:store_proc_name/1.
+    put(sup_pid, SupPid),
     {ok, undefined, {continue, QRef}}.
 
 -spec handle_continue(rabbit_amqqueue:name(), undefined) ->

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker_sup.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker_sup.erl
@@ -1,0 +1,30 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+%% Per-queue supervisor for a single rabbit_fifo_dlx_worker process.
+%% Started as a temporary child of rabbit_fifo_dlx_sup_sup (simple_one_for_one).
+%% This isolation prevents a burst of DLX worker crashes from taking down
+%% the top-level supervisor and stranding unrelated queues.
+-module(rabbit_fifo_dlx_worker_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/1, init/1]).
+
+start_link(QRef) ->
+    supervisor:start_link(?MODULE, [QRef]).
+
+init([QRef]) ->
+    DlxWorkerSupPid = self(),
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 0,
+                 period => 1},
+    ChildSpec = #{id => rabbit_fifo_dlx_worker,
+                  start => {rabbit_fifo_dlx_worker, start_link, [QRef, DlxWorkerSupPid]},
+                  type => worker,
+                  restart => transient,
+                  shutdown => 5000},
+    {ok, {SupFlags, [ChildSpec]}}.

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker_sup.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker_sup.erl
@@ -21,10 +21,12 @@ init([QRef]) ->
     DlxWorkerSupPid = self(),
     SupFlags = #{strategy => one_for_one,
                  intensity => 0,
-                 period => 1},
+                 period => 1,
+                 auto_shutdown => any_significant},
     ChildSpec = #{id => rabbit_fifo_dlx_worker,
                   start => {rabbit_fifo_dlx_worker, start_link, [QRef, DlxWorkerSupPid]},
                   type => worker,
                   restart => transient,
+                  significant => true,
                   shutdown => 5000},
     {ok, {SupFlags, [ChildSpec]}}.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -2842,7 +2842,7 @@ queue_vm_stats_sups() ->
     {[quorum_queue_procs,
       quorum_queue_dlx_procs],
      [[ra_server_sup_sup],
-      [rabbit_fifo_dlx_sup]]}.
+      [rabbit_fifo_dlx_sup_sup]]}.
 
 queue_vm_ets() ->
     {[quorum_ets],

--- a/deps/rabbit/src/rabbit_vm.erl
+++ b/deps/rabbit/src/rabbit_vm.erl
@@ -22,7 +22,7 @@ memory() ->
     %% example for existing info keys:
     %% [{queue_procs,          queue_sups()},
     %%  {quorum_queue_procs,   [ra_server_sup_sup]},
-    %%  {quorum_queue_dlx_procs, [rabbit_fifo_dlx_sup]},
+    %%  {quorum_queue_dlx_procs, [rabbit_fifo_dlx_sup_sup]},
     %%  {stream_queue_procs,   [osiris_server_sup]},
     %%  {stream_queue_replica_reader_procs,  [osiris_replica_reader_sup]},
     %%  {stream_queue_coordinator_procs, [rabbit_stream_coordinator]}]

--- a/deps/rabbit/test/rabbit_fifo_dlx_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_dlx_SUITE.erl
@@ -128,7 +128,7 @@ switch_strategies(_Config) ->
                      name = <<"blah">>},
     application:set_env(rabbit, dead_letter_worker_consumer_prefetch, 1),
     application:set_env(rabbit, dead_letter_worker_publisher_confirm_timeout, 1000),
-    {ok, _} = rabbit_fifo_dlx_sup:start_link(),
+    {ok, _} = rabbit_fifo_dlx_sup_sup:start_link(),
     S0 = rabbit_fifo_dlx:init(),
 
     Handler0 = undefined,
@@ -141,7 +141,8 @@ switch_strategies(_Config) ->
                   {aux, {dlx, setup}}],
                  Effects0),
     rabbit_fifo_dlx:handle_aux(leader, {dlx, setup}, fake_aux, QRes, Handler1, S1),
-    [{_, WorkerPid, worker, _}] = supervisor:which_children(rabbit_fifo_dlx_sup),
+    [{_, WorkerSupPid, supervisor, _}] = supervisor:which_children(rabbit_fifo_dlx_sup_sup),
+    [{_, WorkerPid, worker, _}] = supervisor:which_children(WorkerSupPid),
     {S2, _} = rabbit_fifo_dlx:discard([make_msg(1)], because, Handler1, S1),
     Checkout = rabbit_fifo_dlx:make_checkout(WorkerPid, 1),
     {S3, _} = rabbit_fifo_dlx:apply(meta(2), Checkout, Handler1, S2),
@@ -158,7 +159,7 @@ switch_strategies(_Config) ->
                     [1, 1, "queue 'blah' in vhost '/'"]]}],
                  Effects),
     ?assertMatch([_, {active, 0}, _, _],
-                 supervisor:count_children(rabbit_fifo_dlx_sup)),
+                 supervisor:count_children(rabbit_fifo_dlx_sup_sup)),
     ?assertMatch(#{num_discarded := 0}, rabbit_fifo_dlx:overview(S5)),
     ok.
 

--- a/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
@@ -154,7 +154,7 @@ end_per_testcase(Testcase, Config) ->
     ?awaitMatch(
        true,
        begin
-           DlxWorkers = rabbit_ct_broker_helpers:rpc_all(Config, supervisor, which_children, [rabbit_fifo_dlx_sup_sup]),
+           DlxWorkers = rabbit_ct_broker_helpers:rpc_all(Config, ?MODULE, dlx_workers, []),
            lists:all(fun(L) -> L =:= [] end, DlxWorkers)
        end, 60000),
 
@@ -513,7 +513,7 @@ drop_head_falls_back_to_at_most_once(Config) ->
     consistently(
       ?_assertMatch(
          [_, {active, 0}, _, _],
-         rpc(Config, Server, supervisor, count_children, [rabbit_fifo_dlx_sup_sup]))).
+         rpc(Config, Server, ?MODULE, dlx_count_children, []))).
 
 %% Test that dynamically switching dead-letter-strategy works.
 switch_strategy(Config) ->
@@ -935,7 +935,7 @@ single_dlx_worker(Config) ->
        [[_, {active, 1}, _, _],
         [_, {active, 0}, _, _],
         [_, {active, 0}, _, _]],
-       rabbit_ct_broker_helpers:rpc_all(Config, supervisor, count_children, [rabbit_fifo_dlx_sup_sup])),
+       rabbit_ct_broker_helpers:rpc_all(Config, ?MODULE, dlx_count_children, [])),
 
     ok = rabbit_ct_broker_helpers:stop_broker(Config, Server1),
     RaName = ra_name(SourceQ),
@@ -948,7 +948,7 @@ single_dlx_worker(Config) ->
     consistently(
       ?_assertEqual(
          0,
-         length(rpc(Config, Server1, supervisor, which_children, [rabbit_fifo_dlx_sup_sup], 1000)))),
+         length(rpc(Config, Server1, ?MODULE, dlx_workers, [], 1000)))),
 
     %% Kill the leader node to verify the DLX worker follows leadership.
     %% We kill the node rather than just the Ra process: killing only the process
@@ -965,7 +965,7 @@ single_dlx_worker(Config) ->
 
 assert_active_dlx_workers(N, Config, Server) ->
     ?awaitMatch(N,
-                length(rpc(Config, Server, supervisor, which_children, [rabbit_fifo_dlx_sup_sup], 5000)),
+                length(rpc(Config, Server, ?MODULE, dlx_workers, [], 5000)),
                 60_000).
 
 declare_queue(Channel, Queue, Args) ->
@@ -999,3 +999,18 @@ counted(Metric, Config) ->
 metric(Metric, Counters) ->
     Metrics = maps:get(#{queue_type => rabbit_quorum_queue, dead_letter_strategy => at_least_once}, Counters),
     maps:get(Metric, Metrics).
+
+%% Returns the list of DLX worker children, handling both the old
+%% (rabbit_fifo_dlx_sup) and new (rabbit_fifo_dlx_sup_sup) supervisor names
+%% for mixed-cluster compatibility.
+dlx_workers() ->
+    supervisor:which_children(dlx_sup_name()).
+
+dlx_count_children() ->
+    supervisor:count_children(dlx_sup_name()).
+
+dlx_sup_name() ->
+    case whereis(rabbit_fifo_dlx_sup_sup) of
+        undefined -> rabbit_fifo_dlx_sup;
+        _         -> rabbit_fifo_dlx_sup_sup
+    end.

--- a/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
@@ -154,7 +154,7 @@ end_per_testcase(Testcase, Config) ->
     ?awaitMatch(
        true,
        begin
-           DlxWorkers = rabbit_ct_broker_helpers:rpc_all(Config, supervisor, which_children, [rabbit_fifo_dlx_sup]),
+           DlxWorkers = rabbit_ct_broker_helpers:rpc_all(Config, supervisor, which_children, [rabbit_fifo_dlx_sup_sup]),
            lists:all(fun(L) -> L =:= [] end, DlxWorkers)
        end, 60000),
 
@@ -513,7 +513,7 @@ drop_head_falls_back_to_at_most_once(Config) ->
     consistently(
       ?_assertMatch(
          [_, {active, 0}, _, _],
-         rpc(Config, Server, supervisor, count_children, [rabbit_fifo_dlx_sup]))).
+         rpc(Config, Server, supervisor, count_children, [rabbit_fifo_dlx_sup_sup]))).
 
 %% Test that dynamically switching dead-letter-strategy works.
 switch_strategy(Config) ->
@@ -935,7 +935,7 @@ single_dlx_worker(Config) ->
        [[_, {active, 1}, _, _],
         [_, {active, 0}, _, _],
         [_, {active, 0}, _, _]],
-       rabbit_ct_broker_helpers:rpc_all(Config, supervisor, count_children, [rabbit_fifo_dlx_sup])),
+       rabbit_ct_broker_helpers:rpc_all(Config, supervisor, count_children, [rabbit_fifo_dlx_sup_sup])),
 
     ok = rabbit_ct_broker_helpers:stop_broker(Config, Server1),
     RaName = ra_name(SourceQ),
@@ -948,7 +948,7 @@ single_dlx_worker(Config) ->
     consistently(
       ?_assertEqual(
          0,
-         length(rpc(Config, Server1, supervisor, which_children, [rabbit_fifo_dlx_sup], 1000)))),
+         length(rpc(Config, Server1, supervisor, which_children, [rabbit_fifo_dlx_sup_sup], 1000)))),
 
     %% Kill the leader node to verify the DLX worker follows leadership.
     %% We kill the node rather than just the Ra process: killing only the process
@@ -965,7 +965,7 @@ single_dlx_worker(Config) ->
 
 assert_active_dlx_workers(N, Config, Server) ->
     ?awaitMatch(N,
-                length(rpc(Config, Server, supervisor, which_children, [rabbit_fifo_dlx_sup], 5000)),
+                length(rpc(Config, Server, supervisor, which_children, [rabbit_fifo_dlx_sup_sup], 5000)),
                 60_000).
 
 declare_queue(Channel, Queue, Args) ->

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -51,7 +51,7 @@
          build_acyclic_graph/3]).
 -export([const/1]).
 -export([ntoa/1, ntoab/1]).
--export([is_process_alive/1,
+-export([is_process_alive/1, is_local_process_alive/1,
          process_info/2]).
 -export([pget/2, pget/3, pupdate/3, pget_or_die/2, pmerge/3, pset/3, plmerge/2]).
 -export([deep_pget/2, deep_pget/3]).
@@ -824,6 +824,13 @@ is_process_alive(Pid) ->
     Node = node(Pid),
     lists:member(Node, [node() | nodes(connected)]) andalso
         rpc:call(Node, erlang, is_process_alive, [Pid]) =:= true.
+
+-spec is_local_process_alive(Pid :: pid()) -> boolean().
+is_local_process_alive(Pid)
+  when node(Pid) =:= node() ->
+    erlang:is_process_alive(Pid);
+is_local_process_alive(_) ->
+    false.
 
 %% Get process info of a prossibly remote process.
 %% We try to avoid reconnecting to down nodes.


### PR DESCRIPTION
## Summary

Fixes #16652.

A burst of DLX worker crashes can trip the flat `rabbit_fifo_dlx_sup` supervisor's restart intensity (100/1s), rendering it permanently unavailable. Once unavailable on all nodes, every `at_least_once` DLX quorum queue that enters leader state crashes its Ra server on `{noproc, start_child}`. Each Ra server then trips `ra_server_sup` (intensity 2/period 5), permanently stranding the queue with no automatic recovery.

## Changes

Replace the flat `simple_one_for_one` supervisor with a two-level hierarchy:

- `rabbit_fifo_dlx_sup_sup` - top-level `simple_one_for_one` whose children are per-queue worker supervisors (`restart => temporary`).
- `rabbit_fifo_dlx_worker_sup` - per-queue `one_for_one` with `intensity => 0`. A worker crash terminates only its own supervisor, isolating failures to a single queue without affecting the top-level supervisor or any other queue.

With `restart => temporary` children in the sup_sup, crashes never increment the top-level intensity counter (OTP `supervisor.erl` skips `add_restart` for temporary children in `do_restart`). The sup_sup itself can never reach max restart intensity regardless of how many workers crash simultaneously.

Additional fixes included in this PR:

- `ensure_worker_started` now checks live supervisor state via `find_worker_sup/1` before starting a new worker, preventing duplicate worker_sups from concurrent `state_enter` and `{dlx, setup}` aux calls racing.
- `state_enter(eol, ...)` now terminates the DLX worker on queue deletion, preventing orphaned worker_sups.

## How to reproduce

See the reproduction steps in #16652. The simplest deterministic trigger:

1. `erlang:unregister(rabbit_fifo_dlx_sup)` on all nodes (simulates supervisor unavailability)
2. Transfer leadership of an `at_least_once` DLX quorum queue
3. Observe the queue becomes permanently stranded (`noproc`)

With the fix applied, step 1 is no longer possible - individual worker crashes are isolated to their own `rabbit_fifo_dlx_worker_sup` and cannot affect the top-level supervisor or other queues.

## Test

- `rabbit_fifo_dlx_SUITE` - 5/5 pass
- `rabbit_fifo_dlx_integration_SUITE` - 19/19 pass (multiple clean runs)
