### PR TITLE
stream_queue_SUITE: use publisher confirms

### DIFF
--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -975,7 +975,7 @@ recover(Config) ->
     queue_utils:wait_for_messages(Config, [[Q, <<"1">>, <<"1">>, <<"0">>]], 60),
 
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
-    publish(Ch1, Q),
+    publish_confirm(Ch1, Q, [<<"msg">>]),
     queue_utils:wait_for_messages(Config, [[Q, <<"2">>, <<"2">>, <<"0">>]]),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 


### PR DESCRIPTION
Without confirms, a race condition was possible
https://github.com/rabbitmq/rabbitmq-server/actions/runs/28232855559/job/83640548393
