### PR TITLE
Native STOMP: align queue.declare argument handling with the other protocols

### DIFF
--- a/deps/rabbitmq_stomp/Makefile
+++ b/deps/rabbitmq_stomp/Makefile
@@ -31,7 +31,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 DEPS = ranch rabbit_common rabbit
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management proper
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management proper meck
 
 PLT_APPS += rabbitmq_cli elixir ssl
 

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -19,6 +19,10 @@
          handle_down/2,
          handle_queue_event/2]).
 
+-ifdef(TEST).
+-export([check_dead_letter_exchange_access/4]).
+-endif.
+
 -include_lib("kernel/include/logger.hrl").
 -include("rabbit_stomp_frame.hrl").
 -include("rabbit_stomp.hrl").
@@ -1664,6 +1668,21 @@ ensure_binding(QName, {Exchange, RoutingKey}, _State = #state{cfg = #cfg{
             ok
     end.
 
+check_dead_letter_exchange_access(QName = #resource{virtual_host = VHost},
+                                  Args, User, AuthzCtx) ->
+    case rabbit_misc:r_arg(VHost, exchange, Args, ?HEADER_X_DEAD_LETTER_EXCHANGE) of
+        undefined ->
+            ok;
+        {error, {invalid_type, Type}} ->
+            rabbit_misc:protocol_error(
+              precondition_failed,
+              "invalid type '~ts' for arg '~ts'",
+              [Type, ?HEADER_X_DEAD_LETTER_EXCHANGE]);
+        DLX ->
+            ok = check_resource_access(User, QName, read, AuthzCtx),
+            ok = check_resource_access(User, DLX, write, AuthzCtx)
+    end.
+
 check_resource_access(User, Resource, Perm, Context) ->
     V = {Resource, Context, Perm},
     Cache = case get(permission_cache) of
@@ -1939,6 +1958,8 @@ create_queue(Amqqueue, _State = #state{authz_ctx = AuthzCtx,
 
     %% configure access to queue required for queue.declare
     ok = check_resource_access(User, QName, configure, AuthzCtx),
+    ok = check_dead_letter_exchange_access(
+           QName, amqqueue:get_arguments(Amqqueue), User, AuthzCtx),
 
     case rabbit_vhost_limit:is_over_queue_limit(VHost) of
         false ->

--- a/deps/rabbitmq_stomp/test/system_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/system_SUITE.erl
@@ -28,6 +28,9 @@ groups() ->
     Tests = [
         publish_no_dest_error,
         publish_unauthorized_error,
+        declare_with_authorised_dlx,
+        declare_with_restricted_dlx,
+        declare_without_dlx,
         subscribe_error,
         subscribe,
         subscribe_with_x_priority,
@@ -109,6 +112,21 @@ init_per_testcase0(publish_unauthorized_error, Config) ->
     StompPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
     {ok, ClientFoo} = rabbit_stomp_client:connect(Version, "user", "pass", StompPort),
     rabbit_ct_helpers:set_config(Config, [{client_foo, ClientFoo}]);
+init_per_testcase0(TestCase, Config)
+  when TestCase =:= declare_with_authorised_dlx;
+       TestCase =:= declare_with_restricted_dlx;
+       TestCase =:= declare_without_dlx ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_auth_backend_internal, add_user,
+                                 [<<"stompuser">>, <<"pass">>, <<"acting-user">>]),
+    %% configure, write and read confined to the stomp.* namespace
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_auth_backend_internal, set_permissions,
+                                 [<<"stompuser">>, <<"/">>,
+                                  <<"^stomp\\.">>, <<"^stomp\\.">>, <<"^stomp\\.">>,
+                                  <<"acting-user">>]),
+    Version = ?config(version, Config),
+    StompPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
+    {ok, ClientFoo} = rabbit_stomp_client:connect(Version, "stompuser", "pass", StompPort),
+    rabbit_ct_helpers:set_config(Config, [{client_foo, ClientFoo}]);
 init_per_testcase0(_, Config) ->
     Config.
 
@@ -117,6 +135,15 @@ end_per_testcase0(publish_unauthorized_error, Config) ->
     rabbit_stomp_client:disconnect(ClientFoo),
     rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_auth_backend_internal, delete_user,
                                  [<<"user">>, <<"acting-user">>]),
