### PR TITLE
Web STOMP, Web MQTT: introduce strict origin validation

### DIFF
--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_websocket_origin.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_websocket_origin.erl
@@ -5,10 +5,9 @@
 %% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
-%% WebSocket `Origin` header validation shared by the Web-STOMP and Web-MQTT
-%% plugins. The policy decision (`validate/4`) is pure: the caller passes in the
-%% configuration and the request's own origin, so it can be tested without a
-%% running broker.
+%% WebSocket `Origin` header validation shared by the Web STOMP and Web MQTT
+%% plugins. `validate/4` is pure: configuration and the request origin are
+%% passed in by the caller.
 -module(rabbit_web_dispatch_websocket_origin).
 
 -include_lib("kernel/include/logger.hrl").
@@ -23,14 +22,15 @@
 %%   list of origins - only an Origin present in the list is accepted
 -type allow_origins() :: [] | same_origin | [string()].
 
-%% The request's own origin as seen by the server: scheme, host, and port.
+%% The request's own origin as the server observes it: scheme from the listener
+%% transport, host and port from the Host header. With TLS terminated upstream
+%% these may differ from the values the browser used.
 -type server_origin() :: {Scheme :: binary(),
                           Host :: binary(),
                           Port :: inet:port_number()}.
 
-%% Reads both origin-validation settings from a plugin's application
-%% environment. Centralised here so the two plugins and their listeners share
-%% one definition of the setting names and defaults.
+%% Reads both origin settings from a plugin's environment, so the two plugins
+%% share one definition of the setting names and defaults.
 -spec config(App :: atom()) -> {allow_origins(), Strict :: boolean()}.
 config(App) ->
     {application:get_env(App, allow_origins, []),
@@ -45,9 +45,8 @@ config(App) ->
 %% No restriction configured: accept every Origin, including a missing one.
 validate(_Origin, _ServerOrigin, [], _Strict) ->
     ok;
-%% A policy is in effect but the request carries no Origin header. Such a
-%% request cannot come from a same-origin-bound browser, so it is accepted
-%% to keep non-browser WebSocket clients working unless strict mode is on.
+%% A restriction is set but the request has no Origin header: accept it unless
+%% strict mode is on.
 validate(undefined, _ServerOrigin, _AllowOrigins, Strict) ->
     case Strict of
         true  -> {error, origin_not_allowed};
@@ -65,9 +64,8 @@ validate(Origin, _ServerOrigin, AllowOrigins, _Strict)
         false -> {error, origin_not_allowed}
     end.
 
-%% Returns a warning to log at startup when a listener accepts any Origin, or
-%% `none` when a restriction is in place. Pure so the message text can be
-%% asserted in tests.
+%% Returns the warning text when a listener accepts any Origin, or `none' when a
+%% restriction is configured.
 -spec permissive_warning(PluginLabel :: iodata(), allow_origins()) ->
           iodata() | none.
 permissive_warning(PluginLabel, []) ->
@@ -79,9 +77,8 @@ permissive_warning(PluginLabel, []) ->
 permissive_warning(_PluginLabel, _AllowOrigins) ->
     none.
 
-%% Logs the permissive-default warning for App (labelled PluginLabel) when no
-%% Origin restriction is configured; a no-op otherwise. Called once per plugin
-%% at listener startup.
+%% Logs the warning for App at listener startup when no restriction is
+%% configured.
 -spec warn_if_permissive(App :: atom(), PluginLabel :: iodata()) -> ok.
 warn_if_permissive(App, PluginLabel) ->
     {AllowOrigins, _Strict} = config(App),
@@ -117,8 +114,7 @@ parse_origin(Origin) ->
                 Port      -> {ok, {Scheme, Host, Port}}
             end;
         _ ->
-            %% Opaque Origins such as "null" carry no scheme/host and are
-            %% never treated as same-origin.
+            %% Values without a scheme and host (e.g. "null") do not match.
             error
     catch
         _:_ -> error

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_websocket_origin.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_websocket_origin.erl
@@ -1,0 +1,133 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% WebSocket `Origin` header validation shared by the Web-STOMP and Web-MQTT
+%% plugins. The policy decision (`validate/4`) is pure: the caller passes in the
+%% configuration and the request's own origin, so it can be tested without a
+%% running broker.
+-module(rabbit_web_dispatch_websocket_origin).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([config/1, validate/4, permissive_warning/2, warn_if_permissive/2]).
+
+-export_type([allow_origins/0, server_origin/0]).
+
+%% Resolved value of a plugin's `allow_origins` setting:
+%%   `[]`            - no restriction; any Origin is accepted (the default)
+%%   `same_origin`   - only an Origin equal to the request's own origin is accepted
+%%   list of origins - only an Origin present in the list is accepted
+-type allow_origins() :: [] | same_origin | [string()].
+
+%% The request's own origin as seen by the server: scheme, host, and port.
+-type server_origin() :: {Scheme :: binary(),
+                          Host :: binary(),
+                          Port :: inet:port_number()}.
+
+%% Reads both origin-validation settings from a plugin's application
+%% environment. Centralised here so the two plugins and their listeners share
+%% one definition of the setting names and defaults.
+-spec config(App :: atom()) -> {allow_origins(), Strict :: boolean()}.
+config(App) ->
+    {application:get_env(App, allow_origins, []),
+     application:get_env(App, strict_origin_validation, false)}.
+
+-spec validate(Origin, ServerOrigin, AllowOrigins, Strict) ->
+          ok | {error, origin_not_allowed} when
+      Origin :: binary() | undefined,
+      ServerOrigin :: server_origin(),
+      AllowOrigins :: allow_origins(),
+      Strict :: boolean().
+%% No restriction configured: accept every Origin, including a missing one.
+validate(_Origin, _ServerOrigin, [], _Strict) ->
+    ok;
+%% A policy is in effect but the request carries no Origin header. Such a
+%% request cannot come from a same-origin-bound browser, so it is accepted
+%% to keep non-browser WebSocket clients working unless strict mode is on.
+validate(undefined, _ServerOrigin, _AllowOrigins, Strict) ->
+    case Strict of
+        true  -> {error, origin_not_allowed};
+        false -> ok
+    end;
+validate(Origin, ServerOrigin, same_origin, _Strict) when is_binary(Origin) ->
+    case is_same_origin(Origin, ServerOrigin) of
+        true  -> ok;
+        false -> {error, origin_not_allowed}
+    end;
+validate(Origin, _ServerOrigin, AllowOrigins, _Strict)
+  when is_binary(Origin), is_list(AllowOrigins) ->
+    case lists:member(binary_to_list(Origin), AllowOrigins) of
+        true  -> ok;
+        false -> {error, origin_not_allowed}
+    end.
+
+%% Returns a warning to log at startup when a listener accepts any Origin, or
+%% `none` when a restriction is in place. Pure so the message text can be
+%% asserted in tests.
+-spec permissive_warning(PluginLabel :: iodata(), allow_origins()) ->
+          iodata() | none.
+permissive_warning(PluginLabel, []) ->
+    [PluginLabel,
+     " WebSocket Origin validation is disabled: 'allow_origins' is not set, so "
+     "WebSocket upgrade requests from any Origin are accepted. If browser "
+     "clients connect to this node, restrict them by setting 'allow_origins' to "
+     "the trusted origins, or to 'same_origin'."];
+permissive_warning(_PluginLabel, _AllowOrigins) ->
+    none.
+
+%% Logs the permissive-default warning for App (labelled PluginLabel) when no
+%% Origin restriction is configured; a no-op otherwise. Called once per plugin
+%% at listener startup.
+-spec warn_if_permissive(App :: atom(), PluginLabel :: iodata()) -> ok.
+warn_if_permissive(App, PluginLabel) ->
+    {AllowOrigins, _Strict} = config(App),
+    case permissive_warning(PluginLabel, AllowOrigins) of
+        none -> ok;
+        Msg  -> ?LOG_WARNING("~ts", [Msg])
+    end.
+
+%%
+%% Implementation
+%%
+
+-spec is_same_origin(binary(), server_origin()) -> boolean().
+is_same_origin(Origin, {Scheme, Host, Port}) ->
+    case parse_origin(Origin) of
+        {ok, {OScheme, OHost, OPort}} ->
+            %% Scheme and host are compared case-insensitively per RFC 6454;
+            %% the port must match exactly after default-port normalisation.
+            string:equal(OScheme, Scheme, true) andalso
+                string:equal(OHost, Host, true) andalso
+                OPort =:= Port;
+        error ->
+            false
+    end.
+
+-spec parse_origin(binary()) ->
+          {ok, {binary(), binary(), inet:port_number()}} | error.
+parse_origin(Origin) ->
+    try uri_string:parse(Origin) of
+        #{scheme := Scheme, host := Host} = Parsed ->
+            case maps:get(port, Parsed, default_port(Scheme)) of
+                undefined -> error;
+                Port      -> {ok, {Scheme, Host, Port}}
+            end;
+        _ ->
+            %% Opaque Origins such as "null" carry no scheme/host and are
+            %% never treated as same-origin.
+            error
+    catch
+        _:_ -> error
+    end.
+
+-spec default_port(binary()) -> inet:port_number() | undefined.
+default_port(Scheme) ->
+    case string:lowercase(Scheme) of
+        <<"https">> -> 443;
+        <<"http">>  -> 80;
+        _           -> undefined
+    end.

--- a/deps/rabbitmq_web_dispatch/test/rabbit_web_dispatch_websocket_origin_SUITE.erl
+++ b/deps/rabbitmq_web_dispatch/test/rabbit_web_dispatch_websocket_origin_SUITE.erl
@@ -1,0 +1,165 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_web_dispatch_websocket_origin_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-define(M, rabbit_web_dispatch_websocket_origin).
+-define(SERVER, {<<"http">>, <<"localhost">>, 15674}).
+
+all() ->
+    [{group, unit}, {group, properties}].
+
+groups() ->
+    [{unit, [parallel],
+      [no_restriction_allows_any_origin,
+       allowlist_accepts_listed_origin,
+       allowlist_rejects_unlisted_origin,
+       missing_origin_allowed_without_strict,
+       missing_origin_rejected_with_strict,
+       same_origin_accepts_matching_origin,
+       same_origin_rejects_different_port,
+       same_origin_rejects_different_host,
+       same_origin_rejects_different_scheme,
+       same_origin_accepts_default_ports,
+       same_origin_is_case_insensitive,
+       same_origin_rejects_opaque_origin,
+       same_origin_rejects_malformed_origin,
+       permissive_warning_only_for_allow_all]},
+     {properties, [parallel],
+      [prop_same_origin_matches_self,
+       prop_same_origin_rejects_other_port,
+       prop_same_origin_is_case_insensitive]}].
+
+init_per_suite(Config) -> Config.
+end_per_suite(Config) -> Config.
+init_per_group(_, Config) -> Config.
+end_per_group(_, Config) -> Config.
+init_per_testcase(_, Config) -> Config.
+end_per_testcase(_, Config) -> Config.
+
+%%
+%% Unit tests
+%%
+
+%% The default (no allowlist) accepts every Origin, including a missing one;
+%% strict mode is a no-op because there is no allowlist to enforce.
+no_restriction_allows_any_origin(_Config) ->
+    ?assertEqual(ok, ?M:validate(<<"https://evil.example.com">>, ?SERVER, [], false)),
+    ?assertEqual(ok, ?M:validate(undefined, ?SERVER, [], false)),
+    ?assertEqual(ok, ?M:validate(<<"https://evil.example.com">>, ?SERVER, [], true)),
+    ?assertEqual(ok, ?M:validate(undefined, ?SERVER, [], true)).
+
+allowlist_accepts_listed_origin(_Config) ->
+    List = ["https://a.example.com", "https://b.example.com"],
+    ?assertEqual(ok, ?M:validate(<<"https://b.example.com">>, ?SERVER, List, false)).
+
+allowlist_rejects_unlisted_origin(_Config) ->
+    List = ["https://a.example.com"],
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<"https://evil.example.com">>, ?SERVER, List, false)).
+
+missing_origin_allowed_without_strict(_Config) ->
+    ?assertEqual(ok, ?M:validate(undefined, ?SERVER, ["https://a.example.com"], false)),
+    ?assertEqual(ok, ?M:validate(undefined, ?SERVER, same_origin, false)).
+
+missing_origin_rejected_with_strict(_Config) ->
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(undefined, ?SERVER, ["https://a.example.com"], true)),
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(undefined, ?SERVER, same_origin, true)).
+
+same_origin_accepts_matching_origin(_Config) ->
+    ?assertEqual(ok, ?M:validate(<<"http://localhost:15674">>, ?SERVER, same_origin, false)).
+
+same_origin_rejects_different_port(_Config) ->
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<"http://localhost:15670">>, ?SERVER, same_origin, false)).
+
+same_origin_rejects_different_host(_Config) ->
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<"http://other:15674">>, ?SERVER, same_origin, false)).
+
+same_origin_rejects_different_scheme(_Config) ->
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<"https://localhost:15674">>, ?SERVER, same_origin, false)).
+
+%% An Origin without an explicit port matches a server on the scheme's
+%% default port (80 for http, 443 for https).
+same_origin_accepts_default_ports(_Config) ->
+    ?assertEqual(ok, ?M:validate(<<"http://example.com">>,
+                                 {<<"http">>, <<"example.com">>, 80}, same_origin, false)),
+    ?assertEqual(ok, ?M:validate(<<"https://example.com">>,
+                                 {<<"https">>, <<"example.com">>, 443}, same_origin, false)).
+
+same_origin_is_case_insensitive(_Config) ->
+    ?assertEqual(ok, ?M:validate(<<"HTTP://LOCALHOST:15674">>, ?SERVER, same_origin, false)).
+
+%% Browsers send "Origin: null" from sandboxed/opaque contexts; it is never
+%% same-origin.
+same_origin_rejects_opaque_origin(_Config) ->
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<"null">>, ?SERVER, same_origin, false)).
+
+%% A value that is not a parseable absolute URI has no scheme/host.
+same_origin_rejects_malformed_origin(_Config) ->
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<"not a url">>, ?SERVER, same_origin, false)).
+
+permissive_warning_only_for_allow_all(_Config) ->
+    ?assertNotEqual(none, ?M:permissive_warning(<<"Web STOMP:">>, [])),
+    ?assertEqual(none, ?M:permissive_warning(<<"Web STOMP:">>, same_origin)),
+    ?assertEqual(none, ?M:permissive_warning(<<"Web STOMP:">>, ["https://a.example.com"])).
+
+%%
+%% Properties — fuzz the same-origin URI parsing and comparison
+%%
+
+prop_same_origin_matches_self(_Config) ->
+    ?assert(quickcheck(
+        ?FORALL(T, origin_triple(),
+                ?M:validate(build_origin(T), T, same_origin, false) =:= ok))).
+
+prop_same_origin_rejects_other_port(_Config) ->
+    ?assert(quickcheck(
+        ?FORALL(T = {Scheme, Host, Port}, origin_triple(),
+                ?M:validate(build_origin(T),
+                            {Scheme, Host, other_port(Port)},
+                            same_origin, false) =:= {error, origin_not_allowed}))).
+
+prop_same_origin_is_case_insensitive(_Config) ->
+    ?assert(quickcheck(
+        ?FORALL(T = {Scheme, Host, Port}, origin_triple(),
+                ?M:validate(build_origin({string:uppercase(Scheme),
+                                          string:uppercase(Host), Port}),
+                            T, same_origin, false) =:= ok))).
+
+%%
+%% Generators and helpers
+%%
+
+scheme() -> elements([<<"http">>, <<"https">>]).
+
+host() ->
+    ?LET(S, non_empty(list(elements("abcdefghijklmnopqrstuvwxyz0123456789"))),
+         list_to_binary(S)).
+
+origin_triple() -> {scheme(), host(), range(1, 65535)}.
+
+build_origin({Scheme, Host, Port}) ->
+    <<Scheme/binary, "://", Host/binary, ":", (integer_to_binary(Port))/binary>>.
+
+other_port(65535) -> 1;
+other_port(Port)  -> Port + 1.
+
+quickcheck(Prop) ->
+    proper:quickcheck(Prop, [{numtests, 500}, {to_file, user}]).

--- a/deps/rabbitmq_web_dispatch/test/rabbit_web_dispatch_websocket_origin_SUITE.erl
+++ b/deps/rabbitmq_web_dispatch/test/rabbit_web_dispatch_websocket_origin_SUITE.erl
@@ -34,11 +34,13 @@ groups() ->
        same_origin_is_case_insensitive,
        same_origin_rejects_opaque_origin,
        same_origin_rejects_malformed_origin,
+       same_origin_rejects_non_uri_origin,
        permissive_warning_only_for_allow_all]},
      {properties, [parallel],
       [prop_same_origin_matches_self,
        prop_same_origin_rejects_other_port,
-       prop_same_origin_is_case_insensitive]}].
+       prop_same_origin_is_case_insensitive,
+       prop_validate_never_crashes]}].
 
 init_per_suite(Config) -> Config.
 end_per_suite(Config) -> Config.
@@ -51,8 +53,7 @@ end_per_testcase(_, Config) -> Config.
 %% Unit tests
 %%
 
-%% The default (no allowlist) accepts every Origin, including a missing one;
-%% strict mode is a no-op because there is no allowlist to enforce.
+%% With no allowlist, every Origin is accepted and strict mode has no effect.
 no_restriction_allows_any_origin(_Config) ->
     ?assertEqual(ok, ?M:validate(<<"https://evil.example.com">>, ?SERVER, [], false)),
     ?assertEqual(ok, ?M:validate(undefined, ?SERVER, [], false)),
@@ -104,8 +105,7 @@ same_origin_accepts_default_ports(_Config) ->
 same_origin_is_case_insensitive(_Config) ->
     ?assertEqual(ok, ?M:validate(<<"HTTP://LOCALHOST:15674">>, ?SERVER, same_origin, false)).
 
-%% Browsers send "Origin: null" from sandboxed/opaque contexts; it is never
-%% same-origin.
+%% A "null" Origin has no scheme/host and does not match.
 same_origin_rejects_opaque_origin(_Config) ->
     ?assertEqual({error, origin_not_allowed},
                  ?M:validate(<<"null">>, ?SERVER, same_origin, false)).
@@ -114,6 +114,13 @@ same_origin_rejects_opaque_origin(_Config) ->
 same_origin_rejects_malformed_origin(_Config) ->
     ?assertEqual({error, origin_not_allowed},
                  ?M:validate(<<"not a url">>, ?SERVER, same_origin, false)).
+
+%% Empty and non-URI byte values do not match.
+same_origin_rejects_non_uri_origin(_Config) ->
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<>>, ?SERVER, same_origin, false)),
+    ?assertEqual({error, origin_not_allowed},
+                 ?M:validate(<<0, 1, 2, 255>>, ?SERVER, same_origin, false)).
 
 permissive_warning_only_for_allow_all(_Config) ->
     ?assertNotEqual(none, ?M:permissive_warning(<<"Web STOMP:">>, [])),
@@ -143,6 +150,16 @@ prop_same_origin_is_case_insensitive(_Config) ->
                                           string:uppercase(Host), Port}),
                             T, same_origin, false) =:= ok))).
 
+%% validate/4 returns ok or origin_not_allowed for any input under any policy.
+prop_validate_never_crashes(_Config) ->
+    ?assert(quickcheck(
+        ?FORALL({Origin, Policy, Strict},
+                {arbitrary_origin(),
+                 oneof([[], same_origin, ["https://app.example.com"]]),
+                 boolean()},
+                lists:member(?M:validate(Origin, ?SERVER, Policy, Strict),
+                             [ok, {error, origin_not_allowed}])))).
+
 %%
 %% Generators and helpers
 %%
@@ -154,6 +171,16 @@ host() ->
          list_to_binary(S)).
 
 origin_triple() -> {scheme(), host(), range(1, 65535)}.
+
+%% Valid, absent, and malformed Origin values: `binary()' covers arbitrary
+%% bytes, the list adds non-URI shapes.
+arbitrary_origin() ->
+    oneof([undefined,
+           binary(),
+           ?LET(T, origin_triple(), build_origin(T)),
+           elements([<<"null">>, <<"   ">>, <<"http://">>, <<"https://">>,
+                     <<"notaurl">>, <<"javascript:alert(1)">>,
+                     <<"//evil.example.com">>, <<"http://[::1]:15674">>])]).
 
 build_origin({Scheme, Host, Port}) ->
     <<Scheme/binary, "://", Host/binary, ":", (integer_to_binary(Port))/binary>>.

--- a/deps/rabbitmq_web_mqtt/Makefile
+++ b/deps/rabbitmq_web_mqtt/Makefile
@@ -18,7 +18,7 @@ BUILD_WITHOUT_QUIC=1
 export BUILD_WITHOUT_QUIC
 
 LOCAL_DEPS = ssl
-DEPS = rabbit cowboy rabbitmq_mqtt
+DEPS = rabbit cowboy rabbitmq_mqtt rabbitmq_web_dispatch
 TEST_DEPS = gun emqtt rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management rabbitmq_stomp rabbitmq_consistent_hash_exchange
 
 PLT_APPS += rabbitmq_cli elixir cowlib ssl

--- a/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
+++ b/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
@@ -27,7 +27,7 @@
     [{datatype, string}]}.
 
 {mapping, "web_mqtt.allow_origins", "rabbitmq_web_mqtt.allow_origins", [
-    {datatype, {enum, [none]}}
+    {datatype, {enum, [none, same_origin]}}
 ]}.
 
 {mapping, "web_mqtt.allow_origins.$name", "rabbitmq_web_mqtt.allow_origins", [
@@ -38,11 +38,16 @@
 fun(Conf) ->
     case cuttlefish:conf_get("web_mqtt.allow_origins", Conf, undefined) of
         none -> [];
+        same_origin -> same_origin;
         _ ->
             Settings = cuttlefish_variable:filter_by_prefix("web_mqtt.allow_origins", Conf),
             [V || {_, V} <- Settings]
     end
 end}.
+
+{mapping, "web_mqtt.strict_origin_validation", "rabbitmq_web_mqtt.strict_origin_validation", [
+    {datatype, boolean}
+]}.
 
 {translation,
     "rabbitmq_web_mqtt.tcp_config",

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
@@ -94,7 +94,17 @@ mqtt_init() ->
                  stream_handlers => [rabbit_web_mqtt_stream_handler, cowboy_stream_h]
                 },
     start_tcp_listener(TcpConfig, CowboyOpts),
-    start_tls_listener(SslConfig, CowboyOpts).
+    start_tls_listener(SslConfig, CowboyOpts),
+    maybe_warn_about_origins(TcpConfig, SslConfig).
+
+%% Warns once at startup when a listener is configured but accepts WebSocket
+%% upgrades from any Origin.
+maybe_warn_about_origins(TcpConfig, SslConfig) ->
+    case TcpConfig =/= [] orelse SslConfig =/= [] of
+        false -> ok;
+        true  -> rabbit_web_dispatch_websocket_origin:warn_if_permissive(
+                   rabbitmq_web_mqtt, <<"Web MQTT:">>)
+    end.
 
 start_tcp_listener([], _) -> ok;
 start_tcp_listener(TCPConf0, CowboyOpts) ->

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
@@ -97,8 +97,8 @@ mqtt_init() ->
     start_tls_listener(SslConfig, CowboyOpts),
     maybe_warn_about_origins(TcpConfig, SslConfig).
 
-%% Warns once at startup when a listener is configured but accepts WebSocket
-%% upgrades from any Origin.
+%% Warns at startup when a listener is configured but no Origin restriction is
+%% set.
 maybe_warn_about_origins(TcpConfig, SslConfig) ->
     case TcpConfig =/= [] orelse SslConfig =/= [] of
         false -> ok;

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -345,20 +345,13 @@ no_supported_sub_protocol(Protocol, Req) ->
      #state{}}.
 
 check_origin(Req) ->
-    case application:get_env(?APP, allow_origins, []) of
-        [] ->
-            ok;
-        AllowedOrigins ->
-            case cowboy_req:header(<<"origin">>, Req) of
-                undefined ->
-                    ok;
-                Origin ->
-                    case lists:member(binary_to_list(Origin), AllowedOrigins) of
-                        true -> ok;
-                        false -> {error, origin_not_allowed}
-                    end
-            end
-    end.
+    {AllowOrigins, Strict} = rabbit_web_dispatch_websocket_origin:config(?APP),
+    ServerOrigin = {cowboy_req:scheme(Req),
+                    cowboy_req:host(Req),
+                    cowboy_req:port(Req)},
+    Origin = cowboy_req:header(<<"origin">>, Req),
+    rabbit_web_dispatch_websocket_origin:validate(Origin, ServerOrigin,
+                                                  AllowOrigins, Strict).
 
 handle_data(Data, State0 = #state{}) ->
     case handle_data1(Data, State0) of

--- a/deps/rabbitmq_web_mqtt/test/web_mqtt_config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
+++ b/deps/rabbitmq_web_mqtt/test/web_mqtt_config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
@@ -228,5 +228,30 @@
 {proxy_protocol_enabled,
   "web_mqtt.proxy_protocol = true",
   [{rabbitmq_web_mqtt,[{proxy_protocol,true}]}],
+  [rabbitmq_web_mqtt]},
+
+ %%
+ %% WebSocket Origin validation
+ %%
+
+ {allow_origins_none,
+  "web_mqtt.allow_origins = none",
+  [{rabbitmq_web_mqtt,[{allow_origins, []}]}],
+  [rabbitmq_web_mqtt]},
+
+ {allow_origins_same_origin,
+  "web_mqtt.allow_origins = same_origin",
+  [{rabbitmq_web_mqtt,[{allow_origins, same_origin}]}],
+  [rabbitmq_web_mqtt]},
+
+ {allow_origins_list,
+  "web_mqtt.allow_origins.1 = https://a.example.com
+   web_mqtt.allow_origins.2 = https://b.example.com",
+  [{rabbitmq_web_mqtt,[{allow_origins, ["https://a.example.com", "https://b.example.com"]}]}],
+  [rabbitmq_web_mqtt]},
+
+ {strict_origin_validation,
+  "web_mqtt.strict_origin_validation = true",
+  [{rabbitmq_web_mqtt,[{strict_origin_validation, true}]}],
   [rabbitmq_web_mqtt]}
 ].

--- a/deps/rabbitmq_web_mqtt/test/web_mqtt_origin_SUITE.erl
+++ b/deps/rabbitmq_web_mqtt/test/web_mqtt_origin_SUITE.erl
@@ -22,7 +22,12 @@ all() ->
      allowed_origin_connects,
      disallowed_origin_rejected,
      no_origin_header_allowed_when_allowlist_set,
-     multiple_allowed_origins].
+     multiple_allowed_origins,
+     same_origin_matching_origin_connects,
+     same_origin_cross_origin_rejected,
+     same_origin_missing_origin_allowed,
+     strict_missing_origin_rejected,
+     strict_allowed_origin_connects].
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
@@ -49,6 +54,24 @@ init_per_testcase(multiple_allowed_origins, Config) ->
       application, set_env, [rabbitmq_web_mqtt, allow_origins,
                               [?ALLOWED, ?ALLOWED2]]),
     Config;
