### PR TITLE
Handle unexpected failures during channel termination cleanup

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -724,26 +724,32 @@ terminate(_Reason,
           State = #ch{cfg = #conf{user = #user{username = Username}},
                       consumer_mapping = CM,
                       queue_states = QueueCtxs}) ->
-    rabbit_queue_type:close(QueueCtxs),
-    {_Res, _State1} = notify_queues(State),
-    pg:leave(pg_scope(), self(), self()),
-    rabbit_event:if_enabled(State, #ch.stats_timer,
-                            fun() -> emit_stats(State) end),
-    [delete_stats(Tag) || {Tag, _} <- get()],
-    maybe_decrease_global_publishers(State),
-    maps:foreach(
-      fun (_, _) ->
-              rabbit_global_counters:consumer_deleted(amqp091)
-      end, CM),
-    rabbit_core_metrics:channel_closed(self()),
-    rabbit_event:notify(channel_closed, [{pid, self()},
-                                         {user_who_performed_action, Username},
-                                         {consumer_count, maps:size(CM)}]),
-    case rabbit_confirms:size(State#ch.unconfirmed) of
-        0 -> ok;
-        NumConfirms ->
-            ?LOG_WARNING("Channel is stopping with ~b pending publisher confirms",
-                               [NumConfirms])
+    try
+        rabbit_queue_type:close(QueueCtxs),
+        {_Res, _State1} = notify_queues(State),
+        pg:leave(pg_scope(), self(), self()),
+        rabbit_event:if_enabled(State, #ch.stats_timer,
+                                fun() -> emit_stats(State) end),
+        [delete_stats(Tag) || {Tag, _} <- get()],
+        maybe_decrease_global_publishers(State),
+        maps:foreach(
+          fun (_, _) ->
+                  rabbit_global_counters:consumer_deleted(amqp091)
+          end, CM),
+        rabbit_core_metrics:channel_closed(self()),
+        rabbit_event:notify(channel_closed, [{pid, self()},
+                                             {user_who_performed_action, Username},
+                                             {consumer_count, maps:size(CM)}]),
+        case rabbit_confirms:size(State#ch.unconfirmed) of
+            0 -> ok;
+            NumConfirms ->
+                ?LOG_WARNING("Channel is stopping with ~b pending publisher confirms",
+                                   [NumConfirms])
+        end
+    catch
+        _Class:Reason ->
+            ?LOG_WARNING("Channel ~tp termination cleanup failed with reason: ~tp",
+                         [self(), Reason])
     end.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/deps/rabbit/test/channel_SUITE.erl
+++ b/deps/rabbit/test/channel_SUITE.erl
@@ -22,7 +22,8 @@ all() ->
 groups() ->
     [
       {non_parallel_tests, [], [
-          ready_for_close_with_dead_writer
+          ready_for_close_with_dead_writer,
+          terminate_safely_handles_cleanup_failures
         ]}
     ].
 
@@ -93,6 +94,46 @@ ready_for_close_with_dead_writer1(_Config) ->
         throw(channel_did_not_terminate)
     end,
     passed.
+
+terminate_safely_handles_cleanup_failures(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, terminate_safely_handles_cleanup_failures1, [Config]).
+
+terminate_safely_handles_cleanup_failures1(_Config) ->
+    {Writer, Ch} = start_channel_and_writer(),
+    MRef = erlang:monitor(process, Ch),
+
+    %% Make rabbit_queue_type:close/1 crash to simulate an unexpected
+    %% failure during channel termination cleanup.
+    ok = meck:new(rabbit_queue_type, [passthrough]),
+    meck:expect(rabbit_queue_type, close,
+                fun(_) -> error(fake_cleanup_failure) end),
+
+    rabbit_channel_common:do(Ch, #'channel.close'{reply_code = 200,
+                                                  reply_text = <<"OK">>,
+                                                  class_id = 0,
+                                                  method_id = 0}),
+    receive
+        {channel_closing, Ch} -> ok
+    after ?TIMEOUT ->
+        meck:unload(rabbit_queue_type),
+        throw(failed_to_receive_channel_closing)
+    end,
+
+    exit(Writer, kill),
+
+    rabbit_channel_common:ready_for_close(Ch),
+    receive
+        {'DOWN', MRef, process, Ch, normal} ->
+            meck:unload(rabbit_queue_type),
+            passed;
+        {'DOWN', MRef, process, Ch, Reason} ->
+            meck:unload(rabbit_queue_type),
+            throw({channel_should_terminate_normally, Reason})
+    after ?TIMEOUT ->
+        meck:unload(rabbit_queue_type),
+        throw(channel_did_not_terminate)
+    end.
 
 start_channel_and_writer() ->
     {Writer, _Limiter, Ch} = rabbit_ct_broker_helpers:test_channel(),


### PR DESCRIPTION
## Proposed Changes

During termination, channel cleanup is not guaranteed to complete as expected. We want to ensure any unexpected and unordered cleanup failures are handled appropriately without crashing the terminating channels entirely. 

Example, simulated `fake_cleanup_failure` crash in ct-tests:

```
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> ** Generic server <0.501.0> terminating
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> ** Last message in was {'$gen_cast',ready_for_close}
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> ** When Server state == {ch,{conf,closing,1,<0.498.0>,<0.499.0>,<0.498.0>,[],
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                 {user,<<"guest">>,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                     [administrator],
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                     [{rabbit_auth_backend_internal,none}]},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                 <<"/">>,<<>>,<0.498.0>,[],none,0,1800000,#{},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                 infinity,1000000000,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                 #{protocol => amqp091,vhost => <<"/">>,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                   username => <<"guest">>,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                                   connection_name => []}},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             {lstate,<0.500.0>,false},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             none,1,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             {0,[],[]},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             #{},#{},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             {state,none,5000,undefined},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             false,1,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             {rabbit_confirms,undefined,#{}},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             [],[],none,flow,[],
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             {rabbit_queue_type,#{}},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>                             #Ref<0.2670106036.1356595201.34271>,false}
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> ** Reason for termination ==
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> ** {fake_cleanup_failure,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>        [{channel_SUITE,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>             '-terminate_safely_handles_cleanup_failures1/1-fun-0-',1,
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>             [{file,"channel_SUITE.erl"},{line,110}]},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>         {rabbit_channel,terminate,2,[{file,"rabbit_channel.erl"},{line,739}]},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>         {gen_server2,terminate,3,[{file,"gen_server2.erl"},{line,1158}]},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>         {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,333}]},
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0>         {rabbit_queue_type,close,[{rabbit_queue_type,#{}}],[]}]}
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> ** In 'terminate' callback with reason ==
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> ** normal
2026-06-19 16:57:49.581062+01:00 [error] <0.501.0> 
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>   crasher:
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     initial call: rabbit_channel:init/1
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     pid: <0.501.0>
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     registered_name: []
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     exception exit: {fake_cleanup_failure,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                         [{channel_SUITE,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              '-terminate_safely_handles_cleanup_failures1/1-fun-0-',
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              1,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              [{file,"channel_SUITE.erl"},{line,110}]},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                          {rabbit_channel,terminate,2,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              [{file,"rabbit_channel.erl"},{line,739}]},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                          {gen_server2,terminate,3,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              [{file,"gen_server2.erl"},{line,1158}]},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                          {proc_lib,init_p_do_apply,3,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              [{file,"proc_lib.erl"},{line,333}]},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                          {rabbit_queue_type,close,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              [{rabbit_queue_type,#{}}],
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                              []}]}
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       in function  gen_server2:terminate/3 (gen_server2.erl:1162)
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     ancestors: [<0.498.0>]
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     message_queue_len: 0
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     messages: []
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     links: [<0.498.0>]
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     dictionary: [{rand_seed,{#{max => 288230376151711743,type => exsplus,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                                 next => #Fun<rand.5.71067687>,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                                 jump => #Fun<rand.3.71067687>},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                               [52673571142754889|19364566787630068]}},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                   {permission_cache_can_expire,false},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                   {'$logger_metadata$',#{domain => [rabbitmq,channel]}},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                   {channel_operation_timeout,15000},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                   {process_name,{rabbit_channel,{[],1}}},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                   {'$meck_call',undefined}]
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     trap_exit: true
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     status: running
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     heap_size: 6772
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     stack_size: 29
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     reductions: 30901
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>   neighbours:
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     neighbour:
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       pid: <0.500.0>
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       registered_name: []
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       initial call: rabbit_limiter:init/1
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       current_function: {gen_server2,process_next_msg,1}
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       ancestors: [<0.498.0>]
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       message_queue_len: 0
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       links: [<0.498.0>]
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       trap_exit: false
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       status: waiting
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       heap_size: 233
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       stack_size: 8
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       reductions: 150
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       current_stacktrace: [{gen_server2,process_next_msg,1,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                                [{file,"gen_server2.erl"},{line,673}]},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                   {proc_lib,init_p_do_apply,3,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                             [{file,"proc_lib.erl"},{line,333}]}]
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>     neighbour:
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       pid: <0.498.0>
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       registered_name: []
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       initial_call: {erpc,execute_call,4}
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       current_function: {channel_SUITE,terminate_safely_handles_cleanup_failures1,1}
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       ancestors: []
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       message_queue_len: 0
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       links: [<0.501.0>,<0.503.0>,<0.500.0>]
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       trap_exit: false
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       status: waiting
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       heap_size: 10958
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       stack_size: 11
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       reductions: 3457
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>       current_stacktrace: [{channel_SUITE,terminate_safely_handles_cleanup_failures1,1,
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                                  [{file,"channel_SUITE.erl"},{line,125}]},
2026-06-19 16:57:49.581293+01:00 [error] <0.501.0>                   {erpc,execute_call,4,[{file,"erpc.erl"},{line,1262}]}]
```

We encounter a lot of these kind of crashes in `rabbit_channel:terminate/2` in real environments e.g.

```
2026-06-16 10:04:46.126619+00:00 [error] <0.430811.0> ** Reason for termination ==
2026-06-16 10:04:46.126619+00:00 [error] <0.430811.0> ** noproc
2026-06-16 10:04:46.126619+00:00 [error] <0.430811.0>
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>   crasher:
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     initial call: rabbit_channel:init/1
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     pid: <0.430811.0>
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     registered_name: []
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     exception exit: noproc
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>       in function  gen_server2:terminate/3 (gen_server2.erl, line 1172)
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     ancestors: [<0.430808.0>,<0.430806.0>,<0.430801.0>,<0.430800.0>,
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>                   <0.11036.0>,<0.11035.0>,<0.11034.0>,<0.11032.0>,<0.11031.0>,
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>                   rabbit_sup,<0.228.0>]
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     message_queue_len: 1
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     messages: [{'EXIT',<0.430808.0>,shutdown}]
2026-06-16 10:04:46.129527+00:00 [error] <0.430811.0>     links: [<0.430808.0>]
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
