### PR TITLE
CLI: Add leadership transfer commands to `rabbitmq-queues` and `rabbitmq-streams`

### DIFF
--- a/deps/rabbit/docs/rabbitmq-queues.8
+++ b/deps/rabbit/docs/rabbitmq-queues.8
@@ -163,6 +163,14 @@ Example:
 .Sp
 .Dl rabbitmq-queues delete_member --vhost Qo a-vhost Qc Qo a-queue Qc Qo rabbit@decomissioned-node Qc
 .\" ------------------------------------
+.It Cm transfer_leadership Ar queue Ar node Fl -vhost Ar virtual-host
+.Pp
+Transfers the leadership of a quorum queue to the given node.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-queues transfer_leadership --vhost Qo a-vhost Qc Qo a-queue Qc Qo rabbit@new-leader-node Qc
+.\" ------------------------------------
 .El
 .Ss Queues
 .Bl -tag -width Ds

--- a/deps/rabbit/docs/rabbitmq-streams.8
+++ b/deps/rabbit/docs/rabbitmq-streams.8
@@ -107,6 +107,14 @@ Example:
 .Sp
 .Dl rabbitmq-streams delete_replica --vhost Qo a-vhost Qc Qo a-queue Qc Qo rabbit@decomissioned-node Qc
 .\" ------------------------------------
+.It Cm transfer_leadership Ar stream Ar node Fl -vhost Ar virtual-host
+.Pp
+Transfers the leadership of a stream to the given node.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-streams transfer_leadership --vhost Qo a-vhost Qc Qo a-stream Qc Qo rabbit@new-leader-node Qc
+.\" ------------------------------------
 .El
 .Ss Monitoring, observability and health checks
 .Bl -tag -width Ds

--- a/deps/rabbit/src/rabbit_queue_type_ra.erl
+++ b/deps/rabbit/src/rabbit_queue_type_ra.erl
@@ -18,7 +18,8 @@
          all_members_stable/2,
          drain/2,
          revive/1,
-         transfer_leadership/2]).
+         transfer_leadership/2,
+         transfer_leadership/3]).
 
 -export_type([ra_membership/0]).
 
@@ -341,6 +342,12 @@ transfer_leadership(Queue, Destination) ->
         {error, _} = Err ->
             Err
     end.
+
+-spec transfer_leadership(rabbit_types:vhost(), rabbit_misc:resource_name(), node()) ->
+    {ok, node()} | {error, term()}.
+transfer_leadership(VHost, Name, Destination) ->
+    with_ra_queue(VHost, Name,
+                  fun(_Mod, Q) -> transfer_leadership(Q, Destination) end).
 
 get_nodes(Queue) ->
     rabbit_amqqueue:get_quorum_nodes(Queue).

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -898,8 +898,13 @@ transfer_leadership(Q, Destination) ->
 -spec transfer_leadership(rabbit_types:vhost(), rabbit_misc:resource_name(), node()) ->
     {ok, node()} | {error, term()}.
 transfer_leadership(VHost, Name, Destination) ->
-    case rabbit_amqqueue:lookup(Name, VHost) of
-        {ok, Q} when ?amqqueue_type_is(Q, ?MODULE) ->
+    QName = queue_resource(VHost, Name),
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} when ?amqqueue_is_classic(Q) ->
+            {error, classic_queue_not_supported};
+        {ok, Q} when ?amqqueue_is_quorum(Q) ->
+            {error, quorum_queue_not_supported};
+        {ok, Q} when ?amqqueue_is_stream(Q) ->
             transfer_leadership(Q, Destination);
         {ok, Q} ->
             {error, {not_supported_for_type, amqqueue:get_type(Q)}};

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -31,6 +31,7 @@
          queue_length/1,
          get_replicas/1,
          transfer_leadership/2,
+         transfer_leadership/3,
          init/1,
          close/1,
          state_info/1,
@@ -892,6 +893,18 @@ transfer_leadership(Q, Destination) ->
             {error, timeout};
         {error, _} = Err ->
             Err
+    end.
+
+-spec transfer_leadership(rabbit_types:vhost(), rabbit_misc:resource_name(), node()) ->
+    {ok, node()} | {error, term()}.
+transfer_leadership(VHost, Name, Destination) ->
+    case rabbit_amqqueue:lookup(Name, VHost) of
+        {ok, Q} when ?amqqueue_type_is(Q, ?MODULE) ->
+            transfer_leadership(Q, Destination);
+        {ok, Q} ->
+            {error, {not_supported_for_type, amqqueue:get_type(Q)}};
+        E ->
+            E
     end.
 
 -spec status(rabbit_types:vhost(), Name :: rabbit_misc:resource_name()) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/transfer_leadership_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/transfer_leadership_command.ex
@@ -25,6 +25,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.TransferLeadershipCommand do
       {:error, :not_found} ->
         {:error, {:not_found, :queue, vhost, name}}
 