+init_per_testcase(TC, Config)
+  when TC =:= same_origin_matching_origin_connects;
+       TC =:= same_origin_cross_origin_rejected;
+       TC =:= same_origin_missing_origin_allowed ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_mqtt, allow_origins, same_origin]),
+    Config;
+init_per_testcase(TC, Config)
+  when TC =:= strict_missing_origin_rejected;
+       TC =:= strict_allowed_origin_connects ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_mqtt, allow_origins, [?ALLOWED]]),
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_mqtt, strict_origin_validation, true]),
+    Config;
 init_per_testcase(_Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(
       Config, 0,
@@ -60,6 +83,9 @@ end_per_testcase(_Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(
       Config, 0,
       application, unset_env, [rabbitmq_web_mqtt, allow_origins]),
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, unset_env, [rabbitmq_web_mqtt, strict_origin_validation]),
     Config.
 
 %% When no allowlist is configured, any Origin is accepted.
@@ -116,6 +142,42 @@ multiple_allowed_origins(Config) ->
 
     Resp3 = raw_ws_upgrade(Port, [{"Origin", "https://evil.example.com"}]),
     ?assertNotEqual(nomatch, binary:match(Resp3, <<"403">>)).
+
+%% With same_origin, an Origin equal to the request's own scheme/host/port
+%% is accepted.
+same_origin_matching_origin_connects(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", "http://127.0.0.1:" ++ PortStr}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
+
+%% With same_origin, an Origin on a different port is cross-origin and rejected.
+same_origin_cross_origin_rejected(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", "http://127.0.0.1:1"}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"403">>)).
+
+%% A missing Origin is still accepted under same_origin without strict mode.
+same_origin_missing_origin_allowed(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, []),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
+
+%% With strict mode and an allowlist set, a request without an Origin is rejected.
+strict_missing_origin_rejected(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, []),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"403">>)).
+
+%% Strict mode still accepts an allowlisted Origin.
+strict_allowed_origin_connects(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", ?ALLOWED}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
 
 %%
 %% Helpers

--- a/deps/rabbitmq_web_stomp/Makefile
+++ b/deps/rabbitmq_web_stomp/Makefile
@@ -19,7 +19,7 @@ define PROJECT_APP_EXTRA_KEYS
 	{broker_version_requirements, []}
 endef
 
-DEPS = cowboy rabbit_common rabbit rabbitmq_stomp
+DEPS = cowboy rabbit_common rabbit rabbitmq_stomp rabbitmq_web_dispatch
 TEST_DEPS = gun rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 
 PLT_APPS += cowlib

--- a/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
+++ b/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
@@ -33,7 +33,7 @@
     [{datatype, string}]}.
 
 {mapping, "web_stomp.allow_origins", "rabbitmq_web_stomp.allow_origins", [
-    {datatype, {enum, [none]}}
+    {datatype, {enum, [none, same_origin]}}
 ]}.
 
 {mapping, "web_stomp.allow_origins.$name", "rabbitmq_web_stomp.allow_origins", [
@@ -44,11 +44,16 @@
 fun(Conf) ->
     case cuttlefish:conf_get("web_stomp.allow_origins", Conf, undefined) of
         none -> [];
+        same_origin -> same_origin;
         _ ->
             Settings = cuttlefish_variable:filter_by_prefix("web_stomp.allow_origins", Conf),
             [V || {_, V} <- Settings]
     end
 end}.
+
+{mapping, "web_stomp.strict_origin_validation", "rabbitmq_web_stomp.strict_origin_validation", [
+    {datatype, boolean}
+]}.
 
 {mapping, "web_stomp.use_http_auth", "rabbitmq_web_stomp.use_http_auth",
     [{datatype, boolean}]}.

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -362,20 +362,13 @@ safe_terminate(Pid) ->
 %%----------------------------------------------------------------------------
 
 check_origin(Req) ->
-    case application:get_env(?APP, allow_origins, []) of
-        [] ->
-            ok;
-        AllowedOrigins ->
-            case cowboy_req:header(<<"origin">>, Req) of
-                undefined ->
-                    ok;
-                Origin ->
-                    case lists:member(binary_to_list(Origin), AllowedOrigins) of
-                        true -> ok;
-                        false -> {error, origin_not_allowed}
-                    end
-            end
-    end.
+    {AllowOrigins, Strict} = rabbit_web_dispatch_websocket_origin:config(?APP),
+    ServerOrigin = {cowboy_req:scheme(Req),
+                    cowboy_req:host(Req),
+                    cowboy_req:port(Req)},
+    Origin = cowboy_req:header(<<"origin">>, Req),
+    rabbit_web_dispatch_websocket_origin:validate(Origin, ServerOrigin,
+                                                  AllowOrigins, Strict).
 
 %% The protocols v10.stomp, v11.stomp and v12.stomp are registered
 %% at IANA: https://www.iana.org/assignments/websocket/websocket.xhtml

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
@@ -56,8 +56,8 @@ init() ->
     maybe_warn_about_origins(TCPConf, SSLConf),
     ok.
 
-%% Warns once at startup when a listener is configured but accepts WebSocket
-%% upgrades from any Origin.
+%% Warns at startup when a listener is configured but no Origin restriction is
+%% set.
 maybe_warn_about_origins(TCPConf, SSLConf) ->
     case TCPConf =/= [] orelse SSLConf =/= [] of
         false -> ok;

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
@@ -43,15 +43,27 @@ init() ->
     ],
     Routes = cowboy_router:compile([{'_',  VhostRoutes}]), % any vhost
 
-    case get_env(tcp_config, []) of
-        []       -> ok;
-        TCPConf0 -> start_tcp_listener(TCPConf0, CowboyOpts, Routes)
+    TCPConf = get_env(tcp_config, []),
+    SSLConf = get_env(ssl_config, []),
+    case TCPConf of
+        []      -> ok;
+        _       -> start_tcp_listener(TCPConf, CowboyOpts, Routes)
     end,
-    case get_env(ssl_config, []) of
-        []       -> ok;
-        TLSConf0 -> start_tls_listener(TLSConf0, CowboyOpts, Routes)
+    case SSLConf of
+        []      -> ok;
+        _       -> start_tls_listener(SSLConf, CowboyOpts, Routes)
     end,
+    maybe_warn_about_origins(TCPConf, SSLConf),
     ok.
+
+%% Warns once at startup when a listener is configured but accepts WebSocket
+%% upgrades from any Origin.
+maybe_warn_about_origins(TCPConf, SSLConf) ->
+    case TCPConf =/= [] orelse SSLConf =/= [] of
+        false -> ok;
+        true  -> rabbit_web_dispatch_websocket_origin:warn_if_permissive(
+                   rabbitmq_web_stomp, <<"Web STOMP:">>)
+    end.
 
 stop(State) ->
     rabbit_networking:stop_ranch_listeners_of_protocol(?TCP_PROTOCOL),

--- a/deps/rabbitmq_web_stomp/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
+++ b/deps/rabbitmq_web_stomp/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
@@ -233,6 +233,31 @@
   [{rabbitmq_web_stomp,[
                         {proxy_protocol, true}
                        ]}],
+  [rabbitmq_web_stomp]},
+
+ %%
+ %% WebSocket Origin validation
+ %%
+
+ {allow_origins_none,
+  "web_stomp.allow_origins = none",
+  [{rabbitmq_web_stomp,[{allow_origins, []}]}],
+  [rabbitmq_web_stomp]},
+
+ {allow_origins_same_origin,
+  "web_stomp.allow_origins = same_origin",
+  [{rabbitmq_web_stomp,[{allow_origins, same_origin}]}],
+  [rabbitmq_web_stomp]},
+
+ {allow_origins_list,
+  "web_stomp.allow_origins.1 = https://a.example.com
+   web_stomp.allow_origins.2 = https://b.example.com",
+  [{rabbitmq_web_stomp,[{allow_origins, ["https://a.example.com", "https://b.example.com"]}]}],
+  [rabbitmq_web_stomp]},
+
+ {strict_origin_validation,
+  "web_stomp.strict_origin_validation = true",
+  [{rabbitmq_web_stomp,[{strict_origin_validation, true}]}],
   [rabbitmq_web_stomp]}
 
 ].

