### PR TITLE
rabbitmq-plugins: fix remote node file path handling, offline mode remote node validation and  is-enabled false positives

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -9,17 +9,10 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
   @behaviour RabbitMQ.CLI.FormatterBehaviour
 
   def format_output(
-        %{status: :node_down, format: format},
+        %{status: status, format: format, plugins: plugins},
         options
       ) do
-    legend(:node_down, format, options)
-  end
-
-  def format_output(
-        %{status: :running, format: format, plugins: plugins},
-        options
-      ) do
-    legend(:running, format, options) ++ format_plugins(plugins, format)
+    legend(status, format, options) ++ format_plugins(plugins, format)
   end
 
   def format_output(%{enabled: enabled, mode: _} = output, options) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -195,6 +195,10 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
     "[failed to contact #{node} - status not shown]"
   end
 
+  defp status_message(:offline, node) do
+    "#{node} is stopped; * (running) status is not available"
+  end
+
   defp applying(%{mode: :offline, set: set_plugins}, _) do
     set_plugins_message =
       case length(set_plugins) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -44,6 +44,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
     Validators.chain(
       [
         &require_rabbit_and_plugins/2,
+        &PluginHelpers.validate_node_and_mode/2,
         &PluginHelpers.enabled_plugins_file/2,
         &plugins_dir/2
       ],

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -49,7 +49,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
         ]
       else
         [
-          &require_rabbit_and_plugins/2,
           &PluginHelpers.validate_node_and_mode/2
         ]
       end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -39,26 +39,34 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
   end
 
   def validate_execution_environment(args, opts) do
-    Validators.chain(
-      [
-        &PluginHelpers.can_set_plugins_with_mode/2,
-        &require_rabbit_and_plugins/2,
-        &PluginHelpers.enabled_plugins_file/2,
-        &plugins_dir/2
-      ],
-      [args, opts]
-    )
+    validators =
+      if PluginHelpers.node_is_local?(opts) do
+        [
+          &require_rabbit_and_plugins/2,
+          &PluginHelpers.validate_node_and_mode/2,
+          &PluginHelpers.enabled_plugins_file/2,
+          &plugins_dir/2
+        ]
+      else
+        [
+          &require_rabbit_and_plugins/2,
+          &PluginHelpers.validate_node_and_mode/2
+        ]
+      end
+
+    Validators.chain(validators, [args, opts])
   end
 
   def run(plugin_names, %{all: all_flag, node: node_name} = opts) do
+    all = PluginHelpers.list(opts)
+
     plugins =
       case all_flag do
         false -> for s <- plugin_names, do: String.to_atom(s)
-        true -> PluginHelpers.plugin_names(PluginHelpers.list(opts))
+        true -> PluginHelpers.plugin_names(all)
       end
 
     enabled = PluginHelpers.read_enabled(opts)
-    all = PluginHelpers.list(opts)
     implicit = :rabbit_plugins.dependencies(false, enabled, all)
     to_disable_deps = :rabbit_plugins.dependencies(true, plugins, all)
     plugins_to_set = MapSet.difference(MapSet.new(enabled), MapSet.new(to_disable_deps))

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -49,7 +49,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
         ]
       else
         [
-          &require_rabbit_and_plugins/2,
           &PluginHelpers.validate_node_and_mode/2
         ]
       end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -39,27 +39,84 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
   end
 
   def validate_execution_environment(args, opts) do
-    Validators.chain(
-      [
-        &PluginHelpers.can_set_plugins_with_mode/2,
-        &require_rabbit_and_plugins/2,
-        &PluginHelpers.enabled_plugins_file/2,
-        &plugins_dir/2
-      ],
-      [args, opts]
-    )
+    validators =
+      if PluginHelpers.node_is_local?(opts) do
+        [
+          &require_rabbit_and_plugins/2,
+          &PluginHelpers.validate_node_and_mode/2,
+          &PluginHelpers.enabled_plugins_file/2,
+          &plugins_dir/2
+        ]
+      else
+        [
+          &require_rabbit_and_plugins/2,
+          &PluginHelpers.validate_node_and_mode/2
+        ]
+      end
+
+    Validators.chain(validators, [args, opts])
   end
 
-  def run(plugin_names, %{all: all_flag} = opts) do
+  def run(plugin_names, %{all: all_flag, node: node_name} = opts) do
+    all = PluginHelpers.list(opts)
+
     plugins =
       case all_flag do
         false -> for s <- plugin_names, do: String.to_atom(s)
-        true -> PluginHelpers.plugin_names(PluginHelpers.list(opts))
+        true -> PluginHelpers.plugin_names(all)
       end
 
     case PluginHelpers.validate_plugins(plugins, opts) do
-      :ok -> do_run(plugins, opts)
-      other -> other
+      :ok ->
+        enabled = PluginHelpers.read_enabled(opts)
+        implicit = :rabbit_plugins.dependencies(false, enabled, all)
+        enabled_implicitly = MapSet.difference(MapSet.new(implicit), MapSet.new(enabled))
+
+        plugins_to_set =
+          MapSet.union(
+            MapSet.new(enabled),
+            MapSet.difference(MapSet.new(plugins), enabled_implicitly)
+          )
+
+        mode = PluginHelpers.mode(opts)
+
+        case PluginHelpers.set_enabled_plugins(MapSet.to_list(plugins_to_set), opts) do
+          {:ok, enabled_plugins} ->
+            {:stream,
+             Stream.concat([
+               [:rabbit_plugins.strictly_plugins(enabled_plugins, all)],
+               RabbitMQ.CLI.Core.Helpers.defer(fn ->
+                 case PluginHelpers.update_enabled_plugins(
+                        enabled_plugins,
+                        mode,
+                        node_name,
+                        opts
+                      ) do
+                   %{set: new_enabled} = result ->
+                     newly_enabled = new_enabled -- implicit
+
+                     filter_strictly_plugins(
+                       Map.put(
+                         result,
+                         :enabled,
+                         :rabbit_plugins.strictly_plugins(newly_enabled, all)
+                       ),
+                       all,
+                       [:set, :started, :stopped]
+                     )
+
+                   other ->
+                     other
+                 end
+               end)
+             ])}
+
+          {:error, _} = err ->
+            err
+        end
+
+      other ->
+        other
     end
   end
 
@@ -103,47 +160,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
   #
   # Implementation
   #
