### PR TITLE
Fix SigV4 SignatureDoesNotMatch on body-less requests (e.g. S3 GET)

### DIFF
--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -514,7 +514,7 @@ perform_request_with_creds(State, Service, Method, Headers, Path, Body, Options,
 %% @end
 perform_request_with_creds(State, Method, URI, Headers, undefined, "", Options0) ->
     Options1 = ensure_timeout(Options0),
-    Response = httpc:request(Method, {URI, Headers}, Options1, []),
+    Response = httpc:request(Method, {URI, Headers}, Options1, [{headers_as_is, true}]),
     {format_response(Response), State};
 perform_request_with_creds(State, Method, URI, Headers, ContentType, Body, Options0) ->
     Options1 = ensure_timeout(Options0),

--- a/deps/rabbitmq_aws/test/rabbitmq_aws_tests.erl
+++ b/deps/rabbitmq_aws/test/rabbitmq_aws_tests.erl
@@ -195,7 +195,7 @@ gen_server_call_test_() ->
                             {"https://ec2.us-east-1.amazonaws.com/?Action=DescribeTags&Version=2015-10-01",
                                 _Headers},
                             _Options,
-                            []
+                            [{headers_as_is, true}]
                         ) ->
                             {ok, {
                                 {"HTTP/1.0", 200, "OK"},
@@ -415,7 +415,7 @@ perform_request_test_() ->
                     meck:expect(
                         httpc,
                         request,
-                        fun(get, {URI, _Headers}, _Options, []) ->
+                        fun(get, {URI, _Headers}, _Options, [{headers_as_is, true}]) ->
                             case URI of
                                 ExpectURI ->
                                     {ok, {
@@ -452,7 +452,14 @@ perform_request_test_() ->
                     Body = "",
                     Options = [],
                     Host = undefined,
-                    meck:expect(httpc, request, fun(get, {_URI, _Headers}, _Options, []) ->
+                    meck:expect(httpc, request, fun(
+                        get,
+                        {_URI, _Headers},
+                        _Options,
+                        [
+                            {headers_as_is, true}
+                        ]
+                    ) ->
                         {ok, {
                             {"HTTP/1.0", 400, "RequestFailure"},
                             [{"content-type", "application/json"}],
@@ -502,6 +509,83 @@ perform_request_test_() ->
                     State = #state{error = unit_test},
                     Expectation = {{error, {credentials, State#state.error}}, State},
                     ?assertEqual(Expectation, rabbitmq_aws:perform_request_creds_error(State))
+                end
+            }
+        ]
+    }.
+
+perform_request_headers_as_is_test_() ->
+    {
+        foreach,
+        fun() ->
+            meck:new(httpc, []),
+            meck:new(rabbitmq_aws_config, []),
+            [httpc, rabbitmq_aws_config]
+        end,
+        fun meck:unload/1,
+        [
+            {
+                "body-less request passes {headers_as_is, true} so the signed "
+                "content-length header is not stripped by httpc (SignatureDoesNotMatch)",
+                fun() ->
+                    State = #state{
+                        access_key = "AKIDEXAMPLE",
+                        secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                        region = "us-east-1"
+                    },
+                    meck:expect(httpc, request, fun(get, {_URI, _Headers}, _Options, HTTPCOpts) ->
+                        put(httpc_options, HTTPCOpts),
+                        {ok, {
+                            {"HTTP/1.0", 200, "OK"},
+                            [{"content-type", "application/json"}],
+                            "{\"pass\": true}"
+                        }}
+                    end),
+                    rabbitmq_aws:perform_request(
+                        State,
+                        "s3",
+                        get,
+                        [],
+                        "/bucket/key",
+                        "",
+                        [],
+                        undefined
+                    ),
+                    ?assertEqual([{headers_as_is, true}], get(httpc_options)),
+                    meck:validate(httpc)
+                end
+            },
+            {
+                "body-bearing request is unaffected (httpc keeps content-length "
+                "when a body is present), so headers_as_is is not added",
+                fun() ->
+                    State = #state{
+                        access_key = "AKIDEXAMPLE",
+                        secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                        region = "us-east-1"
+                    },
+                    meck:expect(httpc, request, fun(
+                        post, {_URI, _Headers, _ContentType, _Body}, _Options, HTTPCOpts
+                    ) ->
+                        put(httpc_options, HTTPCOpts),
+                        {ok, {
+                            {"HTTP/1.0", 200, "OK"},
+                            [{"content-type", "application/json"}],
+                            "{\"pass\": true}"
+                        }}
+                    end),
+                    rabbitmq_aws:perform_request(
+                        State,
+                        "s3",
+                        post,
+                        [{"content-type", "application/x-amz-json-1.0"}],
+                        "/bucket/key",
+                        "{\"some\": \"body\"}",
+                        [],
+                        undefined
+                    ),
+                    ?assertNot(lists:member({headers_as_is, true}, get(httpc_options))),
+                    meck:validate(httpc)
                 end
             }
         ]


### PR DESCRIPTION
## Proposed Changes

This fixes a SigV4 signing bug that causes **every empty-body AWS request to fail with `SignatureDoesNotMatch` (HTTP 403)**. The most visible symptom is that fetching an object via S3 (`GetObject`) fails 100% of the time.

Root cause:

1. The SigV4 signer includes `content-length` in the signed-header set for every request. For an empty body its value is `"0"`, and it becomes part of the canonical/signed headers the signature is computed over.
2. The body-less request clause in `perform_request_with_creds/7` calls `httpc:request/4` with an empty options list. For a request with no body, Erlang/OTP `httpc` **strips** the `content-length` header before transmitting.

Because `content-length` is signed but not sent, the headers the service receives no longer match the signed-header set, and AWS rejects the request with `SignatureDoesNotMatch`.

Body-bearing requests (e.g. Secrets Manager `GetSecretValue`, any POST/PUT) are unaffected, because httpc preserves `content-length` when a body is present -- which is why this bug is invisible for most of the API surface and only bites empty-body GETs like S3.

The fix passes `{headers_as_is, true}` to httpc on the body-less clause so the signed headers -- including `content-length: 0` -- are transmitted verbatim and match the signature. The body-bearing clause is unchanged.

```erlang
-    Response = httpc:request(Method, {URI, Headers}, Options1, []),
+    Response = httpc:request(Method, {URI, Headers}, Options1, [{headers_as_is, true}]),
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN, no existing issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

This is a one-line change, but here is the reasoning and the alternatives considered:

- **Why `headers_as_is` rather than not signing `content-length`?** An alternative fix is to omit `content-length` from the signed-header set for empty bodies in `rabbitmq_aws_sign`, so the signed set matches what httpc actually sends. That also works, but it is a larger change in the signer and changes signing behavior; `{headers_as_is, true}` is the minimal, localized fix that makes the transport honor what was already signed.

- **Verification.** Tested live against two services using the same credentials: with the change, an S3 `GetObject` succeeds; without it, the same S3 GET fails with `SignatureDoesNotMatch` while Secrets Manager `GetSecretValue` succeeds -- confirming the failure is specific to the empty-body path and not a credential/region issue.

