### PR TITLE
Make definition export over the HTTP API more efficient by combining incremental encoding with HTTP response streaming

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -507,7 +507,8 @@ get_all_for_destination(Dst) ->
 %% and folding over the returned binding list.
 %%
 %% Just used by prometheus_rabbitmq_core_metrics_collector to iterate over the
-%% bindings.
+%% bindings. Runs the callback inside the Khepri server process; for callbacks
+%% that may block (e.g. streaming), use `fold_projection/2` instead.
 %%
 %% @returns the fold accumulator.
 %%

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -20,7 +20,8 @@
          get_all/3,
          get_all_for_source/1,
          get_all_for_destination/1,
-         fold/2]).
+         fold/2,
+         fold_projection/2]).
 
 %% Routing. These functions are in the hot code path
 -export([match/2, match_routing_key/3]).
@@ -377,6 +378,28 @@ get_all() ->
     catch
         error:badarg ->
             []
+    end.
+
+-spec fold_projection(Fun, Acc) -> Acc when
+      Fun :: fun((Binding :: rabbit_types:binding(), Acc) -> Acc),
+      Acc :: any().
+%% @doc Folds over all explicit binding records from the local projection,
+%% without building an intermediate list.
+%%
+%% Unlike `fold/2`, this runs in the calling process rather than the Khepri
+%% server process, so the callback may block (e.g. on streaming backpressure)
+%% without stalling the metadata store.
+%%
+%% @private
+
+fold_projection(Fun, Acc) ->
+    try
+        ets:foldl(
+          fun(#route{binding = Binding}, Acc0) -> Fun(Binding, Acc0) end,
+          Acc, ?KHEPRI_BINDINGS_PROJECTION)
+    catch
+        error:badarg ->
+            Acc
     end.
 
 -spec get_all(VHostName) -> [Binding] when

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -22,6 +22,7 @@
          get_targets/1,
          get_all/0,
          get_all/1,
+         fold/2,
          get_all_by_type/1,
          get_all_by_type_and_vhost/2,
          get_all_by_type_and_node/3,
@@ -98,6 +99,29 @@ get_all() ->
               catch
                   error:badarg ->
                       []
+              end
+      end).
+
+-spec fold(Fun, Acc) -> Acc when
+      Fun :: fun((Queue :: amqqueue:amqqueue(), Acc) -> Acc),
+      Acc :: term().
+
+%% @doc Folds over all queue records without materialising them into a list,
+%% making it more memory-efficient than get_all/0 followed by a fold over the
+%% returned list. Useful when iterating over very large numbers of queues.
+%%
+%% @returns the fold accumulator.
+%%
+%% @private
+
+fold(Fun, Acc) ->
+    list_with_possible_retry(
+      fun() ->
+              try
+                  ets:foldl(Fun, Acc, ?KHEPRI_PROJECTION)
+              catch
+                  error:badarg ->
+                      Acc
               end
       end).
 

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -107,7 +107,7 @@ get_all() ->
       Acc :: term().
 
 %% @doc Folds over all queue records without materialising them into a list,
-%% making it more memory-efficient than get_all/0 followed by a fold over the
+%% making it more memory-efficient than `get_all/0` followed by a fold over the
 %% returned list. Useful when iterating over very large numbers of queues.
 %%
 %% @returns the fold accumulator.

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -114,16 +114,15 @@ get_all() ->
 %%
 %% @private
 
+%% Not wrapped in list_with_possible_retry/1: the callback may have side effects
+%% and the accumulator is arbitrary, so the fold must never be replayed.
 fold(Fun, Acc) ->
-    list_with_possible_retry(
-      fun() ->
-              try
-                  ets:foldl(Fun, Acc, ?KHEPRI_PROJECTION)
-              catch
-                  error:badarg ->
-                      Acc
-              end
-      end).
+    try
+        ets:foldl(Fun, Acc, ?KHEPRI_PROJECTION)
+    catch
+        error:badarg ->
+            Acc
+    end.
 
 -spec get_all(VHostName) -> [Queue] when
       VHostName :: vhost:name(),

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -48,7 +48,7 @@
          should_skip_if_unchanged/0
         ]).
 