-
-  def do_run(plugins, %{node: node_name} = opts) do
-    enabled = PluginHelpers.read_enabled(opts)
-    all = PluginHelpers.list(opts)
-    implicit = :rabbit_plugins.dependencies(false, enabled, all)
-    enabled_implicitly = MapSet.difference(MapSet.new(implicit), MapSet.new(enabled))
-
-    plugins_to_set =
-      MapSet.union(
-        MapSet.new(enabled),
-        MapSet.difference(MapSet.new(plugins), enabled_implicitly)
-      )
-
-    mode = PluginHelpers.mode(opts)
-
-    case PluginHelpers.set_enabled_plugins(MapSet.to_list(plugins_to_set), opts) do
-      {:ok, enabled_plugins} ->
-        {:stream,
-         Stream.concat([
-           [:rabbit_plugins.strictly_plugins(enabled_plugins, all)],
-           RabbitMQ.CLI.Core.Helpers.defer(fn ->
-             case PluginHelpers.update_enabled_plugins(enabled_plugins, mode, node_name, opts) do
-               %{set: new_enabled} = result ->
-                 enabled = new_enabled -- implicit
-
-                 filter_strictly_plugins(
-                   Map.put(result, :enabled, :rabbit_plugins.strictly_plugins(enabled, all)),
-                   all,
-                   [:set, :started, :stopped]
-                 )
-
-               other ->
-                 other
-             end
-           end)
-         ])}
-
-      {:error, _} = err ->
-        err
-    end
-  end
 
   defp filter_strictly_plugins(map, _all, []) do
     map

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
@@ -44,6 +44,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand do
     Validators.chain(
       [
         &require_rabbit_and_plugins/2,
+        &PluginHelpers.validate_node_and_mode/2,
         &PluginHelpers.enabled_plugins_file/2,
         &plugins_dir/2
       ],
@@ -71,7 +72,10 @@ defmodule RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand do
   end
 
   def run(args, %{offline: true} = opts) do
-    plugins = PluginHelpers.list_names(opts) |> Enum.map(&Atom.to_string/1) |> Enum.sort()
+    enabled = PluginHelpers.read_enabled(opts)
+    all = PluginHelpers.list(opts)
+    all_enabled = :rabbit_plugins.dependencies(false, enabled, all)
+    plugins = Enum.map(all_enabled, &Atom.to_string/1) |> Enum.sort()
 
     case Enum.filter(args, fn x -> not Enum.member?(plugins, x) end) do
       [] -> {:ok, positive_result_message(args, opts)}

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -37,14 +37,18 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   end
 
   def validate_execution_environment(args, opts) do
-    Validators.chain(
-      [
-        &require_rabbit_and_plugins/2,
-        &PluginHelpers.enabled_plugins_file/2,
-        &plugins_dir/2
-      ],
-      [args, opts]
-    )
+    if PluginHelpers.node_is_local?(opts) do
+      Validators.chain(
+        [
+          &require_rabbit_and_plugins/2,
+          &PluginHelpers.enabled_plugins_file/2,
+          &plugins_dir/2
+        ],
+        [args, opts]
+      )
+    else
+      :ok
+    end
   end
 
   def run([pattern], %{node: node_name} = opts) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -80,8 +80,15 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
 
     {status, running} =
       case remote_running_plugins(node_name) do
-        :error -> {:node_down, []}
-        {:ok, active} -> {:running, active}
+        :error ->
+          if PluginHelpers.node_is_local?(opts) do
+            {:offline, []}
+          else
+            {:node_down, []}
+          end
+
+        {:ok, active} ->
+          {:running, active}
       end
 
     {:ok, re} = Regex.compile(pattern)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -31,15 +31,22 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
   end
 
   def validate_execution_environment(args, opts) do
-    Validators.chain(
-      [
-        &PluginHelpers.can_set_plugins_with_mode/2,
-        &require_rabbit_and_plugins/2,
-        &PluginHelpers.enabled_plugins_file/2,
-        &plugins_dir/2
-      ],
-      [args, opts]
-    )
+    validators =
+      if PluginHelpers.node_is_local?(opts) do
+        [
+          &require_rabbit_and_plugins/2,
+          &PluginHelpers.validate_node_and_mode/2,
+          &PluginHelpers.enabled_plugins_file/2,
+          &plugins_dir/2
+        ]
+      else
+        [
+          &require_rabbit_and_plugins/2,
+          &PluginHelpers.validate_node_and_mode/2
+        ]
+      end
+
+    Validators.chain(validators, [args, opts])
   end
 
   def run(plugin_names, opts) do
@@ -92,7 +99,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
   # Implementation
   #
 
-  def do_run(plugins, %{node: node_name} = opts) do
+  defp do_run(plugins, %{node: node_name} = opts) do
     all = PluginHelpers.list(opts)
     mode = PluginHelpers.mode(opts)
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -41,7 +41,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
         ]
       else
         [
-          &require_rabbit_and_plugins/2,
           &PluginHelpers.validate_node_and_mode/2
         ]
       end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -12,7 +12,8 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
   alias RabbitMQ.CLI.Core.{Config, Validators}
 
   def mode(opts) do
-    %{online: online, offline: offline} = opts
+    online = Map.get(opts, :online, false)
+    offline = Map.get(opts, :offline, false)
 
     case {online, offline} do
       {true, false} -> :online
@@ -21,26 +22,124 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     end
   end
 
-  def can_set_plugins_with_mode(args, opts) do
+  def validate_node_and_mode(args, opts) do
     case mode(opts) do
-      # can always set offline plugins list
       :offline ->
-        :ok
+        require_offline_node_is_local(args, opts)
 
-      # assume online mode, fall back to offline mode in case of errors
+      # For the local node, assume online and fall back to offline if the node is not running.
+      # For a remote node, a running node is required: offline changes cannot reach a remote node's plugins file.
       :best_effort ->
-        :ok
+        if node_is_local?(opts) do
+          :ok
+        else
+          require_node_running(args, opts)
+        end
 
-      # a running node is required
       :online ->
-        Validators.chain(
-          [&Validators.node_is_running/2, &Validators.rabbit_is_running/2],
-          [args, opts]
-        )
+        require_node_running(args, opts)
     end
   end
 
