### PR TITLE
Shovel: add support for `src-consumer-args` in AMQP 1.0

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -112,13 +112,14 @@ parse_source(Def) ->
     SrcCName = pget(<<"src-consumer-name">>, Def, <<>>),
     GlobalPredeclared = proplists:get_value(predeclared, application:get_env(?APP, topology, []), false),
     Predeclared = pget(<<"src-predeclared">>, Def, GlobalPredeclared),
+    SrcCArgs = pget(<<"src-consumer-args">>, Def, []),
     {#{module => rabbit_amqp10_shovel,
        uris => Uris,
        source_address => Address,
        delete_after => opt_b2a(DeleteAfter),
        prefetch_count => PrefetchCount,
        predeclared => Predeclared,
-       consumer_args => [],
+       consumer_args => SrcCArgs,
        consumer_name => SrcCName}, Headers}.
 
 parse_dest({_VHost, _Name}, _ClusterName, Def, _SourceHeaders) ->
@@ -153,7 +154,8 @@ validate_src_funs(_Def, User) ->
      {<<"src-prefetch-count">>, fun rabbit_parameter_validation:number/2, optional},
      {<<"src-consumer-name">>, fun rabbit_parameter_validation:binary/2, optional},
      {<<"src-delete-after">>, fun validate_amqp10_delete_after/2, optional},
-     {<<"src-predeclared">>,  fun rabbit_parameter_validation:boolean/2, optional}
+     {<<"src-predeclared">>,  fun rabbit_parameter_validation:boolean/2, optional},
+     {<<"src-consumer-args">>, fun rabbit_shovel_util:validate_consumer_args/2, optional}
     ].
 
 validate_dest_funs(_Def, User) ->
@@ -181,6 +183,7 @@ connect_source(State = #{name := Name,
                          source := #{uris := [Uri | _],
                                      source_address := Addr,
                                      predeclared := Predeclared,
+                                     consumer_args := CArgs,
                                      consumer_name := CName} = Src}) ->
     SndSettleMode = case AckMode of
                         no_ack -> settled;
@@ -188,7 +191,8 @@ connect_source(State = #{name := Name,
                         on_confirm -> unsettled
                     end,
     AttachFun = fun(S, L, A, SSM, D) ->
-                        amqp10_client:attach_receiver_link(S, L, A, SSM, D, #{}, #{}, true)
+                        Filter = translate_consumer_args_to_filter(CArgs),
+                        amqp10_client:attach_receiver_link(S, L, A, SSM, D, Filter, #{}, true)
                 end,
     LinkNameOverride = case CName of
                            <<>> -> undefined;
@@ -406,7 +410,7 @@ close_source(#{source := #{current := #{conn := Conn,
 close_source(_Config) -> ok.
 
 connection_close(Conn, Sess, LinkRef) ->
-    catch amqp10_client:detach_link(LinkRef),
+    _ = try amqp10_client:detach_link(LinkRef) catch _:_ -> ok end,
     _ = amqp10_client:end_session(Sess),
     _ = amqp10_client:close_connection(Conn).
 
@@ -546,3 +550,12 @@ decl_queue(Sess, Addr, false) ->
         _ ->
             ok
     end.
+
+translate_consumer_args_to_filter(CArgs) ->
+    List = rabbit_data_coercion:to_proplist(CArgs),
+    lists:foldl(
+      fun({<<"x-stream-offset">>, Val}, Acc) ->
+              Acc#{<<"rabbitmq:stream-offset-spec">> => Val};
+         ({Key, Val}, Acc) ->
+              Acc#{Key => Val}
+      end, #{}, List).

--- a/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
@@ -323,7 +323,9 @@ simple_stream(Config, AckMode, NMsgs) ->
               amqp10_declare_queue(Sess, Src, #{<<"x-queue-type">> => {utf8, <<"stream">>}}),
               amqp10_declare_queue(Sess, Dest, #{<<"x-queue-type">> => {utf8, <<"stream">>}}),
               set_param(Config, Param,
-                        ?config(shovel_args, Config) ++ [{<<"ack-mode">>, AckMode}]),
+                        ?config(shovel_args, Config) ++
+                        [{<<"ack-mode">>, AckMode},
+                         {<<"src-consumer-args">>, #{<<"x-stream-offset">> => <<"first">>}}]),
               DestAddress = rabbitmq_amqp_address:queue(Dest),
               Receiver = amqp10_subscribe(Sess, DestAddress),
               SrcAddress = rabbitmq_amqp_address:queue(Src),


### PR DESCRIPTION
Add support for `src-consumer-args` in AMQP 1.0. It's already supported in 0.9.1 and local shovels.

Use this feature to prevent a race condition in shovel tests.