+    Config;
+end_per_testcase0(TestCase, Config)
+  when TestCase =:= declare_with_authorised_dlx;
+       TestCase =:= declare_with_restricted_dlx;
+       TestCase =:= declare_without_dlx ->
+    ClientFoo = ?config(client_foo, Config),
+    rabbit_stomp_client:disconnect(ClientFoo),
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_auth_backend_internal, delete_user,
+                                 [<<"stompuser">>, <<"acting-user">>]),
     Config;
 end_per_testcase0(_, Config) ->
     Config.
@@ -197,6 +224,37 @@ publish_unauthorized_error(Config) ->
     {ok, _Client1, Hdrs, _} = stomp_receive(ClientFoo, 'ERROR'),
     <<"access_refused">> = maps:get(<<"message">>, Hdrs),
     ok.
+
+declare_with_authorised_dlx(Config) ->
+    ClientFoo = ?config(client_foo, Config),
+    subscribe_with_dlx(ClientFoo, <<"/queue/stomp.authorised">>, <<"stomp.target">>),
+    {ok, _Client1, _Hdrs, _} = stomp_receive(ClientFoo, 'RECEIPT'),
+    ok.
+
+declare_with_restricted_dlx(Config) ->
+    ClientFoo = ?config(client_foo, Config),
+    subscribe_with_dlx(ClientFoo, <<"/queue/stomp.restricted">>, <<"restricted.x">>),
+    {ok, _Client1, Hdrs, _} = stomp_receive(ClientFoo, 'ERROR'),
+    <<"access_refused">> = maps:get(<<"message">>, Hdrs),
+    ok.
+
+declare_without_dlx(Config) ->
+    ClientFoo = ?config(client_foo, Config),
+    rabbit_stomp_client:send(
+      ClientFoo, 'SUBSCRIBE',
+      [{<<"destination">>, <<"/queue/stomp.plain">>},
+       {<<"id">>, <<"s0">>},
+       {<<"receipt">>, <<"r0">>}]),
+    {ok, _Client1, _Hdrs, _} = stomp_receive(ClientFoo, 'RECEIPT'),
+    ok.
+
+subscribe_with_dlx(Client, Destination, DLX) ->
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE',
+      [{<<"destination">>, Destination},
+       {<<"id">>, <<"s0">>},
+       {<<"receipt">>, <<"r0">>},
+       {<<"x-dead-letter-exchange">>, DLX}]).
 
 subscribe_error(Config) ->
     Client = ?config(stomp_client, Config),