+  def node_is_local?(%{node: node_name}) do
+    case node_locality(node_name) do
+      :local -> true
+      {:remote, _} -> false
+    end
+  end
+
+  def node_is_local?(_opts), do: true
+
+  defp require_offline_node_is_local(_args, %{offline: true} = opts) do
+    case node_locality(opts.node) do
+      :local ->
+        :ok
+
+      {:remote, reason} ->
+        {:validation_failure,
+         {:bad_argument,
+          "--offline mode operates on the local node's environment and cannot be used with a " <>
+            "remote node. #{reason}. Use --online to target the remote node."}}
+    end
+  end
+
+  defp require_offline_node_is_local(_args, _opts), do: :ok
+
+  defp require_node_running(args, opts) do
+    Validators.chain(
+      [&Validators.node_is_running/2, &Validators.rabbit_is_running/2],
+      [args, opts]
+    )
+  end
+
+  # :nonode and :nonode@nohost are Erlang's sentinels for "distribution not started"; treat them as local.
+  defp node_locality(:nonode), do: :local
+  defp node_locality(:"nonode@nohost"), do: :local
+
+  defp node_locality(node_name) do
+    local_node_str = :rabbit_env.get_context()[:nodename] |> to_string()
+    node_str = to_string(node_name)
+
+    if node_str == local_node_str do
+      :local
+    else
+      case String.split(local_node_str, "@", parts: 2) do
+        [local_name, local_host] ->
+          case String.split(node_str, "@", parts: 2) do
+            [name, host] ->
+              name_ok = name == local_name
+              host_ok = hosts_match?(host, local_host)
+
+              if name_ok and host_ok do
+                :local
+              else
+                reason =
+                  cond do
+                    not name_ok and not host_ok ->
+                      "node #{node_name} has a different name and host than the local node #{local_node_str}"
+
+                    not name_ok ->
+                      "node #{node_name} has a different name than the local node #{local_node_str}"
+
+                    true ->
+                      "node #{node_name} is on a different host than the local node"
+                  end
+
+                {:remote, reason}
+              end
+
+            [bare] ->
+              if bare == local_name do
+                :local
+              else
+                {:remote,
+                 "node #{node_name} has a different name than the local node #{local_node_str}"}
+              end
+          end
+
+        _ ->
+          {:remote, "could not determine the local node name"}
+      end
+    end
+  end
+
+  # Treats a short hostname and its fully-qualified form as the same host (e.g. "host" matches "host.example.com").
+  defp hosts_match?(a, b) do
+    a == b or String.starts_with?(a, b <> ".") or String.starts_with?(b, a <> ".")
+  end
+
   def list(opts) do
+    if mode(opts) == :offline or node_is_local?(opts) do
+      list_local(opts)
+    else
+      case list_remote(opts.node) do
+        {:ok, plugins} -> plugins
+        {:error, _} -> []
+      end
+    end
+  end
+
+  defp list_local(opts) do
     case plugins_dir(opts) do
       {:ok, dir} ->
         add_all_to_path(dir)
@@ -51,18 +150,38 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     end
   end
 
-  def list_names(opts) do
-    list(opts) |> plugin_names
+  defp list_remote(node_name) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_plugins, :list, []) do
+      {:badrpc, reason} -> {:error, {:badrpc, reason}}
+      plugins when is_list(plugins) -> {:ok, plugins}
+      other -> {:error, {:unexpected_response, other}}
+    end
   end
 
   def read_enabled(opts) do
+    if mode(opts) == :offline or node_is_local?(opts) do
+      read_enabled_local(opts)
+    else
+      read_enabled_remote(opts)
+    end
+  end
+
+  defp read_enabled_local(opts) do
     case enabled_plugins_file(opts) do
-      {:ok, enabled} ->
-        :rabbit_plugins.read_enabled(to_charlist(enabled))
+      {:ok, file} ->
+        :rabbit_plugins.read_enabled(to_charlist(file))
 
       # Existence of enabled_plugins_file should be validated separately
       {:error, :no_plugins_file} ->
         []
+    end
+  end
+
+  defp read_enabled_remote(%{node: node_name}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_plugins, :enabled_plugins, []) do
+      {:badrpc, _} -> []
+      plugins when is_list(plugins) -> plugins
+      _ -> []
     end
   end
 
@@ -77,11 +196,23 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     enabled_plugins_file(opts)
   end
 
+  defp rpc_enabled_plugins_file(node_name) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_plugins, :enabled_plugins_file, []) do
+      {:badrpc, reason} -> {:error, {:badrpc, reason}}
+      file -> {:ok, file}
+    end
+  end
+
   def set_enabled_plugins(plugins, opts) do
     plugin_atoms = :lists.usort(for plugin <- plugins, do: to_atom(plugin))
     _ = require_rabbit_and_plugins(opts)
-    {:ok, plugins_file} = enabled_plugins_file(opts)
-    write_enabled_plugins(plugin_atoms, plugins_file, opts)
+
+    if mode(opts) == :offline or node_is_local?(opts) do
+      {:ok, plugins_file} = enabled_plugins_file(opts)
+      write_enabled_plugins(plugin_atoms, plugins_file, opts)
+    else
+      write_enabled_plugins_on_remote(opts.node, plugin_atoms, opts)
+    end
   end
 
   @spec update_enabled_plugins(
@@ -91,37 +222,22 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
           map()
         ) :: map() | {:error, any()}
   def update_enabled_plugins(enabled_plugins, mode, node_name, opts) do
-    {:ok, plugins_file} = enabled_plugins_file(opts)
-
     case mode do
       :online ->
-        case update_enabled_plugins(node_name, plugins_file) do
-          {:ok, started, stopped} ->
-            %{
-              mode: :online,
-              started: Enum.sort(started),
-              stopped: Enum.sort(stopped),
-              set: Enum.sort(enabled_plugins)
-            }
-
-          {:error, _} = err ->
-            err
-        end
+        update_enabled_plugins(node_name, enabled_plugins, opts)
 
       :best_effort ->
-        case update_enabled_plugins(node_name, plugins_file) do
-          {:ok, started, stopped} ->
-            %{
-              mode: :online,
-              started: Enum.sort(started),
-              stopped: Enum.sort(stopped),
-              set: Enum.sort(enabled_plugins)
-            }
+        case update_enabled_plugins(node_name, enabled_plugins, opts) do
+          %{} = result ->
+            result
 
           {:error, :offline} ->
             %{mode: :offline, set: Enum.sort(enabled_plugins)}
 
           {:error, {:enabled_plugins_mismatch, _, _}} = err ->
+            err
+
+          {:error, _} = err ->
             err
         end
 
@@ -132,13 +248,14 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
 
   def validate_plugins(requested_plugins, opts) do
     ## Maybe check all plugins
+    all = list(opts)
+
     plugins =
       case opts do
-        %{all: true} -> plugin_names(list(opts))
+        %{all: true} -> plugin_names(all)
         _ -> requested_plugins
       end
 
-    all = list(opts)
     deps = :rabbit_plugins.dependencies(false, plugins, all)
 
     deps_plugins =
@@ -191,7 +308,7 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
   end
 
   defp write_enabled_plugins(plugins, plugins_file, opts) do
-    all = list(opts)
+    all = list_local(opts)
     all_plugin_names = Enum.map(all, &plugin_name/1)
     missing = MapSet.difference(MapSet.new(plugins), MapSet.new(all_plugin_names))
 
@@ -213,12 +330,74 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     end
   end
 