--- a/deps/rabbitmq_web_stomp/test/origin_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/origin_SUITE.erl
@@ -22,7 +22,12 @@ all() ->
      allowed_origin_connects,
      disallowed_origin_rejected,
      no_origin_header_allowed_when_allowlist_set,
-     multiple_allowed_origins].
+     multiple_allowed_origins,
+     same_origin_matching_origin_connects,
+     same_origin_cross_origin_rejected,
+     same_origin_missing_origin_allowed,
+     strict_missing_origin_rejected,
+     strict_allowed_origin_connects].
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
@@ -49,6 +54,24 @@ init_per_testcase(multiple_allowed_origins, Config) ->
       application, set_env, [rabbitmq_web_stomp, allow_origins,
                               [?ALLOWED, ?ALLOWED2]]),
     Config;
+init_per_testcase(TC, Config)
+  when TC =:= same_origin_matching_origin_connects;
+       TC =:= same_origin_cross_origin_rejected;
+       TC =:= same_origin_missing_origin_allowed ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_stomp, allow_origins, same_origin]),
+    Config;
+init_per_testcase(TC, Config)
+  when TC =:= strict_missing_origin_rejected;
+       TC =:= strict_allowed_origin_connects ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_stomp, allow_origins, [?ALLOWED]]),
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_stomp, strict_origin_validation, true]),
+    Config;
 init_per_testcase(_Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(
       Config, 0,
@@ -60,6 +83,9 @@ end_per_testcase(_Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(
       Config, 0,
       application, unset_env, [rabbitmq_web_stomp, allow_origins]),
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, unset_env, [rabbitmq_web_stomp, strict_origin_validation]),
     Config.
 
 %% When no allowlist is configured, any Origin is accepted.
@@ -116,6 +142,42 @@ multiple_allowed_origins(Config) ->
 
     Resp3 = raw_ws_upgrade(Port, [{"Origin", "https://evil.example.com"}]),
     ?assertNotEqual(nomatch, binary:match(Resp3, <<"403">>)).
+
+%% With same_origin, an Origin equal to the request's own scheme/host/port
+%% is accepted.
+same_origin_matching_origin_connects(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", "http://127.0.0.1:" ++ PortStr}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
+
+%% With same_origin, an Origin on a different port is cross-origin and rejected.
+same_origin_cross_origin_rejected(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", "http://127.0.0.1:1"}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"403">>)).
+
+%% A missing Origin is still accepted under same_origin without strict mode.
+same_origin_missing_origin_allowed(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, []),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
+
+%% With strict mode and an allowlist set, a request without an Origin is rejected.
+strict_missing_origin_rejected(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, []),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"403">>)).
+
+%% Strict mode still accepts an allowlisted Origin.
+strict_allowed_origin_connects(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", ?ALLOWED}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
 
 %%
 %% Helpers


### PR DESCRIPTION
Introduce strict origin validation mode for the Web STOMP and the Web MQTT plugins.

A number of shared helpers was added to `rabbitmq_web_dispatch`
as the closest common base to the two WebSockets-based
messaging plugins.

While at it, add support for `web_{protocol}.allowed_origins = same origin`
(a special value).