### PR TITLE
QQ AZ awareness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 # Plugins to enable for `gmake run-broker`, `gmake start-cluster`, etc.
 # To override:
 #     gmake ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream" run-broker
-#     gmake NODES=3 ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management" start-cluster
+#     gmake NODES=3 AZ=3 ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management" start-cluster
 #
 # Note: ENABLED_PLUGINS only takes effect on first start. On subsequent starts,
 # the enabled_plugins file is preserved. To change plugins on restart, either:

--- a/deps/rabbit/include/node_metadata.hrl
+++ b/deps/rabbit/include/node_metadata.hrl
@@ -1,0 +1,14 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2023-2026 Broadcom. All Rights Reserved. The term “Broadcom”
+%% refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+-type node_tag() :: {Key :: binary(), Value :: binary()}.
+-type node_metadata_map() :: #{node_tags => [node_tag()]}.
+
+-record(node_metadata, {
+          node :: node(),
+          metadata = #{} :: node_metadata_map()
+         }).

--- a/deps/rabbit/include/rabbit_khepri.hrl
+++ b/deps/rabbit/include/rabbit_khepri.hrl
@@ -24,6 +24,9 @@
 -define(RABBITMQ_KHEPRI_MAINTENANCE_PATH(Node),
         ?RABBITMQ_KHEPRI_ROOT_PATH([node_maintenance, Node])).
 
+-define(RABBITMQ_KHEPRI_NODE_METADATA_PATH(Node),
+        ?RABBITMQ_KHEPRI_ROOT_PATH([node_metadata, Node])).
+
 -define(RABBITMQ_KHEPRI_GLOBAL_RUNTIME_PARAM_PATH(Key),
         ?RABBITMQ_KHEPRI_ROOT_PATH([runtime_params, Key])).
 
@@ -62,3 +65,8 @@
 
 -define(RABBITMQ_KHEPRI_QUEUE_PATH(VHost, Name),
         ?RABBITMQ_KHEPRI_VHOST_PATH(VHost, [queues, Name])).
+
+-record(node_metadata, {
+          node,
+          metadata = #{}
+        }).

--- a/deps/rabbit/include/rabbit_khepri.hrl
+++ b/deps/rabbit/include/rabbit_khepri.hrl
@@ -24,8 +24,13 @@
 -define(RABBITMQ_KHEPRI_MAINTENANCE_PATH(Node),
         ?RABBITMQ_KHEPRI_ROOT_PATH([node_maintenance, Node])).
 
+-define(RABBITMQ_KHEPRI_NODE_PATH(Node),
+        ?RABBITMQ_KHEPRI_NODE_PATH(Node, [])).
+-define(RABBITMQ_KHEPRI_NODE_PATH(Node, Rest),
+        ?RABBITMQ_KHEPRI_ROOT_PATH([nodes, Node | Rest])).
+
 -define(RABBITMQ_KHEPRI_NODE_METADATA_PATH(Node),
-        ?RABBITMQ_KHEPRI_ROOT_PATH([node_metadata, Node])).
+        ?RABBITMQ_KHEPRI_NODE_PATH(Node, [node_metadata])).
 
 -define(RABBITMQ_KHEPRI_GLOBAL_RUNTIME_PARAM_PATH(Key),
         ?RABBITMQ_KHEPRI_ROOT_PATH([runtime_params, Key])).

--- a/deps/rabbit/include/rabbit_khepri.hrl
+++ b/deps/rabbit/include/rabbit_khepri.hrl
@@ -70,8 +70,3 @@
 
 -define(RABBITMQ_KHEPRI_QUEUE_PATH(VHost, Name),
         ?RABBITMQ_KHEPRI_VHOST_PATH(VHost, [queues, Name])).
-
--record(node_metadata, {
-          node,
-          metadata = #{}
-        }).

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2596,6 +2596,10 @@ end}.
   {datatype, {integer, positive}}
 ]}.
 
+{mapping, "quorum_queue.member_placement_tag", "rabbit.quorum_queue_member_placement_tag", [
+  {datatype, binary}
+]}.
+
 {mapping, "quorum_queue.commands_soft_limit", "rabbit.quorum_commands_soft_limit", [
   {datatype, {integer, positive}}
 ]}.

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -982,7 +982,8 @@ declare_args() ->
      {<<"x-stream-max-segment-size-bytes">>, fun check_non_neg_int_arg/2},
      {<<"x-stream-filter-size-bytes">>, fun check_non_neg_int_arg/2},
      {<<"x-initial-cluster-size">>, fun check_initial_cluster_size_arg/2},