-  defp update_enabled_plugins(node_name, plugins_file) do
+  defp write_enabled_plugins_on_remote(node_name, plugins, opts) do
+    with {:ok, all} <- list_remote(node_name),
+         {:ok, remote_file} <- rpc_enabled_plugins_file(node_name) do
+      all_plugin_names = Enum.map(all, &plugin_name/1)
+      missing = MapSet.difference(MapSet.new(plugins), MapSet.new(all_plugin_names))
+
+      hard_write = Map.get(opts, :hard_write, false)
+
+      case Enum.empty?(missing) or hard_write do
+        true ->
+          case :rabbit_misc.rpc_call(node_name, :rabbit_file, :write_term_file, [
+                 remote_file,
+                 [plugins]
+               ]) do
+            :ok ->
+              all_enabled = :rabbit_plugins.dependencies(false, plugins, all)
+              {:ok, Enum.sort(all_enabled)}
+
+            {:badrpc, reason} ->
+              {:error, {:badrpc, reason}}
+
+            {:error, reason} ->
+              {:error, {:cannot_write_enabled_plugins_file, remote_file, reason}}
+          end
+
+        false ->
+          {:error, {:plugins_not_found, Enum.to_list(missing)}}
+      end
+    end
+  end
+
+  # File was already written to local disk by set_enabled_plugins;
+  defp update_enabled_plugins(node_name, enabled_plugins, opts) do
+    if node_is_local?(opts) do
+      # Tell the running node to re-read it.
+      {:ok, plugins_file} = enabled_plugins_file(opts)
+      rpc_ensure(node_name, plugins_file, enabled_plugins)
+    else
+      # Tell the remote node to re-read and apply its own enabled plugins file.
+      case rpc_enabled_plugins_file(node_name) do
+        {:error, _} ->
+          # Node went down after the file write; changes will take effect at next restart.
+          {:error, :offline}
+
+        {:ok, remote_file} ->
+          rpc_ensure(node_name, remote_file, enabled_plugins)
+      end
+    end
+  end
+
+  defp rpc_ensure(node_name, plugins_file, enabled_plugins) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_plugins, :ensure, [to_list(plugins_file)]) do
-      {:badrpc, _} -> {:error, :offline}
-      {:error, :rabbit_not_running} -> {:error, :offline}
-      {:ok, start, stop} -> {:ok, start, stop}
-      {:error, _} = err -> err
+      {:badrpc, _} ->
+        {:error, :offline}
+
+      {:error, :rabbit_not_running} ->
+        {:error, :offline}
+
+      {:ok, started, stopped} ->
+        %{
+          mode: :online,
+          started: Enum.sort(started),
+          stopped: Enum.sort(stopped),
+          set: Enum.sort(enabled_plugins)
+        }
+
+      {:error, _} = err ->
+        err
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -72,10 +72,6 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     )
   end
 
-  # :nonode and :nonode@nohost are Erlang's sentinels for "distribution not started"; treat them as local.
-  defp node_locality(:nonode), do: :local
-  defp node_locality(:"nonode@nohost"), do: :local
-
   defp node_locality(node_name) do
     local_node_str = :rabbit_env.get_context()[:nodename] |> to_string()
     node_str = to_string(node_name)

--- a/deps/rabbitmq_cli/test/plugins/directories_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/directories_command_test.exs
@@ -86,6 +86,15 @@ defmodule DirectoriesCommandTest do
              {:validation_failure, :plugins_dir_does_not_exist}
   end
 
+  test "validate_execution_environment: --offline with a remote node fails validation", context do
+    opts = context[:opts] |> Map.merge(%{offline: true, node: :jake@thedog})
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate_execution_environment([], opts)
+           )
+  end
+
   test "validate_execution_environment: when --online is used, specifying a non-existent enabled_plugins_file passes validation",
        context do
     opts = context[:opts] |> Map.merge(%{online: true, enabled_plugins_file: "none"})

--- a/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
@@ -123,17 +123,38 @@ defmodule DisablePluginsCommandTest do
              @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
 
     result = Enum.to_list(test_stream)
+
     expected = [
-      [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
-      %{mode: :offline, disabled: [:rabbitmq_stomp], set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation]}
+      [
+        :rabbitmq_exchange_federation,
+        :rabbitmq_federation,
+        :rabbitmq_federation_common,
+        :rabbitmq_queue_federation
+      ],
+      %{
+        mode: :offline,
+        disabled: [:rabbitmq_stomp],
+        set: [
+          :rabbitmq_exchange_federation,
+          :rabbitmq_federation,
+          :rabbitmq_federation_common,
+          :rabbitmq_queue_federation
+        ]
+      }
     ]
+
     assert normalize_stream_result(expected) == normalize_stream_result(result)
-
     assert {:ok, [[:rabbitmq_federation]]} == :file.consult(context[:opts][:enabled_plugins_file])
+  end
 
-    result = :rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, [])
-    expected = [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp]
-    assert_lists_equal(expected, result)
+  test "validate_execution_environment: --offline with a remote node fails validation",
+       context do
+    opts = Map.merge(context[:opts], %{online: false, offline: true, node: :jake@thedog})
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate_execution_environment(["rabbitmq_stomp"], opts)
+           )
   end
 
   test "in offline mode, writes out enabled plugins and reports implicitly enabled plugin list",
@@ -145,16 +166,41 @@ defmodule DisablePluginsCommandTest do
              )
 
     result = Enum.to_list(test_stream)
+
     expected = [
-      [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
-      %{mode: :offline, disabled: [:rabbitmq_stomp], set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation]}
+      [
+        :rabbitmq_exchange_federation,
+        :rabbitmq_federation,
+        :rabbitmq_federation_common,
+        :rabbitmq_queue_federation
+      ],
+      %{
+        mode: :offline,
+        disabled: [:rabbitmq_stomp],
+        set: [
+          :rabbitmq_exchange_federation,
+          :rabbitmq_federation,
+          :rabbitmq_federation_common,
+          :rabbitmq_queue_federation
+        ]
+      }
     ]
+
     assert normalize_stream_result(expected) == normalize_stream_result(result)
 
     assert {:ok, [[:rabbitmq_federation]]} == :file.consult(context[:opts][:enabled_plugins_file])
 
     active_plugins = :rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, [])
-    expected_active = [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp]
+
+    expected_active = [
+      :amqp_client,
+      :rabbitmq_exchange_federation,
+      :rabbitmq_federation,
+      :rabbitmq_federation_common,
+      :rabbitmq_queue_federation,
+      :rabbitmq_stomp
+    ]
+
     assert_lists_equal(expected_active, active_plugins)
   end
 
@@ -167,10 +213,21 @@ defmodule DisablePluginsCommandTest do
              )
 
     result = Enum.to_list(test_stream0)
+
     expected = [
       [:rabbitmq_stomp],
-      %{mode: :offline, disabled: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation], set: [:rabbitmq_stomp]}
+      %{
+        mode: :offline,
+        disabled: [
+          :rabbitmq_exchange_federation,
+          :rabbitmq_federation,
+          :rabbitmq_federation_common,
+          :rabbitmq_queue_federation
+        ],
+        set: [:rabbitmq_stomp]
+      }
     ]
+
     assert normalize_stream_result(expected) == normalize_stream_result(result)
 
     assert {:ok, [[:rabbitmq_stomp]]} == :file.consult(context[:opts][:enabled_plugins_file])
