### PR TITLE
Ignore strict match on exception class in rabbit_queue_type_util:erpc_call/5

### DIFF
--- a/deps/rabbit/src/rabbit_queue_type_util.erl
+++ b/deps/rabbit/src/rabbit_queue_type_util.erl
@@ -77,7 +77,7 @@ erpc_call(Node, M, F, A, _Timeout)
         Result ->
             Result
     catch
-        error:Err ->
+        _:Err ->
             {error, Err}
     end;
 erpc_call(Node, M, F, A, Timeout) ->
@@ -87,7 +87,7 @@ erpc_call(Node, M, F, A, Timeout) ->
                 Result ->
                     Result
             catch
-                error:Err ->
+                _:Err ->
                     {error, Err}
             end;
         false ->


### PR DESCRIPTION
## Proposed Changes

Currently, only an `error` exception class is expected in `rabbit_queue_type_util:erpc_call/5` - but `erpc:call/5` can fail with `exit`, which results in crashes such as below - which are caught but don't match `error` and still crash. We'd rather just ignore the exception class and avoid these crash terminations/logs and have the expected behavior, e.g. a normal failure on a `queue.declare` scenario as below. 

```

2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0> ** Generic server <0.132172297.0> terminating
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0> ** Last message in was {'$gen_cast',
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            {method,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                                {'queue.declare',0,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                                    <<"xxxxxxxxxxxxxxxxxxx">>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                                    false,true,false,false,false,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                                    [{<<"x-expires">>,signedint,1000}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                                none,noflow}}
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0> ** When Server state == {ch,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          {conf,running,rabbit_framing_amqp_0_9_1,1,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           <0.132169584.0>,<0.132175453.0>,<0.132169584.0>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           <<"xxxxxxxxx -> xxxxxxxxx">>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           {user,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            <<"xxxxxxxxx">>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            [],
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            [{rabbit_auth_backend_xxxxx,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                              {auth_user,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                               <<"xxxxxxxxx">>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                               undefined,none}}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           <<"xxxxxxxxx">>,<<>>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           <0.132166647.0>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           [{<<"authentication_failure_close">>,bool,true},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            {<<"basic.nack">>,bool,true},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            {<<"connection.blocked">>,bool,true},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            {<<"consumer_cancel_notify">>,bool,true},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            {<<"publisher_confirms">>,bool,true}],
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           none,0,undefined,#{},infinity,1000000000,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           #{protocol => amqp091,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                             vhost => <<"xxxxxxxxx">>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                             username =>
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                              <<"xxxxxxxxx">>,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                             connection_name =>
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                              <<"xxxxxxxxx -> xxxxxxxxx">>}},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          {lstate,<0.132173482.0>,false},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          none,1,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          {0,[],[]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          #{},#{},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          {state,fine,30000,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                           #Ref<0.3898622424.1301807106.70605>},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          false,1,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          {rabbit_confirms,undefined,#{}},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          [],[],none,flow,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          [{rabbit_xxxxx_interceptor,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                            <<"xxxxxxxxx">>}],
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          {rabbit_queue_type,#{}},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                          #Ref<0.3898622424.1301807106.70601>,false}
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0> ** Reason for termination ==
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0> ** {{exception,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>         {noproc,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>             {gen_statem,call,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                 [{'xxxxxxxxx_xxxxxxxxxxxxxxxxxxx',
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                      'rabbit@host-xxxx'},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>                  trigger_election,5000]}}},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>     [{erpc,call,5,[{file,"erpc.erl"},{line,264}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>      {rabbit_queue_type_util,erpc_call,5,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>          [{file,"rabbit_queue_type_util.erl"},{line,70}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>      {rabbit_quorum_queue,start_cluster,1,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>          [{file,"rabbit_quorum_queue.erl"},{line,302}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>      {rabbit_channel,handle_method,6,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>          [{file,"rabbit_channel.erl"},{line,2495}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>      {rabbit_channel,handle_method,3,
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>          [{file,"rabbit_channel.erl"},{line,1596}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>      {rabbit_channel,handle_cast,2,[{file,"rabbit_channel.erl"},{line,609}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>      {gen_server2,handle_msg,2,[{file,"gen_server2.erl"},{line,1056}]},
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>      {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,329}]}]}
2026-06-15 15:00:29.108445+00:00 [error] <0.132172297.0>
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>   crasher:
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     initial call: rabbit_channel:init/1
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     pid: <0.132172297.0>
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     registered_name: []
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     exception exit: {{exception,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                          {noproc,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                              {gen_statem,call,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                                  [{'xxxxxxxxx_xxxxxxxxxxxxxxxxxxx',
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                                       'rabbit@host-xxxx'},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                                   trigger_election,5000]}}},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                      [{erpc,call,5,[{file,"erpc.erl"},{line,264}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {rabbit_queue_type_util,erpc_call,5,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           [{file,"rabbit_queue_type_util.erl"},{line,70}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {rabbit_quorum_queue,start_cluster,1,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           [{file,"rabbit_quorum_queue.erl"},{line,302}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {rabbit_channel,handle_method,6,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           [{file,"rabbit_channel.erl"},{line,2495}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {rabbit_channel,handle_method,3,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           [{file,"rabbit_channel.erl"},{line,1596}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {rabbit_channel,handle_cast,2,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           [{file,"rabbit_channel.erl"},{line,609}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {gen_server2,handle_msg,2,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           [{file,"gen_server2.erl"},{line,1056}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {proc_lib,init_p_do_apply,3,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           [{file,"proc_lib.erl"},{line,329}]}]}
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>       in function  gen_server2:terminate/3 (gen_server2.erl, line 1174)
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     ancestors: [<0.132174212.0>,<0.132167179.0>,<0.132169342.0>,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                   <0.132170474.0>,<0.26966.0>,<0.26965.0>,<0.26964.0>,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                   <0.26962.0>,<0.26961.0>,rabbit_sup,<0.451.0>]
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     message_queue_len: 0
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     messages: []
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     links: [<0.132174212.0>]
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     dictionary: [{permission_cache,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       [{{resource,<<"xxxxxxxxx">>,queue,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                             <<"xxxxxxxxxxxxxxxxxxx">>},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                         #{},configure}]},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                   {permission_cache_can_expire,false},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                   {rand_seed,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {#{max => 288230376151711743,type => exsplus,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                          next => #Fun<rand.5.40079776>,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                          jump => #Fun<rand.3.40079776>},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                        [74806623684120864|154460557800938674]}},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                   {'$logger_metadata$',#{domain => [rabbitmq,channel]}},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                   {channel_operation_timeout,15000},
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                   {process_name,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                       {rabbit_channel,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                           {<<"xxxxxxxxx -> xxxxxxxxx">>,
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>                            1}}}]
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     trap_exit: true
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     status: running
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     heap_size: 28690
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     stack_size: 36
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>     reductions: 86517
2026-06-15 15:00:29.109016+00:00 [error] <0.132172297.0>   neighbours:


```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