--- a/deps/rabbitmq_stomp/test/unit_dead_letter_access_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/unit_dead_letter_access_SUITE.erl
@@ -1,0 +1,155 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+%% Unit and property tests for the dead-letter-exchange permission check used by
+%% the Native STOMP queue.declare path. rabbit_access_control is mocked so the
+%% authorization branches can be exercised without a running broker.
+-module(unit_dead_letter_access_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-define(VHOST, <<"/">>).
+-define(DLX_HEADER, <<"x-dead-letter-exchange">>).
+-define(ITERATIONS, 500).
+
+all() ->
+    [absent_dlx_arg_skips_checks,
+     invalid_dlx_arg_type_rejected,
+     both_permissions_granted,
+     queue_read_denied_skips_dlx_write,
+     dlx_write_denied,
+     prop_read_then_write].
+
+init_per_testcase(_Testcase, Config) ->
+    ok = meck:new(rabbit_access_control, [no_link]),
+    Config.
+
+end_per_testcase(_Testcase, _Config) ->
+    ok = meck:unload(rabbit_access_control).
+
+absent_dlx_arg_skips_checks(_Config) ->
+    ok = mock_permitted([]),
+    ?assertEqual(ok, check(qname(<<"stomp.q">>), [])),
+    ?assertEqual(0, total_calls()).
+
+invalid_dlx_arg_type_rejected(_Config) ->
+    ok = mock_permitted([]),
+    Args = [{?DLX_HEADER, long, 42}],
+    ?assertExit(#amqp_error{name = precondition_failed},
+                check(qname(<<"stomp.q">>), Args)),
+    ?assertEqual(0, total_calls()).
+
+both_permissions_granted(_Config) ->
+    Q = qname(<<"stomp.q">>),
+    X = xname(<<"stomp.dlx">>),
+    ok = mock_permitted([{Q, read}, {X, write}]),
+    ?assertEqual(ok, check(Q, dlx_args(<<"stomp.dlx">>))),
+    ?assertEqual(1, num_calls(Q, read)),
+    ?assertEqual(1, num_calls(X, write)).
+
+queue_read_denied_skips_dlx_write(_Config) ->
+    Q = qname(<<"stomp.q">>),
+    X = xname(<<"stomp.dlx">>),
+    ok = mock_permitted([{X, write}]),
+    ?assertExit(#amqp_error{name = access_refused},
+                check(Q, dlx_args(<<"stomp.dlx">>))),
+    ?assertEqual(1, num_calls(Q, read)),
+    ?assertEqual(0, num_calls(X, write)).
+
+dlx_write_denied(_Config) ->
+    Q = qname(<<"stomp.q">>),
+    X = xname(<<"stomp.dlx">>),
+    ok = mock_permitted([{Q, read}]),
+    ?assertExit(#amqp_error{name = access_refused},
+                check(Q, dlx_args(<<"stomp.dlx">>))),
+    ?assertEqual(1, num_calls(Q, read)),
+    ?assertEqual(1, num_calls(X, write)).
+
+%% Success requires both grants, and the dead-letter exchange write is only
+%% attempted after the queue read passes.
+prop_read_then_write(_Config) ->
+    rabbit_ct_proper_helpers:run_proper(
+      fun prop_read_then_write_/0, [], ?ITERATIONS).
+
+prop_read_then_write_() ->
+    ?FORALL(
+       {ReadOk, WriteOk, QBin, XBin},
+       {boolean(), boolean(), resource_name(), resource_name()},
+       begin
+           Q = qname(QBin),
+           X = xname(XBin),
+           Permitted = [{Q, read} || ReadOk] ++ [{X, write} || WriteOk],
+           ok = mock_permitted(Permitted),
+           ok = meck:reset(rabbit_access_control),
+           Result = (catch check(Q, dlx_args(XBin))),
+           Reads = num_calls(Q, read),
+           Writes = num_calls(X, write),
+           case {ReadOk, WriteOk} of
+               {true, true} ->
+                   Result =:= ok andalso Reads =:= 1 andalso Writes =:= 1;
+               {false, _} ->
+                   is_access_refused(Result) andalso Reads =:= 1 andalso Writes =:= 0;
+               {true, false} ->
+                   is_access_refused(Result) andalso Reads =:= 1 andalso Writes =:= 1
+           end
+       end).
+
+resource_name() ->
+    ?LET(N, non_empty(list(choose($a, $z))), list_to_binary(N)).
+
+%% The wrapper caches granted permissions in the process dictionary, so it is
+%% cleared before every call to keep mocked permission sets authoritative.
+check(QName, Args) ->
+    erase(permission_cache),
+    rabbit_stomp_processor:check_dead_letter_exchange_access(
+      QName, Args, user(), authz_ctx()).
+
+mock_permitted(Permitted) ->
+    meck:expect(
+      rabbit_access_control, check_resource_access,
+      fun(_User, Resource, Perm, _Context) ->
+              case lists:member({Resource, Perm}, Permitted) of
+                  true ->
+                      ok;
+                  false ->
+                      rabbit_misc:protocol_error(
+                        access_refused, "access to ~ts refused",
+                        [rabbit_misc:rs(Resource)])
+              end
+      end).
+
+total_calls() ->
+    meck:num_calls(rabbit_access_control, check_resource_access,
+                   ['_', '_', '_', '_']).
+
+num_calls(Resource, Perm) ->
+    meck:num_calls(rabbit_access_control, check_resource_access,
+                   ['_', Resource, Perm, '_']).
+
+is_access_refused({'EXIT', #amqp_error{name = access_refused}}) ->
+    true;
+is_access_refused(_) ->
+    false.
+
+qname(Name) ->
+    #resource{virtual_host = ?VHOST, kind = queue, name = Name}.
+
+xname(Name) ->
+    #resource{virtual_host = ?VHOST, kind = exchange, name = Name}.
+
+dlx_args(XBin) ->
+    [{?DLX_HEADER, longstr, XBin}].
+
+user() ->
+    #user{username = <<"stompuser">>}.
+
+authz_ctx() ->
+    #{}.


### PR DESCRIPTION
This change is specific to the native STOMP implementation in `main`, #9141.

Older series are still Erlang client-based.