### PR TITLE
UI: encrypt sensitive values that pass through local storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,9 @@ rabbitmq-server-*.tar.xz
 rabbitmq-server-*.zip
 secondary_dist/
 
+# RabbitMQ javascript files generated from EJS templates 
+deps/*/priv/www/js/*-ejs.js 
+
 # Trace tools output.
 *-ttb
 *.ti

--- a/.gitignore
+++ b/.gitignore
@@ -127,8 +127,8 @@ rabbitmq-server-*.tar.xz
 rabbitmq-server-*.zip
 secondary_dist/
 
-# RabbitMQ javascript files generated from EJS templates 
-deps/*/priv/www/js/*-ejs.js 
+# RabbitMQ javascript files generated from EJS templates
+deps/*/priv/www/js/*-ejs.js
 
 # Trace tools output.
 *-ttb

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -504,6 +504,13 @@ end}.
 {mapping, "management.disable_basic_auth", "rabbitmq_management.disable_basic_auth",
     [{datatype, boolean}]}.
 
+%% When set, the management UI stores an AES-256-GCM encrypted bearer token
+%% (prefixed "rmqe.") instead of a plaintext base64(username:password).
+%% The value must be identical on every node in the cluster.
+{mapping, "management.credential_encryption_secret",
+          "rabbitmq_management.credential_encryption_secret",
+    [{datatype, [tagged_binary, binary]}]}.
+
 %% Management only
 
 {mapping, "management.disable_stats", "rabbitmq_management.disable_management_stats", [

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -2092,7 +2092,9 @@ function change_own_password(sammy) {
         if (req.readyState == 4 && !done) {
             clearTimeout(timeout);
             if (req.status >= 200 && req.status < 300) {
-                set_basic_auth(username, new_password);
+                // Re-login via api/login so encrypted-credential mode stores
+                // a fresh token instead of plaintext Basic credentials.
+                login(username, new_password);
                 finish();
                 go_to('#/users');
             } else {

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -105,8 +105,7 @@ function start_app_login () {
     this.get('#/', function () {})
     if (!oauth.enabled || !oauth.oauth_disable_basic_auth) {
       this.put('#/login', function() {
-        set_basic_auth(this.params['username'], this.params['password'])
-        check_login()
+        login(this.params['username'], this.params['password']);
       });
     }
   })
@@ -136,34 +135,68 @@ function check_login () {
     }
     return false;
   }
-  check_version()
-  hide_popup_warn()
-  replace_content('outer', format('layout', {}))
-  var user_login_session_timeout = parseInt(user.login_session_timeout)
-  if (!isNaN(user_login_session_timeout)) {
-    update_login_session_timeout(user_login_session_timeout)
+  load_ui(user);
+  return true;
+}
+
+function do_login(username, password) {
+    var result = null;
+    $.ajax({
+        async: false,
+        type: 'POST',
+        url: 'api/login',
+        data: {username: username, password: password},
+        success: function(resp) { result = resp; },
+        error: function(xhr) {
+            try { result = JSON.parse(xhr.responseText); } catch(e) {}
+            if (!result) result = {error: 'login_failed', reason: 'Login failed'};
+        }
+    });
+    return result;
+}
+
+function login(username, password) {
+  var result = do_login(username, password);
+  if (!result || result.error) {
+    replace_content('login-status', '<p>Login failed</p>');
+    if (result && result.reason && typeof result.reason === 'string') {
+      show_popup('warn', fmt_escape_html(result.reason));
+    }
+    return false;
   }
+  user = result.user;
+  clear_local_pref(SESSION_EXPIRY);
+  var scheme = result.token.type === 'bearer' ? 'Bearer' : 'Basic';
+  set_auth(scheme, result.token.value);
+  
+  load_ui(user);
+  return true;
+}
+
+function load_ui(user) {
+  set_session_expiry_if_required(user.login_session_timeout);
+  check_version();
+  hide_popup_warn();
+  replace_content('outer', format('layout', {}));
 
   ui_data_model.vhosts = JSON.parse(sync_get('/vhosts'));
-  ac.update(user, ui_data_model)
+  ac.update(user, ui_data_model);
   if (ac.isMonitoringUser()) {
-    ui_data_model.nodes = JSON.parse(sync_get('/nodes'))
+    ui_data_model.nodes = JSON.parse(sync_get('/nodes'));
   }
-  var overview = JSON.parse(sync_get('/overview'))
+  var overview = JSON.parse(sync_get('/overview'));
 
-  display.update(overview, ui_data_model)
+  display.update(overview, ui_data_model);
 
-  setup_global_vars(overview)
+  setup_global_vars(overview);
 
-  setup_constant_events()
-  update_vhosts()
-  update_interval()
+  setup_constant_events();
+  update_vhosts();
+  update_interval();
   setup_extensions(function onCompleted() {
     console.info("All extensions have been loaded. Starting application ..");
     start_app();
   });
-
-  return true
 }
 
 

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -295,9 +295,7 @@ function oauth_redirectToLogin(error) {
 }
 export function oauth_completeLogin() {
     mgr.signinRedirectCallback().then(function(user) {
-      // Clear the stored timeout so a fresh login re-applies the configured
-      // value; the silent token renewal path in addUserLoaded must not.
-      clear_local_pref(LOGIN_SESSION_TIMEOUT)
+      clear_local_pref(SESSION_EXPIRY);
       set_token_auth(user.access_token);
       oauth_redirectToHome();
     }).catch(function(err) {

--- a/deps/rabbitmq_management/priv/www/js/prefs.js
+++ b/deps/rabbitmq_management/priv/www/js/prefs.js
@@ -1,17 +1,8 @@
-function local_storage_available() {
-    try {
-        return 'localStorage' in window && window['localStorage'] !== null;
-    } catch (e) {
-        return false;
-    }
-}
-
 /// Credential management
 
 const CREDENTIALS = 'credentials'
 const AUTH_SCHEME = "auth-scheme"
-const LOGGED_IN = 'loggedIn'
-const LOGIN_SESSION_TIMEOUT = "login_session_timeout"
+const SESSION_EXPIRY = 'session_expiry'
 const AUTH_RESOURCE = 'auth_resource'
 
 const BASIC_AUTH_SCHEME = "Basic"
@@ -30,9 +21,13 @@ function get_auth_resource() {
 
 // When auth_scheme is undefined, matches any scheme for backwards compatibility.
 function has_auth_credentials(auth_scheme) {
-    let authenticated =get_local_pref(CREDENTIALS) != undefined && get_local_pref(AUTH_SCHEME) != undefined &&
-      get_cookie_value(LOGGED_IN) != undefined;
-    return authenticated && (auth_scheme == undefined 
+    let expiry = get_local_pref(SESSION_EXPIRY);
+    let authenticated = get_local_pref(CREDENTIALS) != undefined &&
+                        get_local_pref(AUTH_SCHEME) != undefined;
+    if (authenticated && expiry != undefined) {
+        authenticated = Date.now() < parseInt(expiry, 10);
+    }
+    return authenticated && (auth_scheme == undefined
         || auth_scheme == get_auth_scheme());
 }
 function get_auth_credentials() {
@@ -44,26 +39,33 @@ function get_auth_scheme() {
 function clear_auth() {
     clear_local_pref(CREDENTIALS)
     clear_local_pref(AUTH_SCHEME)
-    clear_local_pref(LOGIN_SESSION_TIMEOUT)
-    clear_cookie_value(LOGGED_IN)
+    clear_local_pref(SESSION_EXPIRY)
     clear_local_pref(AUTH_RESOURCE)
+    $.ajax({ async: false, type: 'DELETE', url: 'api/login' })
 }
 function set_basic_auth(username, password) {
-    // Clear the stored timeout so a fresh login re-applies the configured value.
-    clear_local_pref(LOGIN_SESSION_TIMEOUT)
-    set_auth("Basic", b64_encode_utf8(username + ":" + password), default_hard_session_timeout())
+    set_auth("Basic", b64_encode_utf8(username + ":" + password))
 }
 function set_token_auth(token) {
-    set_auth("Bearer", token, default_hard_session_timeout())
+    set_auth("Bearer", token)
 }
-function set_auth(auth_scheme, credentials, validUntil) {
+function set_auth(auth_scheme, credentials) {
     clear_local_pref(CREDENTIALS)
     clear_local_pref(AUTH_SCHEME)
     store_local_pref(CREDENTIALS, credentials)
-    store_local_pref(AUTH_SCHEME, auth_scheme)
-    store_cookie_value_with_expiration(LOGGED_IN, "true", validUntil) // session marker
+    store_local_pref(AUTH_SCHEME, auth_scheme)    
 }
-
+const DEFAULT_HARD_LOGIN_SESSION_TIMEOUT = 480; // 8 hours
+function set_session_expiry_if_required(login_session_timeout) {    
+    if (get_local_pref(SESSION_EXPIRY) != undefined) return;
+    var timeout = parseInt(login_session_timeout);
+    if (isNaN(timeout)) {
+        timeout = DEFAULT_HARD_LOGIN_SESSION_TIMEOUT;
+    }
+    var date = new Date();
+    date.setMinutes(date.getMinutes() + timeout);
+    store_local_pref(SESSION_EXPIRY, date.getTime());
+}
 function authorization_header() {
     if (has_auth_credentials()) {
         return get_auth_scheme() + ' ' + get_auth_credentials();
@@ -71,21 +73,16 @@ function authorization_header() {
         return null;
     }
 }
-function default_hard_session_timeout() {
-  var date  = new Date();
-  date.setHours(date.getHours() + 8);
-  return date;
+
+function print_logging_session_info (user_login_session_timeout) {
+  let authenticated = has_auth_credentials()
+  let session_expiry = get_local_pref(SESSION_EXPIRY)
+  console.log('user_login_session_timeout: ' + user_login_session_timeout)
+  console.log('has_auth_credentials: ' + authenticated)
+  console.log('session_expiry: ' + session_expiry)
+  console.log('isNaN(user_login_session_timeout): ' + isNaN(user_login_session_timeout))
 }
 
-function update_login_session_timeout(login_session_timeout) {
-    if (get_local_pref(LOGIN_SESSION_TIMEOUT) != undefined || !has_auth_credentials()) {
-      return;
-    }
-    var date = new Date();
-    date.setMinutes(date.getMinutes() + login_session_timeout);
-    store_local_pref(LOGIN_SESSION_TIMEOUT, login_session_timeout);
-    store_cookie_value_with_expiration(LOGGED_IN, "true", date)
-}
 
 /// End Credential Management
 
@@ -102,83 +99,33 @@ function encode_utf8(str) {
   return unescape(encodeURIComponent(str));
 }
 
-function store_cookie_value(k, v) {
-    var d = parse_cookie();
-    d[short_key(k)] = v;
-    store_cookie(d);
-}
+// All preferences and credentials are stored in localStorage.
+// The management UI requires localStorage; without it no part of the UI functions.
 
-function store_cookie_value_with_expiration(k, v, expiration_date) {
-    var d = parse_cookie();
-    d[short_key(k)] = v;
-    store_cookie_with_expiration(d, expiration_date);
-}
-
-function clear_cookie_value(k) {
-    var d = parse_cookie();
-    delete d[short_key(k)];
-    store_cookie(d);
-}
-
-function get_cookie_value(k) {
-    var r;
-    r = parse_cookie()[short_key(k)];
-    return r == undefined ? default_pref(k) : r;
-}
 function store_local_pref(k, v) {
-    if (local_storage_available()) {
-        window.localStorage.setItem('rabbitmq.' + k, v);
-    }else {
-      throw "Local Storage not available. RabbitMQ requires localStorage"
-    }
+    window.localStorage.setItem('rabbitmq.' + k, v);
 }
+
 function clear_local_pref(k) {
-    if (local_storage_available()) {
-        window.localStorage.removeItem('rabbitmq.' + k);
-    }
+    window.localStorage.removeItem('rabbitmq.' + k);
+}
+
+function get_local_pref(k) {
+    return window.localStorage.getItem('rabbitmq.' + k);
 }
 
 function store_pref(k, v) {
-    if (local_storage_available()) {
-        window.localStorage['rabbitmq.' + k] = v;
-    }
-    else {
-        var d = parse_cookie();
-        d[short_key(k)] = v;
-        store_cookie(d);
-    }
+    store_local_pref(k, v);
 }
 
 function clear_pref(k) {
-    if (local_storage_available()) {
-        window.localStorage.removeItem('rabbitmq.' + k);
-    }
-    else {
-        var d = parse_cookie();
-        delete d[short_key(k)];
-        store_cookie(d);
-    }
-}
-function get_local_pref(k) {
-  if (local_storage_available()) {
-      return window.localStorage.getItem('rabbitmq.' + k)
-  }else {
-    throw "Local Storage not available. RabbitMQ requires localStorage"
-  }
+    clear_local_pref(k);
 }
 
 function get_pref(k, defaultValue = undefined) {
-    var val;
-    if (local_storage_available()) {
-        val = window.localStorage['rabbitmq.' + k];
-    }
-    else {
-        val = parse_cookie()[short_key(k)];
-
-    }
-    var res = (val == undefined) ? 
+    var val = get_local_pref(k);
+    return (val == undefined) ?
         (defaultValue != undefined ? defaultValue : default_pref(k)) : val;
-    return res;
 }
 
 function section_pref(template, name) {
@@ -218,57 +165,3 @@ function default_column_pref(key0) {
     return 'false';
 }
 
-// ---------------------------------------------------------------------------
-
-function parse_cookie() {
-    var c = get_cookie('m');
-    var items = c.length == 0 ? [] : c.split('|');
-
-    var start = 0;
-    var dict = {};
-    for (var i in items) {
-        var kv = items[i].split(':');
-        dict[kv[0]] = unescape(kv[1]);
-    }
-    return dict;
-}
-
-function store_cookie(dict) {
-    store_cookie_with_expiration(dict, default_hard_session_timeout());
-}
-
-function store_cookie_with_expiration(dict, expiration_date) {
-    var enc = [];
-    for (var k in dict) {
-        enc.push(k + ':' + escape(dict[k]));
-    }
-    document.cookie = 'm=' + enc.join('|') + '; expires=' + expiration_date.toUTCString() + "; path=/";
-//    console.log("Cookie m expires at " + expiration_date);
-}
-
-function get_cookie(key) {
-    var cookies = document.cookie.split(';');
-    for (var i in cookies) {
-        var kv = cookies[i].trim().split('=');
-        if (kv[0] == key) return kv[1];
-    }
-    return '';
-}
-
-// Try to economise on space since cookies have limited length.
-function short_key(k) {
-    var res = Math.abs(k.hashCode() << 16 >> 16);
-    res = res.toString(16);
-    return res;
-}
-
-String.prototype.hashCode = function() {
-    var hash = 0;
-    if (this.length == 0) return code;
-    for (i = 0; i < this.length; i++) {
-        char = this.charCodeAt(i);
-        hash = 31*hash+char;
-        hash = hash & hash; // Convert to 32bit integer
-    }
-    return hash;
-}

--- a/deps/rabbitmq_management/priv/www/js/prefs.js
+++ b/deps/rabbitmq_management/priv/www/js/prefs.js
@@ -43,9 +43,6 @@ function clear_auth() {
     clear_local_pref(AUTH_RESOURCE)
     $.ajax({ async: false, type: 'DELETE', url: 'api/login' })
 }
-function set_basic_auth(username, password) {
-    set_auth("Basic", b64_encode_utf8(username + ":" + password))
-}
 function set_token_auth(token) {
     set_auth("Bearer", token)
 }
@@ -53,10 +50,10 @@ function set_auth(auth_scheme, credentials) {
     clear_local_pref(CREDENTIALS)
     clear_local_pref(AUTH_SCHEME)
     store_local_pref(CREDENTIALS, credentials)
-    store_local_pref(AUTH_SCHEME, auth_scheme)    
+    store_local_pref(AUTH_SCHEME, auth_scheme)
 }
 const DEFAULT_HARD_LOGIN_SESSION_TIMEOUT = 480; // 8 hours
-function set_session_expiry_if_required(login_session_timeout) {    
+function set_session_expiry_if_required(login_session_timeout) {
     if (get_local_pref(SESSION_EXPIRY) != undefined) return;
     var timeout = parseInt(login_session_timeout);
     if (isNaN(timeout)) {
@@ -74,30 +71,7 @@ function authorization_header() {
     }
 }
 
-function print_logging_session_info (user_login_session_timeout) {
-  let authenticated = has_auth_credentials()
-  let session_expiry = get_local_pref(SESSION_EXPIRY)
-  console.log('user_login_session_timeout: ' + user_login_session_timeout)
-  console.log('has_auth_credentials: ' + authenticated)
-  console.log('session_expiry: ' + session_expiry)
-  console.log('isNaN(user_login_session_timeout): ' + isNaN(user_login_session_timeout))
-}
-
-
 /// End Credential Management
-
-// Our base64 library takes a string that is really a byte sequence,
-// and will throw if given a string with chars > 255 (and hence not
-// DTRT for chars > 127). So encode a unicode string as a UTF-8
-// sequence of "bytes".
-function b64_encode_utf8(str) {
-    return base64.encode(encode_utf8(str));
-}
-
-// encodeURIComponent handles utf-8, unescape does not. Neat!
-function encode_utf8(str) {
-  return unescape(encodeURIComponent(str));
-}
 
 // All preferences and credentials are stored in localStorage.
 // The management UI requires localStorage; without it no part of the UI functions.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_basic_credentials_token.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_basic_credentials_token.erl
@@ -1,0 +1,70 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% Encrypted credentials token for the management UI.
+%%
+%% When management.credential_encryption_secret is configured, the
+%% management UI stores an AES-256-GCM encrypted token (prefixed "rmqe.")
+%% instead of a plaintext base64(username:password) credential.
+%%
+%% Token wire format (after stripping the "rmqe." prefix and base64-decoding):
+%%   <<IV:12/bytes, Tag:16/bytes, Ciphertext/binary>>
+%% where Ciphertext decrypts to <<ExpiresAt:64/integer, Username/binary, ":", Password/binary>>.
+
+-module(rabbit_mgmt_basic_credentials_token).
+
+-export([derive_key/1, issue/4, verify/2]).
+
+-define(PREFIX, <<"rmqe.">>).
+-define(IV_LEN, 12).
+-define(TAG_LEN, 16).
+%% Fixed AAD binds the token to its purpose.
+-define(AAD, <<"rabbit-mgmt-credentials">>).
+
+%% Derives a 32-byte AES-256 key from an arbitrary-length secret using
+%% HMAC-SHA256. The result is deterministic, so the same secret always
+%% produces the same key — required for multi-node clusters.
+-spec derive_key(binary() | string()) -> binary().
+derive_key(Secret) when is_list(Secret) ->
+    derive_key(list_to_binary(Secret));
+derive_key(Secret) when is_binary(Secret) ->
+    crypto:mac(hmac, sha256, Secret, ?AAD).
+
+%% Encrypts Username and Password into a "rmqe."-prefixed bearer token.
+-spec issue(binary(), binary(), binary(), integer()) -> {ok, binary()}.
+issue(Key, Username, Password, ExpiresAt) ->
+    IV = crypto:strong_rand_bytes(?IV_LEN),
+    PlainText = <<ExpiresAt:64/integer, Username/binary, ":", Password/binary>>,
+    {CipherText, Tag} = crypto:crypto_one_time_aead(
+                            aes_256_gcm, Key, IV, PlainText, ?AAD, ?TAG_LEN, true),
+    Payload = base64:encode(<<IV/binary, Tag/binary, CipherText/binary>>),
+    {ok, <<?PREFIX/binary, Payload/binary>>}.
+
+%% Decrypts a token produced by issue/4.
+%% Returns {ok, Username, Password, ExpiresAt},
+%% {error, not_an_encrypted_token} when the token does not carry the "rmqe." prefix, 
+%% or {error, invalid_token} when decryption or authentication fails.
+-spec verify(binary(), binary()) ->
+    {ok, binary(), binary(), integer()} | {error, not_an_encrypted_token | invalid_token}.
+verify(<<"rmqe.", Payload/binary>>, Key) ->
+    try
+        Bin = base64:decode(Payload),
+        <<IV:?IV_LEN/bytes, Tag:?TAG_LEN/bytes, CipherText/binary>> = Bin,
+        case crypto:crypto_one_time_aead(
+                 aes_256_gcm, Key, IV, CipherText, ?AAD, Tag, false) of
+            error ->
+                {error, invalid_token};
+            PlainText ->
+                <<ExpiresAt:64/integer, Rest/binary>> = PlainText,
+                [Username, Password] = binary:split(Rest, <<":">>),
+                {ok, Username, Password, ExpiresAt}
+        end
+    catch _:_ ->
+        {error, invalid_token}
+    end;
+verify(_, _) ->
+    {error, not_an_encrypted_token}.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_login.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_login.erl
@@ -70,7 +70,7 @@ login(<<"GET">>, Req, State) ->
                 _ -> {ok, cowboy_req:reply(405, Req), State}
             end;
         {Type, Value} ->
-            redirect_to_home_with_cookie(Type, Value, Req, State)
+            redirect_to_home_with_cookie(?OAUTH2_BOOTSTRAP_PATH, Type, Value, Req, State)
     end;
 
 login(_, Req0, State) ->
@@ -82,7 +82,7 @@ handleStrictOrPreferredAuthMechanism(Req, Body, State) ->
             {ok, cowboy_req:reply(302, #{<<"Location">> => iolist_to_binary(get_home_uri(Req))}, 
                                         <<>>, Req), State};
         {Type, Value} ->
-            redirect_to_home_with_cookie(Type, Value, Req, State)
+            redirect_to_home_with_cookie(?OAUTH2_BOOTSTRAP_PATH, Type, Value, Req, State)
     end.
             
 get_auth_mechanism(Req, Body) ->
@@ -113,17 +113,18 @@ get_param_or_header(ParamName, Req, Body) ->
 handleAccessToken(Req0, AccessToken, State) ->
    case rabbit_mgmt_util:is_authorized_user(Req0, #context{}, <<"">>, AccessToken, false) of
         {true, Req1, _} ->
-            redirect_to_home_with_cookie(?OAUTH2_ACCESS_TOKEN,
+            redirect_to_home_with_cookie(?OAUTH2_BOOTSTRAP_PATH,
+                                         ?OAUTH2_ACCESS_TOKEN,
                                          AccessToken,
                                          Req1, State);
         {false, ReqData1, Reason} ->
             replyWithError(Reason, ReqData1, State)
     end.
 
-redirect_to_home_with_cookie(CookieName, CookieValue, Req=#{scheme := Scheme}, State) ->
+redirect_to_home_with_cookie(CookiePath, CookieName, CookieValue, Req=#{scheme := Scheme}, State) ->
     CookieSettings0 = #{
         http_only => true,
-        path => rabbit_mgmt_util:prefixed_path(?OAUTH2_BOOTSTRAP_PATH),
+        path => rabbit_mgmt_util:prefixed_path(CookiePath),
         max_age => 30,
         same_site => strict
     },

--- a/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
@@ -76,8 +76,7 @@ get_auth_mechanism(Req) ->
                                     <<"">>, Req, #{
                                         max_age => 0,
                                         http_only => true,
-                                        path => iolist_to_binary([rabbit_mgmt_util:get_path_prefix(),
-                                                                  ?OAUTH2_BOOTSTRAP_PATH]),
+                                        path => rabbit_mgmt_util:prefixed_path(?OAUTH2_BOOTSTRAP_PATH),
                                         same_site => strict
                                 }),
                                 Auth

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -99,8 +99,7 @@ is_authorized_admin(ReqData, Context, Token) ->
     AuthConfig = auth_config(),
     rabbit_web_dispatch_access_control:is_authorized(
       ReqData, Context,
-      AuthConfig#auth_settings.oauth_client_id,
-      Token, <<"Not administrator user">>,
+      <<"">>, Token, <<"Not administrator user">>,
       fun(#user{tags = Tags}) ->
               rabbit_web_dispatch_access_control:is_admin(Tags)
       end, AuthConfig).
@@ -134,13 +133,29 @@ is_authorized_vhost_visible_for_monitoring(ReqData, Context) ->
 
 auth_config() ->
     BasicAuthEnabled = not get_bool_env(rabbitmq_management, disable_basic_auth, false),
-    OauthEnabled = get_bool_env(rabbitmq_management, oauth_enabled, false),
-    OauthClientId = rabbit_data_coercion:to_binary(
-                        application:get_env(rabbitmq_management, oauth_client_id, "")),
-    #auth_settings{auth_realm = ?AUTH_REALM,
-                   basic_auth_enabled = BasicAuthEnabled,
-                   oauth2_enabled = OauthEnabled,
-                   oauth_client_id = OauthClientId}.
+    BearerTokenParser =
+        case application:get_env(rabbitmq_management, credential_encryption_secret, undefined) of
+            undefined -> undefined;
+            Secret ->
+                Key = rabbit_mgmt_basic_credentials_token:derive_key(Secret),
+                fun(Token) ->
+                    case rabbit_mgmt_basic_credentials_token:verify(Token, Key) of
+                        {ok, U, P, ExpiresAt} ->
+                            Now = erlang:system_time(second),
+                            if
+                                Now >= ExpiresAt ->
+                                    {error, <<"Invalid token: expired">>};
+                                true ->
+                                    {basic, U, P}
+                            end;
+                        {error, not_an_encrypted_token} -> {bearer, Token};
+                        {error, _Reason}                -> {error, <<"Invalid token">>}
+                    end
+                end
+        end,
+    #auth_settings{auth_realm          = ?AUTH_REALM,
+                   basic_auth_enabled  = BasicAuthEnabled,
+                   bearer_token_parser = BearerTokenParser}.
 
 disable_stats() ->
     not rabbit_mgmt_agent_config:is_metrics_collector_enabled() orelse

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_login.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_login.erl
@@ -9,9 +9,10 @@
 
 -export([init/2, is_authorized/2,
          allowed_methods/2, accept_content/2, content_types_provided/2,
-         content_types_accepted/2]).
+         content_types_accepted/2, delete_resource/2]).
 -export([variances/2]).
 
+-include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 %%--------------------------------------------------------------------
 
@@ -22,7 +23,7 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 allowed_methods(ReqData, Context) ->
-    {[<<"POST">>, <<"OPTIONS">>], ReqData, Context}.
+    {[<<"POST">>, <<"DELETE">>, <<"OPTIONS">>], ReqData, Context}.
 
 content_types_provided(ReqData, Context) ->
     {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
@@ -31,6 +32,8 @@ content_types_accepted(ReqData, Context) ->
     {[{{<<"application">>, <<"x-www-form-urlencoded">>, '*'}, accept_content}], ReqData, Context}.
 
 is_authorized(#{method := <<"OPTIONS">>} = ReqData, Context) ->
+    {true, ReqData, Context};
+is_authorized(#{method := <<"DELETE">>} = ReqData, Context) ->
     {true, ReqData, Context};
 is_authorized(ReqData0, Context) ->
     {ok, Body, ReqData} = cowboy_req:read_urlencoded_body(ReqData0),
@@ -46,5 +49,29 @@ is_authorized(ReqData0, Context) ->
 accept_content(ReqData, Context) ->
     rabbit_mgmt_util:post_respond(do_login(ReqData, Context)).
 
-do_login(ReqData, Context) ->
-    rabbit_mgmt_util:reply(ok, ReqData, Context).
+do_login(ReqData, Context = #context{user = User}) ->
+    Username = User#user.username,
+    Password = Context#context.password,
+    {TimeoutMins, Expiration} = case application:get_env(rabbitmq_management, login_session_timeout) of
+        undefined  -> {480, []};
+        {ok, Val}  -> {Val, [{login_session_timeout, Val}]}
+    end,
+    Token =
+        case application:get_env(rabbitmq_management, credential_encryption_secret, undefined) of
+            undefined ->
+                #{type  => <<"basic">>,
+                  value => base64:encode(<<Username/binary, ":", Password/binary>>)};
+            Secret ->
+                Key = rabbit_mgmt_basic_credentials_token:derive_key(Secret),
+                ExpiresAt = erlang:system_time(second) + (TimeoutMins * 60),
+                {ok, Encrypted} = rabbit_mgmt_basic_credentials_token:issue(Key, Username, Password, ExpiresAt),
+                #{type  => <<"bearer">>,
+                  value => Encrypted}
+        end,
+    FormattedUser = rabbit_mgmt_format:user(User),
+    rabbit_mgmt_util:reply(
+        #{token => Token, user => FormattedUser ++ Expiration},
+        ReqData, Context).
+
+delete_resource(ReqData, Context) ->
+    {true, ReqData, Context}.

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -225,7 +225,9 @@ all_tests() -> [
     single_active_consumer_qq_test,
     disable_basic_auth_test,
     login_test,
+    login_encrypted_test,
     csp_headers_test,
+    referrer_policy_headers_test,
     auth_attempts_test,
     user_limits_list_test,
     user_limit_set_test,
@@ -4343,23 +4345,91 @@ version_test(Config) ->
 login_test(Config) ->
     http_put(Config, "/users/myuser", [{password, <<"myuser">>},
                                        {tags,     <<"management">>}], {group, '2xx'}),
-    %% Let's do a post without any other form of authorization
-    {ok, {{_, CodeAct, _}, Headers, _}} =
+    %% Successful login returns a structured token envelope and user object
+    {ok, {{_, 200, _}, Headers, Body}} =
         req(Config, 0, post, "/login",
             [{"content-type", "application/x-www-form-urlencoded"}],
             <<"username=myuser&password=myuser">>),
-    ?assertEqual(200, CodeAct),
     ?assert(not proplists:is_defined("set-cookie", Headers)),
+    Decoded = rabbit_json:decode(Body),
+    Token = maps:get(<<"token">>, Decoded),
+    ?assertEqual(<<"basic">>, maps:get(<<"type">>, Token)),
+    ?assertEqual(base64:encode(<<"myuser:myuser">>), maps:get(<<"value">>, Token)),
+    User = maps:get(<<"user">>, Decoded),
+    ?assertEqual(<<"myuser">>, maps:get(<<"name">>, User)),
 
-    %% Let's request a login with an unknown user
-    {ok, {{_, CodeAct2, _}, Headers2, _}} =
+    %% Unknown user returns 401 with no session cookie.
+    {ok, {{_, 401, _}, Headers2, _}} =
         req(Config, 0, post, "/login",
             [{"content-type", "application/x-www-form-urlencoded"}],
             <<"username=misteryusernumber1&password=myuser">>),
-    ?assertEqual(401, CodeAct2),
     ?assert(not proplists:is_defined("set-cookie", Headers2)),
 
     http_delete(Config, "/users/myuser", {group, '2xx'}),
+    passed.
+
+login_encrypted_test(Config) ->
+    rpc(Config, application, set_env,
+        [rabbitmq_management, credential_encryption_secret, <<"test-secret">>]),
+    http_put(Config, "/users/myuser", [{password, <<"myuser">>},
+                                       {tags,     <<"management">>}], {group, '2xx'}),
+    {ok, {{_, 200, _}, _, Body}} =
+        req(Config, 0, post, "/login",
+            [{"content-type", "application/x-www-form-urlencoded"}],
+            <<"username=myuser&password=myuser">>),
+    Decoded = rabbit_json:decode(Body),
+    Token = maps:get(<<"token">>, Decoded),
+    ?assertEqual(<<"bearer">>, maps:get(<<"type">>, Token)),
+    Value = maps:get(<<"value">>, Token),
+    ?assertMatch(<<"rmqe.", _/binary>>, Value),
+
+    %% The encrypted token authenticates a subsequent API call.
+    {ok, {{_, 200, _}, _, _}} =
+        req(Config, get, "/whoami",
+            [{"authorization", "Bearer " ++ binary_to_list(Value)}]),
+
+    %% Force the session timeout to 0 minutes and issue a new token
+    rpc(Config, application, set_env,
+        [rabbitmq_management, login_session_timeout, 0]),
+
+    {ok, {{_, 200, _}, _, Body2}} =
+        req(Config, 0, post, "/login",
+            [{"content-type", "application/x-www-form-urlencoded"}],
+            <<"username=myuser&password=myuser">>),
+    Decoded2 = rabbit_json:decode(Body2),
+    Token2 = maps:get(<<"token">>, Decoded2),
+    Value2 = maps:get(<<"value">>, Token2),
+
+    %% Wait 1.5 seconds to ensure Now > ExpiresAt (which was Now + 0 at issue time)
+    timer:sleep(1500),
+
+    %% Now the new token should be expired
+    {ok, {{_, 401, _}, _, ErrBody}} =
+        req(Config, get, "/whoami",
+            [{"authorization", "Bearer " ++ binary_to_list(Value2)}]),
+    ErrDecoded = rabbit_json:decode(ErrBody),
+    ?assertEqual(<<"Invalid token: expired">>, maps:get(<<"reason">>, ErrDecoded)),
+
+    %% However, the OLD token should STILL be valid because its Expiration was
+    %% fixed at 8 hours at issue time. Changing the global config did not affect it.
+    {ok, {{_, 200, _}, _, _}} =
+        req(Config, get, "/whoami",
+            [{"authorization", "Bearer " ++ binary_to_list(Value)}]),
+
+    %% Reset timeout
+    rpc(Config, application, unset_env,
+        [rabbitmq_management, login_session_timeout]),
+
+    %% Standard Basic auth must also be accepted when encryption is enabled,
+    %% because non-UI clients (curl, REST apps, etc.) always use Basic.
+    BasicValue = base64:encode(<<"myuser:myuser">>),
+    {ok, {{_, 200, _}, _, _}} =
+        req(Config, get, "/whoami",
+            [{"authorization", "Basic " ++ binary_to_list(BasicValue)}]),
+
+    http_delete(Config, "/users/myuser", {group, '2xx'}),
+    rpc(Config, application, unset_env,
+        [rabbitmq_management, credential_encryption_secret]),
     passed.
 
 csp_headers_test(Config) ->
@@ -4369,6 +4439,19 @@ csp_headers_test(Config) ->
     ?assert(lists:keymember("content-security-policy", 1, HdGetCsp0)),
     {ok, {_, HdGetCsp1, _}} = req(Config, get_static, "/index.html", Headers),
     ?assert(lists:keymember("content-security-policy", 1, HdGetCsp1)).
+
+referrer_policy_headers_test(Config) ->
+    AuthHeader = auth_header("guest", "guest"),
+    rpc(Config, application, set_env,
+        [rabbitmq_management, headers, [{referrer_policy, "no-referrer"}]]),
+    {ok, {_, Hd0, _}} = req(Config, get, "/whoami", [AuthHeader]),
+    ?assertEqual("no-referrer",
+                 proplists:get_value("referrer-policy", Hd0)),
+    rpc(Config, application, set_env,
+        [rabbitmq_management, headers, []]),
+    {ok, {_, Hd1, _}} = req(Config, get, "/whoami", [AuthHeader]),
+    ?assertEqual(undefined,
+                 proplists:get_value("referrer-policy", Hd1)).
 
 disable_basic_auth_test(Config) ->
     rpc(Config, application, set_env, [rabbitmq_management, disable_basic_auth, true]),

--- a/deps/rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl
+++ b/deps/rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl
@@ -9,7 +9,16 @@
                   password = none,
                   impl}). % storage for a context of the resource handler
 
--record(auth_settings, {auth_realm = "Basic realm=\"RabbitMQ undefined\"",
-                        basic_auth_enabled = false,
-                        oauth2_enabled = false,
-                        oauth_client_id = <<"">>}).
+%% Pluggable bearer token parser supplied by the hosting application.
+%% Returns {basic, Username, Password} to route through Basic auth,
+%% {bearer, Token} to route through OAuth2, or {error, Reason} to reject.
+-type bearer_token_parser() ::
+    fun((binary()) -> {basic, binary(), binary()}
+                    | {bearer, binary()}
+                    | {error, binary()}).
+
+-record(auth_settings, {
+    auth_realm          = "Basic realm=\"RabbitMQ undefined\"",
+    basic_auth_enabled  = false,
+    bearer_token_parser = undefined :: undefined | bearer_token_parser()
+}).

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
@@ -87,32 +87,48 @@ is_authorized(ReqData, Context, ErrorMsg, Fun, AuthConfig) ->
     end.
 
 is_authorized1(ReqData, Context, ErrorMsg, Fun, AuthConfig) ->
+    BasicAuthDisabled = is_basic_auth_disabled(AuthConfig),
+    case parse_credentials(ReqData, AuthConfig) of
+        {basic, Username, Password} when not BasicAuthDisabled ->
+            is_authorized(ReqData, Context, Username, Password,
+                          ErrorMsg, Fun, AuthConfig);
+        {basic, _, _} ->
+            Msg = "HTTP access denied: basic auth disabled",
+            ?LOG_WARNING(Msg, [], #{domain => ?RMQLOG_DOMAIN_USER}),
+            not_authorised(Msg, ReqData, Context);
+        {bearer, OAuthUsername, Token} ->
+            is_authorized(ReqData, Context, OAuthUsername, Token,
+                          ErrorMsg, Fun, AuthConfig);
+        no_credentials when not BasicAuthDisabled ->
+            Msg = "HTTP access denied: no credentials",
+            ?LOG_WARNING(Msg, [], #{domain => ?RMQLOG_DOMAIN_USER}),
+            {{false, AuthConfig#auth_settings.auth_realm}, ReqData, Context};
+        no_credentials ->
+            Msg = "HTTP access denied: no credentials",
+            ?LOG_WARNING(Msg, [], #{domain => ?RMQLOG_DOMAIN_USER}),
+            not_authorised(Msg, ReqData, Context);
+        {error, Reason} ->
+            not_authorised(Reason, ReqData, Context)
+    end.
+
+parse_credentials(ReqData, AuthConfig) ->
     case cowboy_req:parse_header(<<"authorization">>, ReqData) of
         {basic, Username, Password} ->
-            case is_basic_auth_disabled(AuthConfig) of
-                true ->
-                    Msg = "HTTP access denied: basic auth disabled",
-                    ?LOG_WARNING(Msg, [], #{domain => ?RMQLOG_DOMAIN_USER}),
-                    not_authorised(Msg, ReqData, Context);
-                false ->
-                    is_authorized(ReqData, Context,
-                                  Username, Password,
-                                  ErrorMsg, Fun, AuthConfig)
-            end;
+            {basic, Username, Password};
         {bearer, Token} ->
-            % Username is only used in case is_authorized is not able to parse the token
-            % and extact the username from it
-            Username = AuthConfig#auth_settings.oauth_client_id,
-            is_authorized(ReqData, Context, Username, Token, ErrorMsg, Fun, AuthConfig);
+            case AuthConfig#auth_settings.bearer_token_parser of
+                undefined ->
+                    %% Plain OAuth2 token; username is ignored by the OAuth2 backend.
+                    {bearer, <<"">>, Token};
+                Parser ->
+                    case Parser(Token) of
+                        {basic, U, P} -> {basic, U, P};
+                        {bearer, T}   -> {bearer, <<"">>, T};
+                        {error, _} = E -> E
+                    end
+            end;
         _ ->
-            case is_basic_auth_disabled(AuthConfig) of
-                true ->
-                    Msg = "HTTP access denied: basic auth disabled",
-                    ?LOG_WARNING(Msg, [], #{domain => ?RMQLOG_DOMAIN_USER}),
-                    not_authorised(Msg, ReqData, Context);
-                false ->
-                    {{false, AuthConfig#auth_settings.auth_realm}, ReqData, Context}
-            end
+            no_credentials
     end.
 
 is_authorized_user(ReqData, Context, Username, Password, AuthConfig) ->

--- a/selenium/package.json
+++ b/selenium/package.json
@@ -11,6 +11,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "overrides": {
+    "proxy-agent": "6.5.0"
+  },
   "dependencies": {
     "amqplib": "2.0.1",
     "ejs": "^6.0.1",

--- a/selenium/suites/authnz-mgt/basic-auth-with-encrypted-credentials.sh
+++ b/selenium/suites/authnz-mgt/basic-auth-with-encrypted-credentials.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TEST_CASES_PATH=/basic-auth
+PROFILES="one-minute-session-timeout encrypted-credentials"
+
+source $SCRIPT/../../bin/suite_template $@
+run

--- a/selenium/test/basic-auth/rabbitmq.conf
+++ b/selenium/test/basic-auth/rabbitmq.conf
@@ -6,3 +6,6 @@ loopback_users = none
 
 log.console.level = debug
 log.user.file = user.log
+
+# Always encrypt basic credentials at-rest 
+management.credential_encryption_secret = a-test-secret-value

--- a/selenium/test/oauth/with-sp-initiated/session-expired.js
+++ b/selenium/test/oauth/with-sp-initiated/session-expired.js
@@ -1,0 +1,46 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+const assert = require('assert')
+const { buildDriver, goToHome, captureScreensFor, teardown, delay, idpLoginPage } = require('../../utils')
+
+const SSOHomePage = require('../../pageobjects/SSOHomePage')
+const OverviewPage = require('../../pageobjects/OverviewPage')
+
+describe('Once an OAuth2 user is logged in', function () {
+  let driver
+  let homePage
+  let idpLogin
+  let overview
+  let captureScreen
+  
+  this.timeout(80000)
+
+  before(async function () {
+    driver = buildDriver()
+    await goToHome(driver)
+    homePage = new SSOHomePage(driver)
+    idpLogin = idpLoginPage(driver)
+    overview = new OverviewPage(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+  })
+
+  it('it is forced to log out after the login_session_timeout expires', async function () {
+    await homePage.clickToLogin()
+    await idpLogin.login('rabbit_admin', 'rabbit_admin')
+    await overview.isLoaded()
+
+    // Wait for the 1-minute `login_session_timeout` to expire.
+    // In this suite, token TTL is 30s, so it WILL refresh silently in the background
+    // around ~20-30s. The hard session timeout should STILL kick us out after 60s
+    // regardless of the fact that the token is actively refreshing.
+    await delay(62000)
+    
+    // Attempt an action or wait for the auto-logout to redirect us
+    await homePage.isLoaded()
+    const value = await homePage.getLoginButton()
+    assert.equal(value, 'Click here to log in')
+  })
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})

--- a/selenium/test/pageobjects/BasePage.js
+++ b/selenium/test/pageobjects/BasePage.js
@@ -466,6 +466,7 @@ module.exports = class BasePage {
   async sendKeys (locator, keys) {
     return this.retryOnStale(async () => {
       const element = await this.waitForDisplayed(locator)
+      await this.scrollTo(element)
       await element.click()
       await element.clear()
       return element.sendKeys(keys)


### PR DESCRIPTION
## Proposed Changes

Implement feature requests:
- RMQ-3752 (encrypted http basic credentials)
- RMQ-2544 (move all cookie management to server-side so that we can fully secure them)

The consequences of implementing the second change are the following:
- Removal of the loggedIn cookie: The loggedIn cookie has been completely removed from both the backend API and the client-side JavaScript. The Management UI no longer relies on cookies for session tracking.
- Client-side session enforcement via localStorage: The Management UI enforces session timeouts proactively. Before dispatching any HTTP request, the client verifies that the current browser time has not exceeded the session_expiry timestamp stored in localStorage during login.
- Server-side TTL for encrypted credentials: When RabbitMQ is configured to use encrypted basic credentials (credential_encryption_secret), the backend embeds an expiry timestamp inside the encrypted token payload. The server now actively enforces it during token decryption. This ensures that even if a user manipulates their localStorage timestamp, the stateless backend will securely reject the expired token with a 401 Unauthorized ("Session expired") response.

docs pr: https://github.com/rabbitmq/rabbitmq-website/pull/2543

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