-     {<<"x-queue-leader-locator">>, fun check_queue_leader_locator_arg/2}].
+     {<<"x-queue-leader-locator">>, fun check_queue_leader_locator_arg/2},
+     {<<"x-member-placement-tag">>, fun check_member_placement_tag_arg/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
                    {<<"x-consumer-timeout">>,      fun check_non_neg_int_arg/2},
@@ -1181,6 +1182,17 @@ check_queue_leader_locator_arg(Val, _Args) when is_binary(Val) ->
     end;
 check_queue_leader_locator_arg(_Val, _Args) ->
     {error, invalid_queue_locator_arg}.
+
+check_member_placement_tag_arg({longstr, Val}, _Args) when byte_size(Val) > 0 ->
+    ok;
+check_member_placement_tag_arg({longstr, _}, _Args) ->
+    {error, invalid_member_placement_tag_arg};
+check_member_placement_tag_arg({Type, _}, _Args) ->
+    {error, {unacceptable_type, Type}};
+check_member_placement_tag_arg(Val, _Args) when is_binary(Val), byte_size(Val) > 0 ->
+    ok;
+check_member_placement_tag_arg(_Val, _Args) ->
+    {error, invalid_member_placement_tag_arg}.
 
 check_stream_offset_arg(Val, _Args) ->
     case rabbit_stream_queue:parse_offset_arg(Val) of

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1189,7 +1189,7 @@ check_member_placement_tag_arg({longstr, _}, _Args) ->
     {error, invalid_member_placement_tag_arg};
 check_member_placement_tag_arg({Type, _}, _Args) ->
     {error, {unacceptable_type, Type}};
-check_member_placement_tag_arg(Val, _Args) when is_binary(Val), byte_size(Val) > 0 ->
+check_member_placement_tag_arg(Val, _Args) when is_binary(Val) andalso byte_size(Val) > 0 ->
     ok;
 check_member_placement_tag_arg(_Val, _Args) ->
     {error, invalid_member_placement_tag_arg}.

--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -74,6 +74,9 @@ init() ->
                "DB: initialization successful",
                #{domain => ?RMQLOG_DOMAIN_DB}),
 
+            LocalTags = application:get_env(rabbit, node_tags, []),
+            rabbit_db_node_metadata:set(node(), #{node_tags => LocalTags}),
+
             init_finished(),
 
             ok;

--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -75,7 +75,7 @@ init() ->
                #{domain => ?RMQLOG_DOMAIN_DB}),
 
             LocalTags = application:get_env(rabbit, node_tags, []),
-            rabbit_db_node_metadata:set(node(), #{node_tags => LocalTags}),
+            _ = rabbit_db_node_metadata:set(node(), #{node_tags => LocalTags}),
 
             init_finished(),
 

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -249,6 +249,7 @@ forget_member_using_khepri(_Node, true) ->
        #{domain => ?RMQLOG_DOMAIN_DB}),
     {error, not_supported};
 forget_member_using_khepri(Node, false = _RemoveWhenOffline) ->
+    _ = rabbit_db_node_metadata:delete(Node),
     rabbit_khepri:remove_member(Node).
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_node_metadata.erl
+++ b/deps/rabbit/src/rabbit_db_node_metadata.erl
@@ -17,7 +17,6 @@
 -export([
          set/2,
          get/1,
-         get_consistent/1,
          delete/1
         ]).
 
@@ -31,19 +30,19 @@
 %% set().
 %% -------------------------------------------------------------------
 
--spec set(node(), map()) -> boolean().
+-spec set(node(), map()) -> ok | {error, any()}.
 %% @doc Sets the node metadata map for the given node.
 set(Node, Metadata) when is_map(Metadata) ->
     Path = khepri_node_metadata_path(Node),
     Record = #node_metadata{node = Node, metadata = Metadata},
     case rabbit_khepri:put(Path, Record) of
-        ok ->
-            true;
-        Error ->
+        ok = Ok ->
+            Ok;
+        {error, _} = Error ->
             ?LOG_WARNING("Failed to store node metadata for ~ts in Khepri: ~tp",
                          [Node, Error],
                          #{domain => ?RMQLOG_DOMAIN_DB}),
-            false
+            Error
     end.
 
 %% -------------------------------------------------------------------
@@ -66,33 +65,14 @@ get(Node) ->
     end.
 
 %% -------------------------------------------------------------------
-%% get_consistent().
-%% -------------------------------------------------------------------
-
--spec get_consistent(node()) -> map().
-%% @doc Returns the node metadata map for the given node using a consistent query.
-get_consistent(Node) ->
-    Path = khepri_node_metadata_path(Node),
-    Options = #{favor => consistency},
-    case rabbit_khepri:get(Path, Options) of
-        {ok, #node_metadata{metadata = Metadata}} ->
-            Metadata;
-        _ ->
-            #{}
-    end.
-
-%% -------------------------------------------------------------------
 %% delete().
 %% -------------------------------------------------------------------
 
--spec delete(node()) -> boolean().
+-spec delete(node()) -> ok | {error, any()}.
 %% @doc Deletes the node metadata for the given node.
 delete(Node) ->
     Path = khepri_node_metadata_path(Node),
-    case rabbit_khepri:delete(Path) of
-        ok -> true;
-        _ -> false
-    end.
+    rabbit_khepri:delete(Path).
 
 %% -------------------------------------------------------------------
 %% Khepri paths

--- a/deps/rabbit/src/rabbit_db_node_metadata.erl
+++ b/deps/rabbit/src/rabbit_db_node_metadata.erl
@@ -13,6 +13,7 @@
 -include_lib("rabbit_common/include/logging.hrl").
 
 -include("include/rabbit_khepri.hrl").
+-include("include/node_metadata.hrl").
 
 -export([
          set/2,
@@ -30,7 +31,7 @@
 %% set().
 %% -------------------------------------------------------------------
 
--spec set(node(), map()) -> ok | {error, any()}.
+-spec set(node(), node_metadata_map()) -> ok | {error, any()}.
 %% @doc Sets the node metadata map for the given node.
 set(Node, Metadata) when is_map(Metadata) ->
     Path = khepri_node_metadata_path(Node),
@@ -49,7 +50,7 @@ set(Node, Metadata) when is_map(Metadata) ->
 %% get().
 %% -------------------------------------------------------------------
 
--spec get(node()) -> map().
+-spec get(node()) -> node_metadata_map().
 %% @doc Returns the node metadata map for the given node using the local ETS projection.
 get(Node) ->
     try

--- a/deps/rabbit/src/rabbit_db_node_metadata.erl
+++ b/deps/rabbit/src/rabbit_db_node_metadata.erl
@@ -1,0 +1,102 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_db_node_metadata).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbit_common/include/logging.hrl").
+
+-include("include/rabbit_khepri.hrl").
+
+-export([
+         set/2,
+         get/1,
+         get_consistent/1,
+         delete/1
+        ]).
+
+-export([
+         khepri_node_metadata_path/1
+        ]).
+
+-define(KHEPRI_PROJECTION, rabbit_khepri_node_metadata).
+
+%% -------------------------------------------------------------------
+%% set().
+%% -------------------------------------------------------------------
+
+-spec set(node(), map()) -> boolean().
+%% @doc Sets the node metadata map for the given node.
+set(Node, Metadata) when is_map(Metadata) ->
+    Path = khepri_node_metadata_path(Node),
+    Record = #node_metadata{node = Node, metadata = Metadata},
+    case rabbit_khepri:put(Path, Record) of
+        ok ->
+            true;
+        Error ->
+            ?LOG_WARNING("Failed to store node metadata for ~ts in Khepri: ~tp",
+                         [Node, Error],
+                         #{domain => ?RMQLOG_DOMAIN_DB}),
+            false
+    end.
+
+%% -------------------------------------------------------------------
+%% get().
+%% -------------------------------------------------------------------
+
+-spec get(node()) -> map().
+%% @doc Returns the node metadata map for the given node using the local ETS projection.
+get(Node) ->
+    try
+        case ets:lookup(?KHEPRI_PROJECTION, Node) of
+            [#node_metadata{metadata = Metadata}] ->
+                Metadata;
+            _ ->
+                #{}
+        end
+    catch
+        error:badarg ->
+            #{}
+    end.
+
+%% -------------------------------------------------------------------
+%% get_consistent().
+%% -------------------------------------------------------------------
+
+-spec get_consistent(node()) -> map().
+%% @doc Returns the node metadata map for the given node using a consistent query.
+get_consistent(Node) ->
+    Path = khepri_node_metadata_path(Node),
+    Options = #{favor => consistency},
+    case rabbit_khepri:get(Path, Options) of
+        {ok, #node_metadata{metadata = Metadata}} ->
+            Metadata;
+        _ ->
+            #{}
+    end.
+
+%% -------------------------------------------------------------------
+%% delete().
+%% -------------------------------------------------------------------
+
+-spec delete(node()) -> boolean().
+%% @doc Deletes the node metadata for the given node.
+delete(Node) ->
+    Path = khepri_node_metadata_path(Node),
+    case rabbit_khepri:delete(Path) of
+        ok -> true;
+        _ -> false
+    end.
+
+%% -------------------------------------------------------------------
+%% Khepri paths
+%% -------------------------------------------------------------------
+
+khepri_node_metadata_path(Node) when ?IS_KHEPRI_PATH_CONDITION(Node) ->
+    ?RABBITMQ_KHEPRI_NODE_METADATA_PATH(Node).

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -189,8 +189,10 @@
 -export([topic_binding_projection_v5_enable/1,
          topic_binding_projection_v5_post_enable/1]).
 
+-export([register_projections/0]).
+
 -ifdef(TEST).
--export([register_projections/0,
+-export([
          expand_mnesia_migrations/1,
          mnesia_tables_from_migrations/1]).
 -endif.
@@ -1343,6 +1345,7 @@ register_projections() ->
                fun register_rabbit_bindings_projection/0,
                fun register_rabbit_route_by_source_key_projection/0,
                fun register_rabbit_route_by_source_projection/0,
+               fun register_rabbit_node_metadata_projection/0,
                fun register_rabbit_topic_binding_projection/0],
     rabbit_misc:for_each_while_ok(
       fun(RegisterFun) ->
@@ -1433,6 +1436,18 @@ register_rabbit_user_permissions_projection() ->
                     _VHost = ?KHEPRI_WILDCARD_STAR),
     KeyPos = #user_permission.user_vhost,
     register_simple_projection(Name, PathPattern, KeyPos, false).
+
+register_rabbit_node_metadata_projection() ->
+    Name = rabbit_khepri_node_metadata,
+    PathPattern = rabbit_db_node_metadata:khepri_node_metadata_path(
+                    _WildcardNode = ?KHEPRI_WILDCARD_STAR),
+    Fun = fun([rabbitmq, node_metadata, _Node], #node_metadata{} = Record) ->
+                  Record
+          end,
+    Options = #{keypos => #node_metadata.node,
+                read_concurrency => true},
+    Projection = khepri_projection:new(Name, Fun, Options),
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 register_simple_projection(Name, PathPattern, KeyPos, ReadConcurrency) ->
     Options = #{keypos => KeyPos,

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1440,14 +1440,9 @@ register_rabbit_user_permissions_projection() ->
 register_rabbit_node_metadata_projection() ->
     Name = rabbit_khepri_node_metadata,
     PathPattern = rabbit_db_node_metadata:khepri_node_metadata_path(
-                    _WildcardNode = ?KHEPRI_WILDCARD_STAR),
-    Fun = fun([rabbitmq, node_metadata, _Node], #node_metadata{} = Record) ->
-                  Record
-          end,
-    Options = #{keypos => #node_metadata.node,
-                read_concurrency => true},
-    Projection = khepri_projection:new(Name, Fun, Options),
-    khepri:register_projection(?STORE_ID, PathPattern, Projection).
+                    _NodeName = ?KHEPRI_WILDCARD_STAR),
+    KeyPos = #node_metadata.node,
+    register_simple_projection(Name, PathPattern, KeyPos, true).
 
 register_simple_projection(Name, PathPattern, KeyPos, ReadConcurrency) ->
     Options = #{keypos => KeyPos,

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -96,6 +96,7 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -include("include/rabbit_khepri.hrl").
+-include("include/node_metadata.hrl").
 
 %% Initialisation.
 -export([setup/0,

--- a/deps/rabbit/src/rabbit_member_placement.erl
+++ b/deps/rabbit/src/rabbit_member_placement.erl
@@ -1,0 +1,23 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_member_placement).
+
+%% Behaviour for pluggable quorum queue member placement strategies.
+%%
+%% A placement module is selected via the `member_placement_module` application
+%% environment key (default: `rabbit_member_placement_az`). It is invoked when a
+%% `member-placement-tag` is configured on the queue, policy, or globally.
+
+-callback select_members(
+            Size                  :: pos_integer(),
+            AllNodes              :: [node(), ...],
+            RunningNodes          :: [node()],
+            QueueCount            :: non_neg_integer(),
+            QueueCountStartRandom :: non_neg_integer(),
+            GetQueues             :: function(),
+            TagKey                :: binary()) -> {[node(), ...], function()}.

--- a/deps/rabbit/src/rabbit_member_placement_az.erl
+++ b/deps/rabbit/src/rabbit_member_placement_az.erl
@@ -1,0 +1,190 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_member_placement_az).
+-behaviour(rabbit_member_placement).
+
+%% Callback implementation.
+-export([select_members/7]).
+
+-include_lib("kernel/include/logger.hrl").
+
+%% Exported so they can be mocked in unit tests.
+-export([node/0,
+         nodes/0,
+         node_tags_for_nodes/2]).
+
+%% Diagnostic functions.
+-export([queues_not_fully_az_covered/0,
+         queues_not_fully_az_covered/1,
+         member_distribution_per_az/0,
+         member_distribution_per_az/1]).
+
+-spec select_members(pos_integer(), [node(), ...], [node()],
+                     non_neg_integer(), non_neg_integer(),
+                     function(), binary()) -> {[node(), ...], function()}.
+select_members(Size, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom,
+               GetQueues, TagKey) ->
+    NodeToAZ = ?MODULE:node_tags_for_nodes(AllNodes, TagKey),
+    case lists:any(fun(V) -> V =/= undefined end, maps:values(NodeToAZ)) of
+        false ->
+            ?LOG_WARNING(
+               "Quorum queue member-placement-tag '~ts' is set but no cluster node has "
+               "this tag. Falling back to default member placement.", [TagKey]),
+            rabbit_queue_location:select_members_balanced_fallback(
+              Size, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom, GetQueues);
+        true ->
+            select_members_az_aware(Size, AllNodes, RunningNodes, QueueCount,
+                                    QueueCountStartRandom, GetQueues, NodeToAZ)
+    end.
+
+select_members_az_aware(Size, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom,
+                        GetQueues0, NodeToAZ) ->
+    AZCounts = #{AZ => 0 || AZ <- lists:uniq(maps:values(NodeToAZ))},
+    CandidateNodes = running_first(AllNodes, RunningNodes),
+    case QueueCount >= QueueCountStartRandom of
+        true ->
+            PickFun = fun(Pool) -> hd(shuffle(Pool)) end,
+            Selected = select_az_aware(Size, CandidateNodes, RunningNodes,
+                                       NodeToAZ, AZCounts, PickFun),
+            {Selected, GetQueues0};
+        false ->
+            Queues = GetQueues0(),
+            Counters = rabbit_queue_location:build_node_counters(
+                         #{N => 0 || N <- AllNodes}, Queues),
+            PickFun = fun(Pool) -> pick_balanced(Pool, Counters) end,
+            Selected = select_az_aware(Size, CandidateNodes, RunningNodes,
+                                       NodeToAZ, AZCounts, PickFun),
+            {Selected, fun() -> Queues end}
+    end.
+
+select_az_aware(0, _, _, _, _, _) ->
+    [];
+select_az_aware(_, [], _, _, _, _) ->
+    [];
+select_az_aware(Remaining, CandidateNodes, RunningNodes, NodeToAZ, AZCounts, PickFun) ->
+    Pool = az_aware_candidates(CandidateNodes, RunningNodes, NodeToAZ, AZCounts),
+    Node = PickFun(Pool),
+    NodeAZ = maps:get(Node, NodeToAZ, undefined),
+    NewAZCounts = maps:update_with(NodeAZ, fun(C) -> C + 1 end, AZCounts),
+    [Node | select_az_aware(Remaining - 1, lists:delete(Node, CandidateNodes),
+                            RunningNodes, NodeToAZ, NewAZCounts, PickFun)].
+
+%% Pick the pool of candidate nodes for the next AZ-aware slot.
+%% Prefers nodes in the least-populated AZs; prefers running nodes within that pool.
+%% Falls back to any remaining node if all nodes in min-AZs are already selected.
+az_aware_candidates(CandidateNodes, RunningNodes, NodeToAZ, AZCounts) ->
+    MinCount = lists:min(maps:values(AZCounts)),
+    MinAZs = [AZ || AZ := C <- AZCounts, C =:= MinCount],
+    InMinAZs = [N || N <- CandidateNodes,
+                     lists:member(maps:get(N, NodeToAZ, undefined), MinAZs)],
+    case InMinAZs of
+        [] ->
+            %% All nodes from the minimum AZs are already selected; use any remaining node.
+            CandidateNodes;
+        _ ->
+            case [N || N <- InMinAZs, lists:member(N, RunningNodes)] of
+                []      -> InMinAZs;
+                Running -> Running
+            end
+    end.
+
+pick_balanced(Pool, Counters) ->
+    hd(lists:sort(fun(A, B) -> maps:get(A, Counters, 0) =< maps:get(B, Counters, 0) end, Pool)).
+
+%% Running nodes first so that AZ-aware selection prefers them within each AZ.
+running_first(Nodes, RunningNodes) ->
+    [N || N <- Nodes,     lists:member(N, RunningNodes)]
+    ++ [N || N <- Nodes, not lists:member(N, RunningNodes)].
+
+-spec queues_not_fully_az_covered() -> [#{queue        := rabbit_types:r(queue),
+                                          member_nodes := [node()],
+                                          member_azs   := [binary() | undefined],
+                                          missing_azs  := [binary()]}].
+queues_not_fully_az_covered() ->
+    TagKey = application:get_env(rabbit, quorum_queue_member_placement_tag, undefined),
+    queues_not_fully_az_covered(TagKey).
+
+-spec queues_not_fully_az_covered(binary() | undefined) ->
+    [#{queue        := rabbit_types:r(queue),
+       member_nodes := [node()],
+       member_azs   := [binary() | undefined],
+       missing_azs  := [binary()]}].
+queues_not_fully_az_covered(undefined) ->
+    [];
+queues_not_fully_az_covered(TagKey) ->
+    Nodes = rabbit_nodes:list_members(),
+    NodeToAZ = ?MODULE:node_tags_for_nodes(Nodes, TagKey),
+    AllAZs = lists:usort([AZ || _ := AZ <- NodeToAZ, AZ =/= undefined]),
+    [#{queue        => amqqueue:get_name(Q),
+       member_nodes => MemberNodes,
+       member_azs   => MemberAZs,
+       missing_azs  => MissingAZs}
+     || Q          <- rabbit_amqqueue:list(),
+        amqqueue:get_type(Q) =:= rabbit_quorum_queue,
+        MemberNodes <- [rabbit_quorum_queue:get_replicas(Q)],
+        MemberAZs   <- [lists:usort([maps:get(N, NodeToAZ, undefined)
+                                     || N <- MemberNodes, maps:is_key(N, NodeToAZ)])],
+        MissingAZs  <- [AllAZs -- MemberAZs],
+        MissingAZs  =/= []].
+
+-spec member_distribution_per_az() -> #{binary() | undefined => #{node() => non_neg_integer()}}.
+member_distribution_per_az() ->
+    TagKey = application:get_env(rabbit, quorum_queue_member_placement_tag, undefined),
+    member_distribution_per_az(TagKey).
+
+-spec member_distribution_per_az(binary() | undefined) ->
+    #{binary() | undefined => #{node() => non_neg_integer()}}.
+member_distribution_per_az(undefined) ->
+    #{};
+member_distribution_per_az(TagKey) ->
+    Nodes = rabbit_nodes:list_running(),
+    NodeToAZ = ?MODULE:node_tags_for_nodes(Nodes, TagKey),
+    NodeCounts = lists:foldl(
+                   fun(Q, Acc) ->
+                           case amqqueue:get_type(Q) of
+                               rabbit_quorum_queue ->
+                                   lists:foldl(fun(N, Acc2) ->
+                                                       maps:update_with(N, fun(C) -> C + 1 end, 1, Acc2)
+                                               end, Acc, rabbit_quorum_queue:get_replicas(Q));
+                               _ ->
+                                   Acc
+                           end
+                   end,
+                   #{N => 0 || N <- Nodes},
+                   rabbit_amqqueue:list()),
+    maps:fold(
+      fun(Node, Count, Acc) ->
+              AZ = maps:get(Node, NodeToAZ, undefined),
+              maps:update_with(AZ, fun(M) -> M#{Node => Count} end,
+                               #{Node => Count}, Acc)
+      end,
+      #{},
+      NodeCounts).
+
+%% Returns #{Node => TagValue | undefined} for all Nodes.
+%% Uses rabbit_db_node_metadata (stored in Khepri) to retrieve node tags without RPCs.
+-spec node_tags_for_nodes([node()], binary()) -> #{node() => binary() | undefined}.
+node_tags_for_nodes(Nodes, TagKey) ->
+    maps:from_list([
+      begin
+          Metadata = rabbit_db_node_metadata:get(N),
+          Tags = maps:get(node_tags, Metadata, []),
+          {N, proplists:get_value(TagKey, Tags, undefined)}
+      end || N <- Nodes]).
+
+-spec node() -> node().
+node() -> erlang:node().
+
+-spec nodes() -> [node()].
+nodes() -> erlang:nodes().
+
+%% OTP29 added rand:shuffle but we need to support older OTP versions
+shuffle(L0) when is_list(L0) ->
+    L1 = [{rand:uniform(), E} || E <- L0],
+    L = lists:keysort(1, L1),
+    [E || {_, E} <- L].

--- a/deps/rabbit/src/rabbit_member_placement_az.erl
+++ b/deps/rabbit/src/rabbit_member_placement_az.erl
@@ -88,7 +88,7 @@ az_aware_candidates(CandidateNodes, RunningNodes, NodeToAZ, AZCounts) ->
             CandidateNodes;
         _ ->
             case [N || N <- InMinAZs, lists:member(N, RunningNodes)] of
-                []      -> InMinAZs;
+                [] -> InMinAZs;
                 Running -> Running
             end
     end.
@@ -98,7 +98,7 @@ pick_balanced(Pool, Counters) ->
 
 %% Running nodes first so that AZ-aware selection prefers them within each AZ.
 running_first(Nodes, RunningNodes) ->
-    [N || N <- Nodes,     lists:member(N, RunningNodes)]
+    [N || N <- Nodes, lists:member(N, RunningNodes)]
     ++ [N || N <- Nodes, not lists:member(N, RunningNodes)].
 
 -spec queues_not_fully_az_covered() -> [#{queue        := rabbit_types:r(queue),
@@ -120,11 +120,11 @@ queues_not_fully_az_covered(TagKey) ->
     Nodes = rabbit_nodes:list_members(),
     NodeToAZ = ?MODULE:node_tags_for_nodes(Nodes, TagKey),
     AllAZs = lists:usort([AZ || _ := AZ <- NodeToAZ, AZ =/= undefined]),
-    [#{queue        => amqqueue:get_name(Q),
+    [#{queue => amqqueue:get_name(Q),
        member_nodes => MemberNodes,
-       member_azs   => MemberAZs,
-       missing_azs  => MissingAZs}
-     || Q          <- rabbit_amqqueue:list(),
+       member_azs => MemberAZs,
+       missing_azs => MissingAZs}
+     || Q <- rabbit_amqqueue:list(),
         amqqueue:get_type(Q) =:= rabbit_quorum_queue,
         MemberNodes <- [rabbit_quorum_queue:get_replicas(Q)],
         MemberAZs   <- [lists:usort([maps:get(N, NodeToAZ, undefined)

--- a/deps/rabbit/src/rabbit_member_placement_az.erl
+++ b/deps/rabbit/src/rabbit_member_placement_az.erl
@@ -105,9 +105,20 @@ running_first(Nodes, RunningNodes) ->
                                           member_nodes := [node()],
                                           member_azs   := [binary() | undefined],
                                           missing_azs  := [binary()]}].
+%% Uses each queue's own effective tag key (policy, then queue argument, then
+%% cluster-wide configuration), matching the precedence used by the actual
+%% member placement logic in rabbit_queue_location.
 queues_not_fully_az_covered() ->
-    TagKey = application:get_env(rabbit, quorum_queue_member_placement_tag, undefined),
-    queues_not_fully_az_covered(TagKey).
+    Nodes = rabbit_nodes:list_members(),
+    lists:filtermap(
+      fun(Q) ->
+              case amqqueue:get_type(Q) =:= rabbit_quorum_queue andalso
+                   rabbit_queue_location:placement_tag_key(Q) of
+                  undefined -> false;
+                  false -> false;
+                  TagKey -> queue_az_coverage(Q, Nodes, TagKey)
+              end
+      end, rabbit_amqqueue:list()).
 
 -spec queues_not_fully_az_covered(binary() | undefined) ->
     [#{queue        := rabbit_types:r(queue),
@@ -118,24 +129,48 @@ queues_not_fully_az_covered(undefined) ->
     [];
 queues_not_fully_az_covered(TagKey) ->
     Nodes = rabbit_nodes:list_members(),
+    lists:filtermap(
+      fun(Q) ->
+              amqqueue:get_type(Q) =:= rabbit_quorum_queue andalso
+              queue_az_coverage(Q, Nodes, TagKey)
+      end, rabbit_amqqueue:list()).
+
+%% Returns `{true, Coverage}' if Q is missing members in one or more AZs,
+%% `false' otherwise.
+queue_az_coverage(Q, Nodes, TagKey) ->
     NodeToAZ = ?MODULE:node_tags_for_nodes(Nodes, TagKey),
     AllAZs = lists:usort([AZ || _ := AZ <- NodeToAZ, AZ =/= undefined]),
-    [#{queue => amqqueue:get_name(Q),
-       member_nodes => MemberNodes,
-       member_azs => MemberAZs,
-       missing_azs => MissingAZs}
-     || Q <- rabbit_amqqueue:list(),
-        amqqueue:get_type(Q) =:= rabbit_quorum_queue,
-        MemberNodes <- [rabbit_quorum_queue:get_replicas(Q)],
-        MemberAZs   <- [lists:usort([maps:get(N, NodeToAZ, undefined)
-                                     || N <- MemberNodes, maps:is_key(N, NodeToAZ)])],
-        MissingAZs  <- [AllAZs -- MemberAZs],
-        MissingAZs  =/= []].
+    MemberNodes = rabbit_quorum_queue:get_replicas(Q),
+    MemberAZs = lists:usort([maps:get(N, NodeToAZ, undefined)
+                             || N <- MemberNodes, maps:is_key(N, NodeToAZ)]),
+    case AllAZs -- MemberAZs of
+        [] ->
+            false;
+        MissingAZs ->
+            {true, #{queue => amqqueue:get_name(Q),
+                     member_nodes => MemberNodes,
+                     member_azs => MemberAZs,
+                     missing_azs => MissingAZs}}
+    end.
 
+%% Uses each queue's own effective tag key (policy, then queue argument, then
+%% cluster-wide configuration), matching the precedence used by the actual
+%% member placement logic in rabbit_queue_location. Since different queues
+%% may resolve to different tag keys, nodes with no members are not included.
 -spec member_distribution_per_az() -> #{binary() | undefined => #{node() => non_neg_integer()}}.
 member_distribution_per_az() ->
-    TagKey = application:get_env(rabbit, quorum_queue_member_placement_tag, undefined),
-    member_distribution_per_az(TagKey).
+    Nodes = rabbit_nodes:list_running(),
+    lists:foldl(
+      fun(Q, Acc) ->
+              case amqqueue:get_type(Q) =:= rabbit_quorum_queue andalso
+                   rabbit_queue_location:placement_tag_key(Q) of
+                  undefined -> Acc;
+                  false -> Acc;
+                  TagKey ->
+                      NodeToAZ = ?MODULE:node_tags_for_nodes(Nodes, TagKey),
+                      add_replicas_to_az_counts(Q, NodeToAZ, Acc)
+              end
+      end, #{}, rabbit_amqqueue:list()).
 
 -spec member_distribution_per_az(binary() | undefined) ->
     #{binary() | undefined => #{node() => non_neg_integer()}}.
@@ -144,27 +179,28 @@ member_distribution_per_az(undefined) ->
 member_distribution_per_az(TagKey) ->
     Nodes = rabbit_nodes:list_running(),
     NodeToAZ = ?MODULE:node_tags_for_nodes(Nodes, TagKey),
-    NodeCounts = lists:foldl(
-                   fun(Q, Acc) ->
-                           case amqqueue:get_type(Q) of
-                               rabbit_quorum_queue ->
-                                   lists:foldl(fun(N, Acc2) ->
-                                                       maps:update_with(N, fun(C) -> C + 1 end, 1, Acc2)
-                                               end, Acc, rabbit_quorum_queue:get_replicas(Q));
-                               _ ->
-                                   Acc
-                           end
-                   end,
-                   #{N => 0 || N <- Nodes},
-                   rabbit_amqqueue:list()),
-    maps:fold(
-      fun(Node, Count, Acc) ->
-              AZ = maps:get(Node, NodeToAZ, undefined),
-              maps:update_with(AZ, fun(M) -> M#{Node => Count} end,
-                               #{Node => Count}, Acc)
-      end,
-      #{},
-      NodeCounts).
+    Acc0 = maps:fold(
+             fun(Node, AZ, Acc) ->
+                     maps:update_with(AZ, fun(M) -> M#{Node => 0} end, #{Node => 0}, Acc)
+             end, #{}, NodeToAZ),
+    lists:foldl(
+      fun(Q, Acc) ->
+              case amqqueue:get_type(Q) of
+                  rabbit_quorum_queue -> add_replicas_to_az_counts(Q, NodeToAZ, Acc);
+                  _ -> Acc
+              end
+      end, Acc0, rabbit_amqqueue:list()).
+
+add_replicas_to_az_counts(Q, NodeToAZ, Acc) ->
+    lists:foldl(
+      fun(N, Acc2) ->
+              AZ = maps:get(N, NodeToAZ, undefined),
+              maps:update_with(
+                AZ,
+                fun(M) -> maps:update_with(N, fun(C) -> C + 1 end, 1, M) end,
+                #{N => 1},
+                Acc2)
+      end, Acc, rabbit_quorum_queue:get_replicas(Q)).
 
 %% Returns #{Node => TagValue | undefined} for all Nodes.
 %% Uses rabbit_db_node_metadata (stored in Khepri) to retrieve node tags without RPCs.

--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -54,7 +54,7 @@ select_leader_and_followers(Q, Size)
     QueueType = amqqueue:get_type(Q),
     PlacementTagKey = case QueueType of
         rabbit_quorum_queue -> placement_tag_key(Q);
-        _                   -> undefined
+        _ -> undefined
     end,
     do_select_leader_and_followers(Size, QueueType, LeaderLocator, PlacementTagKey).
 

--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -13,13 +13,17 @@
          select_leader_and_followers/2,
          master_locator_permitted/0]).
 
-%% these are needed because of they are called with ?MODULE:
-%% to allow mecking them in tests
+%% these are needed because they are called with ?MODULE:
+%% to allow mocking them in tests
 -export([node/0,
          queues_per_node/2]).
 
+-export([build_node_counters/2,
+         select_members_balanced_fallback/6,
+         placement_tag_key/1]).
+
 -ifdef(TEST).
--export([select_members/7, leader_node/6, leader_locator/1]).
+-export([select_members/8, leader_node/6, leader_locator/1]).
 -endif.
 
 -rabbit_deprecated_feature(
@@ -48,14 +52,19 @@ select_leader_and_followers(Q, Size)
   when (?is_amqqueue_v2(Q)) andalso is_integer(Size) ->
     LeaderLocator = leader_locator(Q),
     QueueType = amqqueue:get_type(Q),
-    do_select_leader_and_followers(Size, QueueType, LeaderLocator).
+    PlacementTagKey = case QueueType of
+        rabbit_quorum_queue -> placement_tag_key(Q);
+        _                   -> undefined
+    end,
+    do_select_leader_and_followers(Size, QueueType, LeaderLocator, PlacementTagKey).
 
--spec do_select_leader_and_followers(pos_integer(), atom(), queue_leader_locator()) ->
+-spec do_select_leader_and_followers(pos_integer(), atom(), queue_leader_locator(),
+                                      binary() | undefined) ->
     {Leader :: node(), Followers :: [node()]}.
-do_select_leader_and_followers(1, _, <<"client-local">>) ->
-    %% optimisation for classic queues
+do_select_leader_and_followers(1, _, <<"client-local">>, _) ->
+    %% Optimisation for classic queues.
     {?MODULE:node(), []};
-do_select_leader_and_followers(Size, QueueType, LeaderLocator) ->
+do_select_leader_and_followers(Size, QueueType, LeaderLocator, PlacementTagKey) ->
     AllNodes = rabbit_nodes:list_members(),
     RunningNodes = rabbit_nodes:filter_running(AllNodes),
     true = lists:member(?MODULE:node(), AllNodes),
@@ -66,7 +75,8 @@ do_select_leader_and_followers(Size, QueueType, LeaderLocator) ->
     QueueCountStartRandom = application:get_env(rabbit, queue_count_start_random_selection,
                                                 ?QUEUE_COUNT_START_RANDOM_SELECTION),
     {Members, GetQueues} = select_members(Size, QueueType, AllNodes, RunningNodes,
-                                            QueueCount, QueueCountStartRandom, GetQueues0),
+                                          QueueCount, QueueCountStartRandom, GetQueues0,
+                                          PlacementTagKey),
     Leader = leader_node(LeaderLocator, Members, RunningNodes,
                          QueueCount, QueueCountStartRandom, GetQueues),
     Followers = lists:delete(Leader, Members),
@@ -109,48 +119,65 @@ leader_locator0(_) ->
     %% default
     <<"client-local">>.
 
-%% TODO: allow dispatching by queue type
+-type placement_strategy() :: classic | az | random | balanced.
+
+%% Determine the member placement strategy from the queue type, size, queue count and tag.
+-spec placement_strategy(rabbit_queue_type:queue_type(), pos_integer(),
+                          non_neg_integer(), non_neg_integer(), binary() | undefined) ->
+    placement_strategy().
+placement_strategy(rabbit_classic_queue, 1, _, _, _) ->
+    %% Classic queues declare a single member; the leader is chosen later by leader_node/6.
+    classic;
+placement_strategy(_, _, _, _, TagKey) when is_binary(TagKey) ->
+    %% Quorum queues with a placement tag: use the configured placement module.
+    az;
+placement_strategy(_, _, QueueCount, QueueCountStartRandom, _)
+  when QueueCount >= QueueCountStartRandom ->
+    %% Quorum queues and streams above the queue-count threshold: random placement.
+    %% Counting members per node is expensive so random is good enough at scale.
+    random;
+placement_strategy(_, _, _, _, _) ->
+    %% Quorum queues and streams below the threshold: balance across the least-loaded nodes.
+    balanced.
+
 -spec select_members(pos_integer(), rabbit_queue_type:queue_type(), [node(),...], [node(),...],
-                      non_neg_integer(), non_neg_integer(), function()) ->
+                      non_neg_integer(), non_neg_integer(), function(), binary() | undefined) ->
     {[node(),...], function()}.
-select_members(Size, _, AllNodes, _, _, _, Fun)
+select_members(Size, _, AllNodes, _, _, _, Fun, _)
   when length(AllNodes) =< Size ->
     {AllNodes, Fun};
-%% Classic queues: above the threshold, pick a random node
-%% For classic queues, when there's a lot of queues, if we knew that the
-%% distribution of queues between nodes is relatively even, it'd be better
-%% to declare this queue locally rather than randomly. However, currently,
-%% counting queues on each node is relatively expensive. Users can use
-%% the client-local strategy if they know their connections are well balanced
-select_members(1, rabbit_classic_queue, _, RunningNodes, _, _, GetQueues) ->
+select_members(Size, QueueType, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom,
+               GetQueues, TagKey) ->
+    Strategy = placement_strategy(QueueType, Size, QueueCount, QueueCountStartRandom, TagKey),
+    place_members(Strategy, Size, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom,
+                  GetQueues, TagKey).
+
+-spec place_members(placement_strategy(), pos_integer(), [node(),...], [node(),...],
+                     non_neg_integer(), non_neg_integer(), function(), binary() | undefined) ->
+    {[node(),...], function()}.
+place_members(classic, _, _, RunningNodes, _, _, GetQueues, _) ->
+    %% For classic queues, when there's a lot of queues, if we knew that the
+    %% distribution of queues between nodes is relatively even, it'd be better
+    %% to declare this queue locally rather than randomly. However, currently,
+    %% counting queues on each node is relatively expensive. Users can use
+    %% the client-local strategy if they know their connections are well balanced.
     {RunningNodes, GetQueues};
-%% Quorum queues and streams
-%% Select nodes in the following order:
-%% 1.   Local node to have data locality for declaring client.
-%% 2.   Running nodes.
-%% 3.1. If there are many queues: Randomly to avoid expensive calculation of counting members
-%%      per node. Random replica selection is good enough for most use cases.
-%% 3.2. If there are few queues: Nodes with least members to have a "balanced" RabbitMQ cluster.
-select_members(Size, _, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom, GetQueues)
-  when QueueCount >= QueueCountStartRandom ->
+place_members(az, Size, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom,
+              GetQueues, TagKey) ->
+    Mod = application:get_env(rabbit, member_placement_module, rabbit_member_placement_az),
+    Mod:select_members(Size, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom,
+                       GetQueues, TagKey);
+place_members(random, Size, AllNodes, RunningNodes, _, _, GetQueues, _) ->
     L0 = shuffle(lists:delete(?MODULE:node(), AllNodes)),
     L1 = lists:sort(fun(X, _Y) ->
                             lists:member(X, RunningNodes)
                     end, L0),
     {L, _} = lists:split(Size - 1, L1),
     {[?MODULE:node() | L], GetQueues};
-select_members(Size, _, AllNodes, RunningNodes, _, _, GetQueues) ->
+place_members(balanced, Size, AllNodes, RunningNodes, _, _, GetQueues0, _) ->
     Counters0 = maps:from_list([{N, 0} || N <- lists:delete(?MODULE:node(), AllNodes)]),
-    Queues = GetQueues(),
-    Counters = lists:foldl(fun(Q, Acc) ->
-                                   Nodes = rabbit_queue_type:get_nodes(Q),
-                                   lists:foldl(fun(N, A)
-                                                     when is_map_key(N, A) ->
-                                                       maps:update_with(N, fun(C) -> C+1 end, A);
-                                                  (_, A) ->
-                                                       A
-                                               end, Acc, Nodes)
-                           end, Counters0, Queues),
+    Queues = GetQueues0(),
+    Counters = build_node_counters(Counters0, Queues),
     L0 = maps:to_list(Counters),
     L1 = lists:sort(fun({N0, C0}, {N1, C1}) ->
                             case {lists:member(N0, RunningNodes),
@@ -167,11 +194,34 @@ select_members(Size, _, AllNodes, RunningNodes, _, _, GetQueues) ->
     L = lists:map(fun({N, _}) -> N end, L2),
     {[?MODULE:node() | L], fun() -> Queues end}.
 
+-spec select_members_balanced_fallback(pos_integer(), [node(),...], [node(),...],
+                                       non_neg_integer(), non_neg_integer(), function()) ->
+    {[node(),...], function()}.
+select_members_balanced_fallback(Size, AllNodes, RunningNodes, QueueCount, QueueCountStartRandom, GetQueues) ->
+    select_members(Size, undefined, AllNodes, RunningNodes, QueueCount,
+                   QueueCountStartRandom, GetQueues, undefined).
+
+-spec build_node_counters(#{node() => non_neg_integer()}, [amqqueue:amqqueue()]) ->
+    #{node() => non_neg_integer()}.
+build_node_counters(Counters0, Queues) ->
+    lists:foldl(fun(Q, Acc) ->
+                        Nodes = rabbit_queue_type:get_nodes(Q),
+                        lists:foldl(fun(N, A) when is_map_key(N, A) ->
+                                            maps:update_with(N, fun(C) -> C + 1 end, A);
+                                       (_, A) ->
+                                            A
+                                    end, Acc, Nodes)
+                end, Counters0, Queues).
+
 -spec leader_node(queue_leader_locator(), [node(),...], [node(),...],
                   non_neg_integer(), non_neg_integer(), function()) ->
     node().
-leader_node(<<"client-local">>, _, _, _, _, _) ->
-    ?MODULE:node();
+leader_node(<<"client-local">>, Nodes, RunningNodes, QueueCount, QueueCountStartRandom, GetQueues) ->
+    case lists:member(?MODULE:node(), Nodes) of
+        true  -> ?MODULE:node();
+        false -> leader_node(<<"balanced">>, Nodes, RunningNodes,
+                             QueueCount, QueueCountStartRandom, GetQueues)
+    end;
 leader_node(<<"balanced">>, Nodes0, RunningNodes, QueueCount, QueueCountStartRandom, _)
   when QueueCount >= QueueCountStartRandom ->
     Nodes = potential_leaders(Nodes0, RunningNodes),
@@ -222,6 +272,17 @@ queues_per_node(Nodes, GetQueues) ->
                                 Acc
                         end
                 end, Counters0, GetQueues()).
+
+placement_tag_key(Q) ->
+    case rabbit_queue_type_util:args_policy_lookup(
+           <<"member-placement-tag">>,
+           fun (_PolVal, ArgVal) -> ArgVal end,
+           Q) of
+        undefined ->
+            application:get_env(rabbit, quorum_queue_member_placement_tag, undefined);
+        TagKey ->
+            TagKey
+    end.
 
 %% for unit testing
 -spec node() -> node().

--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -276,7 +276,7 @@ queues_per_node(Nodes, GetQueues) ->
 placement_tag_key(Q) ->
     case rabbit_queue_type_util:args_policy_lookup(
            <<"member-placement-tag">>,
-           fun (_PolVal, ArgVal) -> ArgVal end,
+           fun (PolVal, _ArgVal) -> PolVal end,
            Q) of
         undefined ->
             application:get_env(rabbit, quorum_queue_member_placement_tag, undefined);

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -198,6 +198,12 @@
      {mfa, {rabbit_registry, register,
             [policy_merge_strategy, <<"target-group-size">>, ?MODULE]}},
      {mfa, {rabbit_registry, register,
+            [policy_validator, <<"member-placement-tag">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [operator_policy_validator, <<"member-placement-tag">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_merge_strategy, <<"member-placement-tag">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
             [policy_validator, <<"delayed-retry-type">>, ?MODULE]}},
      {mfa, {rabbit_registry, register,
             [policy_validator, <<"delayed-retry-min">>, ?MODULE]}},
@@ -244,6 +250,11 @@ validate_policy0(<<"target-group-size">>, Value) ->
         true  -> ok;
         false -> {error, "~tp is not a valid qq target count value", [Value]}
     end;
+validate_policy0(<<"member-placement-tag">>, Value)
+  when is_binary(Value), byte_size(Value) > 0 ->
+    ok;
+validate_policy0(<<"member-placement-tag">>, Value) ->
+    {error, "~tp is not a valid member-placement-tag value. Must be a non-empty string", [Value]};
 validate_policy0(<<"delayed-retry-type">>, <<"all">>)      -> ok;
 validate_policy0(<<"delayed-retry-type">>, <<"failed">>)   -> ok;
 validate_policy0(<<"delayed-retry-type">>, <<"returned">>) -> ok;
@@ -263,6 +274,8 @@ validate_policy0(<<"delayed-retry-max">>, Value) ->
 
 merge_policy_value(<<"target-group-size">>, Val, OpVal) ->
     max(Val, OpVal);
+merge_policy_value(<<"member-placement-tag">>, _Val, OpVal) ->
+    OpVal;
 merge_policy_value(<<"delayed-retry-type">>, _Val, OpVal) ->
     OpVal;
 merge_policy_value(<<"delayed-retry-min">>, Val, OpVal) ->
@@ -618,6 +631,7 @@ capabilities() ->
                           <<"x-single-active-consumer">>,
                           <<"x-queue-type">>,
                           <<"x-quorum-initial-group-size">>,
+                          <<"x-member-placement-tag">>,
                           <<"x-delivery-limit">>,
                           <<"x-message-ttl">>,
                           <<"x-queue-leader-locator">>,
@@ -1500,59 +1514,73 @@ status(#resource{virtual_host = Vhost, name = QueueName}) ->
 status(Q) when ?amqqueue_is_quorum(Q) ->
     {RName, _} = amqqueue:get_pid(Q),
     Nodes = lists:sort(get_nodes(Q)),
+    TagKey = rabbit_queue_location:placement_tag_key(Q),
+    NodeToAZ = case TagKey of
+                   undefined -> #{};
+                   Key       -> rabbit_member_placement_az:node_tags_for_nodes(Nodes, Key)
+               end,
     [begin
          ServerId = {RName, N},
-         case erpc_call(N, ?MODULE, key_metrics_rpc, [ServerId], ?RPC_TIMEOUT) of
-             #{state := RaftState,
-               membership := Membership,
-               commit_index := Commit,
-               term := Term,
-               last_index := Last,
-               last_applied := LastApplied,
-               last_written_index := LastWritten,
-               snapshot_index := SnapIdx,
-               machine_version := MacVer} ->
-                 [{<<"Node Name">>, N},
-                  {<<"Raft State">>, RaftState},
-                  {<<"Membership">>, Membership},
-                  {<<"Last Log Index">>, Last},
-                  {<<"Last Written">>, LastWritten},
-                  {<<"Last Applied">>, LastApplied},
-                  {<<"Commit Index">>, Commit},
-                  {<<"Snapshot Index">>, SnapIdx},
-                  {<<"Term">>, Term},
-                  {<<"Machine Version">>, MacVer}
-                 ];
-             #{state := noproc,
-               membership := unknown,
-               machine_version := MacVer} ->
-                 [{<<"Node Name">>, N},
-                  {<<"Raft State">>, noproc},
-                  {<<"Membership">>, <<>>},
-                  {<<"Last Log Index">>, <<>>},
-                  {<<"Last Written">>, <<>>},
-                  {<<"Last Applied">>, <<>>},
-                  {<<"Commit Index">>, <<>>},
-                  {<<"Snapshot Index">>, <<>>},
-                  {<<"Term">>, <<>>},
-                  {<<"Machine Version">>, MacVer}
-                 ];
-             {error, Reason} ->
-                 State = case is_atom(Reason) of
-                             true -> Reason;
-                             false -> unknown
-                         end,
-                 [{<<"Node Name">>, N},
-                  {<<"Raft State">>, State},
-                  {<<"Membership">>, <<>>},
-                  {<<"Last Log Index">>, <<>>},
-                  {<<"Last Written">>, <<>>},
-                  {<<"Last Applied">>, <<>>},
-                  {<<"Commit Index">>, <<>>},
-                  {<<"Snapshot Index">>, <<>>},
-                  {<<"Term">>, <<>>},
-                  {<<"Machine Version">>, <<>>}
-                 ]
+         BaseRow = case erpc_call(N, ?MODULE, key_metrics_rpc, [ServerId], ?RPC_TIMEOUT) of
+                       #{state := RaftState,
+                         membership := Membership,
+                         commit_index := Commit,
+                         term := Term,
+                         last_index := Last,
+                         last_applied := LastApplied,
+                         last_written_index := LastWritten,
+                         snapshot_index := SnapIdx,
+                         machine_version := MacVer} ->
+                           [{<<"Node Name">>, N},
+                            {<<"Raft State">>, RaftState},
+                            {<<"Membership">>, Membership},
+                            {<<"Last Log Index">>, Last},
+                            {<<"Last Written">>, LastWritten},
+                            {<<"Last Applied">>, LastApplied},
+                            {<<"Commit Index">>, Commit},
+                            {<<"Snapshot Index">>, SnapIdx},
+                            {<<"Term">>, Term},
+                            {<<"Machine Version">>, MacVer}
+                           ];
+                       #{state := noproc,
+                         membership := unknown,
+                         machine_version := MacVer} ->
+                           [{<<"Node Name">>, N},
+                            {<<"Raft State">>, noproc},
+                            {<<"Membership">>, <<>>},
+                            {<<"Last Log Index">>, <<>>},
+                            {<<"Last Written">>, <<>>},
+                            {<<"Last Applied">>, <<>>},
+                            {<<"Commit Index">>, <<>>},
+                            {<<"Snapshot Index">>, <<>>},
+                            {<<"Term">>, <<>>},
+                            {<<"Machine Version">>, MacVer}
+                           ];
+                       {error, Reason} ->
+                           State = case is_atom(Reason) of
+                                       true -> Reason;
+                                       false -> unknown
+                                   end,
+                           [{<<"Node Name">>, N},
+                            {<<"Raft State">>, State},
+                            {<<"Membership">>, <<>>},
+                            {<<"Last Log Index">>, <<>>},
+                            {<<"Last Written">>, <<>>},
+                            {<<"Last Applied">>, <<>>},
+                            {<<"Commit Index">>, <<>>},
+                            {<<"Snapshot Index">>, <<>>},
+                            {<<"Term">>, <<>>},
+                            {<<"Machine Version">>, <<>>}
+                           ]
+                   end,
+         case TagKey of
+             undefined -> BaseRow;
+             _         -> AZ = case maps:get(N, NodeToAZ, undefined) of
+                                   undefined -> <<>>;
+                                   Val       -> Val
+                               end,
+                          [NodeName | Rest] = BaseRow,
+                          [NodeName, {<<"AZ">>, AZ} | Rest]
          end
      end || N <- Nodes].
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1575,12 +1575,12 @@ status(Q) when ?amqqueue_is_quorum(Q) ->
                    end,
          case TagKey of
              undefined -> BaseRow;
-             _         -> AZ = case maps:get(N, NodeToAZ, undefined) of
-                                   undefined -> <<>>;
-                                   Val       -> Val
-                               end,
-                          [NodeName | Rest] = BaseRow,
-                          [NodeName, {<<"AZ">>, AZ} | Rest]
+             _ -> AZ = case maps:get(N, NodeToAZ, undefined) of
+                           undefined -> <<>>;
+                           Val -> Val
+                       end,
+                  [NodeName | Rest] = BaseRow,
+                  [NodeName, {<<"AZ">>, AZ} | Rest]
          end
      end || N <- Nodes].
 

--- a/deps/rabbit/test/unit_queue_location_SUITE.erl
+++ b/deps/rabbit/test/unit_queue_location_SUITE.erl
@@ -8,13 +8,15 @@
 all() ->
     [
      {group, generic},
-     {group, classic}
+     {group, classic},
+     {group, az_aware}
     ].
 
 groups() ->
     [
      {generic, [], generic_tests()},
-     {classic, [], classic_tests()}
+     {classic, [], classic_tests()},
+     {az_aware, [], az_aware_tests()}
     ].
 
 generic_tests() -> [
@@ -27,6 +29,20 @@ classic_tests() -> [
                     classic_balanced_below_threshold,
                     classic_balanced_above_threshold
                    ].
+
+
+az_aware_tests() -> [
+                     az_aware_no_tag,
+                     az_aware_three_azs,
+                     az_aware_two_azs,
+                     az_aware_null_az_untagged,
+                     az_aware_all_nodes_untagged,
+                     az_aware_above_threshold_random,
+                     az_aware_below_threshold_balanced,
+                     az_aware_fewer_nodes_than_size,
+                     az_aware_running_nodes_preferred,
+                     az_aware_node_tags_for_nodes_offline_nodes
+                    ].
 
 default_strategy(_Config) ->
     ok = meck:new(rabbit_queue_type_util, [passthrough]),
@@ -73,7 +89,8 @@ classic_balanced_below_threshold(_Config) ->
                               RunningNodes,
                               QueueCount,
                               QueueCountStartRandom,
-                              GetQueues),
+                              GetQueues,
+                              undefined),
     %% all running nodes should be considered
     ?assertEqual(RunningNodes, PotentialLeaders),
     % a few different distributions of queues across nodes
@@ -87,7 +104,7 @@ classic_balanced_below_threshold(_Config) ->
                                                           PotentialLeaders,
                                                           RunningNodes,
                                                           QueueCount,
-                                                          QueueCountStartRandom, 
+                                                          QueueCountStartRandom,
                                                           GetQueues)),
     % case 2
     ok = meck:expect(rabbit_queue_location, queues_per_node, fun(_, _) ->
@@ -99,7 +116,7 @@ classic_balanced_below_threshold(_Config) ->
                                                           PotentialLeaders,
                                                           RunningNodes,
                                                           QueueCount,
-                                                          QueueCountStartRandom, 
+                                                          QueueCountStartRandom,
                                                           GetQueues)),
     % case 3
     ok = meck:expect(rabbit_queue_location, queues_per_node, fun(_, _) ->
@@ -111,7 +128,7 @@ classic_balanced_below_threshold(_Config) ->
                                                           PotentialLeaders,
                                                           RunningNodes,
                                                           QueueCount,
-                                                          QueueCountStartRandom, 
+                                                          QueueCountStartRandom,
                                                           GetQueues)),
 
     ok = meck:unload([rabbit_queue_location, rabbit_maintenance]).
@@ -133,7 +150,8 @@ classic_balanced_above_threshold(_Config) ->
                                       RunningNodes,
                                       QueueCount,
                                       QueueCountStartRandom,
-                                      GetQueues),
+                                      GetQueues,
+                                      undefined),
                      rabbit_queue_location:leader_node(<<"balanced">>,
                                                        Members,
                                                        RunningNodes,
@@ -145,3 +163,249 @@ classic_balanced_above_threshold(_Config) ->
     %% we would have to be very unlucky not to see all 3 nodes in the results
     ?assertEqual([node1, node2, node3], lists:sort(lists:uniq(Locations))),
     ok = meck:unload([rabbit_maintenance]).
+
+%% No placement tag (undefined): the existing algorithm is used unchanged.
+az_aware_no_tag(_Config) ->
+    ok = meck:new(rabbit_queue_location, [passthrough]),
+    ok = meck:expect(rabbit_queue_location, node, fun() -> n1 end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    ok = meck:expect(rabbit_queue_type, get_nodes, fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3, n4, n5],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, undefined),
+    %% n1 is always the local (first) member; 3 members total.
+    ?assertEqual(3, length(Members)),
+    ?assert(lists:member(n1, Members)),
+    ok = meck:unload([rabbit_queue_location, rabbit_queue_type]).
+
+%% Three AZs: 3 nodes in az1, 2 in az2, 2 in az3.
+%% A 3-member QQ must end up with one member per AZ.
+az_aware_three_azs(_Config) ->
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3, n4, n5, n6, n7], <<"az">>) ->
+                             #{n1 => <<"az1">>, n2 => <<"az1">>, n3 => <<"az1">>,
+                               n4 => <<"az2">>, n5 => <<"az2">>,
+                               n6 => <<"az3">>, n7 => <<"az3">>}
+                     end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    ok = meck:expect(rabbit_queue_type, get_nodes, fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3, n4, n5, n6, n7],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    ?assertEqual(3, length(Members)),
+    AZMap = #{n1 => <<"az1">>, n2 => <<"az1">>, n3 => <<"az1">>,
+              n4 => <<"az2">>, n5 => <<"az2">>,
+              n6 => <<"az3">>, n7 => <<"az3">>},
+    AZsUsed = lists:sort(lists:uniq([maps:get(N, AZMap) || N <- Members])),
+    ?assertEqual([<<"az1">>, <<"az2">>, <<"az3">>], AZsUsed),
+    ok = meck:unload([rabbit_member_placement_az, rabbit_queue_type]).
+
+%% Two AZs with 2 nodes each; 3-member QQ: both AZs must appear in the result.
+az_aware_two_azs(_Config) ->
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3, n4], <<"az">>) ->
+                             #{n1 => <<"az1">>, n2 => <<"az1">>,
+                               n3 => <<"az2">>, n4 => <<"az2">>}
+                     end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    ok = meck:expect(rabbit_queue_type, get_nodes, fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3, n4],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    ?assertEqual(3, length(Members)),
+    AZMap = #{n1 => <<"az1">>, n2 => <<"az1">>, n3 => <<"az2">>, n4 => <<"az2">>},
+    AZsUsed = lists:uniq([maps:get(N, AZMap) || N <- Members]),
+    ?assertEqual(2, length(AZsUsed)),
+    ok = meck:unload([rabbit_member_placement_az, rabbit_queue_type]).
+
+%% Untagged nodes are treated as a distinct "null AZ" (undefined) and are eligible.
+az_aware_null_az_untagged(_Config) ->
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3], <<"az">>) ->
+                             #{n1 => <<"az1">>, n2 => <<"az2">>, n3 => undefined}
+                     end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    ok = meck:expect(rabbit_queue_type, get_nodes, fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    %% All three nodes should be selected: one per "AZ" (az1, az2, null).
+    ?assertEqual(lists:sort([n1, n2, n3]), lists:sort(Members)),
+    ok = meck:unload([rabbit_member_placement_az, rabbit_queue_type]).
+
+%% When no node has the placement tag, fall back to the default algorithm.
+%% Uses 5 nodes with size=3 so the guard length(AllNodes) =< Size does not trigger early.
+az_aware_all_nodes_untagged(_Config) ->
+    ok = meck:new(rabbit_queue_location, [passthrough]),
+    ok = meck:expect(rabbit_queue_location, node, fun() -> n1 end),
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3, n4, n5], <<"az">>) ->
+                             #{n1 => undefined, n2 => undefined, n3 => undefined,
+                               n4 => undefined, n5 => undefined}
+                     end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    ok = meck:expect(rabbit_queue_type, get_nodes, fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3, n4, n5],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    %% Falls back to default balanced: n1 (local node) + 2 others from 5 nodes.
+    ?assertEqual(3, length(Members)),
+    ?assert(lists:member(n1, Members)),
+    ok = meck:unload([rabbit_queue_location, rabbit_member_placement_az, rabbit_queue_type]).
+
+%% Above the queue count threshold: random selection within the preferred AZ.
+%% Each result must have exactly one member per AZ.
+az_aware_above_threshold_random(_Config) ->
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3, n4, n5, n6, n7], <<"az">>) ->
+                             #{n1 => <<"az1">>, n2 => <<"az1">>, n3 => <<"az1">>,
+                               n4 => <<"az2">>, n5 => <<"az2">>,
+                               n6 => <<"az3">>, n7 => <<"az3">>}
+                     end),
+    AllNodes = [n1, n2, n3, n4, n5, n6, n7],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 5000,
+    QueueCountStartRandom = 1000,
+    AZMap = #{n1 => <<"az1">>, n2 => <<"az1">>, n3 => <<"az1">>,
+              n4 => <<"az2">>, n5 => <<"az2">>,
+              n6 => <<"az3">>, n7 => <<"az3">>},
+    AllResults = [begin
+                      {Members, _} = rabbit_queue_location:select_members(
+                                       3, QueueType, AllNodes, RunningNodes,
+                                       QueueCount, QueueCountStartRandom,
+                                       GetQueues, <<"az">>),
+                      Members
+                  end || _ <- lists:seq(1, 50)],
+    %% Every result must have exactly one member from each of the three AZs.
+    ?assert(lists:all(fun(Members) ->
+                              AZsUsed = lists:sort(lists:uniq([maps:get(N, AZMap) || N <- Members])),
+                              AZsUsed =:= [<<"az1">>, <<"az2">>, <<"az3">>]
+                      end, AllResults)),
+    ok = meck:unload(rabbit_member_placement_az).
+
+%% Below the queue count threshold: pick the least-loaded node within the preferred AZ.
+az_aware_below_threshold_balanced(_Config) ->
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3, n4, n5], <<"az">>) ->
+                             #{n1 => <<"az1">>, n2 => <<"az1">>,
+                               n3 => <<"az2">>, n4 => <<"az2">>,
+                               n5 => <<"az3">>}
+                     end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    %% n3 has 5 existing QQ members, n4 has 1 — so n4 should be preferred within az2.
+    ok = meck:expect(rabbit_queue_type, get_nodes,
+                     fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3, n4, n5],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    FakeQueues = fake_queues([{n3, 5}, {n4, 1}]),
+    GetQueues = fun() -> FakeQueues end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    ?assertEqual(3, length(Members)),
+    %% n4 (1 queue) must be preferred over n3 (5 queues) within az2.
+    ?assert(lists:member(n4, Members)),
+    %% n5 is the only node in az3 and must always be selected.
+    ?assert(lists:member(n5, Members)),
+    ok = meck:unload([rabbit_member_placement_az, rabbit_queue_type]).
+
+%% When AllNodes < requested size the AZ-aware guard is bypassed and all nodes are used.
+az_aware_fewer_nodes_than_size(_Config) ->
+    ok = meck:new(rabbit_queue_location, [passthrough]),
+    ok = meck:expect(rabbit_queue_location, node, fun() -> n1 end),
+    AllNodes = [n1, n2],
+    RunningNodes = AllNodes,
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    ?assertEqual(lists:sort(AllNodes), lists:sort(Members)),
+    ok = meck:unload(rabbit_queue_location).
+
+%% Running nodes are preferred over stopped nodes within the same AZ.
+az_aware_running_nodes_preferred(_Config) ->
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3, n4], <<"az">>) ->
+                             #{n1 => <<"az1">>, n2 => <<"az2">>,
+                               n3 => <<"az2">>, n4 => <<"az3">>}
+                     end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    ok = meck:expect(rabbit_queue_type, get_nodes, fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3, n4],
+    %% n2 is stopped; n3 is in the same AZ (az2) and running.
+    RunningNodes = [n1, n3, n4],
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    ?assertEqual(3, length(Members)),
+    %% n3 (running, az2) must be chosen over n2 (stopped, az2).
+    ?assert(lists:member(n3, Members)),
+    ?assertNot(lists:member(n2, Members)),
+    ok = meck:unload([rabbit_member_placement_az, rabbit_queue_type]).
+
+az_aware_node_tags_for_nodes_offline_nodes(_Config) ->
+    ok = meck:new(rabbit_db_node_metadata, [passthrough]),
+    ok = meck:expect(rabbit_db_node_metadata, get,
+                     fun(n1) -> #{node_tags => [{<<"az">>, <<"az1">>}]};
+                        (n2) -> #{node_tags => [{<<"az">>, <<"az2">>}]};
+                        (n3) -> #{};
+                        (n4) -> #{}
+                     end),
+    Res1 = rabbit_member_placement_az:node_tags_for_nodes([n1, n2, n3, n4], <<"az">>),
+    ?assertEqual(#{n1 => <<"az1">>, n2 => <<"az2">>, n3 => undefined, n4 => undefined}, Res1),
+    ok = meck:unload([rabbit_db_node_metadata]).
+
+%% Build a list of fake queue terms, one per node per count.
+fake_queues(NodeCounts) ->
+    lists:flatmap(fun({Node, Count}) ->
+                          [{fake_queue, Node} || _ <- lists:seq(1, Count)]
+                  end, NodeCounts).

--- a/deps/rabbit/test/unit_queue_location_SUITE.erl
+++ b/deps/rabbit/test/unit_queue_location_SUITE.erl
@@ -41,6 +41,7 @@ az_aware_tests() -> [
                      az_aware_below_threshold_balanced,
                      az_aware_fewer_nodes_than_size,
                      az_aware_running_nodes_preferred,
+                     az_aware_entire_az_down,
                      az_aware_node_tags_for_nodes_offline_nodes
                     ].
 
@@ -390,6 +391,41 @@ az_aware_running_nodes_preferred(_Config) ->
     %% n3 (running, az2) must be chosen over n2 (stopped, az2).
     ?assert(lists:member(n3, Members)),
     ?assertNot(lists:member(n2, Members)),
+    ok = meck:unload([rabbit_member_placement_az, rabbit_queue_type]).
+
+%% An entire AZ can be without any running node (e.g. an outage). Unlike the
+%% non-AZ-aware strategies, which simply prefer whichever nodes are running,
+%% AZ-aware placement must still assign a member to the down AZ (picking one
+%% of its stopped nodes) rather than over-allocating to the AZs that are up.
+%% Balance across AZs is favoured over short-term node availability.
+az_aware_entire_az_down(_Config) ->
+    ok = meck:new(rabbit_member_placement_az, [passthrough]),
+    ok = meck:expect(rabbit_member_placement_az, node_tags_for_nodes,
+                     fun([n1, n2, n3, n4, n5, n6], <<"az">>) ->
+                             #{n1 => <<"az1">>, n2 => <<"az1">>,
+                               n3 => <<"az2">>, n4 => <<"az2">>,
+                               n5 => <<"az3">>, n6 => <<"az3">>}
+                     end),
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    ok = meck:expect(rabbit_queue_type, get_nodes, fun({fake_queue, N}) -> [N] end),
+    AllNodes = [n1, n2, n3, n4, n5, n6],
+    %% Both az3 nodes are stopped: the whole AZ is unavailable.
+    RunningNodes = [n1, n2, n3, n4],
+    QueueType = rabbit_quorum_queue,
+    GetQueues = fun() -> [] end,
+    QueueCount = 0,
+    QueueCountStartRandom = 1000,
+    {Members, _} = rabbit_queue_location:select_members(3, QueueType, AllNodes, RunningNodes,
+                                                        QueueCount, QueueCountStartRandom,
+                                                        GetQueues, <<"az">>),
+    ?assertEqual(3, length(Members)),
+    AZMap = #{n1 => <<"az1">>, n2 => <<"az1">>,
+              n3 => <<"az2">>, n4 => <<"az2">>,
+              n5 => <<"az3">>, n6 => <<"az3">>},
+    AZsUsed = lists:sort(lists:uniq([maps:get(N, AZMap) || N <- Members])),
+    %% az3 must still be represented even though none of its nodes are running.
+    ?assertEqual([<<"az1">>, <<"az2">>, <<"az3">>], AZsUsed),
+    ?assert(lists:member(n5, Members) orelse lists:member(n6, Members)),
     ok = meck:unload([rabbit_member_placement_az, rabbit_queue_type]).
 
 az_aware_node_tags_for_nodes_offline_nodes(_Config) ->