+      {:error, {:unsupported, _}} ->
+        {:error, "Cannot transfer leadership of a non-quorum queue"}
+
+      {:error, :already_leader} ->
+        {:error, "The target node is already the leader of this queue"}
+
       {:ok, new_leader} ->
         {:ok, new_leader}
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/transfer_leadership_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/transfer_leadership_command.ex
@@ -1,0 +1,63 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+
+defmodule RabbitMQ.CLI.Queues.Commands.TransferLeadershipCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+  import RabbitMQ.CLI.Core.DataCoercion
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{vhost: "/"}, opts)}
+  end
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.AcceptsTwoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([name, node] = _args, %{vhost: vhost, node: node_name}) do
+    args = [vhost, name, to_atom(node)]
+
+    case :rabbit_misc.rpc_call(node_name, :rabbit_queue_type_ra, :transfer_leadership, args) do
+      {:error, :not_found} ->
+        {:error, {:not_found, :queue, vhost, name}}
+
+      {:ok, new_leader} ->
+        {:ok, new_leader}
+
+      other ->
+        other
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "transfer_leadership [--vhost <vhost>] <queue> <node>"
+
+  def usage_additional do
+    [
+      ["<queue>", "quorum queue name"],
+      ["<node>", "node to transfer the leadership to"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.quorum_queues()
+    ]
+  end
+
+  def help_section, do: :replication
+
+  def description,
+    do: "Transfers the leadership of a quorum queue to the given node."
+
+  def banner([name, node], _) do
+    [
+      "Transferring leadership of quorum queue #{name} to node #{node}..."
+    ]
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/transfer_leadership_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/transfer_leadership_command.ex
@@ -1,0 +1,71 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+
+defmodule RabbitMQ.CLI.Streams.Commands.TransferLeadershipCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+  import RabbitMQ.CLI.Core.DataCoercion
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{vhost: "/"}, opts)}
+  end
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.AcceptsTwoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([name, node] = _args, %{vhost: vhost, node: node_name}) do
+    args = [vhost, name, to_atom(node)]
+
+    case :rabbit_misc.rpc_call(node_name, :rabbit_stream_queue, :transfer_leadership, args) do
+      {:error, :classic_queue_not_supported} ->
+        {:error, "Cannot transfer leadership of a classic queue"}
+
+      {:error, :quorum_queue_not_supported} ->
+        {:error, "Cannot transfer leadership of a quorum queue"}
+
+      {:error, {:not_supported_for_type, _type}} ->
+        {:error, "Cannot transfer leadership of a non-stream queue"}
+
+      {:error, :not_found} ->
+        {:error, {:not_found, :queue, vhost, name}}
+
+      {:ok, new_leader} ->
+        {:ok, new_leader}
+
+      other ->
+        other
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "transfer_leadership [--vhost <vhost>] <stream> <node>"
+
+  def usage_additional do
+    [
+      ["<stream>", "stream name"],
+      ["<node>", "node to transfer the leadership to"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.streams()
+    ]
+  end
+
+  def help_section, do: :replication
+
+  def description, do: "Transfers the leadership of a stream to the given node."
+
+  def banner([name, node], _) do
+    [
+      "Transferring leadership of stream #{name} to node #{node}..."
+    ]
+  end
+end

--- a/deps/rabbitmq_cli/test/queues/transfer_leadership_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/transfer_leadership_command_test.exs
@@ -1,0 +1,59 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+
+defmodule RabbitMQ.CLI.Queues.Commands.TransferLeadershipCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Queues.Commands.TransferLeadershipCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "validate: when no arguments are provided, returns a failure" do
+    assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: when one argument is provided, returns a failure" do
+    assert @command.validate(["quorum-queue-a"], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: when three or more arguments are provided, returns a failure" do
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(
+             ["quorum-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"],
+             %{}
+           ) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats two positional arguments and default switches as a success" do
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node"], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc" do
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a", "rabbit@new-node"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
+  end
+end

--- a/deps/rabbitmq_cli/test/streams/transfer_leadership_command_test.exs
+++ b/deps/rabbitmq_cli/test/streams/transfer_leadership_command_test.exs
@@ -1,0 +1,59 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+
+defmodule RabbitMQ.CLI.Streams.Commands.TransferLeadershipCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Streams.Commands.TransferLeadershipCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "validate: when no arguments are provided, returns a failure" do
+    assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: when one argument is provided, returns a failure" do
+    assert @command.validate(["stream-queue-a"], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: when three or more arguments are provided, returns a failure" do
+    assert @command.validate(["stream-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(
+             ["stream-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"],
+             %{}
+           ) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats two positional arguments and default switches as a success" do
+    assert @command.validate(["stream-queue-a", "rabbit@new-node"], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc" do
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["stream-queue-a", "rabbit@new-node"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
+  end
+end


### PR DESCRIPTION
This is a minor QoL improvement / fix to add CLI commands to `rabbitmq-queues` and `rabbitmq-streams`, `transfer_leadership <queue> <node> [--vhost=<vhost>]`. Currently this can only be done with an eval command. It's not useful often, but it's good for tricky scenarios like handling https://github.com/rabbitmq/rabbitmq-server/discussions/14137. I think it might be helpful in the future for not-yet-seen failure/recovery scenarios.