### PR TITLE
Test flake chase: Jun 26, 2026 (`v4.2.x`)

### DIFF
--- a/deps/rabbit/test/priority_queue_SUITE.erl
+++ b/deps/rabbit/test/priority_queue_SUITE.erl
@@ -259,7 +259,8 @@ dropwhile_fetchwhile(Config) ->
     [begin
          declare(Ch, Q, Args ++ arguments(3)),
          publish(Ch, Q, [1, 2, 3, 1, 2, 3, 1, 2, 3]),
-         timer:sleep(10),
+         %% Wait for the messages to expire.
+         wait_for_queue_empty(Config, Q),
          get_empty(Ch, Q),
          delete(Ch, Q)
      end ||
@@ -563,6 +564,16 @@ get_partial(Ch, Q, Ack, Ps) ->
 
 get_empty(Ch, Q) ->
     #'basic.get_empty'{} = amqp_channel:call(Ch, #'basic.get'{queue = Q}).
+
+wait_for_queue_empty(Config, Q) ->
+    rabbit_ct_helpers:await_condition(
+      fun () ->
+              {ok, Q0} = rabbit_ct_broker_helpers:rpc(
+                           Config, 0, rabbit_amqqueue, lookup, [Q, <<"/">>]),
+              Info = rabbit_ct_broker_helpers:rpc(
+                       Config, 0, rabbit_amqqueue, info, [Q0, [messages]]),
+              proplists:get_value(messages, Info) =:= 0
+      end, 30000).
 
 get_ok(Ch, Q, Ack, PBin) ->
     {#'basic.get_ok'{delivery_tag = DTag}, #amqp_msg{payload = PBin2}} =

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -1273,36 +1273,36 @@ single_active_consumer_priority(Config) ->
     QueryFun = fun rabbit_fifo:query_single_active_consumer/1,
 
     %% Q1 should have the consumer on Ch1
-    ?assertMatch({ok, {_, {value, {<<"ch1-ctag1">>, _}}}, _},
-                rpc:call(Server0, ra, local_query, [RaNameQ1, QueryFun])),
+    %% Single active consumer election flows through Ra and is applied
+    %% asynchronously, so poll rather than asserting once.
+    ?awaitMatch({ok, {_, {value, {<<"ch1-ctag1">>, _}}}, _},
+                rpc:call(Server0, ra, local_query, [RaNameQ1, QueryFun]), ?DEFAULT_AWAIT),
 
     %% Q2 Ch2
-    ?assertMatch({ok, {_, {value, {<<"ch2-ctag2">>, _}}}, _},
-                rpc:call(Server1, ra, local_query, [RaNameQ2, QueryFun])),
+    ?awaitMatch({ok, {_, {value, {<<"ch2-ctag2">>, _}}}, _},
+                rpc:call(Server1, ra, local_query, [RaNameQ2, QueryFun]), ?DEFAULT_AWAIT),
 
     %% Q3 Ch3
-    ?assertMatch({ok, {_, {value, {<<"ch3-ctag3">>, _}}}, _},
-                rpc:call(Server2, ra, local_query, [RaNameQ3, QueryFun])),
+    ?awaitMatch({ok, {_, {value, {<<"ch3-ctag3">>, _}}}, _},
+                rpc:call(Server2, ra, local_query, [RaNameQ3, QueryFun]), ?DEFAULT_AWAIT),
 
     %% close Ch3
     _ = rabbit_ct_client_helpers:close_channel(Ch3),
-    flush(100),
 
     %% assert Q3 has Ch2 (priority 2) as consumer
-    ?assertMatch({ok, {_, {value, {<<"ch2-ctag3">>, _}}}, _},
-                rpc:call(Server2, ra, local_query, [RaNameQ3, QueryFun])),
+    ?awaitMatch({ok, {_, {value, {<<"ch2-ctag3">>, _}}}, _},
+                rpc:call(Server2, ra, local_query, [RaNameQ3, QueryFun]), ?DEFAULT_AWAIT),
 
     %% close Ch2
     _ = rabbit_ct_client_helpers:close_channel(Ch2),
-    flush(100),
 
     %% assert all queues as has Ch1 as consumer
-    ?assertMatch({ok, {_, {value, {<<"ch1-ctag1">>, _}}}, _},
-                rpc:call(Server0, ra, local_query, [RaNameQ1, QueryFun])),
-    ?assertMatch({ok, {_, {value, {<<"ch1-ctag2">>, _}}}, _},
-                rpc:call(Server0, ra, local_query, [RaNameQ2, QueryFun])),
-    ?assertMatch({ok, {_, {value, {<<"ch1-ctag3">>, _}}}, _},
-                rpc:call(Server0, ra, local_query, [RaNameQ3, QueryFun])),
+    ?awaitMatch({ok, {_, {value, {<<"ch1-ctag1">>, _}}}, _},
+                rpc:call(Server0, ra, local_query, [RaNameQ1, QueryFun]), ?DEFAULT_AWAIT),
+    ?awaitMatch({ok, {_, {value, {<<"ch1-ctag2">>, _}}}, _},
+                rpc:call(Server0, ra, local_query, [RaNameQ2, QueryFun]), ?DEFAULT_AWAIT),
+    ?awaitMatch({ok, {_, {value, {<<"ch1-ctag3">>, _}}}, _},
+                rpc:call(Server0, ra, local_query, [RaNameQ3, QueryFun]), ?DEFAULT_AWAIT),
     ok.
 
 force_shrink_member_to_current_member(Config) ->

--- a/deps/rabbitmq_management/test/clustering_prop_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_prop_SUITE.erl
@@ -111,7 +111,9 @@ prop_connection_channel_counts(Config) ->
                 % ensure we begin with no connections
                 ct:pal("Init testcase"),
                 rabbit_ct_helpers:await_condition(
-                  fun () -> validate_counts(Config, []) end,
+                  fun () ->
+                          force_stats(Config),
+                          validate_counts(Config, []) end,
                   60000),
                 Cons = lists:foldl(fun (Op, Agg) ->
                                           execute_op(Config, Op, Agg)


### PR DESCRIPTION
This is a somewhat different implementation of #16826 for `v4.2.x`.

`v4.3.x` will get its via a Mergify backport.