@@ -192,37 +249,69 @@ defmodule DisablePluginsCommandTest do
     assert {:stream, test_stream0} = @command.run(["rabbitmq_stomp"], context[:opts])
 
     result = Enum.to_list(test_stream0)
+
     expected = [
-      [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
+      [
+        :rabbitmq_exchange_federation,
+        :rabbitmq_federation,
+        :rabbitmq_federation_common,
+        :rabbitmq_queue_federation
+      ],
       %{
         mode: :online,
         started: [],
         stopped: [:rabbitmq_stomp],
         disabled: [:rabbitmq_stomp],
-        set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation]
+        set: [
+          :rabbitmq_exchange_federation,
+          :rabbitmq_federation,
+          :rabbitmq_federation_common,
+          :rabbitmq_queue_federation
+        ]
       }
     ]
+
     assert normalize_stream_result(expected) == normalize_stream_result(result)
 
     assert {:ok, [[:rabbitmq_federation]]} == :file.consult(context[:opts][:enabled_plugins_file])
 
     result = :rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, [])
-    expected = [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation]
+
+    expected = [
+      :amqp_client,
+      :rabbitmq_exchange_federation,
+      :rabbitmq_federation,
+      :rabbitmq_federation_common,
+      :rabbitmq_queue_federation
+    ]
+
     assert_lists_equal(expected, result)
 
     assert {:stream, test_stream1} = @command.run(["rabbitmq_federation"], context[:opts])
 
     result = Enum.to_list(test_stream1)
+
     expected = [
       [],
       %{
         mode: :online,
         started: [],
-        stopped: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
-        disabled: [:rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_exchange_federation, :rabbitmq_federation],
+        stopped: [
+          :rabbitmq_exchange_federation,
+          :rabbitmq_federation,
+          :rabbitmq_federation_common,
+          :rabbitmq_queue_federation
+        ],
+        disabled: [
+          :rabbitmq_federation_common,
+          :rabbitmq_queue_federation,
+          :rabbitmq_exchange_federation,
+          :rabbitmq_federation
+        ],
         set: []
       }
     ]
+
     assert normalize_stream_result(expected) == normalize_stream_result(result)
 
     assert {:ok, [[]]} == :file.consult(context[:opts][:enabled_plugins_file])
@@ -236,7 +325,15 @@ defmodule DisablePluginsCommandTest do
              @command.run(["rabbitmq_stomp", "rabbitmq_federation"], context[:opts])
 
     result = Enum.to_list(test_stream)
-    expected_list = [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp]
+
+    expected_list = [
+      :rabbitmq_exchange_federation,
+      :rabbitmq_federation,
+      :rabbitmq_federation_common,
+      :rabbitmq_queue_federation,
+      :rabbitmq_stomp
+    ]
+
     expected = [
       [],
       %{
@@ -247,6 +344,7 @@ defmodule DisablePluginsCommandTest do
         set: []
       }
     ]
+
     assert normalize_stream_result(expected) == normalize_stream_result(result)
 
     assert {:ok, [[]]} == :file.consult(context[:opts][:enabled_plugins_file])
@@ -258,8 +356,14 @@ defmodule DisablePluginsCommandTest do
   test "disabling a dependency disables all plugins that depend on it", context do
     assert {:stream, test_stream} = @command.run(["amqp_client"], context[:opts])
     result = Enum.to_list(test_stream)
-    expected_disabled = [:rabbitmq_exchange_federation, :rabbitmq_federation,
-                         :rabbitmq_federation_common, :rabbitmq_queue_federation]
+
+    expected_disabled = [
+      :rabbitmq_exchange_federation,
+      :rabbitmq_federation,
+      :rabbitmq_federation_common,
+      :rabbitmq_queue_federation
+    ]
+
     expected = [
       [:rabbitmq_stomp],
       %{
@@ -270,6 +374,7 @@ defmodule DisablePluginsCommandTest do
         set: [:rabbitmq_stomp]
       }
     ]
+
     assert normalize_stream_result(expected) == normalize_stream_result(result)
 
     assert {:ok, [[:rabbitmq_stomp]]} == :file.consult(context[:opts][:enabled_plugins_file])

--- a/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
@@ -120,7 +120,7 @@ defmodule DisablePluginsCommandTest do
   test "node is inaccessible, writes out enabled plugins file and returns implicitly enabled plugin list",
        context do
     assert {:stream, test_stream} =
-             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
+             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :rabbit}))
 
     result = Enum.to_list(test_stream)
 

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -104,7 +104,7 @@ defmodule EnablePluginsCommandTest do
              {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "run: if node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list",
+  test "run: if the local node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list",
        context do
     # Clears enabled plugins file
     set_enabled_plugins([], :offline, :nonode, context[:opts])
@@ -119,9 +119,16 @@ defmodule EnablePluginsCommandTest do
              Enum.to_list(test_stream)
 
     check_plugins_enabled([:rabbitmq_stomp], context)
+  end
 
-    assert [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp] ==
-             currently_active_plugins(context)
+  test "validate_execution_environment: --offline with a remote node fails validation",
+       context do
+    opts = Map.merge(context[:opts], %{online: false, offline: true, node: :jake@thedog})
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate_execution_environment(["rabbitmq_stomp"], opts)
+           )
   end
 
   test "run: in offline mode, writes enabled plugins and reports implicitly enabled plugin list",
@@ -144,7 +151,14 @@ defmodule EnablePluginsCommandTest do
     check_plugins_enabled([:rabbitmq_stomp], context)
 
     assert_equal_sets(
-      [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+      [
+        :amqp_client,
+        :rabbitmq_exchange_federation,
+        :rabbitmq_federation,
+        :rabbitmq_federation_common,
+        :rabbitmq_queue_federation,
+        :rabbitmq_stomp
+      ],
       currently_active_plugins(context)
     )
   end
@@ -174,11 +188,28 @@ defmodule EnablePluginsCommandTest do
              )
 
     assert [
-             [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+             [
+               :rabbitmq_exchange_federation,
+               :rabbitmq_federation,
+               :rabbitmq_federation_common,
+               :rabbitmq_queue_federation,
+               :rabbitmq_stomp
+             ],
              %{
                mode: :offline,
-               enabled: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
-               set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp]
+               enabled: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation
+               ],
+               set: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ]
              }
            ] ==
              Enum.to_list(test_stream1)
@@ -211,13 +242,35 @@ defmodule EnablePluginsCommandTest do
     {:stream, test_stream1} = @command.run(["rabbitmq_federation"], context[:opts])
 
     assert [
-             [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+             [
+               :rabbitmq_exchange_federation,
+               :rabbitmq_federation,
+               :rabbitmq_federation_common,
+               :rabbitmq_queue_federation,
+               :rabbitmq_stomp
+             ],
              %{
                mode: :online,
-               started: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
+               started: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation
+               ],
                stopped: [],
-               enabled: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
-               set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp]
+               enabled: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation
+               ],
+               set: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ]
              }
            ] ==
              Enum.to_list(test_stream1)
