### PR TITLE
rabbitmq-plugins list: omit plugin table when node is unreachable

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -9,10 +9,17 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
   @behaviour RabbitMQ.CLI.FormatterBehaviour
 
   def format_output(
-        %{status: status, format: format, plugins: plugins},
+        %{status: :node_down, format: format},
         options
       ) do
-    legend(status, format, options) ++ format_plugins(plugins, format)
+    legend(:node_down, format, options)
+  end
+
+  def format_output(
+        %{status: :running, format: format, plugins: plugins},
+        options
+      ) do
+    legend(:running, format, options) ++ format_plugins(plugins, format)
   end
 
   def format_output(%{enabled: enabled, mode: _} = output, options) do

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -135,6 +135,11 @@ defmodule ListPluginsCommandTest do
     assert_plugin_states(actual_plugins, expected_plugins)
   end
 
+  test "run: a call to an unreachable node reports a node_down status", context do
+    assert %{status: :node_down} =
+             @command.run([".*"], Map.merge(context[:opts], %{node: :jake@thedog}))
+  end
+
   test "run: reports list of started plugins for started node", context do
     reset_enabled_plugins_to_preconfigured_defaults(context)
 


### PR DESCRIPTION
When `rabbitmq-plugins list` cannot contact the target node, the plugin table is of limited value: running status (*) is unavailable, and E/e markers may reflect the local fallback path rather than the target node's actual enabled plugins file.

This change removes the plugin table from the output in the node-down case and keeps only the legend line, which already reports "[failed to contact <node> - status not shown]".

The generic `format_output` clause matching `%{status: status, ...}` is replaced by two explicit clauses — one for `:node_down` and one for `:running` — since those are the only two values produced by `list_command.ex`.