### PR TITLE
Exchange federation: trap exits later

### DIFF
--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -148,8 +148,8 @@ handle_cast(disconnect_for_shutdown, State = #state{
                 _ ->
                     try
                         {ok, Ch} = amqp_connection:open_channel(Conn),
-                        catch amqp_channel:call(Ch, #'queue.delete'{queue = Queue}),
-                        catch amqp_channel:call(Ch, #'exchange.delete'{exchange = IntExchange})
+                        try amqp_channel:call(Ch, #'queue.delete'{queue = Queue}) catch _:_ -> ok end,
+                        try amqp_channel:call(Ch, #'exchange.delete'{exchange = IntExchange}) catch _:_ -> ok end
                     catch
                         _:_ -> ok
                     end

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
@@ -52,11 +52,9 @@ start_conn_ch(Fun, OUpstream, OUParams,
             case open_monitor(UParams#upstream_params.params, ConnName) of
                 {ok, Conn, Ch} ->
                     %% Don't trap exits until we have established
-                    %% connections so that if we try to delete
-                    %% federation upstreams while waiting for a
-                    %% connection to be established then we don't
-                    %% block
-                    process_flag(trap_exit, true),
+                    %% connections and performed initial setup, so
+                    %% that supervisor shutdown can terminate this
+                    %% process immediately if it blocks during setup.
                     try
                         R = Fun(Conn, Ch, DConn, DCh),
                         ?LOG_INFO("Federation ~ts connected to ~ts",
@@ -65,6 +63,7 @@ start_conn_ch(Fun, OUpstream, OUParams,
                         Name = pget(name, amqp_connection:info(DConn, [name])),
                         rabbit_federation_status:report(
                           OUpstream, OUParams, XorQName, {running, Name}),
+                        process_flag(trap_exit, true),
                         R
                     catch exit:E ->
                             %% terminate/2 will not get this, as we


### PR DESCRIPTION
We already intentionally delayed trapping the exits, but it was still too early, leading
to a timeout in rare cases: https://github.com/rabbitmq/rabbitmq-server/actions/runs/28160826055/job/83400596884?pr=16798