### PR TITLE
Use global lock in run_make_dist

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -245,7 +245,8 @@ teardown_steps_for_vms() ->
 
 run_make_dist(Config) ->
     LockId = {make_dist, self()},
-    global:set_lock(LockId, [node()]),
+    LockNodes = [node() | nodes()],
+    global:set_lock(LockId, LockNodes),
     case os:getenv("SKIP_MAKE_TEST_DIST") of
         false ->
             SrcDir = ?config(current_srcdir, Config),
@@ -260,14 +261,14 @@ run_make_dist(Config) ->
                     %% record the fact we went through it already so we
                     %% save redundant calls.
                     os:putenv("SKIP_MAKE_TEST_DIST", "true"),
-                    global:del_lock(LockId, [node()]),
+                    global:del_lock(LockId, LockNodes),
                     Config;
                 _ ->
-                    global:del_lock(LockId, [node()]),
+                    global:del_lock(LockId, LockNodes),
                     {skip, "Failed to run \"make test-dist\""}
             end;
         _ ->
-            global:del_lock(LockId, [node()]),
+            global:del_lock(LockId, LockNodes),
             ct:log(?LOW_IMPORTANCE, "(skip `$MAKE test-dist`)", []),
             Config
     end.


### PR DESCRIPTION
This is to prevent rare failures where concurrently running jobs step on each other, for example:
https://github.com/rabbitmq/rabbitmq-server/actions/runs/28165718336/job/83417061975?pr=16800

```
make[3]: *** No rule to make target '/home/runner/work/rabbitmq-server/rabbitmq-server/deps/rabbit_commo', needed by 'src/rabbit_db_rtparams_m2k_converter.erl'.  Stop.
```

"deps/rabbit_commo" is obsiosuly truncated, because one job was writing the file while another was reading it.
