### PR TITLE
fix: shell command completion

### DIFF
--- a/scripts/bash_autocomplete.sh
+++ b/scripts/bash_autocomplete.sh
@@ -3,7 +3,7 @@ _rabbitmqctl_complete() {
         COMPREPLY=()
         local LANG=en_US.UTF-8
         local word="${COMP_WORDS[COMP_CWORD]}"
-        local completions="$(export LANG=en_US.UTF-8; export LC_CTYPE=en_US.UTF-8; /usr/lib/rabbitmq/bin/rabbitmqctl --auto-complete $COMP_LINE)"
+        local completions="$(export LANG=en_US.UTF-8; export LC_CTYPE=en_US.UTF-8; /usr/lib/rabbitmq/bin/rabbitmqctl autocomplete -- "$word")"
         COMPREPLY=( $(compgen -W "$completions" -- "$word") )
     fi
 }

--- a/scripts/zsh_autocomplete.sh
+++ b/scripts/zsh_autocomplete.sh
@@ -1,11 +1,11 @@
 _rabbitmqctl_complete() {
     if [ -x /usr/lib/rabbitmq/bin/rabbitmqctl ]; then
-        local word completions a
+        local word
         local LANG=en_US.UTF-8
-        read -cl a
         word="$1"
-        completions="$(export LANG=en_US.UTF-8; export LC_CTYPE=en_US.UTF-8; /usr/lib/rabbitmq/bin/rabbitmqctl --auto-complete ${=a})"
-        reply=( "${(ps:\n:)completions}" )
+        local -a completions
+        completions=("${(@f)$(export LANG=en_US.UTF-8; export LC_CTYPE=en_US.UTF-8; /usr/lib/rabbitmq/bin/rabbitmqctl autocomplete -- "$word")}")
+        reply=("${(@)completions:#--}")
     fi
 }
 


### PR DESCRIPTION
Starting with https://github.com/rabbitmq/rabbitmq-cli/issues/439 the `--auto-complete` flag was moved to its own first-class command.

The {bash,zsh}-completion has not been updated to use this command yet. This MR fixes that.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
