### PR TITLE
rabbit_fifo: Add `reject_publish_dlx` overflow strategy

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -203,8 +203,7 @@
               delayed_op/0]).
 
 -spec init(config()) -> state().
-init(#{name := Name,
-       queue_resource := Resource} = Conf) ->
+init(#{name := Name, queue_resource := Resource} = Conf) ->
     update_config(Conf, #?STATE{cfg = #cfg{name = Name,
                                            resource = Resource}}).
 
@@ -696,9 +695,12 @@ apply_(Meta, {nodeup, Node}, #?STATE{consumers = Cons0,
 apply_(_, {nodedown, _Node}, State) ->
     {State, ok};
 apply_(Meta, #purge_nodes{nodes = Nodes}, State0) ->
-    {State, Effects} = lists:foldl(fun(Node, {S, E}) ->
+    {State1, Effects} = lists:foldl(fun(Node, {S, E}) ->
                                            purge_node(Meta, Node, S, E)
                                    end, {State0, []}, Nodes),
+    State = State1#?STATE{
+        ingress_bytes_by_node =
+            maps:without(Nodes, State1#?STATE.ingress_bytes_by_node)},
     {State, ok, Effects};
 apply_(Meta,
        #update_config{config = #{} = Conf},
@@ -967,8 +969,7 @@ credit_reply_resend_effect(#?STATE{waiting_consumers = Waiting,
       end, [], maps:merge(Consumers, maps:from_list(Waiting))).
 
 convert_v8_to_v9(#{} = _Meta, StateV8) ->
-    State = StateV8,
-    State.
+    erlang:append_element(StateV8, #{}).
 
 purge_node(Meta, Node, State, Effects) ->
     lists:foldl(fun(Pid, {S0, E0}) ->
@@ -1171,7 +1172,8 @@ overview(#?STATE{consumers = Cons,
                  reclaimable_bytes_count => ReclaimableBytes,
                  smallest_raft_index => smallest_raft_index(State),
                  num_active_priorities => NumActivePriorities,
-                 messages_by_priority => Detail
+                 messages_by_priority => Detail,
+                 ingress_bytes_by_node => State#?STATE.ingress_bytes_by_node
                  },
     DlxOverview = dlx_overview(DlxState),
     maps:merge(maps:merge(Overview, DlxOverview), SacOverview).
@@ -1205,7 +1207,13 @@ which_module(7) -> rabbit_fifo_v7;
 which_module(8) -> rabbit_fifo_v8;
 which_module(9) -> ?MODULE.
 
--define(AUX, aux_v4).
+-define(AUX, aux_v5).
+-define(DEFAULT_INGRESS_DECAY_MS, 60_000).
+
+-record(ingress_aux,
+        {last_totals = #{} :: #{node() | undefined => non_neg_integer()},
+         estimators = #{} :: #{node() | undefined => ra_li:state()},
+         decay_ms = ?DEFAULT_INGRESS_DECAY_MS :: pos_integer()}).
 
 -record(snapshot, {index :: ra:index(),
                    timestamp :: milliseconds(),
@@ -1220,7 +1228,8 @@ which_module(9) -> ?MODULE.
                gc = #aux_gc{} :: #aux_gc{},
                tick_pid :: undefined | pid(),
                cache = #{} :: map(),
-               last_checkpoint :: tuple() | #snapshot{}
+               last_checkpoint :: tuple() | #snapshot{},
+               ingress = #ingress_aux{} :: #ingress_aux{}
               }).
 
 init_aux(Name) when is_atom(Name) ->
@@ -1234,11 +1243,38 @@ init_aux(Name) when is_atom(Name) ->
                              ?SNAP_MIN_RECLAIMABLE_B}),
     Range = max(1, SnapMinReclaimable - ?SNAP_MIN_RECLAIMABLE_LOW_B),
     MinReclaimable = ?SNAP_MIN_RECLAIMABLE_LOW_B + rand:uniform(Range),
+    DecayMs = persistent_term:get(rabbit_fifo_ingress_decay_ms,
+                                  ?DEFAULT_INGRESS_DECAY_MS),
     #?AUX{name = Name,
           last_checkpoint = #snapshot{index = 0,
                                       timestamp = erlang:system_time(millisecond),
                                       messages_total = 0,
-                                      min_reclaimable = MinReclaimable}}.
+                                      min_reclaimable = MinReclaimable},
+          ingress = #ingress_aux{decay_ms = DecayMs}}.
+
+update_ingress(Overview, Nodes, #ingress_aux{last_totals = LastTotals,
+                                              estimators = Estimators0,
+                                              decay_ms = DecayMs} = Ingress) ->
+    NewTotals = maps:get(ingress_bytes_by_node, Overview, #{}),
+    Ts = erlang:monotonic_time(millisecond),
+    Estimators1 =
+        maps:fold(fun(Node, NewTotal, Est) ->
+                      Delta = NewTotal - maps:get(Node, LastTotals, 0),
+                      Li0 = maps:get(Node, Est, ra_li:new(DecayMs)),
+                      Li1 = ra_li:update(Delta, Ts, Li0),
+                      Est#{Node => Li1}
+                  end, Estimators0, NewTotals),
+    ActiveNodes = sets:from_list(Nodes, [{version, 2}]),
+    Estimators = maps:filter(fun(Node, _) ->
+                                  Node =:= undefined orelse
+                                  sets:is_element(Node, ActiveNodes)
+                             end, Estimators1),
+    Ingress#ingress_aux{last_totals = NewTotals,
+                        estimators = Estimators}.
+
+compute_ingress_rates(#ingress_aux{estimators = Estimators}) ->
+    Ts = erlang:monotonic_time(millisecond),
+    maps:map(fun(_Node, Li) -> ra_li:rate(Ts, Li) end, Estimators).
 
 handle_aux(RaftState, Tag, Cmd, AuxV2, RaAux)
   when element(1, AuxV2) == aux_v2 ->
@@ -1256,6 +1292,19 @@ handle_aux(RaftState, Tag, Cmd, AuxV3, RaAux)
                   last_checkpoint = element(8, AuxV3)
                  },
     handle_aux(RaftState, Tag, Cmd, AuxV4, RaAux);
+handle_aux(RaftState, Tag, Cmd, AuxV4, RaAux)
+  when element(1, AuxV4) == aux_v4 ->
+    DecayMs = persistent_term:get(rabbit_fifo_ingress_decay_ms,
+                                  ?DEFAULT_INGRESS_DECAY_MS),
+    AuxV5 = #?AUX{name = element(2, AuxV4),
+                  last_decorators_state = element(3, AuxV4),
+                  last_consumer_timeout = element(4, AuxV4),
+                  gc = element(5, AuxV4),
+                  tick_pid = element(6, AuxV4),
+                  cache = element(7, AuxV4),
+                  last_checkpoint = element(8, AuxV4),
+                  ingress = #ingress_aux{decay_ms = DecayMs}},
+    handle_aux(RaftState, Tag, Cmd, AuxV5, RaAux);
 handle_aux(leader, cast, eval,
            #?AUX{last_decorators_state = LastDec,
                  last_consumer_timeout = LastConTimeout0,
@@ -1348,22 +1397,25 @@ handle_aux(_RaftState, cast, {#return{msg_ids = MsgIds,
             %% for returns with a delivery limit set we can just return as before
             {no_reply, Aux0, RaAux0, [{append, Ret, {notify, Corr, Pid}}]}
     end;
-handle_aux(leader, _, {handle_tick, [QName, Overview0, Nodes]},
-           #?AUX{tick_pid = Pid} = Aux, RaAux) ->
-    Overview = Overview0#{members_info => ra_aux:members_info(RaAux)},
-    NewPid =
-        case process_is_alive(Pid) of
-            false ->
-                %% No active TICK pid
-                %% this function spawns and returns the tick process pid
-                rabbit_quorum_queue:handle_tick(QName, Overview, Nodes);
-            true ->
-                %% Active TICK pid, do nothing
-                Pid
-        end,
 
-    %% TODO: check consumer timeouts
-    {no_reply, Aux#?AUX{tick_pid = NewPid}, RaAux, []};
+handle_aux(RaftState, _, {handle_tick, [QName, Overview0, Nodes]},
+           #?AUX{tick_pid = Pid, ingress = Ingress0} = Aux, RaAux) ->
+    Overview = Overview0#{members_info => ra_aux:members_info(RaAux)},
+    Ingress = update_ingress(Overview0, Nodes, Ingress0),
+    Aux1 = Aux#?AUX{ingress = Ingress},
+    case RaftState of
+        leader ->
+            NewPid =
+                case process_is_alive(Pid) of
+                    false ->
+                        rabbit_quorum_queue:handle_tick(QName, Overview, Nodes);
+                    true ->
+                        Pid
+                end,
+            {no_reply, Aux1#?AUX{tick_pid = NewPid}, RaAux, []};
+        _ ->
+            {no_reply, Aux1, RaAux, []}
+    end;
 handle_aux(_, _, {get_checked_out, ConsumerKey, MsgIds}, Aux0, RaAux0) ->
     #?STATE{cfg = #cfg{},
             consumers = Consumers} = ra_aux:machine_state(RaAux0),
@@ -1460,6 +1512,10 @@ handle_aux(leader, _, {dlx, setup}, Aux, RaAux) ->
 handle_aux(_, _, {dlx, teardown, Pid}, Aux, RaAux) ->
     terminate_dlx_worker(Pid),
     {no_reply, Aux, RaAux};
+handle_aux(_, {call, _From}, get_ingress_rates,
+           #?AUX{ingress = Ingress} = Aux, RaAux) ->
+    Rates = compute_ingress_rates(Ingress),
+    {reply, {ok, Rates}, Aux, RaAux};
 handle_aux(_, _, Unhandled, Aux, RaAux) ->
     #?STATE{cfg = #cfg{resource = QR}} = ra_aux:machine_state(RaAux),
     ?LOG_DEBUG("~ts: rabbit_fifo: unhandled aux command ~P",
@@ -1907,12 +1963,24 @@ maybe_return_all(#{system_time := Ts} = Meta, ConsumerKey,
              Effects}
     end.
 
+node_of(undefined) -> undefined;
+node_of(Pid) when is_pid(Pid) -> node(Pid).
+
+bump_ingress(Node, Size, Map) ->
+    maps:update_with(Node, fun(V) -> V + Size end, Size, Map).
+
 apply_enqueue(#{index := RaftIdx,
                 system_time := Ts} = Meta, From,
               Seq, RawMsg, Size, State0) ->
     case maybe_enqueue(RaftIdx, Ts, From, Seq, RawMsg, Size, [], State0) of
         {ok, State1, Effects1} ->
-            checkout(Meta, State0, State1, Effects1);
+            {MetaSize, BodySize} = Size,
+            TotalSize = MetaSize + BodySize,
+            IngressByNode = State1#?STATE.ingress_bytes_by_node,
+            State2 = State1#?STATE{
+                ingress_bytes_by_node =
+                    bump_ingress(node_of(From), TotalSize, IngressByNode)},
+            checkout(Meta, State0, State2, Effects1);
         {out_of_sequence, State, Effects} ->
             {State, not_enqueued, Effects};
         {duplicate, State, Effects} ->

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -290,9 +290,12 @@ apply_(_Meta, #register_enqueuer{pid = Pid},
                 false ->
                     State0#?STATE{enqueuers = Enqueuers0#{Pid => #enqueuer{}}}
             end,
-    Res = case is_over_limit(State) of
-              true when Overflow == reject_publish ->
-                  reject_publish;
+    Res = case Overflow of
+              reject_publish ->
+                  case is_over_limit(State) of
+                      true -> reject_publish;
+                      false -> ok
+                  end;
               _ ->
                   ok
           end,
@@ -1981,6 +1984,10 @@ apply_enqueue(#{index := RaftIdx,
                 ingress_bytes_by_node =
                     bump_ingress(node_of(From), TotalSize, IngressByNode)},
             checkout(Meta, State0, State2, Effects1);
+        {reject_publish_dlx, State, Effects} ->
+            %% Message was rejected and dead-lettered before enqueuing.
+            %% Reply with reject_publish so the client nacks the publisher.
+            checkout(Meta, State0, State, Effects, reject_publish);
         {out_of_sequence, State, Effects} ->
             {State, not_enqueued, Effects};
         {duplicate, State, Effects} ->
@@ -2074,6 +2081,38 @@ maybe_enqueue(RaftIdx, Ts, undefined, undefined, RawMsg,
               {MetaSize, BodySize},
               Effects, #?STATE{msg_bytes_enqueue = Enqueue,
                                messages = Messages,
+                               cfg = #cfg{overflow_strategy = reject_publish_dlx,
+                                          dead_letter_handler = DLH},
+                               dlx = DlxState,
+                               reclaimable_bytes = ReclaimableBytes0,
+                               messages_total = Total} = State0) ->
+    %% Untracked enqueue rejected due to reject_publish_dlx overflow
+    Size = MetaSize + BodySize,
+    case would_overflow(Size, State0) of
+        true ->
+            Header0 = maybe_set_msg_ttl(RawMsg, Ts, Size, State0),
+            Header = maybe_set_msg_delivery_count(RawMsg, Header0),
+            Msg = make_msg(RaftIdx, Header),
+            {_, _, DlxEffects} =
+                discard_or_dead_letter([Msg], maxlen, DLH, DlxState),
+            State = State0#?STATE{reclaimable_bytes = ReclaimableBytes0 +
+                                                      Size + ?ENQ_OVERHEAD_B},
+            {reject_publish_dlx, State, DlxEffects ++ Effects};
+        false ->
+            Header0 = maybe_set_msg_ttl(RawMsg, Ts, Size, State0),
+            Header = maybe_set_msg_delivery_count(RawMsg, Header0),
+            Msg = make_msg(RaftIdx, Header),
+            Priority = msg_priority(RawMsg),
+            State = State0#?STATE{msg_bytes_enqueue = Enqueue + Size,
+                                  messages_total = Total + 1,
+                                  messages = rabbit_fifo_pq:in(Priority, Msg,
+                                                               Messages)},
+            {ok, State, Effects}
+    end;
+maybe_enqueue(RaftIdx, Ts, undefined, undefined, RawMsg,
+              {MetaSize, BodySize},
+              Effects, #?STATE{msg_bytes_enqueue = Enqueue,
+                               messages = Messages,
                                messages_total = Total} = State0) ->
     % direct enqueue without tracking
     Size = MetaSize + BodySize,
@@ -2088,11 +2127,9 @@ maybe_enqueue(RaftIdx, Ts, undefined, undefined, RawMsg,
     {ok, State, Effects};
 maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg,
               {MetaSize, BodySize} = MsgSize,
-              Effects0, #?STATE{msg_bytes_enqueue = BytesEnqueued,
+              Effects0, #?STATE{cfg = Cfg,
                                 enqueuers = Enqueuers0,
-                                messages = Messages,
-                                reclaimable_bytes = ReclaimableBytes0,
-                                messages_total = Total} = State0) ->
+                                reclaimable_bytes = ReclaimableBytes0} = State0) ->
     Size = MetaSize + BodySize,
     case maps:get(From, Enqueuers0, undefined) of
         undefined ->
@@ -2103,27 +2140,31 @@ maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg,
             {Res, State, [{monitor, process, From} | Effects]};
         #enqueuer{next_seqno = MsgSeqNo} = Enq0 ->
             % it is the next expected seqno
-            % TODO: it is not good to query the `mc' container inside the
-            % statemachine as it may be modified to behave differently without
-            % concern for the state machine
-            Header0 = maybe_set_msg_ttl(RawMsg, Ts, Size, State0),
-            Header = maybe_set_msg_delivery_count(RawMsg, Header0),
-            Msg = make_msg(RaftIdx, Header),
             Enq = Enq0#enqueuer{next_seqno = MsgSeqNo + 1},
-            MsgCache = case can_immediately_deliver(State0) of
-                           true ->
-                               {RaftIdx, RawMsg};
-                           false ->
-                               undefined
-                       end,
-            Priority = msg_priority(RawMsg),
-            State = State0#?STATE{msg_bytes_enqueue = BytesEnqueued + Size,
-                                  messages_total = Total + 1,
-                                  messages = rabbit_fifo_pq:in(Priority, Msg, Messages),
-                                  enqueuers = Enqueuers0#{From => Enq},
-                                  msg_cache = MsgCache
-                                 },
-            {ok, State, Effects0};
+            case Cfg of
+                #cfg{overflow_strategy = reject_publish_dlx,
+                     dead_letter_handler = DLH} ->
+                    case would_overflow(Size, State0) of
+                        true ->
+                            Header0 = maybe_set_msg_ttl(RawMsg, Ts, Size, State0),
+                            Header = maybe_set_msg_delivery_count(RawMsg, Header0),
+                            Msg = make_msg(RaftIdx, Header),
+                            {_, _, DlxEffects} =
+                                discard_or_dead_letter([Msg], maxlen, DLH,
+                                                      State0#?STATE.dlx),
+                            State = State0#?STATE{
+                                      reclaimable_bytes =
+                                          ReclaimableBytes0 + Size + ?ENQ_OVERHEAD_B,
+                                      enqueuers = Enqueuers0#{From => Enq}},
+                            {reject_publish_dlx, State, DlxEffects ++ Effects0};
+                        false ->
+                            enqueue_msg(RaftIdx, Ts, RawMsg, Size, Enq, From,
+                                        Effects0, State0)
+                    end;
+                _ ->
+                    enqueue_msg(RaftIdx, Ts, RawMsg, Size, Enq, From,
+                                Effects0, State0)
+            end;
         #enqueuer{next_seqno = Next}
           when MsgSeqNo > Next ->
             %% TODO: when can this happen?
@@ -2136,6 +2177,29 @@ maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg,
                                   ReclaimableBytes0 + Size + ?ENQ_OVERHEAD_B},
             {duplicate, State, Effects0}
     end.
+
+enqueue_msg(RaftIdx, Ts, RawMsg, Size, Enq, From, Effects0,
+            #?STATE{msg_bytes_enqueue = BytesEnqueued,
+                    enqueuers = Enqueuers0,
+                    messages = Messages,
+                    messages_total = Total} = State0) ->
+    Header0 = maybe_set_msg_ttl(RawMsg, Ts, Size, State0),
+    Header = maybe_set_msg_delivery_count(RawMsg, Header0),
+    Msg = make_msg(RaftIdx, Header),
+    MsgCache = case can_immediately_deliver(State0) of
+                   true ->
+                       {RaftIdx, RawMsg};
+                   false ->
+                       undefined
+               end,
+    Priority = msg_priority(RawMsg),
+    State = State0#?STATE{msg_bytes_enqueue = BytesEnqueued + Size,
+                          messages_total = Total + 1,
+                          messages = rabbit_fifo_pq:in(Priority, Msg, Messages),
+                          enqueuers = Enqueuers0#{From => Enq},
+                          msg_cache = MsgCache
+                         },
+    {ok, State, Effects0}.
 
 return(Meta, ConsumerKey, Consumer0,
        MsgIds, IncrDelCount, Anns, Effects0, State0)
@@ -2521,17 +2585,13 @@ evaluate_limit0(Index, BeforeState,
         true when Strategy == reject_publish ->
             %% generate send_msg effect for each enqueuer to let them know
             %% they need to block
-            {Enqs, Effects} =
-                maps:fold(
-                  fun (P, #enqueuer{blocked = undefined} = E0, {Enqs, Acc}) ->
-                          E = E0#enqueuer{blocked = Index},
-                          {Enqs#{P => E},
-                           [{send_msg, P, {queue_status, reject_publish},
-                             [ra_event]} | Acc]};
-                      (_P, _E, Acc) ->
-                          Acc
-                  end, {Enqs0, Effects0}, Enqs0),
+            {Enqs, Effects} = block_enqueuers(Index, Enqs0, Effects0),
             {State0#?STATE{enqueuers = Enqs}, Effects};
+        _ when Strategy == reject_publish_dlx ->
+            %% For reject_publish_dlx, we don't block enqueuers.
+            %% Messages always flow to the server where they are rejected
+            %% and dead-lettered. The publisher gets a nack via the reply.
+            {State0, Effects0};
         false when Strategy == reject_publish ->
             %% TODO: optimise as this case gets called for every command
             %% pretty much
@@ -2547,6 +2607,17 @@ evaluate_limit0(Index, BeforeState,
         false ->
             {State0, Effects0}
     end.
+
+block_enqueuers(Index, Enqs0, Effects0) ->
+    maps:fold(
+      fun (P, #enqueuer{blocked = undefined} = E0, {Enqs, Acc}) ->
+              E = E0#enqueuer{blocked = Index},
+              {Enqs#{P => E},
+               [{send_msg, P, {queue_status, reject_publish},
+                 [ra_event]} | Acc]};
+          (_P, _E, Acc) ->
+              Acc
+      end, {Enqs0, Effects0}, Enqs0).
 
 unblock_enqueuers(Enqs0, Effects0) ->
     maps:fold(
@@ -3335,6 +3406,18 @@ is_over_limit(#?STATE{cfg = #cfg{max_length = MaxLength,
     {NumDlx, BytesDlx} = dlx_stat(DlxState),
     (messages_ready_plus_delayed(State) + NumDlx > MaxLength) orelse
     (BytesEnq + BytesDlx > MaxBytes).
+
+%% Checks whether enqueuing a message of the given size would exceed the limits.
+would_overflow(_Size, #?STATE{cfg = #cfg{max_length = undefined,
+                                         max_bytes = undefined}}) ->
+    false;
+would_overflow(Size, #?STATE{cfg = #cfg{max_length = MaxLength,
+                                         max_bytes = MaxBytes},
+                              msg_bytes_enqueue = BytesEnq,
+                              dlx = DlxState} = State) ->
+    {NumDlx, BytesDlx} = dlx_stat(DlxState),
+    (messages_ready_plus_delayed(State) + NumDlx >= MaxLength) orelse
+    (BytesEnq + Size + BytesDlx > MaxBytes).
 
 is_below_soft_limit(#?STATE{cfg = #cfg{max_length = undefined,
                                         max_bytes = undefined}}) ->

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -295,7 +295,12 @@
          last_active :: option(non_neg_integer()),
          msg_cache :: option({ra:index(), raw_msg()}),
          %% delayed retry messages awaiting redelivery
-         delayed = #delayed{} :: #delayed{}
+         delayed = #delayed{} :: #delayed{},
+         %% bytes enqueued, accumulated per originating node since the
+         %% creation of this state machine. Monotonically non-decreasing
+         %% on every node (under leader replication). Used by leader
+         %% migration tooling to estimate per-node ingress.
+         ingress_bytes_by_node = #{} :: #{node() | undefined => non_neg_integer()}
         }).
 
 -type config() :: #{name := atom(),

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -223,7 +223,9 @@
          unused_1 = ?NIL,
          dead_letter_handler :: dead_letter_handler(),
          become_leader_handler :: option(applied_mfa()),
-         overflow_strategy = drop_head :: drop_head | reject_publish,
+         overflow_strategy = drop_head :: drop_head |
+                                          reject_publish |
+                                          reject_publish_dlx,
          max_length :: option(non_neg_integer()),
          max_bytes :: option(non_neg_integer()),
          %% whether single active consumer is on or not for this queue
@@ -311,7 +313,9 @@
                     % checkpoint_max_indexes => non_neg_integer(),
                     max_length => non_neg_integer(),
                     max_bytes => non_neg_integer(),
-                    overflow_strategy => drop_head | reject_publish,
+                    overflow_strategy => drop_head |
+                                         reject_publish |
+                                         reject_publish_dlx,
                     single_active_consumer_on => boolean(),
                     delivery_limit => non_neg_integer() | -1,
                     expires => non_neg_integer(),

--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -674,17 +674,24 @@ handle_ra_event(QName, Leader, {applied, Seqs},
              end,
 
     Actions0 = lists:reverse(ActionsRev),
-    Actions = case Corrs of
+    Actions1 = case Corrs of
                   [] ->
                       Actions0;
                   _ ->
-                      %%TODO: consider using lists:foldr/3 above because
-                      %% Corrs is returned in the wrong order here.
-                      %% The wrong order does not matter much because the channel sorts the
-                      %% sequence numbers before confirming to the client. But rabbit_fifo_client
-                      %% is sequence numer agnostic: it handles any correlation terms.
                       [{settled, QName, Corrs} | Actions0]
               end,
+    %% Collect rejected correlations and transform into rejected actions
+    {Actions, RejectedCorrs} =
+        lists:foldl(fun ({reject_publish, Corr}, {As, Rs}) ->
+                            {As, [Corr | Rs]};
+                        (A, {As, Rs}) ->
+                            {[A | As], Rs}
+                    end, {[], []}, Actions1),
+    Actions2 = case RejectedCorrs of
+                   [] -> lists:reverse(Actions);
+                   _ -> [{rejected, QName, maxlen, RejectedCorrs}
+                         | lists:reverse(Actions)]
+               end,
     case map_size(State2#state.pending) < SftLmt of
         true when State2#state.slow == true ->
             % we have exited soft limit state
@@ -710,9 +717,9 @@ handle_ra_event(QName, Leader, {applied, Seqs},
                                         send_command(ServerId, undefined, C,
                                                      normal, S0)
                                 end, State3, Commands),
-            {ok, State, [{unblock, cluster_name(State)} | Actions]};
+            {ok, State, [{unblock, cluster_name(State)} | Actions2]};
         _ ->
-            {ok, State2, Actions}
+            {ok, State2, Actions2}
     end;
 handle_ra_event(QName, From, {machine, Del}, State0)
       when element(1, Del) == delivery ->
@@ -834,6 +841,12 @@ seq_applied({Seq, Response},
           when Response =/= not_enqueued ->
             {Corrs, Actions, State#state{pending = Pending}};
         {{Corr, _}, Pending}
+          when Response == reject_publish ->
+            %% Message was rejected (e.g. reject_publish_dlx overflow).
+            %% Remove from pending but do not confirm; signal rejection.
+            {Corrs, [{reject_publish, Corr} | Actions],
+             State#state{pending = Pending}};
+        {{Corr, _}, Pending}
           when Response =/= not_enqueued ->
             {[Corr | Corrs], Actions, State#state{pending = Pending}};
         _ ->
@@ -845,6 +858,9 @@ seq_applied(_Seq, Acc) ->
 maybe_add_action(ok, Acc, State) ->
     {Acc, State};
 maybe_add_action(not_enqueued, Acc, State) ->
+    {Acc, State};
+maybe_add_action(reject_publish, Acc, State) ->
+    %% Handled separately in seq_applied
     {Acc, State};
 maybe_add_action({multi, Actions}, Acc0, State0) ->
     lists:foldl(fun (Act, {Acc, State}) ->

--- a/deps/rabbit/src/rabbit_fifo_v8.erl
+++ b/deps/rabbit/src/rabbit_fifo_v8.erl
@@ -5,18 +5,18 @@
 %% Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
 %% The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
 %% All rights reserved.
--module(rabbit_fifo).
+-module(rabbit_fifo_v8).
 
 -behaviour(ra_machine).
 
 -compile(inline_list_funcs).
 -compile(inline).
 -compile({no_auto_import, [apply/3]}).
--dialyzer({nowarn_function, convert_v8_to_v9/2}).
+-dialyzer({nowarn_function, convert_v7_to_v8/2}).
 -dialyzer(no_improper_lists).
 
 -include("rabbit_queue_type.hrl").
--include("rabbit_fifo.hrl").
+-include("rabbit_fifo_v8.hrl").
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -105,7 +105,8 @@
          make_garbage_collection/0,
          make_delayed/1,
 
-         exec_read/3
+         exec_read/3,
+         convert_v7_to_v8/2
 
         ]).
 
@@ -966,9 +967,69 @@ credit_reply_resend_effect(#?STATE{waiting_consumers = Waiting,
               Acc
       end, [], maps:merge(Consumers, maps:from_list(Waiting))).
 
-convert_v8_to_v9(#{} = _Meta, StateV8) ->
-    State = StateV8,
-    State.
+v7_to_v8_consumer(Con, Timeout) ->
+                     V7Cfg = element(#consumer.cfg, Con),
+                     Status0 = element(#consumer.status, Con),
+                     Ch0 = element(#consumer.checked_out, Con),
+                     Ch = maps:map(fun (_, M) -> ?C_MSG(Timeout, M) end, Ch0),
+                     Cfg = #consumer_cfg{meta = element(#consumer_cfg.meta, V7Cfg),
+                                         pid = element(#consumer_cfg.pid, V7Cfg),
+                                         tag = element(#consumer_cfg.tag, V7Cfg),
+                                         credit_mode = element(#consumer_cfg.credit_mode, V7Cfg),
+                                         lifetime = element(#consumer_cfg.lifetime, V7Cfg),
+                                         priority = element(#consumer_cfg.priority, V7Cfg),
+                                         timeout = ?DEFAULT_CONSUMER_TIMEOUT_MS
+                                        },
+                     Status = case Status0 of
+                                  suspected_down ->
+                                      {suspected_down, up};
+                                  _ ->
+                                      Status0
+                              end,
+                     #consumer{cfg = Cfg,
+                               status = Status,
+                               next_msg_id = element(#consumer.next_msg_id, Con),
+                               checked_out = Ch,
+                               credit = element(#consumer.credit, Con),
+                               delivery_count = element(#consumer.delivery_count, Con)
+                              }.
+
+convert_v7_to_v8(#{system_time := Ts} = _Meta, StateV7) ->
+    %% the structure is intact for now
+    Cons0 = element(#?STATE.consumers, StateV7),
+    Waiting0 = element(#?STATE.waiting_consumers, StateV7),
+    Timeout = Ts + ?DEFAULT_CONSUMER_TIMEOUT_MS,
+    Cons = maps:map(
+             fun (_CKey, Con) ->
+                     v7_to_v8_consumer(Con, Timeout)
+             end, Cons0),
+    Waiting = lists:map(fun({Cid, Con}) ->
+                                {Cid, v7_to_v8_consumer(Con, Timeout)}
+                        end, Waiting0),
+
+    Msgs = element(#?STATE.messages, StateV7),
+    Cfg = element(#?STATE.cfg, StateV7),
+    {Hi, No} = rabbit_fifo_q:to_queues(Msgs),
+    Pq0 = queue:fold(fun (I, Acc) ->
+                             rabbit_fifo_pq:in(9, I, Acc)
+                     end, rabbit_fifo_pq:new(), Hi),
+    Pq = queue:fold(fun (I, Acc) ->
+                            rabbit_fifo_pq:in(?DEFAULT_PRIORITY, I, Acc)
+                    end, Pq0, No),
+    Dlx0 = element(#?STATE.dlx, StateV7),
+    Dlx = Dlx0#?DLX{unused = ?NIL},
+    StateV8 = StateV7,
+    StateV8#?STATE{cfg = Cfg#cfg{consumer_disconnected_timeout = 60_000,
+                                 delayed_retry = disabled},
+                   reclaimable_bytes = 0,
+                   messages = Pq,
+                   consumers = Cons,
+                   waiting_consumers = Waiting,
+                   next_consumer_timeout = Timeout,
+                   last_command_time = Ts,
+                   dlx = Dlx,
+                   delayed = #delayed{}
+                  }.
 
 purge_node(Meta, Node, State, Effects) ->
     lists:foldl(fun(Pid, {S0, E0}) ->
@@ -1192,7 +1253,7 @@ get_checked_out(CKey, From, To, #?STATE{consumers = Consumers}) ->
     end.
 
 -spec version() -> pos_integer().
-version() -> 9.
+version() -> 8.
 
 which_module(0) -> rabbit_fifo_v0;
 which_module(1) -> rabbit_fifo_v1;
@@ -1202,8 +1263,7 @@ which_module(4) -> rabbit_fifo_v7;
 which_module(5) -> rabbit_fifo_v7;
 which_module(6) -> rabbit_fifo_v7;
 which_module(7) -> rabbit_fifo_v7;
-which_module(8) -> rabbit_fifo_v8;
-which_module(9) -> ?MODULE.
+which_module(8) -> ?MODULE.
 
 -define(AUX, aux_v4).
 
@@ -1670,7 +1730,10 @@ query_notify_decorators_info(#?STATE{consumers = Consumers} = State) ->
 
 -spec usage(atom()) -> float().
 usage(Name) when is_atom(Name) ->
-    ets:lookup_element(rabbit_fifo_usage, Name, 2, 0.0).
+    case ets:lookup(rabbit_fifo_usage, Name) of
+        [] -> 0.0;
+        [{_, Use}] -> Use
+    end.
 
 %%% Internal
 
@@ -3520,9 +3583,7 @@ convert(Meta, 6, To, State) ->
     %% no conversion needed, this version only includes a logic change
     convert(Meta, 7, To, State);
 convert(Meta, 7, To, State) ->
-    convert(Meta, 8, To, rabbit_fifo_v8:convert_v7_to_v8(Meta, State));
-convert(Meta, 8, To, State) ->
-    convert(Meta, 9, To, convert_v8_to_v9(Meta, State)).
+    convert(Meta, 8, To, convert_v7_to_v8(Meta, State)).
 
 smallest_raft_index(#?STATE{messages = Messages,
                             returns = Returns,

--- a/deps/rabbit/src/rabbit_fifo_v8.hrl
+++ b/deps/rabbit/src/rabbit_fifo_v8.hrl
@@ -1,0 +1,317 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+%% macros for memory optimised tuple structures
+%% [A|B] saves 1 byte compared to {A,B}
+-define(TUPLE(A, B), [A | B]).
+
+%% We only hold Raft index and message header in memory.
+%% Raw message data is always stored on disk.
+-define(MSG(Index, Header), ?TUPLE(Index, Header)).
+
+-define(C_MSG(Timeout, Msg), {Timeout, Msg}).
+-define(C_MSG(Msg), {_, Msg}).
+-define(NIL, []).
+
+-define(IS_HEADER(H),
+        (is_integer(H) andalso H >= 0) orelse
+        is_list(H) orelse
+        (is_map(H) andalso is_map_key(size, H))).
+
+-define(DELIVERY_SEND_MSG_OPTS, [local, ra_event]).
+
+%% constants for packed msg references where both the raft index and the size
+%% is packed into a single immidate term
+%%
+%% 59 bytes as immedate ints are signed
+-define(PACKED_MAX, 16#7FFF_FFFF_FFFF_FFF).
+%% index bits - enough for 2000 days at 100k indexes p/sec
+-define(PACKED_IDX_BITS, 44).
+-define(PACKED_IDX_MAX, 16#FFFF_FFFF_FFF).
+-define(PACKED_SZ_BITS, 15). %% size
+-define(PACKED_SZ_MAX, 16#7FFF). %% 15 bits
+
+-define(PACK(Idx, Sz),
+        (Idx bxor (Sz bsl ?PACKED_IDX_BITS))).
+-define(PACKED_IDX(PackedInt),
+        (PackedInt band ?PACKED_IDX_MAX)).
+-define(PACKED_SZ(PackedInt),
+        ((PackedInt bsr 44) band 16#7FFF)).
+
+-define(IS_PACKED(Int), (Int >= 0 andalso Int =< ?PACKED_MAX)).
+
+-type optimised_tuple(A, B) :: nonempty_improper_list(A, B).
+
+-type option(T) :: undefined | T.
+
+-type raw_msg() :: term().
+%% The raw message. It is opaque to rabbit_fifo.
+
+-type msg_id() :: non_neg_integer().
+%% A consumer-scoped monotonically incrementing integer included with a
+%% {@link delivery/0.}. Used to settle deliveries using
+%% {@link rabbit_fifo_client:settle/3.}
+
+-type msg_seqno() :: non_neg_integer().
+%% A sender process scoped monotonically incrementing integer included
+%% in enqueue messages. Used to ensure ordering of messages send from the
+%% same process
+
+-type msg_header() :: msg_size() |
+                      optimised_tuple(msg_size(), Expiry :: milliseconds()) |
+                      #{size := msg_size(),
+                        acquired_count => non_neg_integer(),
+                        delivery_count => non_neg_integer(),
+                        expiry => milliseconds()}.
+%% The message header:
+%% size: The size of the message payload in bytes.
+%% delivery_count: The number of unsuccessful delivery attempts.
+%%                 A non-zero value indicates a previous attempt.
+%% return_count: The number of explicit returns.
+%% expiry: Epoch time in ms when a message expires. Set during enqueue.
+%%         Value is determined by per-queue or per-message message TTL.
+%% If it contains only the size it can be condensed to an integer.
+%% If it contains only the size and expiry it can be condensed to an improper list.
+
+-type msg_size() :: non_neg_integer().
+%% the size in bytes of the msg payload
+
+%% 60 byte integer, immediate
+-type packed_msg() :: 0..?PACKED_MAX.
+
+-type msg() :: packed_msg() | optimised_tuple(ra:index(), msg_header()).
+
+%% a consumer message
+-type c_msg() :: {LockExpiration :: milliseconds(), msg()}.
+
+-type delivery_msg() :: {msg_id(), {msg_header(), raw_msg()}}.
+%% A tuple consisting of the message id, and the headered message.
+
+-type delivery() :: {delivery, rabbit_types:ctag(), [delivery_msg()]}.
+%% Represents the delivery of one or more rabbit_fifo messages.
+
+-type consumer_id() :: {rabbit_types:ctag(), pid()}.
+%% The entity that receives messages. Uniquely identifies a consumer.
+
+-type consumer_idx() :: ra:index().
+%% v4 can reference consumers by the raft index they were added at.
+%% The entity that receives messages. Uniquely identifies a consumer.
+-type consumer_key() :: consumer_id() | consumer_idx().
+
+-type credit_mode() ::
+    {credited, InitialDeliveryCount :: rabbit_queue_type:delivery_count()} |
+    %% machine_version 2
+    {simple_prefetch, MaxCredit :: non_neg_integer()}.
+%% determines how credit is replenished
+
+-type checkout_spec() :: {once | auto,
+                          Num :: non_neg_integer(),
+                          credited | simple_prefetch} |
+
+                         {dequeue, settled | unsettled} |
+                         cancel | remove |
+                         %% new v4 format
+                         {once | auto, credit_mode()}.
+
+%% static meta data associated with a consumer
+-type consumer_meta() :: #{ack => boolean(),
+                           username => binary(),
+                           prefetch => non_neg_integer(),
+                           args => list(),
+                           priority => 0..255,
+                           timeout => milliseconds(),
+                           link_state_properties => true}.
+
+-type applied_mfa() :: {module(), atom(), list()}.
+% represents a partially applied module call
+
+-define(CHECK_MIN_INTERVAL_MS, 1000).
+-define(CHECK_MIN_INDEXES, 4096 * 2).
+-define(CHECK_MAX_INDEXES, 666_667).
+%% once these many bytes have been written since the last checkpoint
+%% we request a checkpoint irrespectively
+-define(CHECK_MAX_BYTES, 128_000_000).
+-define(SNAP_OUT_BYTES, 64_000_000).
+-define(SNAP_MIN_RECLAIMABLE_B, 10_000_000).
+-define(SNAP_MIN_RECLAIMABLE_LOW_B, 2_000_000).
+
+-define(USE_AVG_HALF_LIFE, 10000.0).
+%% an average QQ without any message uses about 100KB so setting this limit
+%% to ~10 times that should be relatively safe.
+-define(GC_MEM_LIMIT_B, 2_000_000).
+
+-define(MB, 1_048_576).
+-define(LOW_LIMIT, 0.8).
+-define(DELIVERY_CHUNK_LIMIT_B, 128_000).
+
+-type seconds() :: non_neg_integer().
+-type milliseconds() :: non_neg_integer().
+
+-record(consumer_cfg,
+        {meta = #{} :: consumer_meta(),
+         pid :: pid(),
+         tag :: rabbit_types:ctag(),
+         %% the mode of how credit is incremented
+         %% simple_prefetch: credit is re-filled as deliveries are settled
+         %% or returned.
+         %% credited: credit can only be changed by receiving a consumer_credit
+         %% command: `{credit, ReceiverDeliveryCount, Credit}'
+         credit_mode :: credited | credit_mode(),
+         lifetime = once :: once | auto,
+         priority = 0 :: integer(),
+         timeout = 1_800_000 :: milliseconds()}).
+
+-type consumer_status() :: up | cancelled | quiescing.
+
+-record(consumer,
+        {cfg = #consumer_cfg{},
+         status = up :: consumer_status() |
+                        {suspected_down, consumer_status()} |
+                        %% a message has been pending for longer than the
+                        %% consumer timeout
+                        {timeout, consumer_status()},
+         next_msg_id = 0 :: msg_id(),
+         checked_out = #{} :: #{msg_id() => c_msg()},
+         %% max number of messages that can be sent
+         %% decremented for each delivery
+         credit = 0 :: non_neg_integer(),
+         %% AMQP 1.0 §2.6.7
+         delivery_count :: rabbit_queue_type:delivery_count(),
+         drain = false :: boolean(),
+         timed_out_msg_ids = [] :: [msg_id()]
+        }).
+
+-type consumer() :: #consumer{}.
+
+-type consumer_strategy() :: competing | single_active.
+
+-type dead_letter_handler() :: option({at_most_once, applied_mfa()} | at_least_once).
+
+-type delayed_retry() :: disabled |
+                         {all | failed | returned,
+                          Min :: milliseconds(),
+                          Max :: milliseconds()}.
+
+-type deferral_token() :: binary().
+-type delayed_key() :: optimised_tuple(milliseconds(), ra:index()).
+
+-record(delayed,
+        {tree = gb_trees:empty() :: gb_trees:tree(delayed_key(), msg()),
+         %% Cached smallest entry for O(1) readiness check in take_next_msg
+         next = undefined :: option({milliseconds(), ra:index(), msg()}),
+         %% Map from deferral token to tree key for direct message lookup
+         deferred = #{} :: #{deferral_token() => delayed_key()}}).
+
+-record(enqueuer,
+        {next_seqno = 1 :: msg_seqno(),
+         unused = ?NIL,
+         status = up :: up | suspected_down,
+         %% it is useful to have a record of when this was blocked
+         %% so that we can retry sending the block effect if
+         %% the publisher did not receive the initial one
+         blocked :: option(ra:index()),
+         unused_1 = ?NIL,
+         unused_2 = ?NIL
+        }).
+
+-record(cfg,
+        {name :: atom(),
+         resource :: rabbit_types:r('queue'),
+         unused_1 = ?NIL,
+         dead_letter_handler :: dead_letter_handler(),
+         become_leader_handler :: option(applied_mfa()),
+         overflow_strategy = drop_head :: drop_head | reject_publish,
+         max_length :: option(non_neg_integer()),
+         max_bytes :: option(non_neg_integer()),
+         %% whether single active consumer is on or not for this queue
+         consumer_strategy = competing :: consumer_strategy(),
+         %% the maximum number of unsuccessful delivery attempts permitted
+         delivery_limit :: option(non_neg_integer()),
+         expires :: option(milliseconds()),
+         msg_ttl :: option(milliseconds()),
+         %% time to wait before returning messages when consumer's node
+         %% becomes unreachable
+         consumer_disconnected_timeout = 60_000 :: milliseconds(),
+         %% delayed retry configuration for returned messages
+         delayed_retry = disabled :: delayed_retry()
+        }).
+
+-record(messages,
+        {
+         messages = rabbit_fifo_pq:new() :: rabbit_fifo_pq:state(),
+         messages_total = 0 :: non_neg_integer(),
+         % queue of returned msg_in_ids - when checking out it picks from
+         returns = lqueue:new() :: lqueue:lqueue(term())
+        }).
+
+-record(dlx_consumer,
+        {pid :: pid(),
+         prefetch :: non_neg_integer(),
+         checked_out = #{} :: #{msg_id() =>
+                                optimised_tuple(rabbit_dead_letter:reason(), msg())},
+         next_msg_id = 0 :: msg_id()}).
+
+-record(rabbit_fifo_dlx,
+        {consumer :: option(#dlx_consumer{}),
+         %% Queue of dead-lettered messages.
+         discards = lqueue:new() :: lqueue:lqueue(optimised_tuple(rabbit_dead_letter:reason(), msg())),
+         unused = ?NIL,
+         msg_bytes = 0 :: non_neg_integer(),
+         msg_bytes_checkout = 0 :: non_neg_integer()}).
+
+-record(rabbit_fifo,
+        {cfg :: #cfg{},
+         % unassigned messages
+         messages = rabbit_fifo_pq:new() :: rabbit_fifo_pq:state(),
+         messages_total = 0 :: non_neg_integer(),
+         % queue of returned msg_in_ids - when checking out it picks from
+         returns = lqueue:new() :: lqueue:lqueue(term()),
+         % Reclaimable bytes - a counter that is incremented every time a
+         % command is processed that does not need to be kept (live indexes).
+         % Approximate, used for triggering snapshots.
+         % Reset to 0 when release_cursor gets stored.
+         reclaimable_bytes = 0,
+         % a map containing all the live processes that have ever enqueued
+         % a message to this queue
+         enqueuers = #{} :: #{pid() => #enqueuer{}},
+         last_command_time = 0,
+         next_consumer_timeout = infinity :: infinity | milliseconds(),
+         % consumers need to reflect consumer state at time of snapshot
+         consumers = #{} :: #{consumer_key() => consumer()},
+         % consumers that require further service are queued here
+         service_queue = priority_queue:new() :: priority_queue:q(),
+         %% state for at-least-once dead-lettering
+         dlx = #rabbit_fifo_dlx{} :: #rabbit_fifo_dlx{},
+         msg_bytes_enqueue = 0 :: non_neg_integer(),
+         msg_bytes_checkout = 0 :: non_neg_integer(),
+         %% one is picked if active consumer is cancelled or dies
+         %% used only when single active consumer is on
+         waiting_consumers = [] :: [{consumer_key(), consumer()}],
+         %% records the timestamp whenever the queue was last considered
+         %% active in terms of consumer activity
+         last_active :: option(non_neg_integer()),
+         msg_cache :: option({ra:index(), raw_msg()}),
+         %% delayed retry messages awaiting redelivery
+         delayed = #delayed{} :: #delayed{}
+        }).
+
+-type config() :: #{name := atom(),
+                    queue_resource := rabbit_types:r('queue'),
+                    dead_letter_handler => dead_letter_handler(),
+                    become_leader_handler => applied_mfa(),
+                    % checkpoint_min_indexes => non_neg_integer(),
+                    % checkpoint_max_indexes => non_neg_integer(),
+                    max_length => non_neg_integer(),
+                    max_bytes => non_neg_integer(),
+                    overflow_strategy => drop_head | reject_publish,
+                    single_active_consumer_on => boolean(),
+                    delivery_limit => non_neg_integer() | -1,
+                    expires => non_neg_integer(),
+                    msg_ttl => non_neg_integer(),
+                    created => non_neg_integer(),
+                    consumer_disconnected_timeout => milliseconds(),
+                    delayed_retry => delayed_retry()
+                   }.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -2006,6 +2006,8 @@ dlh(undefined, _, Strategy, _, QName) ->
     undefined;
 dlh(_, _, <<"at-least-once">>, reject_publish, _) ->
     at_least_once;
+dlh(_, _, <<"at-least-once">>, reject_publish_dlx, _) ->
+    at_least_once;
 dlh(Exchange, RoutingKey, <<"at-least-once">>, drop_head, QName) ->
     ?LOG_WARNING("Falling back to dead-letter-strategy at-most-once for ~ts "
                        "because configured dead-letter-strategy at-least-once is incompatible with "
@@ -2436,10 +2438,7 @@ update_type_state(Q, Fun) when ?is_amqqueue(Q) ->
 overflow(undefined, Def, _QName) -> Def;
 overflow(<<"reject-publish">>, _Def, _QName) -> reject_publish;
 overflow(<<"drop-head">>, _Def, _QName) -> drop_head;
-overflow(<<"reject-publish-dlx">> = V, Def, QName) ->
-    ?LOG_WARNING("Invalid overflow strategy ~tp for quorum queue: ~ts",
-                       [V, rabbit_misc:rs(QName)]),
-    Def.
+overflow(<<"reject-publish-dlx">>, _Def, _QName) -> reject_publish_dlx.
 
 -spec notify_decorators(amqqueue:amqqueue()) -> 'ok'.
 notify_decorators(Q) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -4670,7 +4670,8 @@ purge(Config) ->
 
     {'queue.purge_ok', 2} = amqp_channel:call(Ch, #'queue.purge'{queue = QQ}),
 
-    ?assertEqual([0], dirty_query([Server], RaName, fun rabbit_fifo:query_messages_total/1)).
+    ?assertMatch(#{num_messages := 0},  machine_overview({RaName, Server})),
+    ok.
 
 peek(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -195,6 +195,7 @@ all_tests() ->
      message_bytes_metrics,
      queue_length_limit_drop_head,
      queue_length_limit_reject_publish,
+     queue_length_limit_reject_publish_dlx,
      queue_length_limit_policy_cleared,
      subscribe_redelivery_limit,
      subscribe_redelivery_limit_disable,
@@ -4623,6 +4624,43 @@ queue_length_limit_reject_publish(Config) ->
     ok = publish_confirm(Ch, QQ),
     ok.
 
+queue_length_limit_reject_publish_dlx(Config) ->
+    check_quorum_queues_v9_compat(Config),
+    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    DLQ = <<"dead_letter_queue">>,
+    RaName = ra_name(QQ),
+    DLRaName = ra_name(DLQ),
+
+    ?assertEqual({'queue.declare_ok', DLQ, 0, 0},
+                 declare(Ch, DLQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                  {<<"x-max-length">>, long, 3},
+                                  {<<"x-overflow">>, longstr, <<"reject-publish-dlx">>},
+                                  {<<"x-dead-letter-exchange">>, longstr, <<>>},
+                                  {<<"x-dead-letter-routing-key">>, longstr, DLQ}])),
+
+    #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
+    %% Fill the queue up to the limit
+    ok = publish_confirm(Ch, QQ),
+    ok = publish_confirm(Ch, QQ),
+    ok = publish_confirm(Ch, QQ),
+    wait_for_messages_ready(Servers, RaName, 3),
+    %% Next publish should be nacked and dead-lettered
+    fail = publish_confirm(Ch, QQ),
+    fail = publish_confirm(Ch, QQ),
+    %% Source queue stays at max-length
+    wait_for_messages_ready(Servers, RaName, 3),
+    %% Rejected messages arrive at the DLX collector
+    wait_for_messages_ready(Servers, DLRaName, 2),
+
+    [?assertMatch(#'queue.delete_ok'{},
+                  amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
+     || Q <- [QQ, DLQ]].
+
 queue_length_limit_policy_cleared(Config) ->
     [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
@@ -6631,13 +6669,21 @@ basic_get(Ch, Q, NoAck, Attempt) ->
     end.
 
 check_quorum_queues_v8_compat(Config) ->
+    check_quorum_queues_compat(Config, 8).
+
+check_quorum_queues_v9_compat(Config) ->
+    check_quorum_queues_compat(Config, 9).
+
+check_quorum_queues_compat(Config, MinVersion) ->
     Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     MacVer = lists:min([V || {ok, V} <- erpc:multicall(Nodes, rabbit_fifo, version, [])]),
-    case MacVer >= 8 of
+    case MacVer >= MinVersion of
         true ->
             ok;
         false ->
-            throw({skip, "test will only work on QQ machine version >= 8"})
+            throw({skip, lists:flatten(
+                           io_lib:format("test will only work on QQ machine version >= ~b",
+                                         [MinVersion]))})
     end.
 
 lists_interleave([], _List) ->

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -3060,6 +3060,57 @@ reject_publish_applied_after_limit_test(Config) ->
         apply(meta(Config, 1), make_register_enqueuer(Pid2), State5),
     ok.
 
+reject_publish_dlx_test(Config) ->
+    State0 = init(#{name => ?FUNCTION_NAME,
+                    queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+                    max_length => 2,
+                    max_in_memory_length => 0,
+                    overflow_strategy => reject_publish_dlx,
+                    dead_letter_handler =>
+                        {at_most_once, {somemod, somefun, [somearg]}}}),
+    Pid1 = test_util:fake_pid(node()),
+    {State1, ok, [_]} = apply(meta(Config, 1, ?LINE, {notify, 1, Pid1}),
+                              make_register_enqueuer(Pid1), State0),
+    {State2, ok, _} = apply(meta(Config, 2, ?LINE, {notify, 2, Pid1}),
+                            rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
+    {State3, ok, _} = apply(meta(Config, 3, ?LINE, {notify, 3, Pid1}),
+                            rabbit_fifo:make_enqueue(Pid1, 2, two), State2),
+    %% Third enqueue is rejected and dead-lettered (not enqueued).
+    %% Reply is reject_publish so the client can nack the publisher.
+    {State4, reject_publish, Efx4} =
+        apply(meta(Config, 4, ?LINE, {notify, 4, Pid1}),
+              rabbit_fifo:make_enqueue(Pid1, 3, three), State3),
+    %% Dead letter effect for the rejected message (index 4, message three)
+    ?ASSERT_EFF({log, [4], _}, Efx4),
+    %% Queue still has the original 2 messages (one and two)
+    ?assertMatch(#{num_ready_messages := 2}, rabbit_fifo:overview(State4)),
+    ok.
+
+reject_publish_dlx_unblock_test(Config) ->
+    %% Verify that reject_publish_dlx does not block enqueuers.
+    %% Messages always flow to the server for dead-lettering.
+    State0 = init(#{name => ?FUNCTION_NAME,
+                    queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+                    max_length => 2,
+                    max_in_memory_length => 0,
+                    overflow_strategy => reject_publish_dlx,
+                    dead_letter_handler => undefined}),
+    Pid1 = test_util:fake_pid(node()),
+    {State1, ok, [_]} = apply(meta(Config, 1, ?LINE, {notify, 1, Pid1}),
+                              make_register_enqueuer(Pid1), State0),
+    {State2, ok, _} = apply(meta(Config, 2, ?LINE, {notify, 2, Pid1}),
+                            rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
+    %% Second enqueue fills the queue but does NOT block the enqueuer
+    {State3, ok, Efx3} = apply(meta(Config, 3, ?LINE, {notify, 3, Pid1}),
+                               rabbit_fifo:make_enqueue(Pid1, 2, two), State2),
+    ?ASSERT_NO_EFF({send_msg, _P, {queue_status, reject_publish}, [ra_event]}, Efx3),
+    %% Third enqueue is rejected (reply = reject_publish) but no blocking
+    {_State4, reject_publish, Efx4} =
+        apply(meta(Config, 4, ?LINE, {notify, 4, Pid1}),
+              rabbit_fifo:make_enqueue(Pid1, 3, three), State3),
+    ?ASSERT_NO_EFF({send_msg, _P, {queue_status, reject_publish}, [ra_event]}, Efx4),
+    ok.
+
 update_config_delivery_limit_test(Config) ->
     QName = rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
     InitConf = #{name => ?FUNCTION_NAME,

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -4030,7 +4030,7 @@ machine_version_test(Config) ->
                   consumers = #{3 := #consumer{cfg = #consumer_cfg{priority = 0}}},
                   service_queue = S,
                   messages = Msgs}, ok,
-     [_|_]} = apply(meta(Config, Idx), {machine_version, 7, 8}, S1),
+     [_|_]} = apply(meta(Config, Idx), {machine_version, 7, 9}, S1),
 
     ?assertEqual(1, rabbit_fifo_pq:len(Msgs)),
     ?assert(priority_queue:is_queue(S)),
@@ -4058,16 +4058,16 @@ machine_version_waiting_consumer_test(Config) ->
                                                  #consumer_cfg{priority = 0}}},
                   service_queue = S,
                   messages = Msgs}, ok, _} = apply(meta(Config, Idx),
-                                                    {machine_version, 7, 8}, S1),
+                                                    {machine_version, 7, 9}, S1),
     %% validate message conversion to lqueue
     ?assertEqual(0, rabbit_fifo_pq:len(Msgs)),
     ?assert(priority_queue:is_queue(S)),
     ?assertEqual(1, priority_queue:len(S)),
     ok.
 
-convert_v7_to_v8_test(Config) ->
+convert_v7_to_v9_test(Config) ->
     ConfigV7 = [{machine_version, 7} | Config],
-    ConfigV8 = [{machine_version, 8} | Config],
+    ConfigV9 = [{machine_version, 9} | Config],
 
     EPid = test_util:fake_pid(node()),
     Pid1 = test_util:fake_pid(node()),
@@ -4092,7 +4092,7 @@ convert_v7_to_v8_test(Config) ->
     {StateV7, _} = run_log(rabbit_fifo_v7, ConfigV7, Init, Entries,
                            fun (_) -> true end),
     {#rabbit_fifo{consumers = Consumers}, ok, _} =
-        apply(meta(ConfigV8, ?LINE), {machine_version, 7, 8}, StateV7),
+        apply(meta(ConfigV9, ?LINE), {machine_version, 7, 9}, StateV7),
 
     ?assertMatch(#consumer{status = {suspected_down, up}},
                  maps:get(Cid1, Consumers)),
@@ -4925,6 +4925,36 @@ query_single_active_consumer_consumer_info_test(Config) ->
                    consumer_strategy := single_active,
                    num_checked_out := 0}, Info2),
     ok.
