### PR TITLE
Web MQTT, Web STOMP: introduce a way to configure HSTS policy

### DIFF
--- a/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
+++ b/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
@@ -141,6 +141,22 @@ end}.
 
 
 %%
+%% HSTS
+%%
+
+{mapping, "web_mqtt.hsts.policy", "rabbitmq_web_mqtt.strict_transport_security", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_web_mqtt.strict_transport_security",
+fun(Conf) ->
+    case cuttlefish:conf_get("web_mqtt.hsts.policy", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+%%
 %% Cowboy options
 %%
 

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_stream_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_stream_handler.erl
@@ -26,7 +26,7 @@ data(StreamID, IsFin, Data, State = #state{next = Next0}) ->
     {Commands, State#state{next = Next}}.
 
 info(StreamID, {switch_protocol, Headers, _, InitialState}, State) ->
-    do_info(StreamID, {switch_protocol, Headers, rabbit_web_mqtt_handler, InitialState}, State);
+    do_info(StreamID, {switch_protocol, inject_response_headers(Headers), rabbit_web_mqtt_handler, InitialState}, State);
 info(StreamID, Info, State) ->
     do_info(StreamID, Info, State).
 
@@ -39,3 +39,9 @@ terminate(StreamID, Reason, #state{next = Next}) ->
 
 early_error(StreamID, Reason, PartialReq, Resp, Opts) ->
     cowboy_stream:early_error(StreamID, Reason, PartialReq, Resp, Opts).
+
+inject_response_headers(Headers) ->
+    case application:get_env(rabbitmq_web_mqtt, strict_transport_security) of
+        undefined   -> Headers;
+        {ok, Value} -> maps:put(<<"strict-transport-security">>, rabbit_data_coercion:to_binary(Value), Headers)
+    end.

--- a/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
+++ b/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
@@ -150,6 +150,22 @@ end}.
 
 
 %%
+%% HSTS
+%%
+
+{mapping, "web_stomp.hsts.policy", "rabbitmq_web_stomp.strict_transport_security", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_web_stomp.strict_transport_security",
+fun(Conf) ->
+    case cuttlefish:conf_get("web_stomp.hsts.policy", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+%%
 %% Cowboy options
 %%
 

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_stream_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_stream_handler.erl
@@ -26,7 +26,7 @@ data(StreamID, IsFin, Data, State = #state{next = Next0}) ->
     {Commands, State#state{next = Next}}.
 
 info(StreamID, {switch_protocol, Headers, _, InitialState}, State) ->
-    do_info(StreamID, {switch_protocol, Headers, rabbit_web_stomp_handler, InitialState}, State);
+    do_info(StreamID, {switch_protocol, inject_response_headers(Headers), rabbit_web_stomp_handler, InitialState}, State);
 info(StreamID, Info, State) ->
     do_info(StreamID, Info, State).
 
@@ -39,3 +39,9 @@ terminate(StreamID, Reason, #state{next = Next}) ->
 
 early_error(StreamID, Reason, PartialReq, Resp, Opts) ->
     cowboy_stream:early_error(StreamID, Reason, PartialReq, Resp, Opts).
+
+inject_response_headers(Headers) ->
+    case application:get_env(rabbitmq_web_stomp, strict_transport_security) of
+        undefined   -> Headers;
+        {ok, Value} -> maps:put(<<"strict-transport-security">>, rabbit_data_coercion:to_binary(Value), Headers)
+    end.


### PR DESCRIPTION
Web MQTT and Web STOMP would benefit from being able to configure the HSTS header, which is used at the transport level.

Note: other headers that we allow for configuring for the HTTP API (CSP, X-Frame-Options, X-Content-Type-Options) are not relevant for the WebSockets protocol upgrade.

Closes #14161.