### PR TITLE
Improve `rabbit_re`, adopt it in more places

### DIFF
--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -208,29 +208,18 @@ check_topic_access(#auth_user{username = Username},
             end
     end.
 
+-spec expand_topic_permission(binary(), #{binary() => binary()} | undefined) ->
+    binary().
 expand_topic_permission(Permission, ToExpand) when is_map(ToExpand) ->
     Opening = <<"{">>,
     Closing = <<"}">>,
     ReplaceFun = fun(K, V, Acc) ->
                     Placeholder = <<Opening/binary, K/binary, Closing/binary>>,
-                    binary:replace(Acc, Placeholder, escape_regex(V), [global])
+                    binary:replace(Acc, Placeholder, rabbit_re:escape(V), [global])
                  end,
     maps:fold(ReplaceFun, Permission, ToExpand);
 expand_topic_permission(Permission, _ToExpand) ->
     Permission.
-
--spec escape_regex(binary()) -> binary().
-escape_regex(Bin) when is_binary(Bin) ->
-    << <<(escape_regex_char(C))/binary>> || <<C>> <= Bin >>.
-
-escape_regex_char(C)
-  when C =:= $\\; C =:= $^; C =:= $$; C =:= $.;
-       C =:= $|; C =:= $?; C =:= $*; C =:= $+;
-       C =:= $(; C =:= $); C =:= $[; C =:= $];
-       C =:= ${; C =:= $} ->
-    <<$\\, C>>;
-escape_regex_char(C) ->
-    <<C>>.
 
 permission_index(configure) -> #permission.configure;
 permission_index(write)     -> #permission.write;

--- a/deps/rabbit/test/topic_permission_SUITE.erl
+++ b/deps/rabbit/test/topic_permission_SUITE.erl
@@ -408,6 +408,25 @@ topic_permission_checks1(_Config) ->
         }
     ) || Perm <- Permissions],
 
+    %% a variable value is substituted literally: regex metacharacters in the
+    %% value must not widen the pattern, e.g. "-" inside a "[...]" class
+    rabbit_auth_backend_internal:set_topic_permissions(
+        <<"guest">>, <<"other-vhost">>, <<"amq.topic">>,
+        "^[{client_id}]-sensors$", "^[{client_id}]-sensors$", <<"acting-user">>
+    ),
+    Check = fun(ClientId, RoutingKey, Perm) ->
+                    rabbit_auth_backend_internal:check_topic_access(
+                      User, Topic#resource{virtual_host = <<"other-vhost">>}, Perm,
+                      #{routing_key  => RoutingKey,
+                        variable_map => #{<<"client_id">> => ClientId}})
+            end,
+    [begin
+         true  = Check(<<"a-z">>, <<"a-sensors">>, Perm),
+         false = Check(<<"a-z">>, <<"b-sensors">>, Perm),
+         true  = Check(<<"a">>,   <<"a-sensors">>, Perm),
+         false = Check(<<"a">>,   <<"b-sensors">>, Perm)
+     end || Perm <- Permissions],
+
     ok.
 
 %% Topic permission checks must fail closed on metadata store errors.

--- a/deps/rabbit_common/src/rabbit_re.erl
+++ b/deps/rabbit_common/src/rabbit_re.erl
@@ -9,6 +9,7 @@
 
 -export([run/2, run/3,
          matches/2, matches/3,
+         escape/1,
          compile/1, compile/2,
          match_limit/0,
          max_pattern_length/0]).
@@ -61,6 +62,26 @@ matches(Subject, Pattern, Opts) ->
         match -> true;
         _     -> false
     end.
+
+%% Escape every regex metacharacter in a binary so it matches literally, for
+%% embedding untrusted values (topic-permission variables, OAuth2 scopes) in a
+%% pattern without letting them alter its meaning.
+-spec escape(binary()) -> binary().
+escape(Bin) when is_binary(Bin) ->
+    << <<(escape_char(C))/binary>> || <<C>> <= Bin >>.
+
+%% "-" is only special inside a "[...]" character class, where it forms a
+%% range, so it must be escaped alongside the metacharacters that are special
+%% outside a class.
+-spec escape_char(byte()) -> binary().
+escape_char(C)
+  when C =:= $\\; C =:= $^; C =:= $$; C =:= $.;
+       C =:= $|; C =:= $?; C =:= $*; C =:= $+;
+       C =:= $(; C =:= $); C =:= $[; C =:= $];
+       C =:= ${; C =:= $}; C =:= $- ->
+    <<$\\, C>>;
+escape_char(C) ->
+    <<C>>.
 
 -spec compile(iodata()) -> {ok, re:mp()} | {error, term()}.
 compile(Pattern) ->

--- a/deps/rabbit_common/test/rabbit_re_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_re_SUITE.erl
@@ -8,15 +8,11 @@
 -module(rabbit_re_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("proper/include/proper.hrl").
 
 -compile([export_all, nowarn_export_all]).
 
--define(NUM_TESTS, 256).
--define(PROPER_OPTS, [{numtests, ?NUM_TESTS}, {to_file, user}]).
-
 all() ->
-    [{group, units}, {group, properties}].
+    [{group, units}].
 
 groups() ->
     [{units, [parallel],
@@ -39,12 +35,13 @@ groups() ->
        compile_returns_re_error_for_invalid_pattern,
        compile_with_options_passes_them_through,
        match_limit_constant,
-       max_pattern_length_constant]},
-     {properties, [parallel],
-      [run_agrees_with_re_for_short_inputs_prop,
-       compile_returns_too_long_for_overlong_input_prop,
-       run_returns_safe_atom_or_error_prop,
-       matches_always_returns_boolean_prop]}].
+       max_pattern_length_constant,
+       escape_leaves_plain_text_unchanged,
+       escape_escapes_all_metacharacters,
+       escaped_value_matches_itself,
+       escaped_value_cannot_form_range_inside_char_class,
+       escaped_caret_cannot_negate_char_class,
+       escaped_bracket_cannot_terminate_char_class]}].
 
 %% Tests
 
