### PR TITLE
OAuth 2: honour fractional exp token expiry timestamps

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -160,8 +160,9 @@ update_state(AuthUser, NewToken) ->
 -spec expiry_timestamp(rabbit_types:auth_user()) -> integer() | never.
 expiry_timestamp(#auth_user{impl = DecodedTokenFun}) ->
     case DecodedTokenFun() of
-        #{<<"exp">> := Exp} when is_integer(Exp) ->
-            Exp;
+        %% "exp" may be a fractional NumericDate (RFC 7519); accept floats too.
+        #{<<"exp">> := Exp} when is_number(Exp) ->
+            trunc(Exp);
         _ ->
             never
     end.
@@ -235,10 +236,12 @@ ensure_same_username(PreferredUsernameClaims, CurrentDecodedToken, NewDecodedTok
         _ -> {error, mismatch_username_after_token_refresh}
     end.
 
-validate_token_expiry(#{<<"exp">> := Exp}) when is_integer(Exp) ->
+%% "exp" may be a fractional NumericDate (RFC 7519); accept floats too.
+validate_token_expiry(#{<<"exp">> := Exp}) when is_number(Exp) ->
+    ExpSeconds = trunc(Exp),
     Now = os:system_time(seconds),
-    case Exp =< Now of
-        true  -> {error, rabbit_misc:format("Provided JWT token has expired at timestamp ~tp (validated at ~tp)", [Exp, Now])};
+    case ExpSeconds =< Now of
+        true  -> {error, rabbit_misc:format("Provided JWT token has expired at timestamp ~tp (validated at ~tp)", [ExpSeconds, Now])};
         false -> ok
     end;
 validate_token_expiry(#{}) -> ok.

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -40,6 +40,7 @@ all() ->
         test_restricted_vhost_access_with_a_valid_token,
         test_insufficient_permissions_in_a_valid_token,
         test_token_expiration,
+        test_token_expiration_with_float_exp,
         test_invalid_signature,
         test_incorrect_kid,
         normalize_token_scope_using_multiple_scopes_key,
@@ -1175,6 +1176,31 @@ test_insufficient_permissions_in_a_valid_token(_) ->
     assert_resource_access_denied(User, VHost, <<"bar">>, write),
     assert_topic_access_refused(User, VHost, <<"bar">>, read,
         #{routing_key => <<"foo/#">>}).
+
+%% A fractional "exp" (RFC 7519) must still be honoured: an expired float
+%% "exp" is rejected at login, a future one yields a numeric expiry_timestamp.
+test_token_expiration_with_float_exp(_) ->
+    Username = <<"username">>,
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    set_env(key_config, UaaEnv),
+    set_env(resource_server_id, <<"rabbitmq">>),
+
+    Now = os:system_time(seconds),
+
+    ExpiredToken = (?UTIL_MOD:token_with_sub(?UTIL_MOD:fixture_token(), Username))#{
+        <<"exp">> => (Now - 10) + 0.5},
+    ExpiredSigned = ?UTIL_MOD:sign_token_hs(ExpiredToken, Jwk),
+    ?assertMatch({refused, _, _},
+                 user_login_authentication(Username, [{password, ExpiredSigned}])),
+
+    FutureExp = Now + 60,
+    ValidToken = (?UTIL_MOD:token_with_sub(?UTIL_MOD:fixture_token(), Username))#{
+        <<"exp">> => FutureExp + 0.5},
+    ValidSigned = ?UTIL_MOD:sign_token_hs(ValidToken, Jwk),
+    {ok, #auth_user{username = Username} = User} =
+        user_login_authentication(Username, [{password, ValidSigned}]),
+    ?assertEqual(FutureExp, rabbit_auth_backend_oauth2:expiry_timestamp(User)).
 
 test_invalid_signature(_) ->
     Username = <<"username">>,


### PR DESCRIPTION
RFC 7519 allows exp to be a fractional value but
`validate_token_expiry/1` and `expiry_timestamp/1` both guarded on `is_integer/1`.
