### PR TITLE
Adapt required permissions for stream-related operations

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2591,13 +2591,13 @@ handle_frame_post_auth(Transport,
                     {ok, no_route} ->
                         {?RESPONSE_CODE_OK, []};
                     {ok, Strs} ->
-                        AllReadable =
+                        AllWritable =
                             lists:all(fun(Stream) ->
                                               check_write_permitted(
                                                 stream_r(Stream, Connection),
                                                 User) =:= ok
                                       end, Strs),
-                        case AllReadable of
+                        case AllWritable of
                             true ->
                                 {?RESPONSE_CODE_OK, Strs};
                             false ->
@@ -2634,13 +2634,13 @@ handle_frame_post_auth(Transport,
             ok ->
                 case rabbit_stream_manager:partitions(VirtualHost, SuperStream) of
                     {ok, Streams} ->
-                        AllReadable =
+                        AllAccessible =
                             lists:all(fun(Stream) ->
                                               check_read_or_write_permitted(
                                                 stream_r(Stream, Connection),
                                                 User) =:= ok
                                       end, Streams),
-                        case AllReadable of
+                        case AllAccessible of
                             true ->
                                 {?RESPONSE_CODE_OK, Streams};
                             false ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2578,21 +2578,43 @@ handle_frame_post_auth(Transport,
     end;
 handle_frame_post_auth(Transport,
                        #stream_connection{socket = S,
-                                          virtual_host = VirtualHost} =
+                                          virtual_host = VirtualHost,
+                                          user = User} =
                            Connection,
                        State,
                        {request, CorrelationId,
                         {route, RoutingKey, SuperStream}}) ->
+    SuperStreamExchange = #resource{name = SuperStream,
+                                    kind = exchange,
+                                    virtual_host = VirtualHost},
     {ResponseCode, Streams} =
