### PR TITLE
Add configuration setting for max super stream partitions

### DIFF
--- a/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
+++ b/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
@@ -144,3 +144,16 @@ fun(Conf) ->
         _         -> cuttlefish:invalid("should be a non-negative integer")
     end
 end}.
+
+{mapping, "stream.max_super_stream_partitions", "rabbitmq_stream.max_super_stream_partitions",
+    [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbitmq_stream.max_super_stream_partitions",
+fun(Conf) ->
+    case cuttlefish:conf_get("stream.max_super_stream_partitions", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        infinity  -> infinity;
+        Val when is_integer(Val) -> Val;
+        _         -> cuttlefish:invalid("should be a non-negative integer")
+    end
+end}.

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
@@ -176,13 +176,8 @@ run([SuperStream],
       timeout := Timeout,
       partitions := Partitions} =
         Opts) ->
-    Streams =
-        [list_to_binary(binary_to_list(SuperStream)
-                        ++ "-"
-                        ++ integer_to_list(K))
-         || K <- lists:seq(0, Partitions - 1)],
-    RoutingKeys =
-        [integer_to_binary(K) || K <- lists:seq(0, Partitions - 1)],
+    Streams = streams_from_partitions(SuperStream, Partitions),
+    RoutingKeys = routing_keys(Partitions),
     create_super_stream(NodeName,
                         Timeout,
                         VHost,
@@ -196,17 +191,9 @@ run([SuperStream],
       timeout := Timeout,
       binding_keys := BindingKeysStr} =
         Opts) ->
-    BindingKeys =
-        [rabbit_data_coercion:to_binary(
-             string:trim(K))
-         || K
-                <- string:lexemes(
-                       rabbit_data_coercion:to_list(BindingKeysStr), ",")],
-    Streams =
-        [list_to_binary(binary_to_list(SuperStream)
-                        ++ "-"
-                        ++ binary_to_list(K))
-         || K <- BindingKeys],
+    BindingKeys = binding_keys(BindingKeysStr),
+    Streams = streams_from_binding_keys(SuperStream, BindingKeys),
+
     create_super_stream(NodeName,
                         Timeout,
                         VHost,
@@ -214,6 +201,24 @@ run([SuperStream],
                         Streams,
                         stream_arguments(Opts),
                         BindingKeys).
+
+streams_from_partitions(Name, Partitions) ->
+    [<<Name/binary, "-", (integer_to_binary(K))/binary>> ||
+     K <- lists:seq(0, Partitions - 1)].
+
+routing_keys(Partitions) ->
+    [integer_to_binary(K) || K <- lists:seq(0, Partitions - 1)].
+
+binding_keys(BindingKeysBin) ->
+    Keys = binary:split(rabbit_data_coercion:to_binary(BindingKeysBin),
+                        <<",">>, [global]),
+    %% Trim first, then verify the token is not an empty binary
+    [Trimmed || K <- Keys,
+                Trimmed <- [string:trim(K)],
+                Trimmed =/= <<>>].
+
+streams_from_binding_keys(Name, BindingKeys) ->
+    [<<Name/binary, "-", K/binary>> || K <- BindingKeys].
 
 stream_arguments(Opts) ->
     stream_arguments(#{}, Opts).

--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -624,6 +624,7 @@ validate_super_stream_creation(_VirtualHost, _Name, Partitions, BindingKeys)
 validate_super_stream_creation(VirtualHost, Name, Partitions, _BindingKeys) ->
     maybe
         ok ?= validate_super_stream_partitions(Partitions),
+        ok ?= validate_super_stream_max_partitions(Partitions),
         ok ?= case rabbit_vhost_limit:would_exceed_queue_limit(length(Partitions), VirtualHost) of
                   false ->
                       ok;
@@ -668,6 +669,17 @@ validate_super_stream_partitions(Partitions) ->
         _ -> {error, {validation_failed,
                       {rabbit_misc:format("Duplicate partition names found ~ts",
                                           [Partitions])}}}
+    end.
+
+validate_super_stream_max_partitions(Partitions) ->
+    MaxPartitions = rabbit_stream_utils:max_super_stream_partitions(),
+    case erlang:length(Partitions) > MaxPartitions of
+        true ->
+            {error, {validation_failed,
+                     {rabbit_misc:format("The partition number must not exceed ~w",
+                                         [MaxPartitions])}}};
+        false ->
+            ok
     end.
 
 exchange_exists(VirtualHost, Name) ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -16,6 +16,8 @@
 
 -module(rabbit_stream_utils).
 
+-define(MAX_SUPER_STREAM_PARTITIONS, 1000).
+
 %% API
 -export([enforce_correct_name/1,
          write_messages/6,
@@ -33,8 +35,10 @@
          filter_spec/1,
          command_versions/0,
          check_super_stream_management_permitted/4,
+         check_super_stream_permitted/3,
          offset_lag/4,
-         consumer_offset/3]).
+         consumer_offset/3,
+         max_super_stream_partitions/0]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbitmq_stream_common/include/rabbit_stream.hrl").
@@ -192,13 +196,14 @@ check_write_permitted(Resource, User) ->
 check_read_permitted(Resource, User, Context) ->
     check_resource_access(User, Resource, read, Context).
 
--spec check_super_stream_management_permitted(rabbit_types:vhost(), binary(), [binary()], rabbit_types:user()) ->
+-spec check_super_stream_management_permitted(rabbit_types:vhost(), binary(),
+                                              [binary()], rabbit_types:user()) ->
     ok | error.
 check_super_stream_management_permitted(VirtualHost, SuperStream, Partitions, User) ->
     Exchange = e(VirtualHost, SuperStream),
     maybe
         %% exchange creation
-        ok ?= check_configure_permitted(Exchange, User),
+        ok ?= check_super_stream_permitted(VirtualHost, SuperStream, User),
         %% stream creations
         ok ?= check_streams_permissions(fun check_configure_permitted/2,
                                         VirtualHost, Partitions,
@@ -210,6 +215,13 @@ check_super_stream_management_permitted(VirtualHost, SuperStream, Partitions, Us
                                   VirtualHost, Partitions,
                                   User)
     end.
+
+-spec check_super_stream_permitted(rabbit_types:vhost(), binary(),
+                                   rabbit_types:user()) ->
+    ok | error.
+check_super_stream_permitted(Vhost, SuperStream, User) ->
+    Exchange = e(Vhost, SuperStream),
+    check_configure_permitted(Exchange, User).
 
 check_streams_permissions(Fun, VirtualHost, List, User) ->
     case lists:all(fun(S) ->
@@ -346,3 +358,7 @@ offset_lag(_, 0, 0, LastListenerOffset) when LastListenerOffset > 0 ->
     0;
 offset_lag(CommittedOffset, ConsumerOffset, _, _) ->
     CommittedOffset - ConsumerOffset.
+
+max_super_stream_partitions() ->
+    application:get_env(rabbitmq_stream, max_super_stream_partitions,
+                        ?MAX_SUPER_STREAM_PARTITIONS).

--- a/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
+++ b/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
@@ -81,5 +81,9 @@
   {max_super_stream_partitions,
       "stream.max_super_stream_partitions = 100",
       [{rabbitmq_stream,[{max_super_stream_partitions, 100}]}],
+      [rabbitmq_stream]},
+  {max_super_stream_partitions_infinity,
+      "stream.max_super_stream_partitions = infinity",
+      [{rabbitmq_stream,[{max_super_stream_partitions, infinity}]}],
       [rabbitmq_stream]}
 ].

--- a/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
+++ b/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
@@ -77,5 +77,9 @@
   {max_connections,
       "stream.max_connections = 10",
       [{rabbitmq_stream,[{max_connections, 10}]}],
+      [rabbitmq_stream]},
+  {max_super_stream_partitions,
+      "stream.max_super_stream_partitions = 100",
+      [{rabbitmq_stream,[{max_super_stream_partitions, 100}]}],
       [rabbitmq_stream]}
 ].

--- a/deps/rabbitmq_stream/test/rabbit_stream_manager_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_manager_SUITE.erl
@@ -10,6 +10,12 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 
+-import(rabbit_ct_helpers,
+        [set_config/2,
+         run_setup_steps/2,
+         setup_steps/0,
+         merge_app_env/2]).
+
 -compile(export_all).
 
 all() ->
@@ -18,6 +24,7 @@ all() ->
 groups() ->
     [{non_parallel_tests, [],
       [manage_super_stream,
+       manage_super_stream_max_partitions,
        lookup_leader,
        lookup_member,
        partition_index,
@@ -40,27 +47,26 @@ end_per_suite(Config) ->
     Config.
 
 init_per_group(_, Config) ->
-    Config1 =
-        rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, false}]),
-    Config2 =
-        rabbit_ct_helpers:set_config(Config1,
-                                     {rabbitmq_ct_tls_verify, verify_none}),
-    Config3 =
-        rabbit_ct_helpers:set_config(Config2, {rabbitmq_stream, verify_none}),
-    rabbit_ct_helpers:run_setup_steps(Config3,
-                                      [fun(StepConfig) ->
-                                          rabbit_ct_helpers:merge_app_env(StepConfig,
-                                                                          {rabbit,
-                                                                           [{core_metrics_gc_interval,
-                                                                             1000}]})
-                                       end,
-                                       fun(StepConfig) ->
-                                          rabbit_ct_helpers:merge_app_env(StepConfig,
-                                                                          {rabbitmq_stream,
-                                                                           [{connection_negotiation_step_timeout,
-                                                                             500}]})
-                                       end]
-                                      ++ rabbit_ct_broker_helpers:setup_steps()).
+    Config1 = set_config(Config,
+                         [{rmq_nodes_clustered, false},
+                          {rabbitmq_ct_tls_verify, verify_none},
+                          {rabbitmq_stream, verify_none}
+                         ]),
+
+    RmqAppConf = {rabbit,
+                  [{core_metrics_gc_interval,
+                    1000}]},
+    RmqStreamAppConf = {rabbitmq_stream,
+                        [{connection_negotiation_step_timeout, 500},
+                         {max_super_stream_partitions, 5}]},
+    run_setup_steps(Config1,
+                    [fun(StepConfig) ->
+                             merge_app_env(StepConfig, RmqAppConf)
+                     end,
+                     fun(StepConfig) ->
+                             merge_app_env(StepConfig, RmqStreamAppConf)
+                     end]
+                    ++ rabbit_ct_broker_helpers:setup_steps()).
 
 end_per_group(_, Config) ->
     rabbit_ct_helpers:run_steps(Config,
@@ -148,6 +154,19 @@ manage_super_stream(Config) ->
                                      [<<"invoices-0">>, <<"invoices-1">>],
                                      [<<"0">>])),
 
+    ok.
+
+manage_super_stream_max_partitions(Config) ->
+    Partitions = 6,
+    Name = <<"invoices">>,
+    Streams =[<<Name/binary, "-", (integer_to_binary(K))/binary>> ||
+              K <- lists:seq(0, Partitions - 1)],
+    RKs = [integer_to_binary(K) || K <- lists:seq(0, Partitions - 1)],
+
+    ?assertEqual({error,
+                  {validation_failed,
+                   {"The partition number must not exceed 5"}}},
+                 create_super_stream(Config, Name, Streams, RKs)),
     ok.
 
 partition_index(Config) ->

--- a/deps/rabbitmq_stream_management/src/rabbit_stream_super_stream_mgmt.erl
+++ b/deps/rabbitmq_stream_management/src/rabbit_stream_super_stream_mgmt.erl
@@ -23,7 +23,6 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -define(DEFAULT_RPC_TIMEOUT, 30_000).
--define(MAX_PARTITIONS, 1000).
 
 dispatcher() ->
     [{"/stream/super-streams/:vhost/:name", ?MODULE, []}].
@@ -57,52 +56,66 @@ resource_exists(ReqData, Context) ->
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_vhost(ReqData, Context).
 
-accept_content(ReqData0, #context{user = #user{username = ActingUser}} = Context) ->
-    %% TODO validate arguments?
+accept_content(ReqData0, #context{user = User} = Context) ->
     VHost = rabbit_mgmt_util:id(vhost, ReqData0),
     Name = rabbit_mgmt_util:id(name, ReqData0),
+    case rabbit_stream_utils:check_super_stream_permitted(VHost, Name, User) of
+        error ->
+            rabbit_web_dispatch_access_control:not_authorised(
+              <<"Access refused.">>, ReqData0, Context);
+        ok ->
+            maybe_create_super_stream(ReqData0, Context, VHost, Name)
+    end.
+
+maybe_create_super_stream(ReqData0, Context, VHost, Name) ->
     rabbit_mgmt_util:with_decode(
       [], ReqData0, Context,
       fun([], BodyMap, ReqData) ->
               PartitionsBin = maps:get(partitions, BodyMap, undefined),
-              BindingKeysStr = maps:get('binding-keys', BodyMap, undefined),
-              case validate_partitions_or_binding_keys(PartitionsBin, BindingKeysStr, ReqData, Context) of
+              BindingKeysBin = case maps:get('binding-keys', BodyMap, undefined) of
+                                   undefined ->
+                                       undefined;
+                                   B ->
+                                       rabbit_data_coercion:to_binary(B)
+                               end,
+              case validate_partitions_or_binding_keys(PartitionsBin, BindingKeysBin, ReqData, Context) of
                   ok ->
                       Arguments = maps:get(arguments, BodyMap, #{}),
                       case get_node(BodyMap) of
-                      {error, not_member} ->
-                          N = maps:get(<<"node">>, BodyMap, <<>>),
-                          Msg = list_to_binary(
-                                  io_lib:format(
-                                    "Node ~ts is not a cluster member", [N])),
-                          rabbit_mgmt_util:bad_request(Msg, ReqData, Context);
-                      {ok, Node} ->
-                      case PartitionsBin of
-                          undefined ->
-                              BindingKeys = binding_keys(BindingKeysStr),
-                              Streams = streams_from_binding_keys(Name, BindingKeys),
-                              check_and_create_super_stream(
-                                Node, VHost, Name, Streams,
-                                Arguments, BindingKeys, ActingUser,
-                                ReqData, Context);
-                          _ ->
-                              case validate_partitions(PartitionsBin, ReqData, Context) of
-                                  Partitions when is_integer(Partitions) ->
-                                      Streams = streams_from_partitions(Name, Partitions),
-                                      RoutingKeys = routing_keys(Partitions),
+                          {error, not_member} ->
+                              N = maps:get(<<"node">>, BodyMap, <<>>),
+                              Msg = list_to_binary(
+                                      io_lib:format(
+                                        "Node ~ts is not a cluster member", [N])),
+                              rabbit_mgmt_util:bad_request(Msg, ReqData, Context);
+                          {ok, Node} ->
+                              case PartitionsBin of
+                                  undefined ->
+                                      BindingKeys = binding_keys(BindingKeysBin),
+                                      Streams = streams_from_binding_keys(Name, BindingKeys),
                                       check_and_create_super_stream(
                                         Node, VHost, Name, Streams,
-                                        Arguments, RoutingKeys, ActingUser,
+                                        Arguments, BindingKeys,
                                         ReqData, Context);
-                                  Error ->
-                                      Error
+                                  _ ->
+                                      case validate_partitions(PartitionsBin, ReqData, Context) of
+                                          Partitions when is_integer(Partitions) ->
+                                              Streams = streams_from_partitions(Name, Partitions),
+                                              RoutingKeys = routing_keys(Partitions),
+                                              check_and_create_super_stream(
+                                                Node, VHost, Name, Streams,
+                                                Arguments, RoutingKeys,
+                                                ReqData, Context);
+                                          Error ->
+                                              Error
+                                      end
                               end
-                      end
                       end;
                   Error ->
                       Error
               end
       end).
+
 
 %%-------------------------------------------------------------------
 get_node(Props) ->
@@ -111,36 +124,31 @@ get_node(Props) ->
         N         -> rabbit_nodes:resolve_member(binary_to_list(N))
     end.
 
-binding_keys(BindingKeysStr) ->
-    [rabbit_data_coercion:to_binary(
-       string:trim(K))
-     || K
-            <- string:lexemes(
-                 rabbit_data_coercion:to_list(BindingKeysStr), ",")].
+binding_keys(BindingKeysBin) ->
+    Keys = binary:split(BindingKeysBin, <<",">>, [global]),
+    %% Trim first, then verify the token is not an empty binary
+    [Trimmed || K <- Keys,
+                Trimmed <- [string:trim(K)],
+                Trimmed =/= <<>>].
 
 routing_keys(Partitions) ->
     [integer_to_binary(K) || K <- lists:seq(0, Partitions - 1)].
 
 streams_from_binding_keys(Name, BindingKeys) ->
-    [list_to_binary(binary_to_list(Name)
-                    ++ "-"
-                    ++ binary_to_list(K))
-     || K <- BindingKeys].
+    [<<Name/binary, "-", K/binary>> || K <- BindingKeys].
 
 streams_from_partitions(Name, Partitions) ->
-    [list_to_binary(binary_to_list(Name)
-                    ++ "-"
-                    ++ integer_to_list(K))
-     || K <- lists:seq(0, Partitions - 1)].
+    [<<Name/binary, "-", (integer_to_binary(K))/binary>> ||
+     K <- lists:seq(0, Partitions - 1)].
 
 check_and_create_super_stream(NodeName, VHost, SuperStream, Streams,
-                              Arguments, RoutingKeys, ActingUser,
-                              ReqData, #context{user = User} = Context) ->
+                              Arguments, RoutingKeys, ReqData,
+                              #context{user = User} = Context) ->
     case rabbit_stream_utils:check_super_stream_management_permitted(
            VHost, SuperStream, Streams, User) of
         ok ->
             create_super_stream(NodeName, VHost, SuperStream, Streams,
-                                Arguments, RoutingKeys, ActingUser,
+                                Arguments, RoutingKeys,
                                 ReqData, Context);
         error ->
             rabbit_web_dispatch_access_control:not_authorised(
@@ -148,7 +156,8 @@ check_and_create_super_stream(NodeName, VHost, SuperStream, Streams,
     end.
 
 create_super_stream(NodeName, VHost, SuperStream, Streams, Arguments,
-                    RoutingKeys, ActingUser, ReqData, Context) ->
+                    RoutingKeys, ReqData,
+                    #context{user = #user{username = ActingUser}} = Context) ->
     case rabbit_misc:rpc_call(NodeName,
                               rabbit_stream_manager,
                               create_super_stream,
@@ -170,6 +179,30 @@ validate_partitions_or_binding_keys(undefined, undefined, ReqData, Context) ->
     rabbit_mgmt_util:bad_request("Must specify partitions or binding keys", ReqData, Context);
 validate_partitions_or_binding_keys(_, undefined, _, _) ->
     ok;
+validate_partitions_or_binding_keys(undefined, BindingKeysBin, ReqData, Context)
+  when is_binary(BindingKeysBin) ->
+    MaxPartitions = rabbit_stream_utils:max_super_stream_partitions(),
+    %% Fast-fail approximation shield, protect against OOM
+    %% (doesn't account for <<",,,">> or <<"   ,   ,   ">>)
+    ApproxKeys = length(binary:matches(BindingKeysBin, <<",">>)) + 1,
+    case ApproxKeys > MaxPartitions of
+        true ->
+            rabbit_mgmt_util:bad_request(
+              "The number of binding keys must not exceed " ++
+              integer_to_list(MaxPartitions),
+              ReqData, Context);
+        false ->
+            %% Bounded exact validation.
+            %% Safe to split now because ApproxKeys is guaranteed to be <= MaxPartitions.
+            case binding_keys(BindingKeysBin) of
+                [] ->
+                    rabbit_mgmt_util:bad_request(
+                      "The number of binding keys must be greater than 0",
+                      ReqData, Context);
+                _ActualKeys ->
+                    ok
+            end
+    end;
 validate_partitions_or_binding_keys(undefined, _, _, _) ->
     ok;
 validate_partitions_or_binding_keys(_, _, ReqData, Context) ->
@@ -182,13 +215,17 @@ validate_partitions(PartitionsBin, ReqData, Context) ->
                 rabbit_mgmt_util:bad_request(
                   "The partition number must be greater than 0",
                   ReqData, Context);
-            Int when Int > ?MAX_PARTITIONS ->
-                rabbit_mgmt_util:bad_request(
-                  "The partition number must not exceed " ++
-                  integer_to_list(?MAX_PARTITIONS),
-                  ReqData, Context);
             Int ->
-                Int
+                MaxPartitions = rabbit_stream_utils:max_super_stream_partitions(),
+                case Int > MaxPartitions of
+                    true ->
+                        rabbit_mgmt_util:bad_request(
+                          "The partition number must not exceed " ++
+                          integer_to_list(MaxPartitions),
+                          ReqData, Context);
+                    false ->
+                        Int
+                end
         end
     catch
         _:_ ->

--- a/deps/rabbitmq_stream_management/test/http_SUITE.erl
+++ b/deps/rabbitmq_stream_management/test/http_SUITE.erl
@@ -28,6 +28,7 @@ groups() ->
                                create_super_stream,
                                create_super_stream_requires_configure_permission,
                                create_super_stream_partition_limits,
+                               create_super_stream_binding_keys_limit,
                                stream_tracking_requires_vhost_access
                               ]}].
 
@@ -180,6 +181,17 @@ create_super_stream_partition_limits(Config) ->
              #{partitions => 500000000}, ?BAD_REQUEST),
     http_put(Config, "/stream/super-streams/%2F/max-parts",
              #{partitions => 1000}, {group, '2xx'}),
+    ok.
+
+create_super_stream_binding_keys_limit(Config) ->
+    %% A binding-keys list exceeding the partition limit (default 1000) is rejected.
+    OverLimit = iolist_to_binary(
+                  lists:join(
+                    <<",">>,
+                    [<<"k", (integer_to_binary(N))/binary>>
+                     || N <- lists:seq(0, 1000)])),
+    http_put(Config, "/stream/super-streams/%2F/too-many-binding-keys",
+             #{'binding-keys' => OverLimit}, ?BAD_REQUEST),
     ok.
 
 stream_tracking_requires_vhost_access(Config) ->


### PR DESCRIPTION
Introduce the `stream.max_super_stream_partitions` setting to allow cluster administrators to set an explicit cap on partition counts during super stream topology deployment.

Other changes included in this commit:
- Moved partition limits checking to the core stream manager logic, ensuring it is enforced consistently regardless of the incoming protocol.
- Optimized string token processing in the management handler and CLI by relying exclusively on native binary BIFs, significantly reducing the temporary memory overhead associated with parsing lengthy payloads.
- Implemented an early fail-fast validation structure within the management API endpoint to gracefully intercept and terminate requests before allocating memory blocks for sub-stream structures.