+
+
+%% Ingress tracking tests
+
+ingress_bytes_by_node_accumulates_on_enqueue_test(Config) ->
+    S0 = test_init(ingress_accumulates),
+    Msg = mk_mc(<<"hello">>),
+    Pid = self(),
+    Enq = make_enqueue(Pid, 1, Msg),
+    {S1, _, _} = apply(meta(Config, 1, 0, {notify, 1, Pid}), Enq, S0),
+    Ingress = S1#rabbit_fifo.ingress_bytes_by_node,
+    ?assert(maps:get(node(Pid), Ingress, 0) > 0),
+    ok.
+
+ingress_bytes_by_node_survives_snapshot_test(Config) ->
+    S0 = test_init(ingress_snapshot),
+    Msg = mk_mc(<<"test">>),
+    Pid = self(),
+    Enq = make_enqueue(Pid, 1, Msg),
+    {S1, _, _} = apply(meta(Config, 1, 0, {notify, 1, Pid}), Enq, S0),
+    Ingress = S1#rabbit_fifo.ingress_bytes_by_node,
+    ?assert(maps:size(Ingress) > 0),
+    %% Simulate snapshot/restore via serialization round-trip
+    S2 = binary_to_term(term_to_binary(S1)),
+    Ingress2 = S2#rabbit_fifo.ingress_bytes_by_node,
+    ?assertEqual(Ingress, Ingress2),
+    ok.
+
+
+%% Ingress tracking tests end
 
 
 %% Utility

