### PR TITLE
MQTT: fix a couple of flakes (`v4.2.x`)

### DIFF
--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -1692,10 +1692,10 @@ trace(Config) ->
                    <<"routed_queues">> := [<<"mqtt-subscription-trace_subscriberqos0">>]},
                  rabbit_misc:amqp_table(PublishHeaders)),
 
-    {#'basic.get_ok'{routing_key = <<"deliver.mqtt-subscription-trace_subscriberqos0">>},
-     #amqp_msg{props = #'P_basic'{headers = DeliverHeaders},
-               payload = Payload}} =
-    amqp_channel:call(Ch, #'basic.get'{queue = TraceQ}),
+    {_, #amqp_msg{props = #'P_basic'{headers = DeliverHeaders}, payload = Payload}} =
+        ?awaitMatch({#'basic.get_ok'{routing_key = <<"deliver.mqtt-subscription-trace_subscriberqos0">>}, _},
+                    amqp_channel:call(Ch, #'basic.get'{queue = TraceQ}),
+                    5_000),
     ?assertMatch(#{<<"exchange_name">> := <<"amq.topic">>,
                    <<"routing_keys">> := [Topic],
                    <<"connection">> := <<"127.0.0.1:", _/binary>>,

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -164,6 +164,10 @@ login_timeout(Config) ->
 
 stats(Config) ->
     C = connect(?FUNCTION_NAME, Config),
+    %% A connection from a prior (shuffled) test case may still be deregistering.
+    rabbit_ct_helpers:await_condition(fun() ->
+        length(all_connection_pids(Config)) =:= 1
+    end, 10_000),
     [Pid] = all_connection_pids(Config),
     [{pid, Pid}] = rpc(Config, rabbit_mqtt_reader, info, [Pid, [pid]]),
     rabbit_ct_helpers:await_condition(fun() ->
@@ -276,6 +280,10 @@ rabbit_mqtt_qos0_queue_overflow(Config) ->
                         {buffer, 256}]}],
     Sub = connect(<<"subscriber">>, Config, Opts),
     {ok, _, [0]} = emqtt:subscribe(Sub, Topic, qos0),
+    %% A connection from a prior (shuffled) test case may still be deregistering.
+    rabbit_ct_helpers:await_condition(fun() ->
+        length(all_connection_pids(Config)) =:= 1
+    end, 10_000),
     [ServerConnectionPid] = all_connection_pids(Config),
 
     %% Suspend the receiving client such that it stops reading from its socket


### PR DESCRIPTION
One of these flakes was previously fixed in `main` and `v4.3.x`.
