### PR TITLE
Shovels: refactor in follow-up to #14256

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -121,30 +121,15 @@ parse_source(Def) ->
        consumer_args => [],
        consumer_name => SrcCName}, Headers}.
 
-parse_dest({_VHost, _Name}, _ClusterName, Def, SourceHeaders) ->
+parse_dest({_VHost, _Name}, _ClusterName, Def, _SourceHeaders) ->
     Uris = deobfuscated_uris(<<"dest-uri">>, Def),
     Address = pget(<<"dest-address">>, Def),
-    Properties =
-        rabbit_data_coercion:to_proplist(
-            pget(<<"dest-properties">>, Def, [])),
-    AppProperties =
-        rabbit_data_coercion:to_proplist(
-            pget(<<"dest-application-properties">>, Def, [])),
-    MessageAnns =
-        rabbit_data_coercion:to_proplist(
-            pget(<<"dest-message-annotations">>, Def, [])),
     GlobalPredeclared = proplists:get_value(predeclared, application:get_env(?APP, topology, []), false),
     Predeclared = pget(<<"dest-predeclared">>, Def, GlobalPredeclared),
     #{module => rabbit_amqp10_shovel,
       uris => Uris,
       target_address => Address,
       predeclared => Predeclared,
-      message_annotations => maps:from_list(MessageAnns),
-      application_properties => maps:from_list(AppProperties ++ SourceHeaders),
-      properties => maps:from_list(
-                      lists:map(fun({K, V}) ->
-                                        {rabbit_data_coercion:to_atom(K), V}
-                                end, Properties)),
       add_timestamp_header => pget(<<"dest-add-timestamp-header">>, Def, false),
       add_forward_headers => pget(<<"dest-add-forward-headers">>, Def, false),
       unacked => #{}

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
@@ -147,18 +147,16 @@ src_protocol(Def) when is_map(Def) ->
     src_protocol(rabbit_data_coercion:to_proplist(Def));
 src_protocol(Def) when is_list(Def) ->
     case lists:keyfind(<<"src-protocol">>, 1, Def) of
-        {_, SrcProtocol} ->
-            rabbit_data_coercion:to_atom(SrcProtocol);
-        false -> amqp091
+        {_, Protocol} -> registered_protocol_to_atom(Protocol);
+        false         -> amqp091
     end.
 
 dest_protocol(Def) when is_map(Def) ->
     dest_protocol(rabbit_data_coercion:to_proplist(Def));
 dest_protocol(Def) when is_list(Def) ->
     case lists:keyfind(<<"dest-protocol">>, 1, Def) of
-        {_, DstProtocol} ->
-            rabbit_data_coercion:to_atom(DstProtocol);
-        false -> amqp091
+        {_, Protocol} -> registered_protocol_to_atom(Protocol);
+        false         -> amqp091
     end.
 
 protocols(Def) when is_map(Def) ->
@@ -167,6 +165,12 @@ protocols(Def) ->
     Src = src_protocol(Def),
     Dst = dest_protocol(Def),
     {Src, Dst}.
+
+registered_protocol_to_atom(Protocol) when is_atom(Protocol) -> Protocol;
+registered_protocol_to_atom(<<"amqp091">>)                  -> amqp091;
+registered_protocol_to_atom(<<"amqp10">>)                   -> amqp10;
+registered_protocol_to_atom(<<"local">>)                    -> local;
+registered_protocol_to_atom(_)                              -> amqp091.
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
@@ -37,8 +37,10 @@ groups() ->
           validate_amqp10_with_a_map,
           test_src_protocol_defaults,
           test_src_protocol_explicit,
+          test_src_protocol_unknown,
           test_dest_protocol_defaults,
           test_dest_protocol_explicit,
+          test_dest_protocol_unknown,
           test_protocols_defaults,
           test_protocols_explicit,
           test_protocols_mixed,
@@ -281,11 +283,6 @@ parse_amqp10_0() ->
               dest := #{module := rabbit_amqp10_shovel,
                         uris := ["amqp://remotehost:5672"],
                         target_address := <<"a-dest-queue">>,
-                        message_annotations := #{<<"some-message-ann">> :=
-                                                 <<"message-ann-value">>},
-                        application_properties := #{<<"some-app-prop">> :=
-                                                    <<"app-prop-value">>},
-                        properties := #{user_id := <<"some-user">>},
                         add_timestamp_header := true,
                         add_forward_headers := true
                        }
@@ -432,6 +429,13 @@ test_src_protocol_explicit(_Config) ->
     ?assertEqual(local, rabbit_shovel_parameters:src_protocol(DefMapLocal)),
     ok.
 
+test_src_protocol_unknown(_Config) ->
+    ?assertEqual(amqp091, rabbit_shovel_parameters:src_protocol(
+                            [{<<"src-protocol">>, <<"not-a-real-protocol">>}])),
+    ?assertEqual(amqp091, rabbit_shovel_parameters:src_protocol(
+                            #{<<"src-protocol">> => <<"not-a-real-protocol">>})),
+    ok.
+
 test_dest_protocol_defaults(_Config) ->
     DefProplist = [{<<"src-uri">>, <<"amqp://localhost">>},
                    {<<"dest-uri">>, <<"amqp://remote">>}],
@@ -460,6 +464,13 @@ test_dest_protocol_explicit(_Config) ->
 
     DefMapLocal = #{<<"dest-protocol">> => <<"local">>},
     ?assertEqual(local, rabbit_shovel_parameters:dest_protocol(DefMapLocal)),
+    ok.
+
+test_dest_protocol_unknown(_Config) ->
+    ?assertEqual(amqp091, rabbit_shovel_parameters:dest_protocol(
+                            [{<<"dest-protocol">>, <<"not-a-real-protocol">>}])),
+    ?assertEqual(amqp091, rabbit_shovel_parameters:dest_protocol(
+                            #{<<"dest-protocol">> => <<"not-a-real-protocol">>})),
     ok.
 
 test_protocols_defaults(_Config) ->


### PR DESCRIPTION
As of #14256 (shipped in `4.2.0`), AMQP 1.0 shovels stop modifying properties and simply pass an immutable message along.

This means we can drop the `properties` translation part entirely, avoiding a completely useless conversion.

While at it, do not try to convert unknown protocol names, fall back to AMQP 0-9-1 instead of storing an aribtrary protocol name.
