### PR TITLE
Use CSPRNG for generating password salts

### DIFF
--- a/deps/rabbit_common/src/rabbit_password.erl
+++ b/deps/rabbit_common/src/rabbit_password.erl
@@ -25,8 +25,7 @@ hash(HashingMod, Cleartext) ->
     <<SaltBin/binary, Hash/binary>>.
 
 generate_salt() ->
-    Salt = rand:uniform(16#ffffffff),
-    <<Salt:32>>.
+    crypto:strong_rand_bytes(4).
 
 salted_hash(Salt, Cleartext) ->
     salted_hash(hashing_mod(), Salt, Cleartext).


### PR DESCRIPTION
What:
Use a Cryptographically Secure Pseudo-Random Number Generator (CSPRNG) for generating internal user password salts instead of a standard PRNG.

Why:
The `rand` module in Erlang is a PRNG and is not cryptographically secure. While a salt primarily needs to be globally unique rather than strictly unpredictable, modern security standards (such as NIST) recommend using a CSPRNG for all cryptographic material, including salts.