--- a/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
@@ -655,8 +655,8 @@ reject_publish_max_length_target_quorum_queue(Config) ->
                      amqp_channel:call(Ch, #'basic.get'{queue = TargetQ}),
                      30000)
      end || N <- lists:seq(1,4)],
-    eventually(?_assertMatch([{0, _}],
-                             dirty_query([Server], RaName, fun rabbit_fifo:query_stat_dlx/1)), 500, 10),
+    eventually(?_assertMatch(#{num_discarded := 0},
+                             machine_overview({RaName, Server}))),
     ?assertEqual(4, counted(messages_dead_lettered_expired_total, Config)),
     eventually(?_assertEqual(4, counted(messages_dead_lettered_confirmed_total, Config))).
 
@@ -706,8 +706,8 @@ reject_publish_down_target_quorum_queue(Config) ->
                          sets:add_element(Msg, S)
                  end, sets:new([{version, 2}]), lists:seq(1, 50)),
     ?assertEqual(50, sets:size(Received)),
-    eventually(?_assertMatch([{0, _}],
-                             dirty_query([Server], RaName, fun rabbit_fifo:query_stat_dlx/1)), 500, 10),
+    eventually(?_assertMatch(#{num_discarded := 0},
+                             machine_overview({RaName, Server}))),
     ?assertEqual(50, counted(messages_dead_lettered_expired_total, Config)),
     eventually(?_assertEqual(50, counted(messages_dead_lettered_confirmed_total, Config))).
 