--export([all_definitions/0]).
+-export([all_definitions/0, fold_queues/3, fold_bindings/3]).
 -export([
   list_users/0, list_vhosts/0, list_permissions/0, list_topic_permissions/0,
   list_runtime_parameters/0, list_global_runtime_parameters/0, list_policies/0,
@@ -295,6 +295,47 @@ all_definitions() ->
         bindings          => Bs,
         exchanges         => Xs
     }.
+
+-spec fold_queues(Scope, Fun, Acc) -> Acc when
+      Scope :: all | {vhost, vhost:name()},
+      Fun :: fun((Queue :: map(), Acc) -> Acc),
+      Acc :: term().
+%% @doc Folds over exported queues as definition maps, optionally restricted to
+%% a single virtual host, without materialising the full queue list. Exclusive
+%% queues are skipped, as they cannot be restored. See also list_queues/0.
+fold_queues(Scope, Fun, Acc) ->
+    rabbit_db_queue:fold(
+      fun(Q, Acc0) ->
+              case amqqueue:get_exclusive_owner(Q) of
+                  none ->
+                      #resource{virtual_host = VHost} = amqqueue:get_name(Q),
+                      case Scope of
+                          all            -> Fun(queue_definition(Q), Acc0);
+                          {vhost, VHost} -> Fun(queue_definition(Q), Acc0);
+                          _              -> Acc0
+                      end;
+                  _ ->
+                      Acc0
+              end
+      end, Acc).
+
+-spec fold_bindings(Scope, Fun, Acc) -> Acc when
+      Scope :: all | {vhost, vhost:name()},
+      Fun :: fun((Binding :: map(), Acc) -> Acc),
+      Acc :: term().
+%% @doc Folds over exported (explicit) bindings as definition maps, optionally
+%% restricted to a single virtual host, without materialising the full binding
+%% list, which matters on data sets with very many bindings. See also
+%% list_bindings/0.
+fold_bindings(Scope, Fun, Acc) ->
+    rabbit_db_binding:fold(
+      fun(#binding{source = #resource{virtual_host = VHost}} = Binding, Acc0) ->
+              case Scope of
+                  all            -> Fun(binding_definition(Binding), Acc0);
+                  {vhost, VHost} -> Fun(binding_definition(Binding), Acc0);
+                  _              -> Acc0
+              end
+      end, Acc).
 
 -spec has_configured_definitions_to_load() -> boolean().
 has_configured_definitions_to_load() ->

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -1114,11 +1114,7 @@ exchange_definition(#exchange{name = #resource{virtual_host = VHost, name = Name
       <<"arguments">> => rabbit_misc:amqp_table(Args)}.
 
 list_queues() ->
-    %% exclude exclusive queues, they cannot be restored
-    [queue_definition(Q) || Q <- lists:filter(fun(Q0) ->
-                                                amqqueue:get_exclusive_owner(Q0) =:= none
-                                              end,
-                                              rabbit_amqqueue:list())].
+    lists:reverse(fold_queues(all, fun(Q, Acc) -> [Q | Acc] end, [])).
 
 queue_definition(Q) ->
     #resource{virtual_host = VHost, name = Name} = amqqueue:get_name(Q),
@@ -1156,7 +1152,7 @@ vhost_definition(VHost) ->
     Name = vhost:get_name(VHost),
     #{
         <<"name">> => Name,
-        <<"limits">> => vhost:get_limits(VHost),
+        <<"limits">> => maps:from_list(vhost:get_limits(VHost)),
         <<"metadata">> => vhost:get_metadata(VHost)
     }.
 

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -302,7 +302,7 @@ all_definitions() ->
       Acc :: term().
 %% @doc Folds over exported queues as definition maps, optionally restricted to
 %% a single virtual host, without materialising the full queue list. Exclusive
-%% queues are skipped, as they cannot be restored. See also list_queues/0.
+%% queues are skipped, as they cannot be restored. See also `list_queues/0`.
 fold_queues(Scope, Fun, Acc) ->
     rabbit_db_queue:fold(
       fun(Q, Acc0) ->
@@ -325,10 +325,10 @@ fold_queues(Scope, Fun, Acc) ->
       Acc :: term().
 %% @doc Folds over exported (explicit) bindings as definition maps, optionally
 %% restricted to a single virtual host, without materialising the full binding
-%% list, which matters on data sets with very many bindings. See also
-%% list_bindings/0.
+%% list. Uses the projection-based fold so the streaming callback runs in the
+%% calling process rather than the Khepri server process. See also `list_bindings/0`.
 fold_bindings(Scope, Fun, Acc) ->
-    rabbit_db_binding:fold(
+    rabbit_db_binding:fold_projection(
       fun(#binding{source = #resource{virtual_host = VHost}} = Binding, Acc0) ->
               case Scope of
                   all            -> Fun(binding_definition(Binding), Acc0);

--- a/deps/rabbitmq_management/src/rabbit_mgmt_login.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_login.erl
@@ -69,8 +69,8 @@ login(<<"GET">>, Req, State) ->
                                         <<>>, Req), State};
                 _ -> {ok, cowboy_req:reply(405, Req), State}
             end;
-        {Type, Value} -> 
-            redirect_to_home_with_cookie(?OAUTH2_BOOTSTRAP_PATH, Type, Value, Req, State)
+        {Type, Value} ->
+            redirect_to_home_with_cookie(Type, Value, Req, State)
     end;
 
 login(_, Req0, State) ->
@@ -82,7 +82,7 @@ handleStrictOrPreferredAuthMechanism(Req, Body, State) ->
             {ok, cowboy_req:reply(302, #{<<"Location">> => iolist_to_binary(get_home_uri(Req))}, 
                                         <<>>, Req), State};
         {Type, Value} ->
-            redirect_to_home_with_cookie(?OAUTH2_BOOTSTRAP_PATH, Type, Value, Req, State)
+            redirect_to_home_with_cookie(Type, Value, Req, State)
     end.
             
 get_auth_mechanism(Req, Body) ->
@@ -113,18 +113,17 @@ get_param_or_header(ParamName, Req, Body) ->
 handleAccessToken(Req0, AccessToken, State) ->
    case rabbit_mgmt_util:is_authorized_user(Req0, #context{}, <<"">>, AccessToken, false) of
         {true, Req1, _} ->
-            redirect_to_home_with_cookie(?OAUTH2_BOOTSTRAP_PATH,
-                                         ?OAUTH2_ACCESS_TOKEN,
+            redirect_to_home_with_cookie(?OAUTH2_ACCESS_TOKEN,
                                          AccessToken,
                                          Req1, State);
         {false, ReqData1, Reason} ->
             replyWithError(Reason, ReqData1, State)
     end.
 
-redirect_to_home_with_cookie(CookiePath, CookieName, CookieValue, Req=#{scheme := Scheme}, State) ->
+redirect_to_home_with_cookie(CookieName, CookieValue, Req=#{scheme := Scheme}, State) ->
     CookieSettings0 = #{
         http_only => true,
-        path => CookiePath,
+        path => rabbit_mgmt_util:get_oauth2_bootstrap_cookie_path(),
         max_age => 30,
         same_site => strict
     },

--- a/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
@@ -76,7 +76,7 @@ get_auth_mechanism(Req) ->
                                     <<"">>, Req, #{
                                         max_age => 0,
                                         http_only => true,
-                                        path => ?OAUTH2_BOOTSTRAP_PATH,
+                                        path => rabbit_mgmt_util:get_oauth2_bootstrap_cookie_path(),
                                         same_site => strict
                                 }),
                                 Auth
@@ -128,7 +128,7 @@ set_token_auth(AuthSettings, Req0) ->
                                     ?OAUTH2_ACCESS_TOKEN, <<"">>, Req0, #{
                                         max_age => 0,
                                         http_only => true,
-                                        path => ?OAUTH2_BOOTSTRAP_PATH,
+                                        path => rabbit_mgmt_util:get_oauth2_bootstrap_cookie_path(),
                                         same_site => strict
                                     }),
                                 ["set_token_auth(", rabbit_json:encode(Token), ");"]

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -46,6 +46,7 @@
 -export([direct_request/6]).
 -export([qs_val/2]).
 -export([get_path_prefix/0]).
+-export([get_oauth2_bootstrap_cookie_path/0]).
 -export([catch_no_such_user_or_vhost/2]).
 -export([method_not_allowed/3]).
 
@@ -465,6 +466,11 @@ fixup_prefix(EnvPrefix) when is_list(EnvPrefix) ->
     "/" ++ EnvPrefix;
 fixup_prefix(EnvPrefix) when is_binary(EnvPrefix) ->
     fixup_prefix(rabbit_data_coercion:to_list(EnvPrefix)).
+
+%% Path for the short-lived /login cookies. It must carry the HTTP API path
+%% prefix, or the browser will not send them to the prefixed bootstrap.js.
+get_oauth2_bootstrap_cookie_path() ->
+    iolist_to_binary([get_path_prefix(), ?OAUTH2_BOOTSTRAP_PATH]).
 
 %% XXX sort_list_and_paginate/2 is a more proper name for this function, keeping it
 %% with this name for backwards compatibility

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -114,7 +114,7 @@ small_parts({vhost, VHostName}) ->
                                         io_lib:format("Definitions of virtual host '~ts'", [VHostName])),
         metadata                   => vhost:get_metadata(VHost),
         description                => vhost:get_description(VHost),
-        limits                     => vhost:get_limits(VHost),
+        limits                     => maps:from_list(vhost:get_limits(VHost)),
         parameters                 => Keep(rabbit_definitions:list_runtime_parameters()),
         policies                   => Keep(rabbit_definitions:list_policies()),
         exchanges                  => Keep(rabbit_definitions:list_exchanges())

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -58,14 +58,17 @@ to_json(ReqData, Context) ->
 %% materialised in memory.
 export(Scope, ReqData0, Context) ->
     ReqData = maybe_content_disposition(ReqData0),
-    SmallParts = small_parts(Scope),
-    case maps:get(media_type, ReqData, undefined) of
-        {<<"application">>, <<"bert">>, _} ->
-            buffered(Scope, SmallParts, fun erlang:term_to_binary/1, ReqData, Context);
+    case cowboy_req:method(ReqData) of
+        %% A HEAD response carries no body, so skip gathering the definitions.
+        <<"HEAD">> ->
+            {<<>>, cowboy_req:set_resp_header(<<"cache-control">>, <<"no-cache">>, ReqData), Context};
         _ ->
-            case cowboy_req:method(ReqData) of
-                <<"GET">> -> stream_export(Scope, SmallParts, ReqData, Context);
-                _         -> buffered(Scope, SmallParts, fun rabbit_json:encode/1, ReqData, Context)
+            SmallParts = small_parts(Scope),
+            case maps:get(media_type, ReqData, undefined) of
+                {<<"application">>, <<"bert">>, _} ->
+                    buffered(Scope, SmallParts, fun erlang:term_to_binary/1, ReqData, Context);
+                _ ->
+                    stream_export(Scope, SmallParts, ReqData, Context)
             end
     end.
 
@@ -120,9 +123,8 @@ small_parts({vhost, VHostName}) ->
         exchanges                  => Keep(rabbit_definitions:list_exchanges())
     }.
 