--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -117,7 +117,9 @@ RABBITMQ_STREAM_DIR="$(call node_stream_dir,$(2))" \
 RABBITMQ_FEATURE_FLAGS_FILE="$(call node_feature_flags_file,$(2))" \
 RABBITMQ_PLUGINS_DIR="$(call node_plugins_dir)" \
 RABBITMQ_PLUGINS_EXPAND_DIR="$(call node_plugins_expand_dir,$(2))" \
-RABBITMQ_SERVER_START_ARGS="$(RABBITMQ_SERVER_START_ARGS)"
+RABBITMQ_SERVER_START_ARGS="$(RABBITMQ_SERVER_START_ARGS)" \
+RABBITMQ_CONFIG_FILE="$(RABBITMQ_CONFIG_FILE)" \
+RABBITMQ_CONFIG_FILES="$(RABBITMQ_CONFIG_FILES)"
 endef
 
 # Only set RABBITMQ_ENABLED_PLUGINS if the enabled plugins file doesn't
@@ -390,6 +392,7 @@ stop-node:
 # --------------------------------------------------------------------
 
 NODES ?= 3
+AZ ?= 3
 
 start-brokers start-cluster: $(DIST_TARGET)
 	# nodes start in parallel; if the cookie file doesn't exist
@@ -414,10 +417,14 @@ start-brokers start-cluster: $(DIST_TARGET)
 	fi; \
 	for n in $$(seq $(NODES)); do \
 		nodename="rabbit-$$n@$(HOSTNAME)"; \