@@ -160,64 +157,42 @@ max_pattern_length_constant(_Config) ->
     true = is_integer(Len) andalso Len > 0,
     ok.
 
-%% Property runners
+escape_leaves_plain_text_unchanged(_Config) ->
+    <<"abc/def123">> = rabbit_re:escape(<<"abc/def123">>),
+    ok.
 
-run_agrees_with_re_for_short_inputs_prop(_Config) ->
-    true = proper:quickcheck(run_agrees_with_re_for_short_inputs(),
-                             ?PROPER_OPTS).
+escape_escapes_all_metacharacters(_Config) ->
+    lists:foreach(fun(M) ->
+                          <<$\\, M>> = rabbit_re:escape(<<M>>)
+                  end, "\\^$.|?*+()[]{}-"),
+    ok.
 
-compile_returns_too_long_for_overlong_input_prop(_Config) ->
-    true = proper:quickcheck(compile_returns_too_long_for_overlong_input(),
-                             ?PROPER_OPTS).
+escaped_value_matches_itself(_Config) ->
+    Hostile = <<"a.b*c+d?e^f$g|h(i)j[k]l{m}n\\o-p">>,
+    Pattern = <<"^", (rabbit_re:escape(Hostile))/binary, "$">>,
+    match = rabbit_re:run(Hostile, Pattern),
+    ok.
 
-run_returns_safe_atom_or_error_prop(_Config) ->
-    true = proper:quickcheck(run_returns_safe_atom_or_error(),
-                             ?PROPER_OPTS).
+%% "a-z" inside a "[...]" class must stay a literal set, not become a range.
+escaped_value_cannot_form_range_inside_char_class(_Config) ->
+    Pattern = <<"^[", (rabbit_re:escape(<<"a-z">>))/binary, "]-sensors$">>,
+    match   = rabbit_re:run(<<"a-sensors">>, Pattern),
+    match   = rabbit_re:run(<<"z-sensors">>, Pattern),
+    nomatch = rabbit_re:run(<<"b-sensors">>, Pattern),
+    nomatch = rabbit_re:run(<<"m-sensors">>, Pattern),
+    ok.
 