@@ -225,7 +278,14 @@ defmodule EnablePluginsCommandTest do
     check_plugins_enabled([:rabbitmq_stomp, :rabbitmq_federation], context)
 
     assert_equal_sets(
-      [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+      [
+        :amqp_client,
+        :rabbitmq_exchange_federation,
+        :rabbitmq_federation,
+        :rabbitmq_federation_common,
+        :rabbitmq_queue_federation,
+        :rabbitmq_stomp
+      ],
       currently_active_plugins(context)
     )
 
@@ -240,13 +300,37 @@ defmodule EnablePluginsCommandTest do
              @command.run(["rabbitmq_stomp", "rabbitmq_federation"], context[:opts])
 
     assert [
-             [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+             [
+               :rabbitmq_exchange_federation,
+               :rabbitmq_federation,
+               :rabbitmq_federation_common,
+               :rabbitmq_queue_federation,
+               :rabbitmq_stomp
+             ],
              %{
                mode: :online,
-               started: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+               started: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ],
                stopped: [],
-               enabled: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
-               set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp]
+               enabled: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ],
+               set: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ]
              }
            ] ==
              Enum.to_list(test_stream)
@@ -254,7 +338,14 @@ defmodule EnablePluginsCommandTest do
     check_plugins_enabled([:rabbitmq_stomp, :rabbitmq_federation], context)
 
     assert_equal_sets(
-      [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+      [
+        :amqp_client,
+        :rabbitmq_exchange_federation,
+        :rabbitmq_federation,
+        :rabbitmq_federation_common,
+        :rabbitmq_queue_federation,
+        :rabbitmq_stomp
+      ],
       currently_active_plugins(context)
     )
 
@@ -267,14 +358,36 @@ defmodule EnablePluginsCommandTest do
     assert {:stream, test_stream} = @command.run(["amqp_client"], context[:opts])
 
     assert [
-             [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
-             %{mode: :online, started: [], stopped: [], enabled: [], set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation]}
+             [
+               :rabbitmq_exchange_federation,
+               :rabbitmq_federation,
+               :rabbitmq_federation_common,
+               :rabbitmq_queue_federation
+             ],
+             %{
+               mode: :online,
+               started: [],
+               stopped: [],
+               enabled: [],
+               set: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation
+               ]
+             }
            ] ==
              Enum.to_list(test_stream)
 
     check_plugins_enabled([:rabbitmq_federation], context)
 
-    assert [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation] ==
+    assert [
+             :amqp_client,
+             :rabbitmq_exchange_federation,
+             :rabbitmq_federation,
+             :rabbitmq_federation_common,
+             :rabbitmq_queue_federation
+           ] ==
              currently_active_plugins(context)
 
     reset_enabled_plugins_to_preconfigured_defaults(context)

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -107,10 +107,13 @@ defmodule EnablePluginsCommandTest do
   test "run: if the local node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list",
        context do
     # Clears enabled plugins file
-    set_enabled_plugins([], :offline, :nonode, context[:opts])
+    set_enabled_plugins([], :offline, :rabbit, context[:opts])
 
     assert {:stream, test_stream} =
-             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
+             @command.run(
+               ["rabbitmq_stomp"],
+               Map.merge(context[:opts], %{node: :rabbit})
+             )
 
     assert [
              [:rabbitmq_stomp],

--- a/deps/rabbitmq_cli/test/plugins/is_enabled_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/is_enabled_command_test.exs
@@ -85,6 +85,15 @@ defmodule PluginIsEnabledCommandTest do
              {:validation_failure, :plugins_dir_does_not_exist}
   end
 
+  test "validate_execution_environment: --offline with a remote node fails validation", context do
+    opts = context[:opts] |> Map.merge(%{online: false, offline: true, node: :jake@thedog})
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate_execution_environment(["rabbitmq_stomp"], opts)
+           )
+  end
+
   test "run: when given a single enabled plugin, reports it as such", context do
     opts = context[:opts] |> Map.merge(%{online: true, offline: false})
 
@@ -120,5 +129,58 @@ defmodule PluginIsEnabledCommandTest do
              {:error, _},
              assert(@command.run(["rabbitmq_stomp", "abc_xyz"], opts))
            )
+  end
+
+  test "run: --offline with a plugin that is in the enabled_plugins file reports it as enabled",
+       context do
+    opts = context[:opts] |> Map.merge(%{online: false, offline: true})
+    set_enabled_plugins([:rabbitmq_stomp], :offline, context[:opts][:node], opts)
+
+    on_exit(fn ->
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
+    end)
+
+    assert match?({:ok, _}, @command.run(["rabbitmq_stomp"], opts))
+  end
+
+  test "run: --offline with a plugin that is available but not in the enabled_plugins file reports it as not enabled",
+       context do
+    opts = context[:opts] |> Map.merge(%{online: false, offline: true})
+    set_enabled_plugins([:rabbitmq_stomp], :offline, context[:opts][:node], opts)
+
+    on_exit(fn ->
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
+    end)
+
+    # rabbitmq_management is installed but not enabled; --offline must read the file, not the plugins dir.
+    assert match?({:error, _}, @command.run(["rabbitmq_management"], opts))
+  end
+
+  test "run: --offline with an implicit dependency of an enabled plugin reports it as enabled",
+       context do
+    opts = context[:opts] |> Map.merge(%{online: false, offline: true})
+    set_enabled_plugins([:rabbitmq_management], :offline, context[:opts][:node], opts)
+
+    on_exit(fn ->
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
+    end)
+
+    # rabbitmq_management_agent is implicitly enabled as a dependency of rabbitmq_management.
+    assert match?({:ok, _}, @command.run(["rabbitmq_management_agent"], opts))
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -135,8 +135,9 @@ defmodule ListPluginsCommandTest do
     assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "run: a call to an unreachable node reports a node_down status", context do
-    assert %{status: :node_down} =
+  test "run: a call to an unreachable node returns node_down status with an empty plugin list",
+       context do
+    assert %{status: :node_down, plugins: []} =
              @command.run([".*"], Map.merge(context[:opts], %{node: :jake@thedog}))
   end
 

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -130,7 +130,7 @@ defmodule ListPluginsCommandTest do
 
     %{
       plugins: actual_plugins
-    } = @command.run([".*"], Map.merge(context[:opts], %{node: :nonode}))
+    } = @command.run([".*"], Map.merge(context[:opts], %{node: :rabbit}))
 
     assert_plugin_states(actual_plugins, expected_plugins)
   end

--- a/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
@@ -83,6 +83,41 @@ defmodule PluginsFormatterTest do
            ]
   end
 
