### PR TITLE
Maintenance mode: drain and revive tolerate failing housekeeping callbacks

### DIFF
--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -70,6 +70,16 @@ is_enabled() ->
 -spec drain() -> ok.
 drain() ->
     ?LOG_WARNING("This node is being put into maintenance (drain) mode"),
+    %% Marking the node as being drained is the single load-bearing step:
+    %% it is what makes the rest of the cluster stop routing new work here.
+    %% It must succeed for the drain to be meaningful, so a failure here
+    %% is intentionally propagated. Every step that follows is
+    %% housekeeping around cleaning up in-flight state; a failure in one
+    %% of them (e.g. a stuck federation link, a plugin drain callback
+    %% that crashes, a channel that refuses to shut down within the
+    %% termination timeout) must not abort the drain and must not
+    %% surface as a non-zero CLI exit code, or automation like
+    %% Kubernetes preStop hooks becomes unreliable. See GH #3369.
     mark_as_being_drained(),
     ?LOG_INFO("Marked this node as undergoing maintenance"),
     %% We intentionally do not rely on the internal event (see below) to stop federation links,
@@ -77,29 +87,42 @@ drain() ->
     %% interference with client connection listeners being stopped
     %% (that will affect all federation links that connect to this node).
     %% See rabbitmq/rabbitmq-server#15271 for details.
-    disconnect_federation_links(),
+    safe_maintenance_step(fun disconnect_federation_links/0,
+                          "disconnect federation links during drain"),
 
     %% Listeners must be stopped after all federation links are disconnected (if any),
     %% otherwise we may end up with a lot of scary log exceptions in case the federation
     %% connections are local.
-    _ = suspend_all_client_listeners(),
+    _ = safe_maintenance_step(fun suspend_all_client_listeners/0,
+                              "suspend client listeners during drain"),
     ?LOG_WARNING("Suspended all listeners and will no longer accept client connections"),
-    {ok, NConnections} = close_all_client_connections(),
-    ?LOG_WARNING("Closed ~b local client connections", [NConnections]),
+    safe_maintenance_step(
+        fun () ->
+            {ok, NConnections} = close_all_client_connections(),
+            ?LOG_WARNING("Closed ~b local client connections", [NConnections])
+        end,
+        "close local client connections during drain"),
     %% allow plugins to react e.g. by closing their protocol connections
     rabbit_event:notify(maintenance_connections_closed, #{
         reason => <<"node is being put into maintenance">>
     }),
 
-    TransferCandidates = primary_replica_transfer_candidate_nodes(),
+    TransferCandidates =
+        safe_maintenance_step(fun primary_replica_transfer_candidate_nodes/0,
+                              "compute primary replica transfer candidates during drain",
+                              []),
 
     %% Transfer metadata store before queues as each queue needs to perform
     %% a metadata update after an election
-    transfer_leadership_of_metadata_store(TransferCandidates),
+    safe_maintenance_step(
+        fun () -> transfer_leadership_of_metadata_store(TransferCandidates) end,
+        "transfer metadata store leadership during drain"),
 
     %% Note: only QQ leadership is transferred because it is a reasonably quick thing to do a lot of queues
     %% in the cluster, unlike with CMQs.
