### PR TITLE
Implement #16725 for Mnesia for `v4.2.x` and older series

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -448,6 +448,12 @@ get_all_in_khepri() ->
 %% @private
 
 fold_projection(Fun, Acc) ->
+    rabbit_khepri:handle_fallback(
+      #{mnesia => fun() -> fold_in_mnesia(Fun, Acc) end,
+        khepri => fun() -> fold_projection_in_khepri(Fun, Acc) end
+       }).
+
+fold_projection_in_khepri(Fun, Acc) ->
     try
         ets:foldl(
           fun(#route{binding = Binding}, Acc0) -> Fun(Binding, Acc0) end,

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -141,6 +141,15 @@ get_all_in_khepri() ->
 %% Not wrapped in list_with_possible_retry/1: the callback may have side effects
 %% and the accumulator is arbitrary, so the fold must never be replayed.
 fold(Fun, Acc) ->
+    rabbit_khepri:handle_fallback(
+      #{mnesia => fun() -> fold_in_mnesia(Fun, Acc) end,
+        khepri => fun() -> fold_in_khepri(Fun, Acc) end
+       }).
+
+fold_in_mnesia(Fun, Acc) ->
+    ets:foldl(Fun, Acc, ?MNESIA_TABLE).
+
+fold_in_khepri(Fun, Acc) ->
     try
         ets:foldl(Fun, Acc, ?KHEPRI_PROJECTION)
     catch


### PR DESCRIPTION
#16725 introduced a Khepri-specific folding function. For `v4.2.x` and older series, we need to add a Mnesia implementation.