+  test "format_output with offline status renders legend and full plugin table" do
+    result =
+      @formatter.format_output(
+        %{
+          status: :offline,
+          format: :normal,
+          plugins: [
+            %{
+              name: :rabbitmq_federation,
+              enabled: :enabled,
+              running: false,
+              version: ~c"4.0.0",
+              running_version: nil
+            },
+            %{
+              name: :rabbitmq_stomp,
+              enabled: :enabled,
+              running: false,
+              version: ~c"4.0.0",
+              running_version: nil
+            }
+          ]
+        },
+        %{node: "rabbit@localhost"}
+      )
+
+    assert result == [
+             " Configured: E = explicitly enabled; e = implicitly enabled",
+             " | Status: rabbit@localhost is stopped; * (running) status is not available",
+             " |/",
+             "[E ] rabbitmq_federation 4.0.0",
+             "[E ] rabbitmq_stomp      4.0.0"
+           ]
+  end
+
   test "format_output pending upgrade version message" do
     result =
       @formatter.format_output(

--- a/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
@@ -65,6 +65,24 @@ defmodule PluginsFormatterTest do
            ]
   end
 
+  test "format_output with node_down status renders legend without plugin table" do
+    result =
+      @formatter.format_output(
+        %{
+          status: :node_down,
+          format: :normal,
+          plugins: []
+        },
+        %{node: "rabbit@remotehost"}
+      )
+
+    assert result == [
+             " Configured: E = explicitly enabled; e = implicitly enabled",
+             " | Status: [failed to contact rabbit@remotehost - status not shown]",
+             " |/"
+           ]
+  end
+
   test "format_output pending upgrade version message" do
     result =
       @formatter.format_output(

--- a/deps/rabbitmq_cli/test/plugins/plugins_helpers_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_helpers_test.exs
@@ -74,7 +74,7 @@ defmodule PluginsHelpersTest do
     end
 
     test "returns false for a bare node name that does not match the local name" do
-      refute PluginHelpers.node_is_local?(%{node: :"definitelynotthelocalnodename"})
+      refute PluginHelpers.node_is_local?(%{node: :definitelynotthelocalnodename})
     end
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/plugins_helpers_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_helpers_test.exs
@@ -33,7 +33,10 @@ defmodule PluginsHelpersTest do
 
     test "returns false for a node on a clearly different host", context do
       name = context[:local_name]
-      refute PluginHelpers.node_is_local?(%{node: String.to_atom("#{name}@unknownhost.example.com")})
+
+      refute PluginHelpers.node_is_local?(%{
+               node: String.to_atom("#{name}@unknownhost.example.com")
+             })
     end
 
     test "returns false for a node with a different name on the local host", context do

--- a/deps/rabbitmq_cli/test/plugins/plugins_helpers_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_helpers_test.exs
@@ -1,0 +1,80 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule PluginsHelpersTest do
+  use ExUnit.Case, async: false
+
+  alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
+
+  setup_all do
+    local_node_str = :rabbit_env.get_context()[:nodename] |> to_string()
+
+    case String.split(local_node_str, "@", parts: 2) do
+      [local_name, local_host] ->
+        {:ok, local_name: local_name, local_host: local_host}
+
+      _ ->
+        {:ok, local_name: local_node_str, local_host: nil}
+    end
+  end
+
+  describe "node_is_local?/1" do
+    test "returns true when opts has no node key" do
+      assert PluginHelpers.node_is_local?(%{})
+    end
+
+    test "returns true for the configured local node", context do
+      local_atom = String.to_atom("#{context[:local_name]}@#{context[:local_host]}")
+      assert PluginHelpers.node_is_local?(%{node: local_atom})
+    end
+
+    test "returns false for a node on a clearly different host", context do
+      name = context[:local_name]
+      refute PluginHelpers.node_is_local?(%{node: String.to_atom("#{name}@unknownhost.example.com")})
+    end
+
+    test "returns false for a node with a different name on the local host", context do
+      if host = context[:local_host] do
+        refute PluginHelpers.node_is_local?(%{node: String.to_atom("differentname@#{host}")})
+      end
+    end
+
+    test "returns false for a node with a different name and different host" do
+      refute PluginHelpers.node_is_local?(%{node: :"othername@otherhost.example.com"})
+    end
+
+    ## hosts_match?/2 treats a short hostname and its FQDN as the same host.
+    test "returns true for a FQDN form of the local host (short-name prefix match)", context do
+      if host = context[:local_host] do
+        name = context[:local_name]
+        fqdn_node = String.to_atom("#{name}@#{host}.localdomain")
+        assert PluginHelpers.node_is_local?(%{node: fqdn_node})
+      end
+    end
+
+    test "returns true when the local host is a FQDN and the node uses the short form", context do
+      if host = context[:local_host] do
+        name = context[:local_name]
+        short_node = String.to_atom("#{name}@#{String.split(host, ".", parts: 2) |> hd()}")
+
+        if String.contains?(host, ".") do
+          assert PluginHelpers.node_is_local?(%{node: short_node})
+        end
+      end
+    end
+
+    test "returns true for a bare node name matching the local name", context do
+      if context[:local_host] do
+        bare_node = String.to_atom(context[:local_name])
+        assert PluginHelpers.node_is_local?(%{node: bare_node})
+      end
+    end
+
+    test "returns false for a bare node name that does not match the local name" do
+      refute PluginHelpers.node_is_local?(%{node: :"definitelynotthelocalnodename"})
+    end
+  end
+end

--- a/deps/rabbitmq_cli/test/plugins/set_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/set_plugins_command_test.exs
@@ -82,7 +82,7 @@ defmodule SetPluginsCommandTest do
              {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "will write enabled plugins file if node is inaccessible and report implicitly enabled list",
+  test "will write enabled plugins file if local node is inaccessible and report implicitly enabled list",
        context do
     assert {:stream, test_stream} =
              @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
@@ -91,9 +91,16 @@ defmodule SetPluginsCommandTest do
              Enum.to_list(test_stream)
 
     assert {:ok, [[:rabbitmq_stomp]]} = :file.consult(context[:opts][:enabled_plugins_file])
+  end
 
-    assert [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp] =
-             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+  test "validate_execution_environment: --offline with a remote node fails validation",
+       context do
+    opts = Map.merge(context[:opts], %{online: false, offline: true, node: :jake@thedog})
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate_execution_environment([], opts)
+           )
   end
 
   test "will write enabled plugins in offline mode and report implicitly enabled list", context do
@@ -108,7 +115,14 @@ defmodule SetPluginsCommandTest do
 
     assert {:ok, [[:rabbitmq_stomp]]} = :file.consult(context[:opts][:enabled_plugins_file])
 
-    assert [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp] =
+    assert [
+             :amqp_client,
+             :rabbitmq_exchange_federation,
+             :rabbitmq_federation,
+             :rabbitmq_federation_common,
+             :rabbitmq_queue_federation,
+             :rabbitmq_stomp
+           ] =
              Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
@@ -120,7 +134,12 @@ defmodule SetPluginsCommandTest do
              %{
                mode: :online,
                started: [],
-               stopped: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
+               stopped: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation
+               ],
                set: [:rabbitmq_stomp]
              }
            ] = Enum.to_list(test_stream0)