+		az_idx=$$(( ($$n - 1) % $(AZ) + 1 )); \
+		mkdir -p "$(TEST_TMPDIR)/$$nodename"; \
+		printf 'node_tags.az = az%d\n' "$$az_idx" > "$(TEST_TMPDIR)/$$nodename/node.conf"; \
 		$(MAKE) start-background-broker \
 		  NOBUILD=1 \
 		  RABBITMQ_NODENAME="$$nodename" \
 		  RABBITMQ_NODE_PORT="$$((5672 + $$n - 1))" \
+		  RABBITMQ_CONFIG_FILES="$(TEST_TMPDIR)/$$nodename/node.conf" \
 		  RABBITMQ_SERVER_START_ARGS=" \
 		  -rabbit loopback_users [] \
 		  -rabbit cluster_name localhost \

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -30,7 +30,8 @@ var KNOWN_ARGS = {'alternate-exchange':        {'short': 'AE',  'type': 'string'
                   'x-consumer-disconnected-timeout': {'short': 'CDT', 'type': 'int'},
                   'x-delayed-retry-type':    {'short': 'DRT', 'type': 'string'},
                   'x-delayed-retry-min':     {'short': 'DRm', 'type': 'int'},
-                  'x-delayed-retry-max':     {'short': 'DRM', 'type': 'int'}};
+                  'x-delayed-retry-max':     {'short': 'DRM', 'type': 'int'},
+                  'x-member-placement-tag':  {'short': 'MPT', 'type': 'string'}};
 
 // Things that are like arguments that we format the same way in listings.
 var IMPLICIT_ARGS = {'durable':         {'short': 'D',    'type': 'boolean'},
@@ -274,6 +275,9 @@ var HELP = {
 
     'queue-leader-locator':
        'Set the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are <code>client-local</code> (default) and <code>balanced</code>.',
+
+    'queue-member-placement-tag':
+       'Node tag key used for AZ-aware quorum queue member placement. When set, replicas are spread across distinct values of this tag (e.g. <code>az</code>). Requires nodes to be tagged with the matching key via the <code>node_tags</code> configuration.',
 
     'queue-initial-cluster-size':
        'Set the queue initial cluster size, i.e. number of queue members/replicas',

--- a/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-arguments.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-arguments.ejs
@@ -15,3 +15,4 @@
 | <span class="argument-link" field="arguments" key="x-delayed-retry-type" type="string">Delayed retry type</span><span class="help" id="queue-delayed-retry-type"></span>
 | <span class="argument-link" field="arguments" key="x-delayed-retry-min" type="number">Delayed retry min</span><span class="help" id="queue-delayed-retry-min"></span>
 | <span class="argument-link" field="arguments" key="x-delayed-retry-max" type="number">Delayed retry max</span><span class="help" id="queue-delayed-retry-max"></span>
+| <span class="argument-link" field="arguments" key="x-member-placement-tag" type="string">Member placement tag</span><span class="help" id="queue-member-placement-tag"></span>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-operator-policy-arguments.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-operator-policy-arguments.ejs
@@ -11,6 +11,8 @@
     <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span>
     <span class="help" id="queue-message-ttl"></span> |
     <span class="argument-link" field="definitionop" key="target-group-size" type="number">Target group size</span> |
-    <span class="argument-link" field="definitionop" key="overflow" type="string">Length limit overflow behaviour</span> <span class="help" id="queue-overflow"></span> </br>
+    <span class="argument-link" field="definitionop" key="overflow" type="string">Length limit overflow behaviour</span> <span class="help" id="queue-overflow"></span> |</br>
+    <span class="argument-link" field="definitionop" key="member-placement-tag" type="string">Member placement tag</span>
+    <span class="help" id="queue-member-placement-tag"></span>
   </td>
 </tr>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-user-policy-arguments.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-user-policy-arguments.ejs
@@ -13,5 +13,7 @@
     <span class="help" id="queue-delayed-retry-min"></span> |
     <span class="argument-link" field="definition" key="delayed-retry-max" type="number">Delayed retry max</span>
     <span class="help" id="queue-delayed-retry-max"></span> |
+    <span class="argument-link" field="definition" key="member-placement-tag" type="string">Member placement tag</span>
+    <span class="help" id="queue-member-placement-tag"></span> |
   </td>
 </tr>


### PR DESCRIPTION
Implements AZ-aware membership placement for quorum queues.

Until now, if there's more nodes than QQ members requested, we put one member locally (where the queue is declared) and the other members would be assigned randomly to other nodes, preferring nodes running at the time of declaration.

With this change, you can tag nodes using the existing node_tags feature and specify the tag used as the az information.
For example:
```
node_tags.az = az1
```

AZ awareness can be enabled:
* on the cluster level, using: `rabbit.quorum_queue_member_placement_tag=az`
* on the queue argument level: `member-placement-tag=az`
* using a policy/operator policy: `x-member-placement-tag=az`

When either of these is in effect, we'll make sure that members are evenly spread between nodes with different tag values.

For example, with 7 nodes, 3 tagged with `az = az1`, 2 with `az = az2` and 2 with `az = az3`, all 3-member quorum queues will have one member in az1, one in az2 and one in az3. The distribution of members between nodes within the same AZ remains as before: up to the limit (default of 1000 queues), we make it perfectly even, and if there's more queues - we start to assign nodes randomly (still taking AZ into consideration to be clear).