-    rabbit_queue_type:drain(TransferCandidates),
+    safe_maintenance_step(
+        fun () -> rabbit_queue_type:drain(TransferCandidates) end,
+        "drain one or more queue types"),
 
     %% allow plugins to react
     rabbit_event:notify(maintenance_draining, #{
@@ -112,11 +135,19 @@ drain() ->
 -spec revive() -> ok.
 revive() ->
     ?LOG_INFO("This node is being revived from maintenance (drain) mode"),
-    rabbit_queue_type:revive(),
+    %% Symmetric to drain/0: the queue-type and federation callbacks are
+    %% best-effort housekeeping. If either raises, log a warning and
+    %% still unmark the node so that it starts serving traffic again -
+    %% leaving the DRAINING flag set would keep the node effectively
+    %% unusable and force an operator to intervene manually.
+    safe_maintenance_step(fun () -> rabbit_queue_type:revive() end,
+                          "revive one or more queue types"),
     ?LOG_INFO("Resumed all listeners and will accept client connections again"),
-    _ = resume_all_client_listeners(),
+    _ = safe_maintenance_step(fun resume_all_client_listeners/0,
+                              "resume client listeners during revive"),
     ?LOG_INFO("Resumed all listeners and will accept client connections again"),
-    reconnect_federation_links(),
+    safe_maintenance_step(fun reconnect_federation_links/0,
+                          "reconnect federation links during revive"),
     unmark_as_being_drained(),
     ?LOG_INFO("Marked this node as back from maintenance and ready to serve clients"),
 
@@ -124,6 +155,22 @@ revive() ->
     rabbit_event:notify(maintenance_revived, #{}),
 
     ok.
+
+-spec safe_maintenance_step(fun(() -> T), string()) -> T | ok.
+safe_maintenance_step(Fun, StepDescription) ->
+    safe_maintenance_step(Fun, StepDescription, ok).
+
+-spec safe_maintenance_step(fun(() -> T), string(), U) -> T | U.
+safe_maintenance_step(Fun, StepDescription, Default) ->
+    try Fun()
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_WARNING(
+               "Non-fatal error while attempting to ~ts: ~tp:~tp~n"
+               "Stacktrace: ~tp",
+               [StepDescription, Class, Reason, Stacktrace]),
+            Default
+    end.
 
 -spec mark_as_being_drained() -> boolean().
 mark_as_being_drained() ->

--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -24,7 +24,8 @@ all() ->
 groups() ->
     [
       {cluster_size_1, [], [
-          is_serving_works
+          is_serving_works,
+          drain_and_revive_tolerate_failing_callbacks
       ]},
       {cluster_size_3, [], [
           maintenance_mode_status,
@@ -105,6 +106,44 @@ end_per_testcase(Testcase, Config) ->
 %% -------------------------------------------------------------------
 %% Test Cases
 %% -------------------------------------------------------------------
+
+%% Regression test for GH #3369. A single failing housekeeping step
+%% inside rabbit_maintenance:drain/0 (e.g. a plugin whose drain/1
+%% callback raises, a slow channel that times out shutting down, a
+%% federation link that returns noproc) must not abort the drain and
+%% must not leak into the CLI as a non-zero exit code, because the node
+%% has already been marked as draining and any retry would just repeat
+%% the same transient work. Symmetric expectation for revive/0: a
+%% failing housekeeping step must not leave the DRAINING flag stuck.
+drain_and_revive_tolerate_failing_callbacks(Config) ->
+    [Node] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    rabbit_ct_helpers:await_condition(
+        fun () -> not rabbit_ct_broker_helpers:is_being_drained_local_read(Config, Node) end,
+        10000),
+
+    ok = rabbit_ct_broker_helpers:rpc(Config, Node, meck, new,
+                                     [rabbit_queue_type, [passthrough]]),
+    try
+        _ = rabbit_ct_broker_helpers:rpc(Config, Node, meck, expect,
+                                        [rabbit_queue_type, drain,
+                                         fun(_) -> exit(injected_drain_failure) end]),
+        _ = rabbit_ct_broker_helpers:rpc(Config, Node, meck, expect,
+                                        [rabbit_queue_type, revive,
+                                         fun() -> exit(injected_revive_failure) end]),
+
+        ok = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_maintenance, drain, []),
+        rabbit_ct_helpers:await_condition(
+            fun () -> rabbit_ct_broker_helpers:is_being_drained_local_read(Config, Node) end,
+            10000),
+
+        ok = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_maintenance, revive, []),
+        rabbit_ct_helpers:await_condition(
+            fun () -> not rabbit_ct_broker_helpers:is_being_drained_local_read(Config, Node) end,
+            10000)
+    after
+        _ = rabbit_ct_broker_helpers:rpc(Config, Node, meck, unload, [rabbit_queue_type])
+    end.
 
 is_serving_works(Config) ->
     [Node] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
Closes #3369.

## Root cause

Once `rabbit_maintenance:drain/0` has run `mark_as_being_drained/0`, the node is already in draining state at the cluster level — everything after that (`disconnect_federation_links/0`, `close_all_client_connections/0`, `transfer_leadership_of_metadata_store/1`, `rabbit_queue_type:drain/1`, etc.) is housekeeping around cleaning up in-flight state.

Historically any of those steps could raise:

- a plugin whose `drain/1` callback crashes,
- a channel that refuses to shut down within the termination timeout,
- a stuck federation link that returns `noproc`,
- a slow Ra leadership transfer that errors out.

When they did, the raise propagated out of `drain/0`, back through `rabbit_misc:rpc_call/5` as `{badrpc, {'EXIT', _}}`, and the CLI mapped it to a non-zero exit code (69 / `EX_UNAVAILABLE`) — even though the node was, in fact, drained. A subsequent call to `rabbitmq-upgrade drain` on the same node would return `0` immediately, because there was nothing left to do. Kubernetes preStop hooks and other upgrade automation treated the first failure as a real drain failure, retried or aborted the upgrade, and produced `FailedPreStopHook` events.

`revive/0` had the mirror-image problem: a failing housekeeping callback would raise before `unmark_as_being_drained/0` ran, leaving the DRAINING flag stuck and the node effectively unusable until an operator intervened.

## Fix

- Every housekeeping step in both `drain/0` and `revive/0` now runs through a local `safe_maintenance_step/2,3` helper that logs a warning (with class, reason, and stacktrace) and continues.
- The only step intentionally left unwrapped is `mark_as_being_drained/0` — if the maintenance flag can't be written, the drain hasn't actually happened and the caller must know.
- `revive/0` is now guaranteed to reach `unmark_as_being_drained/0` regardless of whether the queue-type or federation callbacks succeeded.
- The `drain/0 :: () -> ok` and `revive/0 :: () -> ok` specs are preserved: on the happy path, behaviour is unchanged; on a housekeeping failure, callers still see `ok` and can rely on the DRAINING flag reflecting the truth.

Same pattern as `rabbit_networking:close_connection/2`, which already wraps its per-connection shutdown in a `try..catch` for the same reason.

## Test

Added `drain_and_revive_tolerate_failing_callbacks/1` to `maintenance_mode_SUITE`. It:

1. Mecks `rabbit_queue_type:drain/1` and `revive/0` to `exit(injected_..._failure)`,
2. Calls `rabbit_maintenance:drain/0` via RPC and asserts it returns `ok` and the node becomes `is_being_drained_local_read = true`,
3. Calls `rabbit_maintenance:revive/0` via RPC and asserts it returns `ok` and the node becomes `is_being_drained_local_read = false`.

Without this change, step 2's RPC raises and step 3 is never reached.

The existing tests (`listener_suspension_status`, `client_connection_closure`, `quorum_queue_leadership_transfer`, `metadata_store_leadership_transfer`) continue to cover the happy path end to end.