-        case rabbit_stream_manager:route(RoutingKey, VirtualHost, SuperStream)
-        of
-            {ok, no_route} ->
-                {?RESPONSE_CODE_OK, []};
-            {ok, Strs} ->
-                {?RESPONSE_CODE_OK, Strs};
-            {error, _} ->
-                increase_protocol_counter(?STREAM_DOES_NOT_EXIST),
-                {?RESPONSE_CODE_STREAM_DOES_NOT_EXIST, []}
+        case rabbit_stream_utils:check_read_permitted(SuperStreamExchange, User, #{}) of
+            error ->
+                increase_protocol_counter(?ACCESS_REFUSED),
+                {?RESPONSE_CODE_ACCESS_REFUSED, []};
+            ok ->
+                case rabbit_stream_manager:route(RoutingKey, VirtualHost, SuperStream) of
+                    {ok, no_route} ->
+                        {?RESPONSE_CODE_OK, []};
+                    {ok, Strs} ->
+                        AllReadable =
+                            lists:all(fun(Stream) ->
+                                         rabbit_stream_utils:check_read_permitted(
+                                             stream_r(Stream, Connection),
+                                             User,
+                                             #{}) =:= ok
+                                      end, Strs),
+                        case AllReadable of
+                            true ->
+                                {?RESPONSE_CODE_OK, Strs};
+                            false ->
+                                increase_protocol_counter(?ACCESS_REFUSED),
+                                {?RESPONSE_CODE_ACCESS_REFUSED, []}
+                        end;
+                    {error, _} ->
+                        increase_protocol_counter(?STREAM_DOES_NOT_EXIST),
+                        {?RESPONSE_CODE_STREAM_DOES_NOT_EXIST, []}
+                end
         end,
 
     Frame =

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2451,110 +2451,131 @@ handle_frame_post_auth(Transport,
 handle_frame_post_auth(Transport,
                        #stream_connection{socket = S,
                                           virtual_host = VirtualHost,
-                                          transport = TransportLayer} =
+                                          transport = TransportLayer,
+                                          user = User} =
                            Connection,
                        State,
                        {request, CorrelationId, {metadata, Streams}}) ->
-    Topology =
-        lists:foldl(fun(Stream, Acc) ->
-                       Acc#{Stream =>
-                                rabbit_stream_manager:topology(VirtualHost,
-                                                               Stream)}
-                    end,
-                    #{}, Streams),
-
-    %% get the nodes involved in the streams
-    NodesMap =
-        lists:foldl(fun(Stream, Acc) ->
-                       case maps:get(Stream, Topology) of
-                           {ok,
-                            #{leader_node := undefined,
-                              replica_nodes := ReplicaNodes}} ->
-                               lists:foldl(fun(ReplicaNode, NodesAcc) ->
-                                              maps:put(ReplicaNode, ok,
-                                                       NodesAcc)
-                                           end,
-                                           Acc, ReplicaNodes);
-                           {ok,
-                            #{leader_node := LeaderNode,
-                              replica_nodes := ReplicaNodes}} ->
-                               Acc1 = maps:put(LeaderNode, ok, Acc),
-                               lists:foldl(fun(ReplicaNode, NodesAcc) ->
-                                              maps:put(ReplicaNode, ok,
-                                                       NodesAcc)
-                                           end,
-                                           Acc1, ReplicaNodes);
-                           {error, _} -> Acc
-                       end
-                    end,
-                    #{}, Streams),
-
-    Nodes0 =
-        lists:sort(
-            maps:keys(NodesMap)),
-    %% filter out nodes in maintenance
-    Nodes =
-        lists:filter(fun(N) ->
-                        rabbit_maintenance:is_being_drained_consistent_read(N)
-                        =:= false
+    AuthorizedStreams =
+        lists:filter(fun(Stream) ->
+                        rabbit_stream_utils:check_read_permitted(stream_r(Stream,
+                                                                           Connection),
+                                                                 User,
+                                                                 #{})
+                        =:= ok
                      end,
-                     Nodes0),
-    HostFun = advertised_host_fun(TransportLayer),
-    PortFun = advertised_port_fun(TransportLayer),
+                     Streams),
+    case AuthorizedStreams of
+        [] when Streams =/= [] ->
+            response(Transport,
+                     Connection,
+                     metadata,
+                     CorrelationId,
+                     ?RESPONSE_CODE_ACCESS_REFUSED),
+            increase_protocol_counter(?ACCESS_REFUSED),
+            {Connection, State};
+        _ ->
+            Topology =
+                lists:foldl(fun(Stream, Acc) ->
+                               Acc#{Stream =>
+                                        rabbit_stream_manager:topology(VirtualHost,
+                                                                       Stream)}
+                            end,
+                            #{}, AuthorizedStreams),
 
-    FetchFun = fun() -> {rabbit_stream:HostFun(), rabbit_stream:PortFun()} end,
-    Results = erpc:multicall(Nodes, FetchFun, ?METADATA_TIMEOUT),
-    NodeEndpoints =
-        lists:foldl(
-          fun({Node, {ok, {Host, Port}}}, Acc) when is_binary(Host), is_integer(Port) ->
-                 %% Happy path: Node responded in time with valid data
-                 Acc#{Node => {Host, Port}};
-             ({Node, {ok, {Host, Port}}}, Acc) ->
-                 %% Node responded, but data was malformed
-                 ?LOG_WARNING("Error when retrieving broker '~tp' metadata: ~tp ~tp",
-                              [Node, Host, Port]),
-                 Acc;
-             ({Node, Error}, Acc) ->
-                 %% Node timed out, was unreachable, or threw an exception
-                 ?LOG_WARNING("Error/Timeout when retrieving broker '~tp' metadata: ~tp",
-                              [Node, Error]),
-                 Acc
-          end,
-          #{}, lists:zip(Nodes, Results)),
+            %% get the nodes involved in the streams
+            NodesMap =
+                lists:foldl(fun(Stream, Acc) ->
+                               case maps:get(Stream, Topology) of
+                                   {ok,
+                                    #{leader_node := undefined,
+                                      replica_nodes := ReplicaNodes}} ->
+                                       lists:foldl(fun(ReplicaNode, NodesAcc) ->
+                                                      maps:put(ReplicaNode, ok,
+                                                               NodesAcc)
+                                                   end,
+                                                   Acc, ReplicaNodes);
+                                   {ok,
+                                    #{leader_node := LeaderNode,
+                                      replica_nodes := ReplicaNodes}} ->
+                                       Acc1 = maps:put(LeaderNode, ok, Acc),
+                                       lists:foldl(fun(ReplicaNode, NodesAcc) ->
+                                                      maps:put(ReplicaNode, ok,
+                                                               NodesAcc)
+                                                   end,
+                                                   Acc1, ReplicaNodes);
+                                   {error, _} -> Acc
+                               end
+                            end,
+                            #{}, AuthorizedStreams),
 
-    Metadata =
-        lists:foldl(fun(Stream, Acc) ->
-                       case maps:get(Stream, Topology) of
-                           {error, Err} -> Acc#{Stream => Err};
-                           {ok,
-                            #{leader_node := LeaderNode,
-                              replica_nodes := Replicas}} ->
-                               LeaderInfo =
-                                   case NodeEndpoints of
-                                       #{LeaderNode := Info} -> Info;
-                                       _ -> undefined
-                                   end,
-                               ReplicaInfos =
-                                   lists:foldr(fun(Replica, A) ->
-                                                  case NodeEndpoints of
-                                                      #{Replica := I} ->
-                                                          [I | A];
-                                                      _ -> A
-                                                  end
-                                               end,
-                                               [], Replicas),
-                               Acc#{Stream => {LeaderInfo, ReplicaInfos}}
-                       end
-                    end,
-                    #{}, Streams),
-    Endpoints =
-        lists:usort(
-            maps:values(NodeEndpoints)),
-    Frame =
-        rabbit_stream_core:frame({response, CorrelationId,
-                                  {metadata, Endpoints, Metadata}}),
-    send(Transport, S, Frame),
-    {Connection, State};
+            Nodes0 =
+                lists:sort(
+                    maps:keys(NodesMap)),
+            %% filter out nodes in maintenance
+            Nodes =
+                lists:filter(fun(N) ->
+                                rabbit_maintenance:is_being_drained_consistent_read(N)
+                                =:= false
+                             end,
+                             Nodes0),
+            HostFun = advertised_host_fun(TransportLayer),
+            PortFun = advertised_port_fun(TransportLayer),
+
+            FetchFun = fun() -> {rabbit_stream:HostFun(), rabbit_stream:PortFun()} end,
+            Results = erpc:multicall(Nodes, FetchFun, ?METADATA_TIMEOUT),
+            NodeEndpoints =
+                lists:foldl(
+                  fun({Node, {ok, {Host, Port}}}, Acc) when is_binary(Host), is_integer(Port) ->
+                         %% Happy path: Node responded in time with valid data
+                         Acc#{Node => {Host, Port}};
+                     ({Node, {ok, {Host, Port}}}, Acc) ->
+                         %% Node responded, but data was malformed
+                         ?LOG_WARNING("Error when retrieving broker '~tp' metadata: ~tp ~tp",
+                                      [Node, Host, Port]),
+                         Acc;
+                     ({Node, Error}, Acc) ->
+                         %% Node timed out, was unreachable, or threw an exception
+                         ?LOG_WARNING("Error/Timeout when retrieving broker '~tp' metadata: ~tp",
+                                      [Node, Error]),
+                         Acc
+                  end,
+                  #{}, lists:zip(Nodes, Results)),
+
+            Metadata =
+                lists:foldl(fun(Stream, Acc) ->
+                               case maps:get(Stream, Topology) of
+                                   {error, Err} -> Acc#{Stream => Err};
+                                   {ok,
+                                    #{leader_node := LeaderNode,
+                                      replica_nodes := Replicas}} ->
+                                       LeaderInfo =
+                                           case NodeEndpoints of
+                                               #{LeaderNode := Info} -> Info;
+                                               _ -> undefined
+                                           end,
+                                       ReplicaInfos =
+                                           lists:foldr(fun(Replica, A) ->
+                                                          case NodeEndpoints of
+                                                              #{Replica := I} ->
+                                                                  [I | A];
+                                                              _ -> A
+                                                          end
+                                                       end,
+                                                       [], Replicas),
+                                       Acc#{Stream => {LeaderInfo, ReplicaInfos}}
+                               end
+                            end,
+                            #{}, AuthorizedStreams),
+            Endpoints =
+                lists:usort(
+                    maps:values(NodeEndpoints)),
+            Frame =
+                rabbit_stream_core:frame({response, CorrelationId,
+                                          {metadata, Endpoints, Metadata}}),
+            send(Transport, S, Frame),
+            {Connection, State}
+    end;
 handle_frame_post_auth(Transport,
                        #stream_connection{socket = S,
                                           virtual_host = VirtualHost} =

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -87,7 +87,8 @@
 -define(SAC_MOD, rabbit_stream_sac_coordinator).
 
 -import(rabbit_stream_utils, [check_write_permitted/2,
-                              check_read_permitted/3]).
+                              check_read_permitted/3,
+                              check_read_or_write_permitted/2]).
 
 %% client API
 -export([start_link/4,
@@ -2458,10 +2459,9 @@ handle_frame_post_auth(Transport,
                        {request, CorrelationId, {metadata, Streams}}) ->
     {AuthorizedStreams, UnauthorizedStreams} =
         lists:partition(fun(Stream) ->
-                                rabbit_stream_utils:check_read_permitted(
+                                check_read_or_write_permitted(
                                   stream_r(Stream, Connection),
-                                  User,
-                                  #{}
+                                  User
                                  ) =:= ok
                         end,
                         Streams),
@@ -2582,7 +2582,7 @@ handle_frame_post_auth(Transport,
                                     kind = exchange,
                                     virtual_host = VirtualHost},
     {ResponseCode, Streams} =
-        case rabbit_stream_utils:check_read_permitted(SuperStreamExchange, User, #{}) of
+        case check_write_permitted(SuperStreamExchange, User) of
             error ->
                 increase_protocol_counter(?ACCESS_REFUSED),
                 {?RESPONSE_CODE_ACCESS_REFUSED, []};
@@ -2593,10 +2593,9 @@ handle_frame_post_auth(Transport,
                     {ok, Strs} ->
                         AllReadable =
                             lists:all(fun(Stream) ->
-                                         rabbit_stream_utils:check_read_permitted(
-                                             stream_r(Stream, Connection),
-                                             User,
-                                             #{}) =:= ok
+                                              check_write_permitted(
+                                                stream_r(Stream, Connection),
+                                                User) =:= ok
                                       end, Strs),
                         case AllReadable of
                             true ->
@@ -2628,7 +2627,7 @@ handle_frame_post_auth(Transport,
                                     kind = exchange,
                                     virtual_host = VirtualHost},
     {ResponseCode, Partitions} =
-        case rabbit_stream_utils:check_read_permitted(SuperStreamExchange, User, #{}) of
+        case check_read_or_write_permitted(SuperStreamExchange, User) of
             error ->
                 increase_protocol_counter(?ACCESS_REFUSED),
                 {?RESPONSE_CODE_ACCESS_REFUSED, []};
@@ -2637,10 +2636,9 @@ handle_frame_post_auth(Transport,
                     {ok, Streams} ->
                         AllReadable =
                             lists:all(fun(Stream) ->
-                                         rabbit_stream_utils:check_read_permitted(
-                                             stream_r(Stream, Connection),
-                                             User,
-                                             #{}) =:= ok
+                                              check_read_or_write_permitted(
+                                                stream_r(Stream, Connection),
+                                                User) =:= ok
                                       end, Streams),
                         case AllReadable of
                             true ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2625,17 +2625,40 @@ handle_frame_post_auth(Transport,
     {Connection, State};
 handle_frame_post_auth(Transport,
                        #stream_connection{socket = S,
-                                          virtual_host = VirtualHost} =
+                                          virtual_host = VirtualHost,
+                                          user = User} =
                            Connection,
                        State,
                        {request, CorrelationId, {partitions, SuperStream}}) ->
+    SuperStreamExchange = #resource{name = SuperStream,
+                                    kind = exchange,
+                                    virtual_host = VirtualHost},
     {ResponseCode, Partitions} =
-        case rabbit_stream_manager:partitions(VirtualHost, SuperStream) of
-            {ok, Streams} ->
-                {?RESPONSE_CODE_OK, Streams};
-            {error, _} ->
-                increase_protocol_counter(?STREAM_DOES_NOT_EXIST),
-                {?RESPONSE_CODE_STREAM_DOES_NOT_EXIST, []}
+        case rabbit_stream_utils:check_read_permitted(SuperStreamExchange, User, #{}) of
+            error ->
+                increase_protocol_counter(?ACCESS_REFUSED),
+                {?RESPONSE_CODE_ACCESS_REFUSED, []};
+            ok ->
+                case rabbit_stream_manager:partitions(VirtualHost, SuperStream) of
+                    {ok, Streams} ->
+                        AllReadable =
+                            lists:all(fun(Stream) ->
+                                         rabbit_stream_utils:check_read_permitted(
+                                             stream_r(Stream, Connection),
+                                             User,
+                                             #{}) =:= ok
+                                      end, Streams),
+                        case AllReadable of
+                            true ->
+                                {?RESPONSE_CODE_OK, Streams};
+                            false ->
+                                increase_protocol_counter(?ACCESS_REFUSED),
+                                {?RESPONSE_CODE_ACCESS_REFUSED, []}
+                        end;
+                    {error, _} ->
+                        increase_protocol_counter(?STREAM_DOES_NOT_EXIST),
+                        {?RESPONSE_CODE_STREAM_DOES_NOT_EXIST, []}
+                end
         end,
 
     Frame =

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2456,126 +2456,120 @@ handle_frame_post_auth(Transport,
                            Connection,
                        State,
                        {request, CorrelationId, {metadata, Streams}}) ->
-    AuthorizedStreams =
-        lists:filter(fun(Stream) ->
-                        rabbit_stream_utils:check_read_permitted(stream_r(Stream,
-                                                                           Connection),
-                                                                 User,
-                                                                 #{})
-                        =:= ok
+    {AuthorizedStreams, UnauthorizedStreams} =
+        lists:partition(fun(Stream) ->
+                                rabbit_stream_utils:check_read_permitted(
+                                  stream_r(Stream, Connection),
+                                  User,
+                                  #{}
+                                 ) =:= ok
+                        end,
+                        Streams),
+        Topology0 =
+            lists:foldl(fun(Stream, Acc) ->
+                                Acc#{Stream =>
+                                     rabbit_stream_manager:topology(VirtualHost,
+                                                                    Stream)}
+                        end,
+                        #{}, AuthorizedStreams),
+
+
+        UnauthzStrms = #{StrName => {error, stream_not_allowed}
+                         || StrName <- UnauthorizedStreams},
+        Topology = maps:merge(Topology0, UnauthzStrms),
+
+        %% get the nodes involved in the streams
+        NodesMap =
+        lists:foldl(fun(Stream, Acc) ->
+                            case maps:get(Stream, Topology) of
+                                {ok,
+                                 #{leader_node := undefined,
+                                   replica_nodes := ReplicaNodes}} ->
+                                    lists:foldl(fun(ReplicaNode, NodesAcc) ->
+                                                        maps:put(ReplicaNode, ok,
+                                                                 NodesAcc)
+                                                end,
+                                                Acc, ReplicaNodes);
+                                {ok,
+                                 #{leader_node := LeaderNode,
+                                   replica_nodes := ReplicaNodes}} ->
+                                    Acc1 = maps:put(LeaderNode, ok, Acc),
+                                    lists:foldl(fun(ReplicaNode, NodesAcc) ->
+                                                        maps:put(ReplicaNode, ok,
+                                                                 NodesAcc)
+                                                end,
+                                                Acc1, ReplicaNodes);
+                                {error, _} -> Acc
+                            end
+                    end,
+                    #{}, AuthorizedStreams),
+
+        Nodes0 =
+        lists:sort(
+          maps:keys(NodesMap)),
+        %% filter out nodes in maintenance
+        Nodes =
+        lists:filter(fun(N) ->
+                             rabbit_maintenance:is_being_drained_consistent_read(N)
+                             =:= false
                      end,
-                     Streams),
-    case AuthorizedStreams of
-        [] when Streams =/= [] ->
-            response(Transport,
-                     Connection,
-                     metadata,
-                     CorrelationId,
-                     ?RESPONSE_CODE_ACCESS_REFUSED),
-            increase_protocol_counter(?ACCESS_REFUSED),
-            {Connection, State};
-        _ ->
-            Topology =
-                lists:foldl(fun(Stream, Acc) ->
-                               Acc#{Stream =>
-                                        rabbit_stream_manager:topology(VirtualHost,
-                                                                       Stream)}
-                            end,
-                            #{}, AuthorizedStreams),
+                     Nodes0),
+        HostFun = advertised_host_fun(TransportLayer),
+        PortFun = advertised_port_fun(TransportLayer),
 
-            %% get the nodes involved in the streams
-            NodesMap =
-                lists:foldl(fun(Stream, Acc) ->
-                               case maps:get(Stream, Topology) of
-                                   {ok,
-                                    #{leader_node := undefined,
-                                      replica_nodes := ReplicaNodes}} ->
-                                       lists:foldl(fun(ReplicaNode, NodesAcc) ->
-                                                      maps:put(ReplicaNode, ok,
-                                                               NodesAcc)
-                                                   end,
-                                                   Acc, ReplicaNodes);
-                                   {ok,
-                                    #{leader_node := LeaderNode,
-                                      replica_nodes := ReplicaNodes}} ->
-                                       Acc1 = maps:put(LeaderNode, ok, Acc),
-                                       lists:foldl(fun(ReplicaNode, NodesAcc) ->
-                                                      maps:put(ReplicaNode, ok,
-                                                               NodesAcc)
-                                                   end,
-                                                   Acc1, ReplicaNodes);
-                                   {error, _} -> Acc
-                               end
-                            end,
-                            #{}, AuthorizedStreams),
+        FetchFun = fun() -> {rabbit_stream:HostFun(), rabbit_stream:PortFun()} end,
+        Results = erpc:multicall(Nodes, FetchFun, ?METADATA_TIMEOUT),
+        NodeEndpoints =
+        lists:foldl(
+          fun({Node, {ok, {Host, Port}}}, Acc) when is_binary(Host), is_integer(Port) ->
+                  %% Happy path: Node responded in time with valid data
+                  Acc#{Node => {Host, Port}};
+             ({Node, {ok, {Host, Port}}}, Acc) ->
+                  %% Node responded, but data was malformed
+                  ?LOG_WARNING("Error when retrieving broker '~tp' metadata: ~tp ~tp",
+                               [Node, Host, Port]),
+                  Acc;
+             ({Node, Error}, Acc) ->
+                  %% Node timed out, was unreachable, or threw an exception
+                  ?LOG_WARNING("Error/Timeout when retrieving broker '~tp' metadata: ~tp",
+                               [Node, Error]),
+                  Acc
+          end,
+          #{}, lists:zip(Nodes, Results)),
 
-            Nodes0 =
-                lists:sort(
-                    maps:keys(NodesMap)),
-            %% filter out nodes in maintenance
-            Nodes =
-                lists:filter(fun(N) ->
-                                rabbit_maintenance:is_being_drained_consistent_read(N)
-                                =:= false
-                             end,
-                             Nodes0),
-            HostFun = advertised_host_fun(TransportLayer),
-            PortFun = advertised_port_fun(TransportLayer),
-
-            FetchFun = fun() -> {rabbit_stream:HostFun(), rabbit_stream:PortFun()} end,
-            Results = erpc:multicall(Nodes, FetchFun, ?METADATA_TIMEOUT),
-            NodeEndpoints =
-                lists:foldl(
-                  fun({Node, {ok, {Host, Port}}}, Acc) when is_binary(Host), is_integer(Port) ->
-                         %% Happy path: Node responded in time with valid data
-                         Acc#{Node => {Host, Port}};
-                     ({Node, {ok, {Host, Port}}}, Acc) ->
-                         %% Node responded, but data was malformed
-                         ?LOG_WARNING("Error when retrieving broker '~tp' metadata: ~tp ~tp",
-                                      [Node, Host, Port]),
-                         Acc;
-                     ({Node, Error}, Acc) ->
-                         %% Node timed out, was unreachable, or threw an exception
-                         ?LOG_WARNING("Error/Timeout when retrieving broker '~tp' metadata: ~tp",
-                                      [Node, Error]),
-                         Acc
-                  end,
-                  #{}, lists:zip(Nodes, Results)),
-
-            Metadata =
-                lists:foldl(fun(Stream, Acc) ->
-                               case maps:get(Stream, Topology) of
-                                   {error, Err} -> Acc#{Stream => Err};
-                                   {ok,
-                                    #{leader_node := LeaderNode,
-                                      replica_nodes := Replicas}} ->
-                                       LeaderInfo =
-                                           case NodeEndpoints of
-                                               #{LeaderNode := Info} -> Info;
-                                               _ -> undefined
-                                           end,
-                                       ReplicaInfos =
-                                           lists:foldr(fun(Replica, A) ->
-                                                          case NodeEndpoints of
-                                                              #{Replica := I} ->
-                                                                  [I | A];
-                                                              _ -> A
-                                                          end
-                                                       end,
-                                                       [], Replicas),
-                                       Acc#{Stream => {LeaderInfo, ReplicaInfos}}
-                               end
-                            end,
-                            #{}, AuthorizedStreams),
-            Endpoints =
-                lists:usort(
-                    maps:values(NodeEndpoints)),
-            Frame =
-                rabbit_stream_core:frame({response, CorrelationId,
-                                          {metadata, Endpoints, Metadata}}),
-            send(Transport, S, Frame),
-            {Connection, State}
-    end;
+        Metadata =
+        lists:foldl(fun(Stream, Acc) ->
+                            case maps:get(Stream, Topology) of
+                                {error, Err} -> Acc#{Stream => Err};
+                                {ok,
+                                 #{leader_node := LeaderNode,
+                                   replica_nodes := Replicas}} ->
+                                    LeaderInfo =
+                                    case NodeEndpoints of
+                                        #{LeaderNode := Info} -> Info;
+                                        _ -> undefined
+                                    end,
+                                    ReplicaInfos =
+                                    lists:foldr(fun(Replica, A) ->
+                                                        case NodeEndpoints of
+                                                            #{Replica := I} ->
+                                                                [I | A];
+                                                            _ -> A
+                                                        end
+                                                end,
+                                                [], Replicas),
+                                    Acc#{Stream => {LeaderInfo, ReplicaInfos}}
+                            end
+                    end,
+                    #{}, Streams),
+        Endpoints =
+        lists:usort(
+          maps:values(NodeEndpoints)),
+        Frame =
+        rabbit_stream_core:frame({response, CorrelationId,
+                                  {metadata, Endpoints, Metadata}}),
+        send(Transport, S, Frame),
+        {Connection, State};
 handle_frame_post_auth(Transport,
                        #stream_connection{socket = S,
                                           virtual_host = VirtualHost,

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2954,45 +2954,56 @@ handle_frame_post_auth(Transport,
                                           user = #user{username = Username} = User} = Connection,
                        State,
                        {request, CorrelationId, {delete_super_stream, SuperStream}}) ->
-    case rabbit_stream_manager:partitions(VirtualHost, SuperStream) of
-        {ok, Partitions} ->
-            case rabbit_stream_utils:check_super_stream_management_permitted(VirtualHost,
-                                                                             SuperStream,
-                                                                             Partitions,
-                                                                             User) of
-                ok ->
-                    %% Pass the authorization-checked partition snapshot directly to avoid
-                    %% a TOCTOU race where a queue.bind between the authz check and the
-                    %% deletion could allow unauthorized streams to be deleted.
-                    rabbit_stream_manager:delete_super_stream(VirtualHost,
-                                                              SuperStream,
-                                                              Partitions,
-                                                              Username),
-                    response_ok(Transport,
-                                Connection,
-                                delete_super_stream,
-                                CorrelationId),
-                    {Connection1, State1} = clean_state_after_super_stream_deletion(Partitions,
-                                                                                    Connection,
-                                                                                    State,
-                                                                                    Transport, S),
-                    {Connection1, State1};
-                error ->
+    case rabbit_stream_utils:check_super_stream_permitted(VirtualHost, SuperStream, User) of
+        ok ->
+            case rabbit_stream_manager:partitions(VirtualHost, SuperStream) of
+                {ok, Partitions} ->
+                    case rabbit_stream_utils:check_super_stream_management_permitted(VirtualHost,
+                                                                                     SuperStream,
+                                                                                     Partitions,
+                                                                                     User) of
+                        ok ->
+                            %% Pass the authorization-checked partition snapshot directly to avoid
+                            %% a TOCTOU race where a queue.bind between the authz check and the
+                            %% deletion could allow unauthorized streams to be deleted.
+                            rabbit_stream_manager:delete_super_stream(VirtualHost,
+                                                                      SuperStream,
+                                                                      Partitions,
+                                                                      Username),
+                            response_ok(Transport,
+                                        Connection,
+                                        delete_super_stream,
+                                        CorrelationId),
+                            {Connection1, State1} = clean_state_after_super_stream_deletion(Partitions,
+                                                                                            Connection,
+                                                                                            State,
+                                                                                            Transport, S),
+                            {Connection1, State1};
+                        error ->
+                            response(Transport,
+                                     Connection,
+                                     delete_super_stream,
+                                     CorrelationId,
+                                     ?RESPONSE_CODE_ACCESS_REFUSED),
+                            increase_protocol_counter(?ACCESS_REFUSED),
+                            {Connection, State}
+                    end;
+                {error, _} ->
                     response(Transport,
                              Connection,
                              delete_super_stream,
                              CorrelationId,
-                             ?RESPONSE_CODE_ACCESS_REFUSED),
-                    increase_protocol_counter(?ACCESS_REFUSED),
+                             ?RESPONSE_CODE_STREAM_DOES_NOT_EXIST),
+                    increase_protocol_counter(?STREAM_DOES_NOT_EXIST),
                     {Connection, State}
             end;
-        {error, _} ->
+        error ->
             response(Transport,
                      Connection,
                      delete_super_stream,
                      CorrelationId,
-                     ?RESPONSE_CODE_STREAM_DOES_NOT_EXIST),
-            increase_protocol_counter(?STREAM_DOES_NOT_EXIST),
+                     ?RESPONSE_CODE_ACCESS_REFUSED),
+            increase_protocol_counter(?ACCESS_REFUSED),
             {Connection, State}
     end;
 handle_frame_post_auth(Transport,

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -27,6 +27,7 @@
          check_configure_permitted/2,
          check_write_permitted/2,
          check_read_permitted/3,
+         check_read_or_write_permitted/2,
          extract_stream_list/2,
          sort_partitions/1,
          strip_cr_lf/1,
@@ -205,6 +206,14 @@ check_write_permitted(Resource, User) ->
 
 check_read_permitted(Resource, User, Context) ->
     check_resource_access(User, Resource, read, Context).
+
+check_read_or_write_permitted(Resource, User) ->
+    case check_read_permitted(Resource, User, #{}) of
+        ok ->
+            ok;
+        _ ->
+            check_write_permitted(Resource, User)
+    end.
 
 -spec check_super_stream_management_permitted(rabbit_types:vhost(), binary(),
                                               [binary()], rabbit_types:user()) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -69,6 +69,7 @@ groups() ->
        should_receive_metadata_update_after_update_secret,
        store_offset_requires_read_access,
        metadata_requires_read_access,
+       route_requires_read_access,
        offset_lag_calculation,
        test_super_stream_duplicate_partitions,
        authentication_error_should_close_with_delay,
@@ -221,6 +222,10 @@ init_per_testcase(metadata_requires_read_access = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
+init_per_testcase(route_requires_read_access = TestCase, Config) ->
+  ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
+  rabbit_ct_helpers:testcase_started(Config, TestCase);
+
 init_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"other">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
@@ -269,6 +274,10 @@ end_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(metadata_requires_read_access = TestCase, Config) ->
+    ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
+    rabbit_ct_helpers:testcase_finished(Config, TestCase);
+
+end_per_testcase(route_requires_read_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, Config) ->
@@ -1195,6 +1204,52 @@ metadata_requires_read_access(Config) ->
     C8 = test_delete_stream(T, S, Stream1, C7, false),
     C9 = test_delete_stream(T, S, Stream2, C8, false),
     test_close(T, S, C9),
+    closed = wait_for_socket_close(T, S, 10),
+    ok.
+
+route_requires_read_access(Config) ->
+    Username = <<"test">>,
+    rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
+
+    T = gen_tcp,
+    Port = get_port(T, Config),
+    Opts = get_opts(T),
+    {ok, S} = T:connect("localhost", Port, Opts),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(T, S, C0),
+    C2 = test_authenticate(T, S, C1, Username),
+    Ss = atom_to_binary(?FUNCTION_NAME, utf8),
+    Partitions = [unicode:characters_to_binary([Ss, <<"-">>, integer_to_binary(N)])
+                  || N <- lists:seq(0, 2)],
+    Bks = [integer_to_binary(N) || N <- lists:seq(0, 2)],
+
+    %% create the super stream
+    ok = T:send(S, request({create_super_stream, Ss, Partitions, Bks, #{}})),
+    {Cmd1, C3} = receive_commands(T, S, C2),
+    ?assertMatch({response, 1, {create_super_stream, ?RESPONSE_CODE_OK}}, Cmd1),
+
+    %% route should succeed with full permissions
+    RouteFrame = request({route, <<"0">>, Ss}),
+    ok = T:send(S, RouteFrame),
+    {Cmd2, C4} = receive_commands(T, S, C3),
+    ?assertMatch({response, 1, {route, ?RESPONSE_CODE_OK, _}}, Cmd2),
+
+    %% remove read access
+    rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
+                                             <<".*">>, <<".*">>, <<"foobar">>),
+
+    %% route should fail with access refused
+    ok = T:send(S, RouteFrame),
+    {Cmd3, C5} = receive_commands(T, S, C4),
+    ?assertEqual({response, 1, {route, ?RESPONSE_CODE_ACCESS_REFUSED, []}}, Cmd3),
+
+    %% restore full permissions to delete the super stream
+    rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
+    ok = T:send(S, request({delete_super_stream, Ss})),
+    {Cmd4, C6} = receive_commands(T, S, C5),
+    ?assertMatch({response, 1, {delete_super_stream, ?RESPONSE_CODE_OK}}, Cmd4),
+
+    test_close(T, S, C6),
     closed = wait_for_socket_close(T, S, 10),
     ok.
 

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -69,7 +69,7 @@ groups() ->
        should_receive_metadata_update_after_update_secret,
        store_offset_requires_read_access,
        metadata_requires_read_access,
-       route_requires_read_access,
+       route_partitions_require_read_access,
        offset_lag_calculation,
        test_super_stream_duplicate_partitions,
        authentication_error_should_close_with_delay,
@@ -222,7 +222,7 @@ init_per_testcase(metadata_requires_read_access = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
-init_per_testcase(route_requires_read_access = TestCase, Config) ->
+init_per_testcase(route_partitions_require_read_access = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
@@ -276,8 +276,7 @@ end_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
 end_per_testcase(metadata_requires_read_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
-
-end_per_testcase(route_requires_read_access = TestCase, Config) ->
+end_per_testcase(route_partitions_require_read_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, Config) ->
@@ -1207,7 +1206,7 @@ metadata_requires_read_access(Config) ->
     closed = wait_for_socket_close(T, S, 10),
     ok.
 
-route_requires_read_access(Config) ->
+route_partitions_require_read_access(Config) ->
     Username = <<"test">>,
     rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
 
@@ -1228,28 +1227,37 @@ route_requires_read_access(Config) ->
     {Cmd1, C3} = receive_commands(T, S, C2),
     ?assertMatch({response, 1, {create_super_stream, ?RESPONSE_CODE_OK}}, Cmd1),
 
-    %% route should succeed with full permissions
+    %% route and partitions should succeed with full permissions
     RouteFrame = request({route, <<"0">>, Ss}),
     ok = T:send(S, RouteFrame),
     {Cmd2, C4} = receive_commands(T, S, C3),
     ?assertMatch({response, 1, {route, ?RESPONSE_CODE_OK, _}}, Cmd2),
 
+    PartitionsFrame = request({partitions, Ss}),
+    ok = T:send(S, PartitionsFrame),
+    {Cmd3, C5} = receive_commands(T, S, C4),
+    ?assertMatch({response, 1, {partitions, ?RESPONSE_CODE_OK, Partitions}}, Cmd3),
+
     %% remove read access
     rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
                                              <<".*">>, <<".*">>, <<"foobar">>),
 
-    %% route should fail with access refused
+    %% route and partitions should fail with access refused
     ok = T:send(S, RouteFrame),
-    {Cmd3, C5} = receive_commands(T, S, C4),
-    ?assertEqual({response, 1, {route, ?RESPONSE_CODE_ACCESS_REFUSED, []}}, Cmd3),
+    {Cmd4, C6} = receive_commands(T, S, C5),
+    ?assertEqual({response, 1, {route, ?RESPONSE_CODE_ACCESS_REFUSED, []}}, Cmd4),
+
+    ok = T:send(S, PartitionsFrame),
+    {Cmd5, C7} = receive_commands(T, S, C6),
+    ?assertEqual({response, 1, {partitions, ?RESPONSE_CODE_ACCESS_REFUSED, []}}, Cmd5),
 
     %% restore full permissions to delete the super stream
     rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
     ok = T:send(S, request({delete_super_stream, Ss})),
-    {Cmd4, C6} = receive_commands(T, S, C5),
-    ?assertMatch({response, 1, {delete_super_stream, ?RESPONSE_CODE_OK}}, Cmd4),
+    {Cmd6, C8} = receive_commands(T, S, C7),
+    ?assertMatch({response, 1, {delete_super_stream, ?RESPONSE_CODE_OK}}, Cmd6),
 
-    test_close(T, S, C6),
+    test_close(T, S, C8),
     closed = wait_for_socket_close(T, S, 10),
     ok.
 

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -68,6 +68,7 @@ groups() ->
        connection_should_be_closed_on_token_expiry,
        should_receive_metadata_update_after_update_secret,
        store_offset_requires_read_access,
+       metadata_requires_read_access,
        offset_lag_calculation,
        test_super_stream_duplicate_partitions,
        authentication_error_should_close_with_delay,
@@ -216,6 +217,10 @@ init_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
+init_per_testcase(metadata_requires_read_access = TestCase, Config) ->
+  ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
+  rabbit_ct_helpers:testcase_started(Config, TestCase);
+
 init_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"other">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
@@ -261,6 +266,9 @@ end_per_testcase(node_connection_limit = TestCase, Config) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_stream, max_connections, infinity]),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
+    ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
+    rabbit_ct_helpers:testcase_finished(Config, TestCase);
+end_per_testcase(metadata_requires_read_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, Config) ->
@@ -1138,6 +1146,54 @@ store_offset_requires_read_access(Config) ->
     ?assertMatch(timeout, Timeout),
 
     C9 = test_delete_stream(T, S, Stream, C8, true),
+    test_close(T, S, C9),
+    closed = wait_for_socket_close(T, S, 10),
+    ok.
+
+metadata_requires_read_access(Config) ->
+    Username = <<"test">>,
+    rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
+
+    T = gen_tcp,
+    Port = get_port(T, Config),
+    Opts = get_opts(T),
+    {ok, S} = T:connect("localhost", Port, Opts),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(T, S, C0),
+    C2 = test_authenticate(T, S, C1, Username),
+    FunctionName = atom_to_binary(?FUNCTION_NAME, utf8),
+    Stream1 = <<FunctionName/binary, "_1">>,
+    Stream2 = <<FunctionName/binary, "_2">>,
+    C3 = test_create_stream(T, S, Stream1, C2),
+    C4 = test_create_stream(T, S, Stream2, C3),
+
+    %% both streams are accessible
+    ok = T:send(S, request({metadata, [Stream1, Stream2]})),
+    {Cmd1, C5} = receive_commands(T, S, C4),
+    ?assertMatch({response, 1, {metadata, _, #{Stream1 := {_, _}, Stream2 := {_, _}}}}, Cmd1),
+
+    %% no read access anymore
+    rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
+                                             <<".*">>, <<".*">>, <<"foobar">>),
+    %% metadata request fails because the user has no read access to any stream
+    ok = T:send(S, request({metadata, [Stream1, Stream2]})),
+    {Cmd2, C6} = receive_commands(T, S, C5),
+    ?assertEqual({response, 1, {metadata, ?RESPONSE_CODE_ACCESS_REFUSED}}, Cmd2),
+
+    %% give read access to only stream1
+    rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
+                                             <<".*">>, <<".*">>, Stream1),
+    %% metadata request returns topology for only the authorized stream
+    ok = T:send(S, request({metadata, [Stream1, Stream2]})),
+    {Cmd3, C7} = receive_commands(T, S, C6),
+    {response, 1, {metadata, _, MetaMap}} = Cmd3,
+    ?assertMatch(#{Stream1 := {_, _}}, MetaMap),
+    ?assertNot(maps:is_key(Stream2, MetaMap)),
+
+    %% restore full permissions to delete the streams
+    rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
+    C8 = test_delete_stream(T, S, Stream1, C7, false),
+    C9 = test_delete_stream(T, S, Stream2, C8, false),
     test_close(T, S, C9),
     closed = wait_for_socket_close(T, S, 10),
     ok.

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -1186,7 +1186,8 @@ metadata_requires_read_access(Config) ->
     %% metadata request fails because the user has no read access to any stream
     ok = T:send(S, request({metadata, [Stream1, Stream2]})),
     {Cmd2, C6} = receive_commands(T, S, C5),
-    ?assertEqual({response, 1, {metadata, ?RESPONSE_CODE_ACCESS_REFUSED}}, Cmd2),
+    ?assertMatch({response, 1,
+                  {metadata, _, #{Stream1 := stream_not_allowed, Stream2 := stream_not_allowed}}}, Cmd2),
 
     %% give read access to only stream1
     rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
@@ -1196,7 +1197,7 @@ metadata_requires_read_access(Config) ->
     {Cmd3, C7} = receive_commands(T, S, C6),
     {response, 1, {metadata, _, MetaMap}} = Cmd3,
     ?assertMatch(#{Stream1 := {_, _}}, MetaMap),
-    ?assertNot(maps:is_key(Stream2, MetaMap)),
+    ?assertMatch(#{Stream2 := stream_not_allowed}, MetaMap),
 
     %% restore full permissions to delete the streams
     rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -68,8 +68,8 @@ groups() ->
        connection_should_be_closed_on_token_expiry,
        should_receive_metadata_update_after_update_secret,
        store_offset_requires_read_access,
-       metadata_requires_read_access,
-       route_partitions_require_read_access,
+       metadata_requires_read_or_write_access,
+       route_partitions_require_read_or_write_access,
        offset_lag_calculation,
        test_super_stream_duplicate_partitions,
        authentication_error_should_close_with_delay,
@@ -218,11 +218,11 @@ init_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
-init_per_testcase(metadata_requires_read_access = TestCase, Config) ->
+init_per_testcase(metadata_requires_read_or_write_access = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
-init_per_testcase(route_partitions_require_read_access = TestCase, Config) ->
+init_per_testcase(route_partitions_require_read_or_write_access = TestCase, Config) ->
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"test">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
@@ -273,10 +273,10 @@ end_per_testcase(node_connection_limit = TestCase, Config) ->
 end_per_testcase(store_offset_requires_read_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
-end_per_testcase(metadata_requires_read_access = TestCase, Config) ->
+end_per_testcase(metadata_requires_read_or_write_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
-end_per_testcase(route_partitions_require_read_access = TestCase, Config) ->
+end_per_testcase(route_partitions_require_read_or_write_access = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:delete_user(Config, <<"test">>),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, Config) ->
@@ -1158,7 +1158,7 @@ store_offset_requires_read_access(Config) ->
     closed = wait_for_socket_close(T, S, 10),
     ok.
 
-metadata_requires_read_access(Config) ->
+metadata_requires_read_or_write_access(Config) ->
     Username = <<"test">>,
     rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
 
@@ -1180,10 +1180,10 @@ metadata_requires_read_access(Config) ->
     {Cmd1, C5} = receive_commands(T, S, C4),
     ?assertMatch({response, 1, {metadata, _, #{Stream1 := {_, _}, Stream2 := {_, _}}}}, Cmd1),
 
-    %% no read access anymore
+    %% no read/write access anymore
     rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
-                                             <<".*">>, <<".*">>, <<"foobar">>),
-    %% metadata request fails because the user has no read access to any stream
+                                             <<".*">>, <<"foobar">>, <<"foobar">>),
+    %% metadata request fails because the user has no read/write access to any stream
     ok = T:send(S, request({metadata, [Stream1, Stream2]})),
     {Cmd2, C6} = receive_commands(T, S, C5),
     ?assertMatch({response, 1,
@@ -1191,7 +1191,7 @@ metadata_requires_read_access(Config) ->
 
     %% give read access to only stream1
     rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
-                                             <<".*">>, <<".*">>, Stream1),
+                                             <<".*">>, <<"foobar">>, Stream1),
     %% metadata request returns topology for only the authorized stream
     ok = T:send(S, request({metadata, [Stream1, Stream2]})),
     {Cmd3, C7} = receive_commands(T, S, C6),
@@ -1199,15 +1199,25 @@ metadata_requires_read_access(Config) ->
     ?assertMatch(#{Stream1 := {_, _}}, MetaMap),
     ?assertMatch(#{Stream2 := stream_not_allowed}, MetaMap),
 
+    %% give write access to only stream1
+    rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
+                                             <<".*">>, Stream1, <<"foobar">>),
+    %% metadata request returns topology for only the authorized stream
+    ok = T:send(S, request({metadata, [Stream1, Stream2]})),
+    {Cmd4, C8} = receive_commands(T, S, C7),
+    {response, 1, {metadata, _, MetaMap}} = Cmd4,
+    ?assertMatch(#{Stream1 := {_, _}}, MetaMap),
+    ?assertMatch(#{Stream2 := stream_not_allowed}, MetaMap),
+
     %% restore full permissions to delete the streams
     rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
-    C8 = test_delete_stream(T, S, Stream1, C7, false),
-    C9 = test_delete_stream(T, S, Stream2, C8, false),
-    test_close(T, S, C9),
+    C9 = test_delete_stream(T, S, Stream1, C8, false),
+    C10 = test_delete_stream(T, S, Stream2, C9, false),
+    test_close(T, S, C10),
     closed = wait_for_socket_close(T, S, 10),
     ok.
 
-route_partitions_require_read_access(Config) ->
+route_partitions_require_read_or_write_access(Config) ->
     Username = <<"test">>,
     rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
 
@@ -1243,22 +1253,53 @@ route_partitions_require_read_access(Config) ->
     rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
                                              <<".*">>, <<".*">>, <<"foobar">>),
 
-    %% route and partitions should fail with access refused
+    %% route should succeed, it requires write access and has it
+    %% (route is used by producers to route messages)
     ok = T:send(S, RouteFrame),
     {Cmd4, C6} = receive_commands(T, S, C5),
-    ?assertEqual({response, 1, {route, ?RESPONSE_CODE_ACCESS_REFUSED, []}}, Cmd4),
+    ?assertMatch({response, 1, {route, ?RESPONSE_CODE_OK, _}}, Cmd4),
 
+    %% partitions should succeed, it requires read or write
+    %% (partitions is used by both producers and consumers)
     ok = T:send(S, PartitionsFrame),
     {Cmd5, C7} = receive_commands(T, S, C6),
-    ?assertEqual({response, 1, {partitions, ?RESPONSE_CODE_ACCESS_REFUSED, []}}, Cmd5),
+    ?assertEqual({response, 1, {partitions, ?RESPONSE_CODE_OK, Partitions}}, Cmd5),
+
+    %% remove write access
+    rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
+                                             <<".*">>, <<"foobar">>, <<".*">>),
+
+    %% route should fail, it needs write access
+    ok = T:send(S, RouteFrame),
+    {Cmd6, C8} = receive_commands(T, S, C7),
+    ?assertMatch({response, 1, {route, ?RESPONSE_CODE_ACCESS_REFUSED, _}}, Cmd6),
+
+    %% partitions should succeed, it requires read or write
+    ok = T:send(S, PartitionsFrame),
+    {Cmd7, C9} = receive_commands(T, S, C8),
+    ?assertEqual({response, 1, {partitions, ?RESPONSE_CODE_OK, Partitions}}, Cmd7),
+
+    %% remove read and write access
+    rabbit_ct_broker_helpers:set_permissions(Config, Username, <<"/">>,
+                                             <<".*">>, <<"foobar">>, <<"foobar">>),
+
+    %% route should fail, it needs write access
+    ok = T:send(S, RouteFrame),
+    {Cmd8, C10} = receive_commands(T, S, C9),
+    ?assertMatch({response, 1, {route, ?RESPONSE_CODE_ACCESS_REFUSED, _}}, Cmd8),
+
+    %% partitions should fail, it requires read or write
+    ok = T:send(S, PartitionsFrame),
+    {Cmd9, C11} = receive_commands(T, S, C10),
+    ?assertEqual({response, 1, {partitions, ?RESPONSE_CODE_ACCESS_REFUSED, []}}, Cmd9),
 
     %% restore full permissions to delete the super stream
     rabbit_ct_broker_helpers:set_full_permissions(Config, Username, <<"/">>),
     ok = T:send(S, request({delete_super_stream, Ss})),
-    {Cmd6, C8} = receive_commands(T, S, C7),
-    ?assertMatch({response, 1, {delete_super_stream, ?RESPONSE_CODE_OK}}, Cmd6),
+    {Cmd10, C12} = receive_commands(T, S, C11),
+    ?assertMatch({response, 1, {delete_super_stream, ?RESPONSE_CODE_OK}}, Cmd10),
 
-    test_close(T, S, C8),
+    test_close(T, S, C12),
     closed = wait_for_socket_close(T, S, 10),
     ok.
 

--- a/deps/rabbitmq_stream_common/src/rabbit_stream_core.erl
+++ b/deps/rabbitmq_stream_common/src/rabbit_stream_core.erl
@@ -161,7 +161,7 @@
      {metadata, Endpoints :: [endpoint()],
       Metadata ::
           #{stream_name() =>
-                stream_not_found | stream_not_available |
+                stream_not_found | stream_not_available | stream_not_allowed |
                 {Leader :: endpoint() | undefined, Replicas :: [endpoint()]}}} |
      {peer_properties, response_code(), #{binary() => binary()}} |
      {sasl_handshake, response_code(), Mechanisms :: [binary()]} |
@@ -494,7 +494,9 @@ response_body({metadata = Tag, Endpoints, Metadata}) ->
                                   stream_not_found ->
                                       ?RESPONSE_CODE_STREAM_DOES_NOT_EXIST;
                                   stream_not_available ->
-                                      ?RESPONSE_CODE_STREAM_NOT_AVAILABLE
+                                      ?RESPONSE_CODE_STREAM_NOT_AVAILABLE;
+                                  stream_not_allowed ->
+                                      ?RESPONSE_CODE_ACCESS_REFUSED
                               end,
                           StreamLength = byte_size(Stream),
                           [<<StreamLength:16,
@@ -1160,7 +1162,9 @@ parse_meta(<<?STRING(StreamSize, Stream),
             ?RESPONSE_CODE_STREAM_DOES_NOT_EXIST ->
                 stream_not_found;
             ?RESPONSE_CODE_STREAM_NOT_AVAILABLE ->
-                stream_not_available
+                stream_not_available;
+            ?RESPONSE_CODE_ACCESS_REFUSED ->
+                stream_not_allowed
         end,
     parse_meta(Rem, Nodes, Acc#{Stream => StreamDetail}).
 

--- a/deps/rabbitmq_stream_management/src/rabbit_stream_tracking_mgmt.erl
+++ b/deps/rabbitmq_stream_management/src/rabbit_stream_tracking_mgmt.erl
@@ -53,7 +53,19 @@ resource_exists(ReqData, Context) ->
      end,
      ReqData, Context}.
 
-to_json(ReqData, Context) ->
+to_json(ReqData, #context{user = User} = Context) ->
+    VHost = rabbit_mgmt_util:vhost(ReqData),
+    Stream = rabbit_mgmt_util:id(queue, ReqData),
+    Resource = rabbit_misc:r(VHost, queue, Stream),
+    case rabbit_stream_utils:check_read_permitted(Resource, User, #{}) of
+        ok ->
+            do_to_json(ReqData, Context);
+        _ ->
+            rabbit_web_dispatch_access_control:not_authorised(
+              <<"Access refused.">>, ReqData, Context)
+    end.
+
+do_to_json(ReqData, Context) ->
     case rabbit_mgmt_util:disable_stats(ReqData) of
         false ->
             VHost = rabbit_mgmt_util:vhost(ReqData),

--- a/deps/rabbitmq_stream_management/test/http_SUITE.erl
+++ b/deps/rabbitmq_stream_management/test/http_SUITE.erl
@@ -29,7 +29,8 @@ groups() ->
                                create_super_stream_requires_configure_permission,
                                create_super_stream_partition_limits,
                                create_super_stream_binding_keys_limit,
-                               stream_tracking_requires_vhost_access
+                               stream_tracking_requires_vhost_access,
+                               stream_tracking_requires_read_permission
                               ]}].
 
 %% -------------------------------------------------------------------
@@ -210,6 +211,30 @@ stream_tracking_requires_vhost_access(Config) ->
     http_get(Config, "/stream/tracking-vh/test-stream/tracking",
              User, User, ?OK),
     http_delete(Config, "/queues/tracking-vh/test-stream", {group, '2xx'}),
+    rabbit_ct_broker_helpers:delete_user(Config, User),
+    rabbit_ct_broker_helpers:delete_vhost(Config, Vhost),
+    ok.
+
+stream_tracking_requires_read_permission(Config) ->
+    Vhost = <<"tracking-read-perm-vh">>,
+    User = <<"tracking-read-perm-user">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, Vhost),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, <<"guest">>, Vhost),
+    StreamArgs = [{durable, true}, {arguments, [{'x-queue-type', 'stream'}]}],
+    http_put(Config, "/queues/tracking-read-perm-vh/test-stream", StreamArgs, {group, '2xx'}),
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+    %% Grant vhost access but no read permission: must fail with 401.
+    rabbit_ct_broker_helpers:set_permissions(Config, User, Vhost,
+                                             <<"^$">>, <<"^$">>, <<"^$">>),
+    http_get(Config, "/stream/tracking-read-perm-vh/test-stream/tracking",
+             User, User, ?NOT_AUTHORISED),
+    %% Grant read permission: must succeed.
+    rabbit_ct_broker_helpers:set_permissions(Config, User, Vhost,
+                                             <<"^$">>, <<"^$">>, <<".*">>),
+    http_get(Config, "/stream/tracking-read-perm-vh/test-stream/tracking",
+             User, User, ?OK),
+    http_delete(Config, "/queues/tracking-read-perm-vh/test-stream", {group, '2xx'}),
     rabbit_ct_broker_helpers:delete_user(Config, User),
     rabbit_ct_broker_helpers:delete_vhost(Config, Vhost),
     ok.


### PR DESCRIPTION
Adapt the required permissions for some stream-related operations based on the use case:
     * metadata: requires read or write, as used by producers and consumers.
     * route: requires write, as used by producers.
     * partitions: requires read or write, as used by producers and consumers.
    
This is consistent with store_offset: it writes something into a stream, but requires read permission, as it is used by consumers.
    
Note the operations above do not modify or read stream content, they rather get information about the system topology.

This PR also enforces read permission in the stream tracking info endpoint