### PR TITLE
Exit start-background-broker retry loop as soon as await_startup succeeds

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -355,9 +355,10 @@ start-background-broker: node-tmpdir $(DIST_TARGET)
 	ERL_LIBS="$(DIST_ERL_LIBS)" \
 	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) wait --timeout $(RMQCTL_WAIT_TIMEOUT) $(RABBITMQ_PID_FILE) && \
 	for i in $$(seq 1 10); do \
-	  ERL_LIBS="$(DIST_ERL_LIBS)" $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) await_startup || sleep 1; \
-	done && \
-	ERL_LIBS="$(DIST_ERL_LIBS)" $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) await_startup
+	  ERL_LIBS="$(DIST_ERL_LIBS)" $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) await_startup && exit 0; \
+	  sleep 1; \
+	done; \
+	exit 1
 
 start-rabbit-on-node:
 	$(exec_verbose) ERL_LIBS="$(DIST_ERL_LIBS)" \


### PR DESCRIPTION
## What?

`start-background-broker`'s retry loop for `rabbitmqctl await_startup` now exits early as soon as an attempt succeeds, rather than always looping through all 10 attempts before a final check.

## Why?

The previous loop only used `||` to trigger a sleep on failure, so a successful early attempt would still fall through the remaining iterations (and the loop was still followed by an unconditional final `await_startup` call). This wastes time on `make` targets that start a background node, particularly in CI.