-%% Buffered fallback for BERT (cannot be streamed incrementally) and HEAD
-%% (which must not carry a body). Queues and bindings are materialised here;
-%% the common GET+JSON path streams them instead.
+%% Buffered path for BERT, which cannot be streamed incrementally. Queues and
+%% bindings are materialised here; the common GET+JSON path streams them instead.
 buffered(Scope, SmallParts, Encode, ReqData0, Context) ->
     Queues   = lists:reverse(
                  rabbit_definitions:fold_queues(

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -212,11 +212,10 @@ stream_entries([{Key, Value} | Rest], ReqData, First) ->
 encode_key(Key) when is_atom(Key)   -> [$", atom_to_binary(Key, utf8), $"];
 encode_key(Key) when is_binary(Key) -> [$", Key, $"].
 
-%% Category lists (exchanges, users, ...) are lists of maps; they are streamed
-%% element by element, in batches, so a huge category never sits fully encoded
-%% in memory. Any other value -- scalars, maps, and proplists such as a virtual
-%% host's `limits' -- is encoded whole by rabbit_json, which correctly renders
-%% proplists as JSON objects.
+%% Category lists (exchanges, users, ...) are lists of maps streamed element by
+%% element, in batches, so a huge category never sits fully encoded in memory.
+%% Any other value (scalars and maps such as a vhost's metadata) is encoded
+%% whole by rabbit_json.
 stream_value([], ReqData) ->
     ok = cowboy_req:stream_body(<<"[]">>, nofin, ReqData);
 stream_value([H | _] = Value, ReqData) when is_map(H) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -12,8 +12,6 @@
 -export([accept_multipart/2]).
 -export([variances/2]).
 
--import(rabbit_misc, [pget/2]).
-
 -include("rabbit_mgmt.hrl").
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
@@ -40,51 +38,100 @@ allowed_methods(ReqData, Context) ->
 to_json(ReqData, Context) ->
     case rabbit_mgmt_util:vhost(ReqData) of
         none ->
-            all_definitions(ReqData, Context);
+            export(all, ReqData, Context);
         not_found ->
             rabbit_mgmt_util:bad_request(rabbit_data_coercion:to_binary("vhost_not_found"),
                                          ReqData, Context);
-        VHost ->
-            vhost_definitions(ReqData, VHost, Context)
+        VHostName ->
+            export({vhost, VHostName}, ReqData, Context)
     end.
 
-all_definitions(ReqData, Context) ->
-    Xs = [X || X <- rabbit_mgmt_wm_exchanges:basic(ReqData),
-               export_exchange(X)],
-    Qs = [Q || Q <- rabbit_mgmt_wm_queues:basic(ReqData),
-               export_queue(Q)],
-    QNames = [{pget(name, Q), pget(vhost, Q)} || Q <- Qs],
-    Bs = [B || B <- rabbit_mgmt_wm_bindings:basic(ReqData),
-               export_binding(B, QNames)],
-    Vsn = rabbit:base_product_version(),
-    ProductName = rabbit:product_name(),
-    ProductVersion = rabbit:product_version(),
+%% Single, scope-parameterised definitions export shared by the cluster-wide
+%% (GET /api/definitions) and per-virtual-host (GET /api/definitions/:vhost)
+%% endpoints. Scope is 'all' or {vhost, Name}.
+%%
+%% Everything but queues and bindings is gathered up front as maps (the
+%% canonical definition format from rabbit_definitions, the same one used by
+%% `rabbitmqctl export_definitions`), filtered to the virtual host when scoped.
+%% Queues and bindings -- the categories that grow without bound -- are streamed
+%% via rabbit_definitions:fold_queues/3 and fold_bindings/3, so they are never
+%% materialised in memory.
+export(Scope, ReqData0, Context) ->
+    ReqData = maybe_content_disposition(ReqData0),
+    SmallParts = small_parts(Scope),
+    case maps:get(media_type, ReqData, undefined) of
+        {<<"application">>, <<"bert">>, _} ->
+            buffered(Scope, SmallParts, fun erlang:term_to_binary/1, ReqData, Context);
+        _ ->
+            case cowboy_req:method(ReqData) of
+                <<"GET">> -> stream_export(Scope, SmallParts, ReqData, Context);
+                _         -> buffered(Scope, SmallParts, fun rabbit_json:encode/1, ReqData, Context)
+            end
+    end.
 
-    Contents = [
-        {users,             rabbit_mgmt_wm_users:users(all)},
-        {vhosts,            rabbit_mgmt_wm_vhosts:basic()},
-        {permissions,       rabbit_mgmt_wm_permissions:permissions()},
-        {topic_permissions, rabbit_mgmt_wm_topic_permissions:topic_permissions()},
-        {parameters,        rabbit_mgmt_wm_parameters:basic(ReqData)},
-        {global_parameters, rabbit_mgmt_wm_global_parameters:basic()},
-        {policies,          rabbit_mgmt_wm_policies:basic(ReqData)},
-        {queues,            Qs},
-        {exchanges,         Xs},
-        {bindings,          Bs}
-    ],
+%% Gathers every category except queues and bindings. The version/product
+%% metadata and which categories are included depend on the scope; for a single
+%% virtual host the per-item 'vhost' field is stripped, matching the historical
+%% behaviour.
+small_parts(all) ->
+    Vsn = rabbit_data_coercion:to_binary(rabbit:base_product_version()),
+    ClusterName = rabbit_nodes:cluster_name(),
+    #{
+        rabbit_version             => Vsn,
+        rabbitmq_version           => Vsn,
+        product_name               => rabbit_data_coercion:to_binary(rabbit:product_name()),
+        product_version            => rabbit_data_coercion:to_binary(rabbit:product_version()),
+        rabbitmq_definition_format => <<"cluster">>,
+        original_cluster_name      => ClusterName,
+        explanation                => rabbit_data_coercion:to_binary(
+                                        io_lib:format("Definitions of cluster '~ts'", [ClusterName])),
+        users                      => rabbit_definitions:list_users(),
+        vhosts                     => rabbit_definitions:list_vhosts(),
+        permissions                => rabbit_definitions:list_permissions(),
+        topic_permissions          => rabbit_definitions:list_topic_permissions(),
+        parameters                 => rabbit_definitions:list_runtime_parameters(),
+        global_parameters          => rabbit_definitions:list_global_runtime_parameters(),
+        policies                   => rabbit_definitions:list_policies(),
+        exchanges                  => rabbit_definitions:list_exchanges()
+    };
+small_parts({vhost, VHostName}) ->
+    VHost = rabbit_vhost:lookup(VHostName),
+    Vsn = rabbit_data_coercion:to_binary(rabbit:base_product_version()),
+    %% Filter the cluster-wide category to this virtual host and drop the now
+    %% redundant 'vhost' field from each item.
+    Keep = fun(List) ->
+                   [maps:remove(<<"vhost">>, Item)
+                    || Item <- List, maps:get(<<"vhost">>, Item, undefined) =:= VHostName]
+           end,
+    #{
+        rabbit_version             => Vsn,
+        rabbitmq_version           => Vsn,
+        product_name               => rabbit_data_coercion:to_binary(rabbit:product_name()),
+        product_version            => rabbit_data_coercion:to_binary(rabbit:product_version()),
+        rabbitmq_definition_format => <<"single_virtual_host">>,
+        original_vhost_name        => VHostName,
+        explanation                => rabbit_data_coercion:to_binary(
+                                        io_lib:format("Definitions of virtual host '~ts'", [VHostName])),
+        metadata                   => vhost:get_metadata(VHost),
+        description                => vhost:get_description(VHost),
+        limits                     => vhost:get_limits(VHost),
+        parameters                 => Keep(rabbit_definitions:list_runtime_parameters()),
+        policies                   => Keep(rabbit_definitions:list_policies()),
+        exchanges                  => Keep(rabbit_definitions:list_exchanges())
+    }.
 
-    TopLevelDefsAndMetadata = [
-        {rabbit_version, rabbit_data_coercion:to_binary(Vsn)},
-        {rabbitmq_version, rabbit_data_coercion:to_binary(Vsn)},
-        {product_name, rabbit_data_coercion:to_binary(ProductName)},
-        {product_version, rabbit_data_coercion:to_binary(ProductVersion)},
-        {rabbitmq_definition_format, <<"cluster">>},
-        {original_cluster_name, rabbit_nodes:cluster_name()},
-        {explanation, rabbit_data_coercion:to_binary(io_lib:format("Definitions of cluster '~ts'", [rabbit_nodes:cluster_name()]))}
-    ],
-    Result = TopLevelDefsAndMetadata ++ retain_whitelisted(Contents),
-    ReqData1 = maybe_content_disposition(ReqData),
-    rabbit_mgmt_util:reply(Result, ReqData1, Context).
+%% Buffered fallback for BERT (cannot be streamed incrementally) and HEAD
+%% (which must not carry a body). Queues and bindings are materialised here;
+%% the common GET+JSON path streams them instead.
+buffered(Scope, SmallParts, Encode, ReqData0, Context) ->
+    Queues   = lists:reverse(
+                 rabbit_definitions:fold_queues(
+                   Scope, fun(Q, Acc) -> [maybe_strip(Scope, Q) | Acc] end, [])),
+    Bindings = lists:reverse(
+                 rabbit_definitions:fold_bindings(
+                   Scope, fun(B, Acc) -> [maybe_strip(Scope, B) | Acc] end, [])),
+    ReqData = cowboy_req:set_resp_header(<<"cache-control">>, <<"no-cache">>, ReqData0),
+    {Encode(SmallParts#{queues => Queues, bindings => Bindings}), ReqData, Context}.
 
 maybe_content_disposition(ReqData) ->
     Constraint = cowboy_constraints:from_fun(fun cow_http:ensure_token/1),
@@ -98,6 +145,104 @@ maybe_content_disposition(ReqData) ->
                 ReqData)
     end.
 
+maybe_strip({vhost, _}, Map) -> maps:remove(<<"vhost">>, Map);
+maybe_strip(all, Map)        -> Map.
+
+%% Number of array elements (queues, bindings) encoded per streamed chunk.
+%% Large enough to keep HTTP chunk overhead low, small enough to bound peak
+%% memory.
+-define(STREAM_BATCH_SIZE, 2000).
+
+%% Streams the JSON response without ever materialising the whole document. The
+%% small categories are streamed first, then queues and bindings are folded
+%% straight from the store into the socket in batches. The cowboy_rest
+%% content-type response header is already set when the provider callback runs,
+%% so stream_reply/3 picks it up; we only add cache-control. Returns {stop, ...}
+%% so cowboy_rest treats the response as already sent.
+stream_export(Scope, SmallParts, ReqData0, Context) ->
+    ReqData1 = cowboy_req:set_resp_header(<<"cache-control">>, <<"no-cache">>, ReqData0),
+    ReqData = cowboy_req:stream_reply(200, #{}, ReqData1),
+    ok = cowboy_req:stream_body(<<"{">>, nofin, ReqData),
+    %% small_parts/1 always contains metadata, so it is never empty: the folded
+    %% categories below can unconditionally be comma-prefixed.
+    stream_entries(maps:to_list(SmallParts), ReqData, true),
+    stream_folded(<<"queues">>, fun rabbit_definitions:fold_queues/3, Scope, ReqData),
+    stream_folded(<<"bindings">>, fun rabbit_definitions:fold_bindings/3, Scope, ReqData),
+    ok = cowboy_req:stream_body(<<"}">>, fin, ReqData),
+    {stop, ReqData, Context}.
+
+%% Streams `"Key":[ ... ]' where the array elements are produced by
+%% FoldFun(Scope, Fun, Acc), batched so at most ?STREAM_BATCH_SIZE items are
+%% held at a time. Always comma-prefixed (small_parts is never empty).
+stream_folded(Key, FoldFun, Scope, ReqData) ->
+    ok = cowboy_req:stream_body([$,, $", Key, $", $:, $[], nofin, ReqData),
+    {ReqData, First, Pending, _N} =
+        FoldFun(Scope,
+                fun(Item, {Req, Fst, Batch, N}) ->
+                        Item1 = maybe_strip(Scope, Item),
+                        case N + 1 >= ?STREAM_BATCH_SIZE of
+                            true ->
+                                ok = cowboy_req:stream_body(
+                                       encode_batch(lists:reverse([Item1 | Batch]), Fst), nofin, Req),
+                                {Req, false, [], 0};
+                            false ->
+                                {Req, Fst, [Item1 | Batch], N + 1}
+                        end
+                end,
+                {ReqData, true, [], 0}),
+    case Pending of
+        [] -> ok;
+        _  -> ok = cowboy_req:stream_body(encode_batch(lists:reverse(Pending), First), nofin, ReqData)
+    end,
+    ok = cowboy_req:stream_body(<<"]">>, nofin, ReqData).
+
+stream_entries([], _ReqData, _First) ->
+    ok;
+stream_entries([{Key, Value} | Rest], ReqData, First) ->
+    Prefix = case First of
+                 true  -> [encode_key(Key), $:];
+                 false -> [$,, encode_key(Key), $:]
+             end,
+    ok = cowboy_req:stream_body(Prefix, nofin, ReqData),
+    stream_value(Value, ReqData),
+    stream_entries(Rest, ReqData, false).
+
+encode_key(Key) when is_atom(Key)   -> [$", atom_to_binary(Key, utf8), $"];
+encode_key(Key) when is_binary(Key) -> [$", Key, $"].
+
+%% Category lists (exchanges, users, ...) are lists of maps; they are streamed
+%% element by element, in batches, so a huge category never sits fully encoded
+%% in memory. Any other value -- scalars, maps, and proplists such as a virtual
+%% host's `limits' -- is encoded whole by rabbit_json, which correctly renders
+%% proplists as JSON objects.
+stream_value([], ReqData) ->
+    ok = cowboy_req:stream_body(<<"[]">>, nofin, ReqData);
+stream_value([H | _] = Value, ReqData) when is_map(H) ->
+    ok = cowboy_req:stream_body(<<"[">>, nofin, ReqData),
+    stream_array(Value, ReqData, true),
+    ok = cowboy_req:stream_body(<<"]">>, nofin, ReqData);
+stream_value(Value, ReqData) ->
+    ok = cowboy_req:stream_body(rabbit_json:encode(Value), nofin, ReqData).
+
+stream_array([], _ReqData, _First) ->
+    ok;
+stream_array(List, ReqData, First) ->
+    {Batch, Rest} = split_batch(List, ?STREAM_BATCH_SIZE, []),
+    ok = cowboy_req:stream_body(encode_batch(Batch, First), nofin, ReqData),
+    stream_array(Rest, ReqData, false).
+
+split_batch([H | T], N, Acc) when N > 0 -> split_batch(T, N - 1, [H | Acc]);
+split_batch(Rest, _N, Acc)              -> {lists:reverse(Acc), Rest}.
+
+%% First =:= true means this is the opening batch, whose first element must not
+%% be preceded by a comma. Every other element is comma-prefixed.
+encode_batch([], _First) ->
+    [];
+encode_batch([H | T], true) ->
+    [rabbit_json:encode(H) | encode_batch(T, false)];
+encode_batch([H | T], false) ->
+    [$,, rabbit_json:encode(H) | encode_batch(T, false)].
+
 accept_json(ReqData0, Context) ->
     BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size, ?MANAGEMENT_DEFAULT_HTTP_MAX_BODY_SIZE),
     case rabbit_mgmt_util:read_complete_body_with_limit(ReqData0, BodySizeLimit) of
@@ -108,53 +253,6 @@ accept_json(ReqData0, Context) ->
         {ok, Body, ReqData} ->
             accept(Body, ReqData, Context)
     end.
-
-vhost_definitions(ReqData, VHostName, Context) ->
-    %% the existence of this virtual host is verified in the called, 'to_json/2'
-    VHost = rabbit_vhost:lookup(VHostName),
-
-    %% rabbit_mgmt_wm_<>:basic/1 filters by VHost if it is available.
-    %% TODO: should we stop stripping virtual host? Such files cannot be imported on boot, for example.
-    Xs = [strip_vhost(X) || X <- rabbit_mgmt_wm_exchanges:basic(ReqData),
-               export_exchange(X)],
-    VQs = [Q || Q <- rabbit_mgmt_wm_queues:basic(ReqData), export_queue(Q)],
-    Qs = [strip_vhost(Q) || Q <- VQs],
-    QNames = [{pget(name, Q), pget(vhost, Q)} || Q <- VQs],
-    %% TODO: should we stop stripping virtual host? Such files cannot be imported on boot, for example.
-    Bs = [strip_vhost(B) || B <- rabbit_mgmt_wm_bindings:basic(ReqData),
-                            export_binding(B, QNames)],
-    Parameters = [strip_vhost(
-                    rabbit_mgmt_format:parameter(P))
-                  || P <- rabbit_runtime_parameters:list(VHostName)],
-    Contents = [
-        {parameters,  Parameters},
-        {policies,    [strip_vhost(P) || P <- rabbit_mgmt_wm_policies:basic(ReqData)]},
-        {queues,      Qs},
-        {exchanges,   Xs},
-        {bindings,    Bs}
-    ],
-
-    Vsn = rabbit:base_product_version(),
-    ProductName = rabbit:product_name(),
-    ProductVersion = rabbit:product_version(),
-
-    Metadata = vhost:get_metadata(VHost),
-
-    TopLevelDefsAndMetadata = [
-        {rabbit_version, rabbit_data_coercion:to_binary(Vsn)},
-        {rabbitmq_version, rabbit_data_coercion:to_binary(Vsn)},
-        {product_name, rabbit_data_coercion:to_binary(ProductName)},
-        {product_version, rabbit_data_coercion:to_binary(ProductVersion)},
-        {rabbitmq_definition_format, <<"single_virtual_host">>},
-        {original_vhost_name, VHostName},
-        {explanation, rabbit_data_coercion:to_binary(io_lib:format("Definitions of virtual host '~ts'", [VHostName]))},
-        {metadata, Metadata},
-        {description, vhost:get_description(VHost)},
-        {limits, vhost:get_limits(VHost)}
-    ],
-    Result = TopLevelDefsAndMetadata ++ retain_whitelisted(Contents),
-    ReqData1 = maybe_content_disposition(ReqData),
-    rabbit_mgmt_util:reply(Result, ReqData1, Context).
 
 accept_multipart(ReqData0, Context) ->
     BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size,
@@ -304,56 +402,3 @@ get_part(Name, Parts) ->
         false -> unknown;
         {_, Value} -> Value
     end.
-
-export_queue(Queue) ->
-    pget(owner_pid, Queue) == none.
-
-export_binding(Binding, Qs) ->
-    Src      = pget(source,           Binding),
-    Dest     = pget(destination,      Binding),
-    DestType = pget(destination_type, Binding),
-    VHost    = pget(vhost,            Binding),
-    Src =/= <<"">>
-        andalso
-          ( (DestType =:= queue andalso lists:member({Dest, VHost}, Qs))
-            orelse (DestType =:= exchange andalso Dest =/= <<"">>) ).
-
-export_exchange(Exchange) ->
-    export_name(pget(name, Exchange)).
-
-export_name(<<>>)                 -> false;
-export_name(<<"amq.", _/binary>>) -> false;
-export_name(_Name)                -> true.
-
-%%--------------------------------------------------------------------
-
-rw_state() ->
-    [{users,              [name, password_hash, hashing_algorithm, tags, limits]},
-     {vhosts,             [name, description, tags, metadata]},
-     {permissions,        [user, vhost, configure, write, read]},
-     {topic_permissions,  [user, vhost, exchange, write, read]},
-     {parameters,         [vhost, component, name, value]},
-     {global_parameters,  [name, value]},
-     {policies,           [vhost, name, pattern, definition, priority, 'apply-to']},
-     {queues,             [name, vhost, durable, auto_delete, arguments]},
-     {exchanges,          [name, vhost, type, durable, auto_delete, internal,
-                           arguments]},
-     {bindings,           [source, vhost, destination, destination_type, routing_key,
-                           arguments]}].
-
-retain_whitelisted(Items) ->
-    [retain_whitelisted_items(N, V, proplists:get_value(N, rw_state())) || {N, V} <- Items].
-
-retain_whitelisted_items(Name, List, Allowed) ->
-    {Name, [only_whitelisted_for_item(I, Allowed) || I <- List]}.
-
-only_whitelisted_for_item(Item, Allowed) when is_map(Item) ->
-    Map1 = maps:with(Allowed, Item),
-    maps:filter(fun(_Key, Val) ->
-                    Val =/= undefined
-                end, Map1);
-only_whitelisted_for_item(Item, Allowed) when is_list(Item) ->
-    [{K, Fact} || {K, Fact} <- Item, lists:member(K, Allowed), Fact =/= undefined].
-
-strip_vhost(Item) ->
-    lists:keydelete(vhost, 1, Item).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -104,7 +104,8 @@ definitions_group2_tests() ->
 definitions_group3_tests() ->
     [
         definitions_server_named_queue_test,
-        definitions_with_charset_test
+        definitions_with_charset_test,
+        definitions_large_streamed_test
     ].
 
 definitions_group4_tests() ->
@@ -2299,7 +2300,7 @@ definitions_vhost_metadata_test(Config) ->
     %% carries `name', `metadata' and `limits'; its description and tags live
     %% inside `metadata' rather than being duplicated at the top level.
     ?assertEqual(VHostName, maps:get(name, VH)),
-    ?assert(maps:is_key(limits, VH)),
+    ?assert(is_map(maps:get(limits, VH))),
     VHMetadata = maps:get(metadata, VH),
     ?assertEqual(Desc, maps:get(description, VHMetadata)),
     ?assertEqual(DQT, maps:get(default_queue_type, VHMetadata)),
@@ -2439,6 +2440,42 @@ definitions_vhost_test(Config) ->
     http_post(Config, "/definitions/othervhost", Upload, ?NOT_FOUND),
 
     unregister_parameters_and_policy_validator(Config),
+    passed.
+
+%% Exercises the streamed export across the STREAM_BATCH_SIZE (2000) boundary:
+%% every queue and binding must be returned exactly once, in the canonical
+%% format (queues carry their type), with the per-item vhost field stripped.
+definitions_large_streamed_test(Config) ->
+    VHost = "definitions-large-streamed",
+    http_put(Config, "/vhosts/" ++ VHost, #{}, {group, '2xx'}),
+    Perms = [{configure, <<".*">>}, {write, <<".*">>}, {read, <<".*">>}],
+    http_put(Config, "/permissions/" ++ VHost ++ "/guest", Perms, {group, '2xx'}),
+
+    N = 2200,
+    Names = [<<"lq-", (integer_to_binary(I))/binary>> || I <- lists:seq(1, N)],
+    Queues = [#{name => Name, durable => true} || Name <- Names],
+    Bindings = [#{source => <<"amq.direct">>, destination => Name,
+                  destination_type => <<"queue">>,
+                  routing_key => <<"rk-", (integer_to_binary(I))/binary>>,
+                  arguments => #{}}
+                || {I, Name} <- lists:zip(lists:seq(1, N), Names)],
+    http_post(Config, "/definitions/" ++ VHost,
+              #{queues => Queues, bindings => Bindings}, {group, '2xx'}),
+
+    Defs = http_get(Config, "/definitions/" ++ VHost, ?OK),
+    QS = maps:get(queues, Defs),
+    BS = maps:get(bindings, Defs),
+    %% Every item present exactly once: no drops or duplicates at batch edges.
+    ?assertEqual(N, length(QS)),
+    ?assertEqual(N, length(lists:usort([maps:get(name, Q) || Q <- QS]))),
+    ?assertEqual(N, length(BS)),
+    %% Canonical format: queues carry their type, the scoped export drops vhost.
+    ?assert(lists:all(fun(Q) -> maps:is_key(type, Q) end, QS)),
+    ?assertEqual([], [Q || Q <- QS, maps:is_key(vhost, Q)]),
+    %% Empty limits are exported as a JSON object, not a list.
+    ?assert(is_map(maps:get(limits, Defs))),
+
+    http_delete(Config, "/vhosts/" ++ VHost, {group, '2xx'}),
     passed.
 
 definitions_password_test(Config) ->

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -2294,12 +2294,16 @@ definitions_vhost_metadata_test(Config) ->
     {value, VH} = lists:search(fun(VH) ->
                                     maps:get(name, VH) =:= VHostName
                                 end, VHosts),
-    ?assertEqual(#{
-        name => VHostName,
-        description => Desc,
-        tags => Tags,
-        metadata => Metadata
-    }, VH),
+    %% The definitions export uses the canonical rabbit_definitions format
+    %% (the same one as `rabbitmqctl export_definitions`): a virtual host
+    %% carries `name', `metadata' and `limits'; its description and tags live
+    %% inside `metadata' rather than being duplicated at the top level.
+    ?assertEqual(VHostName, maps:get(name, VH)),
+    ?assert(maps:is_key(limits, VH)),
+    VHMetadata = maps:get(metadata, VH),
+    ?assertEqual(Desc, maps:get(description, VHMetadata)),
+    ?assertEqual(DQT, maps:get(default_queue_type, VHMetadata)),
+    ?assertEqual(Tags, maps:get(tags, VHMetadata)),
 
     %% Post the definitions back
     http_post(Config, "/definitions", Definitions, {group, '2xx'}),


### PR DESCRIPTION
This is #16725 without a number of issues, most notably its new `fold/2` implementation for bindings that was executed in the Khepri's Ra machine process, potentially blocking the metadata store for up to hundreds of milliseconds every time a definition export was requested over the HTTP API.

The improvements are meaningful: up to 10x or 18x reduction in transfer time and peak resource (CPU, memory) footprint.

The improvement particularly matters for clusters with a lot of bindings because the root cause was a quadratic operation in the binding filtering step. That code had been around since 2010-2011.