-matches_always_returns_boolean_prop(_Config) ->
-    true = proper:quickcheck(matches_always_returns_boolean(),
-                             ?PROPER_OPTS).
+escaped_caret_cannot_negate_char_class(_Config) ->
+    Pattern = <<"^[", (rabbit_re:escape(<<"^a">>))/binary, "]$">>,
+    match   = rabbit_re:run(<<"a">>, Pattern),
+    match   = rabbit_re:run(<<"^">>, Pattern),
+    nomatch = rabbit_re:run(<<"b">>, Pattern),
+    ok.
 
-%% Properties
-
-run_agrees_with_re_for_short_inputs() ->
-    %% On short alphanumeric inputs the helper agrees with plain `re:run/3`.
-    ?FORALL({Subject, Pattern}, {short_alpha_binary(), short_alpha_binary()},
-            begin
-                Bare = case re:run(Subject, Pattern, [{capture, none}]) of
-                           match   -> match;
-                           nomatch -> nomatch
-                       end,
-                Helper = rabbit_re:run(Subject, Pattern),
-                Bare =:= Helper
-            end).
-
-compile_returns_too_long_for_overlong_input() ->
-    ?FORALL(Extra, non_neg_integer(),
-            begin
-                Len = rabbit_re:max_pattern_length() + Extra + 1,
-                Pat = binary:copy(<<"a">>, Len),
-                {error, pattern_too_long} =:= rabbit_re:compile(Pat)
-            end).
-
-run_returns_safe_atom_or_error() ->
-    %% The helper returns one of the documented shapes for any binary input.
-    ?FORALL({Subject, Pattern}, {binary(), binary()},
-            case rabbit_re:run(Subject, Pattern) of
-                match           -> true;
-                nomatch         -> true;
-                {match, _}      -> true;
-                {error, _}      -> true;
-                _Other          -> false
-            end).
-
-matches_always_returns_boolean() ->
-    ?FORALL({Subject, Pattern}, {binary(), binary()},
-            is_boolean(rabbit_re:matches(Subject, Pattern))).
-
-%% Generators
-
-short_alpha_binary() ->
-    ?LET(L,
-         list(oneof([integer($a, $z), integer($0, $9), $-])),
-         list_to_binary(lists:sublist(L, 30))).
+escaped_bracket_cannot_terminate_char_class(_Config) ->
+    Pattern = <<"^[", (rabbit_re:escape(<<"a].*">>))/binary, "]$">>,
+    match   = rabbit_re:run(<<"a">>, Pattern),
+    match   = rabbit_re:run(<<"]">>, Pattern),
+    nomatch = rabbit_re:run(<<"axyz">>, Pattern),
+    nomatch = rabbit_re:run(<<"b">>, Pattern),
+    ok.