@@ -999,3 +999,11 @@ counted(Metric, Config) ->
 metric(Metric, Counters) ->
     Metrics = maps:get(#{queue_type => rabbit_quorum_queue, dead_letter_strategy => at_least_once}, Counters),
     maps:get(Metric, Metrics).
+
+machine_overview(ServerId) when is_tuple(ServerId) ->
+    case ra:member_overview(ServerId) of
+        {ok, #{machine := Mac}, _} ->
+            Mac;
+        Err ->
+            Err
+    end.

--- a/deps/rabbit/test/rabbit_fifo_prop_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_prop_SUITE.erl
@@ -10,7 +10,7 @@
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
--define(MACHINE_VERSION, 8).
+-define(MACHINE_VERSION, 9).
 
 %%%===================================================================
 %%% Common Test callbacks
@@ -84,7 +84,8 @@ all_tests() ->
      dlx_09,
      single_active_ordering_02,
      two_nodes_same_otp_version,
-     two_nodes_different_otp_version
+     two_nodes_different_otp_version,
+     ingress_bytes_by_node_accumulation
     ].
 
 groups() ->
@@ -1126,6 +1127,29 @@ is_same_otp_version(ConfigOrNode) ->
     ct:pal("Our CT node runs OTP ~s, other node runs OTP ~s", [OurOTP, OtherOTP]),
     OurOTP =:= OtherOTP.
 
+ingress_bytes_by_node_accumulation(_Config) ->
+    Size = 500,
+    run_proper(
+      fun () ->
+              InitConf = config(?FUNCTION_NAME, undefined, undefined, false, undefined),
+              ?FORALL(O, ?LET(Ops, log_gen_different_nodes(Size), expand(Ops, InitConf)),
+                      begin
+                          Indexes = lists:seq(1, length(O)),
+                          Entries = lists:zip(Indexes, O),
+                          InitState = test_init(InitConf),
+                          {State1, _Effs1} = run_log(InitState, Entries),
+                          IngressByNode = State1#rabbit_fifo.ingress_bytes_by_node,
+                          %% Verify the map is properly populated
+                          IsMap = is_map(IngressByNode),
+                          %% Verify all values are non-negative
+                          ValidValues = maps:fold(
+                            fun(_, V, Acc) ->
+                                    Acc andalso is_integer(V) andalso V >= 0
+                            end, true, IngressByNode),
+                          IsMap andalso ValidValues
+                      end)
+      end, [], Size).
+
 two_nodes(Node) ->
     Size = 100,
     run_proper(
@@ -1511,7 +1535,7 @@ different_nodes_prop(Node, Conf, Commands) ->
     Entries = lists:zip(Indexes, Commands),
     InitState = test_init(Conf),
     Fun = fun(_) -> true end,
-    MachineVersion = 8,
+    MachineVersion = rabbit_fifo:version(),
 
     {State1, _Effs1} = run_log(InitState, Entries, Fun, MachineVersion),
     {State2, _Effs2} = erpc:call(Node, ?MODULE, run_log,
@@ -1598,8 +1622,8 @@ valid_simple_prefetch(_, _, _, _, _) ->
     true.
 
 upgrade_prop(Conf, Commands) ->
-    FromVersion = 7,
-    ToVersion = 8,
+    FromVersion = 8,
+    ToVersion = 9,
     FromMod = rabbit_fifo:which_module(FromVersion),
     ToMod = rabbit_fifo:which_module(ToVersion),
     Indexes = lists:seq(1, length(Commands)),


### PR DESCRIPTION
This operates just like the classic queue overflow strategy. If enqueueing a message would overflow the queue, the message is run through the dead lettering route and also the enqueue is rejected.

Prior to this change, QQs would fall back to drop-head when `reject-publish-dlx` was specified.

This is based on the next QQ version PR: #16583.