### PR TITLE
Stream: log a clean message when a client RPC times out

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -963,31 +963,30 @@ open(info, emit_stats,
     Connection1 = emit_stats(Connection, State),
     {keep_state, StatemData#statem_data{connection = Connection1}};
 open(info, check_outstanding_requests,
-     #statem_data{connection = #stream_connection{outstanding_requests = Requests,
+     #statem_data{connection = #stream_connection{name = ConnName,
+                                                  outstanding_requests = Requests,
                                                   request_timeout = Timeout} = Connection0} =
          StatemData) ->
     Time = erlang:monotonic_time(millisecond),
     ?LOG_DEBUG("Checking outstanding requests at ~tp: ~tp", [Time, Requests]),
-    HasTimedOut = maps:fold(fun(_, #request{}, true) ->
-                                    true;
-                               (K, #request{content = Ctnt, start = Start}, false) ->
-                                    case (Time - Start) > Timeout of
-                                        true ->
-                                            ?LOG_DEBUG("Request ~tp with content ~tp has timed out",
-                                                             [K, Ctnt]),
-
-                                            true;
-                                        false ->
-                                            false
-                                    end
-                            end, false, Requests),
-    case HasTimedOut of
-        true ->
-            ?LOG_INFO("Forcing stream connection ~tp closing: request to client timed out",
-                                       [self()]),
+    TimedOut = maps:fold(fun(K, #request{content = Ctnt, start = Start}, Acc) ->
+                                 case (Time - Start) > Timeout of
+                                     true ->
+                                         [{K, Ctnt} | Acc];
+                                     false ->
+                                         Acc
+                                 end
+                         end, [], Requests),
+    case TimedOut of
+        [_ | _] ->
+            %% Stop with a `{shutdown, _}` reason so that gen_statem does not
+            %% emit its verbose crash report (which dumps the full connection
+            %% state) for what is an expected operational condition.
+            ?LOG_INFO("Closing stream connection ~tp (~ts): client did not respond within ~bms to ~b RPC request(s): ~tp",
+                      [self(), ConnName, Timeout, length(TimedOut), TimedOut]),
             _ = demonitor_all_streams(Connection0),
-            {stop, {request_timeout, <<"Request timeout">>}};
-        false ->
+            {stop, {shutdown, {request_timeout, TimedOut}}};
+        [] ->
             Connection1 = ensure_outstanding_requests_timer(
                             Connection0#stream_connection{outstanding_requests_timer = undefined}
                            ),


### PR DESCRIPTION
## Summary

Replace the verbose `gen_statem` crash report emitted when a stream client fails to respond to an outstanding RPC (e.g. `consumer_update`) within `request_timeout` with a single structured `INFO` line.

## Before

`open(info, check_outstanding_requests, ...)` stopped the gen_statem with `{request_timeout, _}` as the exit reason. OTP treats that as abnormal, so each timeout dumped the full `#statem_data{}` and a gen_statem stack trace into the log (as captured in #15744).

## After

The handler returns `{stop, {shutdown, {request_timeout, TimedOut}}}` — OTP treats `{shutdown, _}` as benign and emits no crash report — and logs a single line, e.g.:

```
[info] Closing stream connection <0.19192.0> ([::1]:49321 -> [::1]:5672): client did not respond within 60000ms to 1 RPC request(s): [{0,#{active => true,stream => <<"invoices-0">>,consumer_name => <<"MyApp">>,subscription_id => 0}}]
```

The per-request `#request.content` map already carries `subscription_id`, `stream`, `consumer_name`, and `active`, so the structured fields the issue asked for come along for free.

Closes #15744.

## Test plan

- `erlc` compile of `rabbit_stream_reader.erl` is clean (no new warnings or errors)
- No existing suite asserts on the stop Reason — `rabbit_stream_SUITE` only sets the `request_timeout` env to make tests run faster — so the behaviour change is safe
- Relying on project CI for the full stream and integration suites