--- a/deps/rabbit_common/test/rabbit_re_prop_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_re_prop_SUITE.erl
@@ -1,0 +1,128 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_re_prop_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-define(NUM_TESTS, 256).
+-define(PROPER_OPTS, [{numtests, ?NUM_TESTS}, {to_file, user}]).
+
+all() ->
+    [{group, properties}].
+
+groups() ->
+    [{properties, [parallel],
+      [run_agrees_with_re_for_short_inputs_prop,
+       compile_returns_too_long_for_overlong_input_prop,
+       run_returns_safe_atom_or_error_prop,
+       matches_always_returns_boolean_prop,
+       escape_produces_literal_matcher_prop,
+       escape_prevents_range_inside_char_class_prop]}].
+
+%% Property runners
+
+run_agrees_with_re_for_short_inputs_prop(_Config) ->
+    true = proper:quickcheck(run_agrees_with_re_for_short_inputs(),
+                             ?PROPER_OPTS).
+
+compile_returns_too_long_for_overlong_input_prop(_Config) ->
+    true = proper:quickcheck(compile_returns_too_long_for_overlong_input(),
+                             ?PROPER_OPTS).
+
+run_returns_safe_atom_or_error_prop(_Config) ->
+    true = proper:quickcheck(run_returns_safe_atom_or_error(),
+                             ?PROPER_OPTS).
+
+matches_always_returns_boolean_prop(_Config) ->
+    true = proper:quickcheck(matches_always_returns_boolean(),
+                             ?PROPER_OPTS).
+
+escape_produces_literal_matcher_prop(_Config) ->
+    true = proper:quickcheck(escape_produces_literal_matcher(),
+                             ?PROPER_OPTS).
+
+escape_prevents_range_inside_char_class_prop(_Config) ->
+    true = proper:quickcheck(escape_prevents_range_inside_char_class(),
+                             ?PROPER_OPTS).
+
+%% Properties
+
+run_agrees_with_re_for_short_inputs() ->
+    %% On short alphanumeric inputs the helper agrees with plain `re:run/3`.
+    ?FORALL({Subject, Pattern}, {short_alpha_binary(), short_alpha_binary()},
+            begin
+                Bare = case re:run(Subject, Pattern, [{capture, none}]) of
+                           match   -> match;
+                           nomatch -> nomatch
+                       end,
+                Helper = rabbit_re:run(Subject, Pattern),
+                Bare =:= Helper
+            end).
+
+compile_returns_too_long_for_overlong_input() ->
+    ?FORALL(Extra, non_neg_integer(),
+            begin
+                Len = rabbit_re:max_pattern_length() + Extra + 1,
+                Pat = binary:copy(<<"a">>, Len),
+                {error, pattern_too_long} =:= rabbit_re:compile(Pat)
+            end).
+
+run_returns_safe_atom_or_error() ->
+    %% The helper returns one of the documented shapes for any binary input.
+    ?FORALL({Subject, Pattern}, {binary(), binary()},
+            case rabbit_re:run(Subject, Pattern) of
+                match           -> true;
+                nomatch         -> true;
+                {match, _}      -> true;
+                {error, _}      -> true;
+                _Other          -> false
+            end).
+
+matches_always_returns_boolean() ->
+    ?FORALL({Subject, Pattern}, {binary(), binary()},
+            is_boolean(rabbit_re:matches(Subject, Pattern))).
+
+escape_produces_literal_matcher() ->
+    %% "^escape(V)$" matches V and no other string.
+    ?FORALL({V, Other}, {printable_binary(), printable_binary()},
+            begin
+                Pattern = <<"^", (rabbit_re:escape(V))/binary, "$">>,
+                case Other =:= V of
+                    true  -> rabbit_re:matches(V, Pattern);
+                    false -> not rabbit_re:matches(Other, Pattern)
+                end
+            end).
+
+escape_prevents_range_inside_char_class() ->
+    %% "X-Y" inside a "[...]" class must not form a range: the endpoints
+    %% match, a character strictly between them does not.
+    ?FORALL({Lo, Mid, Hi}, ordered_letters(),
+            begin
+                Class = <<"^[", (rabbit_re:escape(<<Lo, $-, Hi>>))/binary, "]$">>,
+                rabbit_re:matches(<<Lo>>, Class)
+                    andalso rabbit_re:matches(<<Hi>>, Class)
+                    andalso not rabbit_re:matches(<<Mid>>, Class)
+            end).
+
+%% Generators
+
+printable_binary() ->
+    ?LET(L, list(integer(32, 126)), list_to_binary(L)).
+
+ordered_letters() ->
+    ?LET(Lo, integer($a, $x),
+         ?LET(Hi, integer(Lo + 2, $z),
+              ?LET(Mid, integer(Lo + 1, Hi - 1), {Lo, Mid, Hi}))).
+
+short_alpha_binary() ->
+    ?LET(L,
+         list(oneof([integer($a, $z), integer($0, $9), $-])),
+         list_to_binary(lists:sublist(L, 30))).

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -522,12 +522,7 @@ resolve_scope_var(Elem, Token, Vhost, Syntax) ->
     end.
 
 escape_regex_metacharacters(Str) ->
-    %% Escapes "-" as well: inside a [...] character class it forms a range,
-    %% so a template like "[{var}]" with var="a-z" would otherwise match any
-    %% letter rather than the literal three-character value.
-    binary_to_list(
-        re:replace(Str, <<"[.^$|()\\[\\]{}*+?\\\\-]">>, <<"\\\\&">>,
-                   [global, {return, binary}, unicode])).
+    binary_to_list(rabbit_re:escape(iolist_to_binary(Str))).
 
 -spec tags_from(decoded_jwt_token()) -> list(atom()).
 tags_from(DecodedToken) ->


### PR DESCRIPTION
To reduce duplication and to make sure that its
safety properties are shared by more RabbitMQ
plugins/components.
