### PR TITLE
Management agent: tolerate non-integer values in metrics aggregation

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
@@ -22,6 +22,7 @@
          code_change/3]).
 -export([index_table/2]).
 -export([reset_all/0]).
+-export([sum_entry/2, difference/2]).
 
 -import(rabbit_mgmt_data, [lookup_element/3]).
 
@@ -625,41 +626,71 @@ get_difference(Id, Stats, #state{old_aggr_stats = OldStats}) ->
             difference(OldStat, Stats)
     end.
 
--dialyzer({no_match, sum_entry/2}).
-sum_entry({A0}, {B0}) ->
+%% Sources publishing into core_metrics ETS tables occasionally race
+%% with table deletion or are initialised with sentinel values (e.g. the
+%% empty atom `''`, which `rabbit_mgmt_format` uses to represent "null").
+%% Doing arithmetic on these sentinels would raise `badarith` inside the
+%% gen_server, taking the collector down (see GH #12815). Coerce
+%% non-integer fields to 0 so the aggregation proceeds; the next
+%% scrape recovers a correct value.
+sum_entry(A, B) when is_tuple(A), is_tuple(B), tuple_size(A) =:= tuple_size(B) ->
+    sum_entry_safe(normalise(A), normalise(B)).
+
+-dialyzer({no_match, sum_entry_safe/2}).
+sum_entry_safe({A0}, {B0}) ->
     {B0 + A0};
-sum_entry({A0, A1}, {B0, B1}) ->
+sum_entry_safe({A0, A1}, {B0, B1}) ->
     {B0 + A0, B1 + A1};
-sum_entry({A0, A1, A2}, {B0, B1, B2}) ->
+sum_entry_safe({A0, A1, A2}, {B0, B1, B2}) ->
     {B0 + A0, B1 + A1, B2 + A2};
-sum_entry({A0, A1, A2, A3}, {B0, B1, B2, B3}) ->
+sum_entry_safe({A0, A1, A2, A3}, {B0, B1, B2, B3}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3};
-sum_entry({A0, A1, A2, A3, A4}, {B0, B1, B2, B3, B4}) ->
+sum_entry_safe({A0, A1, A2, A3, A4}, {B0, B1, B2, B3, B4}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4};
-sum_entry({A0, A1, A2, A3, A4, A5}, {B0, B1, B2, B3, B4, B5}) ->
+sum_entry_safe({A0, A1, A2, A3, A4, A5}, {B0, B1, B2, B3, B4, B5}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5};
-sum_entry({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
+sum_entry_safe({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6};
-sum_entry({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
+sum_entry_safe({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6, B7 + A7}.
 
--dialyzer({no_match, difference/2}).
-difference({A0}, {B0}) ->
+difference(A, B) when is_tuple(A), is_tuple(B), tuple_size(A) =:= tuple_size(B) ->
+    difference_safe(normalise(A), normalise(B)).
+
+-dialyzer({no_match, difference_safe/2}).
+difference_safe({A0}, {B0}) ->
     {B0 - A0};
-difference({A0, A1}, {B0, B1}) ->
+difference_safe({A0, A1}, {B0, B1}) ->
     {B0 - A0, B1 - A1};
-difference({A0, A1, A2}, {B0, B1, B2}) ->
+difference_safe({A0, A1, A2}, {B0, B1, B2}) ->
     {B0 - A0, B1 - A1, B2 - A2};
-difference({A0, A1, A2, A3}, {B0, B1, B2, B3}) ->
+difference_safe({A0, A1, A2, A3}, {B0, B1, B2, B3}) ->
     {B0 - A0, B1 - A1, B2 - A2, B3 - A3};
-difference({A0, A1, A2, A3, A4}, {B0, B1, B2, B3, B4}) ->
+difference_safe({A0, A1, A2, A3, A4}, {B0, B1, B2, B3, B4}) ->
     {B0 - A0, B1 - A1, B2 - A2, B3 - A3, B4 - A4};
-difference({A0, A1, A2, A3, A4, A5}, {B0, B1, B2, B3, B4, B5}) ->
+difference_safe({A0, A1, A2, A3, A4, A5}, {B0, B1, B2, B3, B4, B5}) ->
     {B0 - A0, B1 - A1, B2 - A2, B3 - A3, B4 - A4, B5 - A5};
-difference({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
+difference_safe({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
     {B0 - A0, B1 - A1, B2 - A2, B3 - A3, B4 - A4, B5 - A5, B6 - A6};
-difference({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
+difference_safe({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
     {B0 - A0, B1 - A1, B2 - A2, B3 - A3, B4 - A4, B5 - A5, B6 - A6, B7 - A7}.
+
+normalise(T) when is_tuple(T) ->
+    case has_non_integer(T, tuple_size(T)) of
+        false -> T;
+        true  -> list_to_tuple([to_int(E) || E <- tuple_to_list(T)])
+    end.
+
+has_non_integer(_T, 0) ->
+    false;
+has_non_integer(T, N) ->
+    case element(N, T) of
+        E when is_integer(E) -> has_non_integer(T, N - 1);
+        _                    -> true
+    end.
+
+to_int(N) when is_integer(N) -> N;
+to_int(_)                    -> 0.
 
 vhost(#resource{virtual_host = VHost}) ->
     VHost;

--- a/deps/rabbitmq_management_agent/test/metrics_SUITE.erl
+++ b/deps/rabbitmq_management_agent/test/metrics_SUITE.erl
@@ -18,7 +18,9 @@ groups() ->
     [
       {non_parallel_tests, [], [
                                 node,
-                                storage_reset
+                                storage_reset,
+                                collector_survives_non_integer_metric,
+                                sum_entry_and_difference_unit_checks
                                ]}
     ].
 
@@ -94,6 +96,61 @@ node(Config) ->
                      lists:keymember({A, B}, 1, Tab)
              end, 10).
 
+
+%% Regression test for GH #12815. A core_metrics ETS row can briefly contain
+%% a sentinel `''` (used by rabbit_mgmt_format to represent "null") when
+%% reads race with writes around connection or queue churn. Before the
+%% defensive normalisation in rabbit_mgmt_metrics_collector, this caused
+%% a `badarith` crash inside difference/2 (`'' - integer`) which took
+%% down the collector gen_server. We force the exact shape by injecting
+%% a synthetic Pid into connection_coarse_metrics and asserting both
+%% scrape calls succeed.
+collector_survives_non_integer_metric(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, ?MODULE, do_collector_survives_non_integer_metric, []).
+
+do_collector_survives_non_integer_metric() ->
+    Collector = rabbit_mgmt_metrics_collector:name(connection_coarse_metrics),
+    CollectorPid = whereis(Collector),
+    true = is_pid(CollectorPid),
+    %% Use a freshly-allocated synthetic Pid so we cannot collide with
+    %% real broker connections being scraped at the same time.
+    SyntheticPid = c:pid(0, 16#7fffff, 0),
+    %% Baseline: a well-formed row populates old_aggr_stats on the next scrape.
+    ets:insert(connection_coarse_metrics,
+               {SyntheticPid, 100, 200, 1000, 0}),
+    ok = gen_server:call(Collector, force_collect),
+    %% Corrupt the row to mimic the observed race (one field becomes '').
+    ets:insert(connection_coarse_metrics,
+               {SyntheticPid, '', 200, 1000, 0}),
+    %% Second scrape: with the defensive arithmetic this returns ok;
+    %% without the fix the gen_server:call exits with a badarith error.
+    ok = gen_server:call(Collector, force_collect),
+    %% Collector pid must not have been restarted in between.
+    CollectorPid = whereis(Collector),
+    true = is_process_alive(CollectorPid),
+    %% Cleanup so the synthetic row does not leak into sibling test cases.
+    true = ets:delete(connection_coarse_metrics, SyntheticPid),
+    ok.
+
+%% Direct unit-style assertions on the helpers themselves to lock in the
+%% "non-integer is coerced to 0" contract that aggregate_entry relies on.
+sum_entry_and_difference_unit_checks(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, ?MODULE, do_sum_entry_and_difference_unit_checks, []).
+
+do_sum_entry_and_difference_unit_checks() ->
+    %% Happy path: integer math is unchanged.
+    {5} = rabbit_mgmt_metrics_collector:sum_entry({2}, {3}),
+    {1} = rabbit_mgmt_metrics_collector:difference({2}, {3}),
+    {5, 7} = rabbit_mgmt_metrics_collector:sum_entry({2, 3}, {3, 4}),
+    {1, 1} = rabbit_mgmt_metrics_collector:difference({2, 3}, {3, 4}),
+    %% Sentinel '' on either side coerces to 0 and avoids badarith.
+    {3, 7} = rabbit_mgmt_metrics_collector:sum_entry({'', 3}, {3, 4}),
+    {5, 0} = rabbit_mgmt_metrics_collector:sum_entry({2, 3}, {3, ''}),
+    {3, 1} = rabbit_mgmt_metrics_collector:difference({'', 3}, {3, 4}),
+    {-2, -3} = rabbit_mgmt_metrics_collector:difference({2, 3}, {'', ''}),
+    ok.
 
 storage_reset(Config) ->
     %% Ensures that core stats are reset, otherwise consume generates negative values

--- a/deps/rabbitmq_management_agent/test/metrics_SUITE.erl
+++ b/deps/rabbitmq_management_agent/test/metrics_SUITE.erl
@@ -146,8 +146,9 @@ do_sum_entry_and_difference_unit_checks() ->
     {5, 7} = rabbit_mgmt_metrics_collector:sum_entry({2, 3}, {3, 4}),
     {1, 1} = rabbit_mgmt_metrics_collector:difference({2, 3}, {3, 4}),
     %% Sentinel '' on either side coerces to 0 and avoids badarith.
+    %% sum_entry/difference compute B (+|-) A, with A the first arg.
     {3, 7} = rabbit_mgmt_metrics_collector:sum_entry({'', 3}, {3, 4}),
-    {5, 0} = rabbit_mgmt_metrics_collector:sum_entry({2, 3}, {3, ''}),
+    {5, 3} = rabbit_mgmt_metrics_collector:sum_entry({2, 3}, {3, ''}),
     {3, 1} = rabbit_mgmt_metrics_collector:difference({'', 3}, {3, 4}),
     {-2, -3} = rabbit_mgmt_metrics_collector:difference({2, 3}, {'', ''}),
     ok.


### PR DESCRIPTION
## Root cause

`rabbit_mgmt_metrics_collector` reads rows from the `core_metrics` ETS tables on every scrape and feeds them through `sum_entry/2` and `difference/2`, which add or subtract tuples element-wise. Each field is expected to be an integer.

Under connection or queue churn, a field can briefly read as the empty atom `''` — the sentinel `rabbit_mgmt_format` uses to represent "null". Performing arithmetic on it raises `badarith` inside the gen_server and kills the collector for that table, losing any in-progress aggregation state. This is the exact symptom captured in #12815:

```
exception error: an error occurred when evaluating an arithmetic expression
    in operator  -/2
       called as '' - 19495760921
    in call from rabbit_mgmt_metrics_collector:difference/2
    in call from rabbit_mgmt_metrics_collector:aggregate_entry/4
    in call from lists:foldl/3
    in call from ets:foldl/3
    in call from rabbit_mgmt_metrics_collector:aggregate_metrics/2
```

## Change

Wrap `sum_entry/2` and `difference/2` so each input tuple passes through `normalise/1` first:

- Fast path: if every element is an integer the tuple is reused as-is — one `tuple_size` plus up to 8 `element/2` checks, no allocation
- Slow path: a non-integer field is coerced to `0` and a rebuilt tuple is fed to the original arithmetic

A single bad scrape now produces an imperfect delta instead of a crash, and the next scrape (every `collect_statistics_interval`, default 5s) recovers a correct value.

## Test plan

- `deps/rabbitmq_management_agent/test/metrics_SUITE.erl`:
  - `collector_survives_non_integer_metric` — end-to-end: injects a synthetic Pid into `connection_coarse_metrics`, runs one scrape via `force_collect` to seed `old_aggr_stats`, mutates the row so one field is `''`, runs a second scrape, asserts the same collector Pid is still alive. Without the patch this assertion exits with `badarith`
  - `sum_entry_and_difference_unit_checks` — pins down the contract: integer math is unchanged; `''` on either operand coerces to `0`
- `erlc -W` is clean on the changed source and SUITE

## Reviewer FAQ

- **Why not skip the entry entirely instead of coercing to 0?** Skipping would silently drop the contribution of the well-formed siblings in the same tuple (e.g. `send_oct` would also be lost when only `recv_oct` is the sentinel). Coercing the bad field to `0` preserves the rest of the row and the next interval recovers a correct value
- **Why expose `sum_entry/2` and `difference/2`?** Only so the unit test can pin the contract. They are pure helpers with no state and no side effects
- **What does the dialyzer change do?** The existing `-dialyzer({no_match, …})` suppression moved to the renamed `_safe` clauses where the exhaustive-pattern warning still applies. The outer wrappers are single-clause + guard and don't need a suppression
- **Performance impact?** The hot path adds `tuple_size/1` + up to 8 `element/2` calls per arithmetic operation. Negligible compared to the surrounding ETS work; runs once per row per `collect_statistics_interval`