@@ -134,18 +153,39 @@ defmodule SetPluginsCommandTest do
     assert {:stream, test_stream1} = @command.run(["rabbitmq_federation"], context[:opts])
 
     assert [
-             [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
+             [
+               :rabbitmq_exchange_federation,
+               :rabbitmq_federation,
+               :rabbitmq_federation_common,
+               :rabbitmq_queue_federation
+             ],
              %{
                mode: :online,
-               started: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation],
+               started: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation
+               ],
                stopped: [:rabbitmq_stomp],
-               set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation]
+               set: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation
+               ]
              }
            ] = Enum.to_list(test_stream1)
 
     assert {:ok, [[:rabbitmq_federation]]} = :file.consult(context[:opts][:enabled_plugins_file])
 
-    assert [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation] =
+    assert [
+             :amqp_client,
+             :rabbitmq_exchange_federation,
+             :rabbitmq_federation,
+             :rabbitmq_federation_common,
+             :rabbitmq_queue_federation
+           ] =
              Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
@@ -157,7 +197,13 @@ defmodule SetPluginsCommandTest do
              %{
                mode: :online,
                started: [],
-               stopped: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+               stopped: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ],
                set: []
              }
            ] = Enum.to_list(test_stream)
@@ -175,19 +221,44 @@ defmodule SetPluginsCommandTest do
              @command.run(["rabbitmq_federation", "rabbitmq_stomp"], context[:opts])
 
     assert [
-             [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+             [
+               :rabbitmq_exchange_federation,
+               :rabbitmq_federation,
+               :rabbitmq_federation_common,
+               :rabbitmq_queue_federation,
+               :rabbitmq_stomp
+             ],
              %{
                mode: :online,
-               started: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp],
+               started: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ],
                stopped: [],
-               set: [:rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp]
+               set: [
+                 :rabbitmq_exchange_federation,
+                 :rabbitmq_federation,
+                 :rabbitmq_federation_common,
+                 :rabbitmq_queue_federation,
+                 :rabbitmq_stomp
+               ]
              }
            ] = Enum.to_list(test_stream)
 
     assert {:ok, [[:rabbitmq_federation, :rabbitmq_stomp]]} =
              :file.consult(context[:opts][:enabled_plugins_file])
 
-    assert [:amqp_client, :rabbitmq_exchange_federation, :rabbitmq_federation, :rabbitmq_federation_common, :rabbitmq_queue_federation, :rabbitmq_stomp] =
+    assert [
+             :amqp_client,
+             :rabbitmq_exchange_federation,
+             :rabbitmq_federation,
+             :rabbitmq_federation_common,
+             :rabbitmq_queue_federation,
+             :rabbitmq_stomp
+           ] =
              Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 

--- a/deps/rabbitmq_cli/test/plugins/set_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/set_plugins_command_test.exs
@@ -85,7 +85,7 @@ defmodule SetPluginsCommandTest do
   test "will write enabled plugins file if local node is inaccessible and report implicitly enabled list",
        context do
     assert {:stream, test_stream} =
-             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
+             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :rabbit}))
 
     assert [[:rabbitmq_stomp], %{mode: :offline, set: [:rabbitmq_stomp]}] =
              Enum.to_list(test_stream)

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -1320,6 +1320,7 @@ rabbitmqctl(Config, Node, Args, Timeout) ->
     Nodename = ?config(nodename, NodeConfig),
     Env0 = [
       {"RABBITMQ_SCRIPTS_DIR", filename:dirname(Rabbitmqctl)},
+      {"RABBITMQ_NODENAME", atom_to_list(Nodename)},
       {"RABBITMQ_PID_FILE", ?config(pid_file, NodeConfig)},
       {"RABBITMQ_MNESIA_DIR", ?config(data_dir, NodeConfig)},
       {"RABBITMQ_PLUGINS_DIR", ?config(plugins_dir, NodeConfig)},


### PR DESCRIPTION
## Motivation

Several bugs in `rabbitmq-plugins` commands were uncovered when testing against remote nodes and offline mode:

 * `enable`, `disable`, and `set` wrote the `enabled_plugins` file using the **local** node's file path and then sent that path to the remote node over RPC. When the remote node stores its `enabled_plugins` file in a different location — the RPC call failed.

 * When an RPC call to a remote node failed mid-operation, the commands silently fell back to writing the local node's enabled_plugins file. This left the system in an inconsistent state: the local node would pick up the new plugin list on its next restart, but the intended remote node would not. The operator had no indication that the change had been applied to the wrong node. All reads and writes for remote node targets now go exclusively through RPC; there is no silent local fallback.

 * `rabbitmq-plugins is_enabled --offline` incorrectly reported every plugin present in the plugins directory as enabled, even if it was not listed in the `enabled_plugins` file. It was calling an internal helper that enumerated all plugins on disk rather than reading the file.

 * `--offline` mode accepted a remote node target (`-n rabbit@remotehost`) without error. Because offline mode reads and writes only local files, using it against a remote node silently operated on the wrong node's environment and discarded the `-n` flag entirely.

## Changes

### `plugins_helpers.ex`

 * Remote node file path handling is corrected. `set_enabled_plugins/2` now calls `write_enabled_plugins_on_remote/3` for remote targets, which fetches the remote node's own `enabled_plugins` path via RPC before writing, rather than assuming the local path is valid on the remote.

 * `is_enabled --offline` now calls `read_enabled/1` to obtain the list of explicitly enabled plugins and then expands transitive dependencies via `rabbit_plugins:dependencies/3`, matching the semantics of online mode. The old `list_names/1` helper (which returned all plugins in the directory) has been removed.

 * `validate_node_and_mode/2` is introduced and enforces: `--offline` mode is rejected when the target node is remote. Best-effort mode requires the node to be running when the target is remote; for the local node it falls back to offline gracefully.

### `list_command.ex`

 * When the node cannot be reached, the command now distinguishes between a stopped local node and an unreachable remote node. For a stopped local node, it returns an `:offline` status with full plugin metadata read from disk; plugins show their enabled (`E`) and implicit (`e`) markers but not the running (`*`) marker. For an unreachable remote node, it returns a `:node_down` status with an empty plugin list, since all metadata would require RPC calls to retrieve.

### `plugins.ex` (formatter)

 * Introduces the `:offline` status for `rabbitmq-plugins list` output, used when the local node is not running. The existing `:node_down` status is now reserved exclusively for unreachable remote nodes. Because all RPCs fail when a remote node is down, the `:node_down` path produces an empty plugin list; the `:offline` path retains full plugin metadata read from disk.

### `enable_command.ex`, `disable_command.ex`, `set_command.ex`

 * `validate_execution_environment/2` in each command delegates to the new `validate_node_and_mode/2`, giving consistent validation across all three mutating plugin commands.
