### PR TITLE
Add ETag/conditional request support to the definitions endpoint

### DIFF
--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -131,6 +131,9 @@
          status/0,
          cli_cluster_status/0]).
 
+%% Cheap, monotonic store version used to derive HTTP cache validators.
+-export([metadata_store_version/0]).
+
 %% "Proxy" functions to Khepri query/update API.
 -export([is_empty/0,
 
@@ -1114,6 +1117,33 @@ get_ra_key_metrics(Node) ->
              end,
     Metrics1 = Metrics0#{machine_version => MacVer},
     Metrics1.
+
+-spec metadata_store_version() -> {ok, Version} | unavailable when
+      Version :: {Term :: non_neg_integer(), LastApplied :: non_neg_integer()}.
+%% @doc Returns a cheap version token for the metadata store.
+%%
+%% The token is the local Ra server's `{term, last_applied}' pair. The applied
+%% index advances on every metadata write. The term is included so the token
+%% still changes across a store reset or member re-initialisation, which can
+%% restart the index from a lower value (a plain index could otherwise collide
+%% with an older state at the same index). It is meant to be used as an HTTP
+%% cache validator (ETag): it always changes when definitions change (no false
+%% negatives), but may also change for unrelated metadata writes (false
+%% positives, which only cost an extra full response). `unavailable' is
+%% returned when the local Ra server cannot be queried cheaply, e.g. early
+%% during boot.
+
+metadata_store_version() ->
+    ServerId = {?RA_CLUSTER_NAME, node()},
+    try ra:key_metrics(ServerId) of
+        #{term := Term, last_applied := LastApplied} ->
+            {ok, {Term, LastApplied}};
+        _ ->
+            unavailable
+    catch
+        _:_ ->
+            unavailable
+    end.
 
 -spec cli_cluster_status() -> Status when
       Status :: [{nodes, [{disc, [node()]}]} |

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -10,7 +10,7 @@
 -export([init/2, to_json/2, content_types_provided/2, is_authorized/2]).
 -export([content_types_accepted/2, allowed_methods/2, accept_json/2]).
 -export([accept_multipart/2]).
--export([variances/2]).
+-export([variances/2, generate_etag/2]).
 
 -include("rabbit_mgmt.hrl").
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
@@ -27,6 +27,28 @@ variances(Req, Context) ->
 
 content_types_provided(ReqData, Context) ->
    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+
+%% Conditional request support: derive a cheap ETag from the metadata store
+%% version (plus the product version, the requested scope and the negotiated
+%% media type) so that an up-to-date client gets a 304 and we never build the
+%% definitions body. Returns 'undefined' (disabling conditional handling) when
+%% the store version cannot be obtained cheaply, e.g. when Khepri is not the
+%% active metadata store.
+generate_etag(ReqData, Context) ->
+    case rabbit_khepri:metadata_store_version() of
+        {ok, StoreVersion} ->
+            Scope = case rabbit_mgmt_util:vhost(ReqData) of
+                        none      -> cluster;
+                        not_found -> cluster;
+                        VHost     -> VHost
+                    end,
+            MediaType = maps:get(media_type, ReqData, undefined),
+            Vsn = rabbit:base_product_version(),
+            Tag = erlang:phash2({Vsn, Scope, MediaType, StoreVersion}),
+            {{strong, integer_to_binary(Tag, 16)}, ReqData, Context};
+        unavailable ->
+            {undefined, ReqData, Context}
+    end.
 
 content_types_accepted(ReqData, Context) ->
    {[{{<<"application">>, <<"json">>, '*'}, accept_json},

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -110,7 +110,8 @@ definitions_group3_tests() ->
 
 definitions_group4_tests() ->
     [
-        definitions_vhost_test
+        definitions_vhost_test,
+        definitions_etag_test
     ].
 
 default_queue_type_group_tests() ->
@@ -2476,6 +2477,61 @@ definitions_large_streamed_test(Config) ->
     ?assert(is_map(maps:get(limits, Defs))),
 
     http_delete(Config, "/vhosts/" ++ VHost, {group, '2xx'}),
+    passed.
+
+definitions_etag_test(Config) ->
+    %% Conditional request support relies on the Khepri metadata store version.
+    case rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_khepri, metadata_store_version, []) of
+        unavailable ->
+            {skip, "metadata store version is unavailable (Khepri not enabled)"};
+        {ok, _} ->
+            definitions_etag_test0(Config)
+    end.
+
+definitions_etag_test0(Config) ->
+    http_put(Config, "/queues/%2F/etag-queue", #{durable => true}, {group, '2xx'}),
+
+    %% A regular request returns 200 with a (strong) ETag.
+    {ok, {{_, 200, _}, JsonHeaders, _}} =
+        req(Config, get, "/definitions", [auth_header("guest", "guest")]),
+    JsonETag = proplists:get_value("etag", JsonHeaders),
+    ?assert(JsonETag =/= undefined),
+
+    %% A different scope (single virtual host) yields a different ETag even
+    %% though the store version is identical.
+    {ok, {{_, 200, _}, VhostHeaders, _}} =
+        req(Config, get, "/definitions/%2F", [auth_header("guest", "guest")]),
+    VhostETag = proplists:get_value("etag", VhostHeaders),
+    ?assert(VhostETag =/= undefined),
+    ?assertNotEqual(JsonETag, VhostETag),
+
+    %% A different representation (BERT) also yields a different ETag.
+    {ok, {{_, 200, _}, BertHeaders, _}} =
+        req(Config, get, "/definitions",
+            [auth_header("guest", "guest"), {"accept", "application/bert"}]),
+    BertETag = proplists:get_value("etag", BertHeaders),
+    ?assert(BertETag =/= undefined),
+    ?assertNotEqual(JsonETag, BertETag),
+
+    %% A conditional request with the current ETag is answered with 304 and an
+    %% empty body, i.e. the definitions are not generated at all.
+    {ok, {{_, 304, _}, _, Body304}} =
+        req(Config, get, "/definitions",
+            [auth_header("guest", "guest"), {"if-none-match", JsonETag}]),
+    ?assertEqual([], Body304),
+
+    %% Changing the topology changes the ETag, so the same conditional request
+    %% now returns the full response with a fresh ETag.
+    http_put(Config, "/queues/%2F/etag-queue-2", #{durable => true}, {group, '2xx'}),
+    {ok, {{_, 200, _}, FreshHeaders, _}} =
+        req(Config, get, "/definitions",
+            [auth_header("guest", "guest"), {"if-none-match", JsonETag}]),
+    FreshETag = proplists:get_value("etag", FreshHeaders),
+    ?assert(FreshETag =/= undefined),
+    ?assertNotEqual(JsonETag, FreshETag),
+
+    http_delete(Config, "/queues/%2F/etag-queue", {group, '2xx'}),
+    http_delete(Config, "/queues/%2F/etag-queue-2", {group, '2xx'}),
     passed.
 
 definitions_password_test(Config) ->


### PR DESCRIPTION
## Proposed Changes

Polling GET /api/definitions regenerates the entire payload on every request, even when nothing has changed. Add an ETag so that an up-to-date client receives a 304 Not Modified and the definitions are never built.

The validator is derived without building the response, from:

 * the product version, so an upgrade invalidates cached definitions
 * the requested scope (whole cluster vs a single virtual host)
 * the negotiated media type (JSON vs BERT)
 * a cheap metadata store version token

The store version token is the local Ra server's `{term, last_applied}` pair, exposed by the new `rabbit_khepri:metadata_store_version/0`. The applied index advances on every metadata write, so the token never fails to change when definitions change. The term is included so the token also changes across a store reset or member re-initialisation, which can restart the index from a lower value (a plain index could otherwise collide with an older state at the same index). Unrelated metadata writes may change the token too, which only costs an extra full response. When the Ra server cannot be queried cheaply (for example early during boot) `metadata_store_version/0` returns `unavailable` and `generate_etag/2` returns `undefined`, so the full response is served as before.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
