### PR TITLE
rabbitmq-plugins list: skip building plugin list when node is unreachable

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -89,27 +89,33 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
         {false, false} -> :normal
       end
 
-    plugins =
-      Enum.filter(
-        all,
-        fn plugin ->
-          name = PluginHelpers.plugin_name(plugin)
+    case status do
+      :node_down ->
+        %{status: :node_down, format: format}
 
-          :rabbit_plugins.is_strictly_plugin(plugin) and
-            Regex.match?(re, to_string(name)) and
-            cond do
-              only_enabled -> Enum.member?(enabled, name)
-              all_enabled -> Enum.member?(enabled ++ enabled_implicitly, name)
-              true -> true
+      :running ->
+        plugins =
+          Enum.filter(
+            all,
+            fn plugin ->
+              name = PluginHelpers.plugin_name(plugin)
+
+              :rabbit_plugins.is_strictly_plugin(plugin) and
+                Regex.match?(re, to_string(name)) and
+                cond do
+                  only_enabled -> Enum.member?(enabled, name)
+                  all_enabled -> Enum.member?(enabled ++ enabled_implicitly, name)
+                  true -> true
+                end
             end
-        end
-      )
+          )
 
-    %{
-      status: status,
-      format: format,
-      plugins: format_plugins(plugins, format, enabled, enabled_implicitly, running)
-    }
+        %{
+          status: :running,
+          format: format,
+          plugins: format_plugins(plugins, format, enabled, enabled_implicitly, running)
+        }
+    end
   end
 
   def banner([pattern], _), do: "Listing plugins with pattern \"#{pattern}\" ..."

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -113,28 +113,6 @@ defmodule ListPluginsCommandTest do
              {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "run: reports list of plugins from file for stopped node", context do
-    reset_enabled_plugins_to_preconfigured_defaults(context)
-
-    node = context[:opts][:node]
-    :ok = :rabbit_misc.rpc_call(node, :application, :stop, [:rabbitmq_stomp])
-
-    on_exit(fn ->
-      :rabbit_misc.rpc_call(node, :application, :start, [:rabbitmq_stomp])
-    end)
-
-    expected_plugins = [
-      %{name: :rabbitmq_federation, enabled: :enabled, running: false},
-      %{name: :rabbitmq_stomp, enabled: :enabled, running: false}
-    ]
-
-    %{
-      plugins: actual_plugins
-    } = @command.run([".*"], Map.merge(context[:opts], %{node: :nonode}))
-
-    assert_plugin_states(actual_plugins, expected_plugins)
-  end
-
   test "run: a call to an unreachable node reports a node_down status", context do
     assert %{status: :node_down} =
              @command.run([".*"], Map.merge(context[:opts], %{node: :jake@thedog}))


### PR DESCRIPTION
Follows up on https://github.com/rabbitmq/rabbitmq-server/pull/16791 which stopped displaying the plugin table when the target node cannot be contacted.

This change avoids building the plugin list in the first place in that case. When the RPC call to the remote node fails, list_command returns %{status: :node_down, format: format} without computing the plugin list at all.

This has two effects:
 * Avoids unnecessary work (filtering, sorting, formatting plugins) when the result will not be displayed
 * Ensures non-default formatters (e.g. --formatter=json) also suppress the plugin list, since the data is no longer present in the map returned by the command
