### PR TITLE
Transfer stream leadership on node drain

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -40,7 +40,8 @@
 -export([is_replicable/1, is_exclusive/1, is_not_exclusive/1, is_dead_exclusive/1]).
 -export([list_local_quorum_queues/0, list_local_quorum_queue_names/0,
          list_local_stream_queues/0, list_stream_queues_on/1,
-         list_local_leaders/0, list_local_followers/0, get_quorum_nodes/1,
+         list_local_leaders/0, list_local_stream_leaders/0,
+         list_local_followers/0, get_quorum_nodes/1,
          list_local_quorum_queues_with_name_matching/1,
          list_local_quorum_queues_with_name_matching/2]).
 -export([is_local_to_node/2, is_local_to_node_set/2]).
@@ -1329,6 +1330,13 @@ list_local_leaders() ->
     [ Q || Q <- list(),
          amqqueue:is_quorum(Q),
          amqqueue:get_state(Q) =/= crashed, amqqueue:get_leader_node(Q) =:= node()].
+
+-spec list_local_stream_leaders() -> [amqqueue:amqqueue()].
+list_local_stream_leaders() ->
+    ThisNode = node(),
+    [Q || Q <- list_local_stream_queues(),
+          is_pid(amqqueue:get_pid(Q)),
+          node(amqqueue:get_pid(Q)) =:= ThisNode].
 
 -spec list_local_followers() -> [amqqueue:amqqueue()].
 list_local_followers() ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1630,8 +1630,11 @@ stop(_VHost) ->
 
 drain(TransferCandidates) ->
     case whereis(rabbit_stream_coordinator) of
-        undefined -> ok;
-        _Pid -> transfer_leadership_of_stream_coordinator(TransferCandidates)
+        undefined ->
+            ok;
+        _Pid ->
+            transfer_leadership_of_stream_coordinator(TransferCandidates),
+            transfer_leadership_of_local_stream_leaders(TransferCandidates)
     end.
 
 revive() ->
@@ -1655,6 +1658,37 @@ transfer_leadership_of_stream_coordinator(TransferCandidates) ->
         Error ->
             ?LOG_WARNING("Skipping leadership transfer of stream coordinator: ~p", [Error])
     end.
+
+-spec transfer_leadership_of_local_stream_leaders([node()]) -> ok.
+transfer_leadership_of_local_stream_leaders([]) ->
+    ?LOG_WARNING("Skipping stream leadership transfer: no candidate "
+                 "(online, not under maintenance) nodes to transfer to");
+transfer_leadership_of_local_stream_leaders(TransferCandidates) ->
+    LocalLeaders = rabbit_amqqueue:list_local_stream_leaders(),
+    ?LOG_INFO("Will transfer leadership of ~b streams with current leader on this node",
+              [length(LocalLeaders)]),
+    lists:foreach(
+      fun (Q) -> transfer_leadership_of_stream(Q, TransferCandidates) end,
+      LocalLeaders),
+    ?LOG_INFO("Leadership transfer for streams hosted on this node has been initiated").
+
+-spec transfer_leadership_of_stream(amqqueue:amqqueue(), [node()]) -> ok.
+transfer_leadership_of_stream(Q, TransferCandidates) ->
+    %% A stream can only elect a new leader on a node that already hosts a replica.
+    Replicas = get_nodes(Q),
+    Options = case [N || N <- TransferCandidates, lists:member(N, Replicas)] of
+                  [] -> #{};
+                  [Preferred | _] -> #{preferred_leader_node => Preferred}
+              end,
+    QNameStr = rabbit_misc:rs(amqqueue:get_name(Q)),
+    case rabbit_stream_coordinator:restart_stream(Q, Options) of
+        {ok, NewLeader} ->
+            ?LOG_DEBUG("Stream ~ts new leader is on node ~tp", [QNameStr, NewLeader]);
+        Error ->
+            ?LOG_WARNING("Failed to transfer leadership of stream ~ts: ~tp",
+                         [QNameStr, Error])
+    end,
+    ok.
 
 queue_vm_stats_sups() ->
     {[stream_queue_procs,

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1659,6 +1659,18 @@ transfer_leadership_of_stream_coordinator(TransferCandidates) ->
             ?LOG_WARNING("Skipping leadership transfer of stream coordinator: ~p", [Error])
     end.
 
+%% Under a busy coordinator (e.g. many active publishers), each
+%% restart_stream/2 command can take up to the coordinator command timeout
+%% per coordinator member before failing. To avoid dragging drain out for
+%% minutes, cap the total wall-clock spent on per-stream transfers and let
+%% shutdown-time re-election handle any remainder.
+-define(STREAM_DRAIN_BUDGET_MS, 30000).
+%% Small pause between per-stream restart_stream commands to reduce
+%% coordinator command queue pressure when there are many local leaders.
+-define(STREAM_DRAIN_INTER_STREAM_MS, 25).
+-define(STREAM_DRAIN_RESTART_ATTEMPTS, 2).
+-define(STREAM_DRAIN_RESTART_BACKOFF_MS, 500).
+
 -spec transfer_leadership_of_local_stream_leaders([node()]) -> ok.
 transfer_leadership_of_local_stream_leaders([]) ->
     ?LOG_WARNING("Skipping stream leadership transfer: no candidate "
@@ -1667,15 +1679,48 @@ transfer_leadership_of_local_stream_leaders(TransferCandidates) ->
     LocalLeaders = rabbit_amqqueue:list_local_stream_leaders(),
     ?LOG_INFO("Will transfer leadership of ~b streams with current leader on this node",
               [length(LocalLeaders)]),
-    lists:foreach(
-      fun (Q) -> transfer_leadership_of_stream(Q, TransferCandidates) end,
-      LocalLeaders),
-    ?LOG_INFO("Leadership transfer for streams hosted on this node has been initiated").
+    Deadline = erlang:monotonic_time(millisecond) + ?STREAM_DRAIN_BUDGET_MS,
+    Outcome = transfer_leaders_until(LocalLeaders, TransferCandidates, Deadline,
+                                     #{transferred => 0, skipped => 0, remaining => 0}),
+    #{transferred := Ok, skipped := Skipped, remaining := Remaining} = Outcome,
+    case Remaining of
+        0 ->
+            ?LOG_INFO("Leadership transfer for streams hosted on this node completed "
+                      "(transferred=~b, skipped=~b)", [Ok, Skipped]);
+        _ ->
+            ?LOG_WARNING("Leadership transfer for streams hosted on this node cut short "
+                         "(transferred=~b, skipped=~b, remaining=~b); shutdown-time "
+                         "re-election will handle the remainder",
+                         [Ok, Skipped, Remaining])
+    end.
 
--define(STREAM_DRAIN_RESTART_ATTEMPTS, 3).
--define(STREAM_DRAIN_RESTART_BACKOFF_MS, 500).
+transfer_leaders_until([], _Candidates, _Deadline, Acc) ->
+    Acc;
+transfer_leaders_until([Q | Rest] = Queues, Candidates, Deadline, Acc) ->
+    case erlang:monotonic_time(millisecond) >= Deadline of
+        true ->
+            Acc#{remaining := length(Queues)};
+        false ->
+            case transfer_leadership_of_stream(Q, Candidates) of
+                {stop, Reason} ->
+                    ?LOG_WARNING("Stopping stream leadership transfer after ~tp; "
+                                 "remaining ~b streams will re-elect at shutdown",
+                                 [Reason, length(Queues)]),
+                    Acc#{remaining := length(Queues)};
+                transferred ->
+                    timer:sleep(?STREAM_DRAIN_INTER_STREAM_MS),
+                    transfer_leaders_until(Rest, Candidates, Deadline,
+                                           maps:update_with(transferred,
+                                                            fun (V) -> V + 1 end, Acc));
+                skipped ->
+                    transfer_leaders_until(Rest, Candidates, Deadline,
+                                           maps:update_with(skipped,
+                                                            fun (V) -> V + 1 end, Acc))
+            end
+    end.
 
--spec transfer_leadership_of_stream(amqqueue:amqqueue(), [node()]) -> ok.
+-spec transfer_leadership_of_stream(amqqueue:amqqueue(), [node()]) ->
+    transferred | skipped | {stop, term()}.
 transfer_leadership_of_stream(Q, TransferCandidates) ->
     %% A stream can only elect a new leader on a node that already hosts a replica.
     Replicas = get_nodes(Q),
@@ -1687,17 +1732,21 @@ transfer_leadership_of_stream(Q, TransferCandidates) ->
             %% another node under maintenance). Skip and let shutdown-time
             %% re-election handle it.
             ?LOG_INFO("Skipping leadership transfer of stream ~ts: no online, "
-                      "non-maintenance replica available", [QNameStr]);
+                      "non-maintenance replica available", [QNameStr]),
+            skipped;
         [Preferred | _] ->
             restart_stream_off_local(Q, QNameStr, Preferred,
                                      ?STREAM_DRAIN_RESTART_ATTEMPTS)
-    end,
-    ok.
+    end.
 
+-spec restart_stream_off_local(amqqueue:amqqueue(), string(), node(),
+                               non_neg_integer()) ->
+    transferred | skipped | {stop, term()}.
 restart_stream_off_local(_Q, QNameStr, _Preferred, 0) ->
     ?LOG_WARNING("Gave up transferring leadership of stream ~ts off ~tp: "
                  "still local after retries",
-                 [QNameStr, node()]);
+                 [QNameStr, node()]),
+    skipped;
 restart_stream_off_local(Q, QNameStr, Preferred, Attempts) ->
     Options = #{preferred_leader_node => Preferred},
     case rabbit_stream_coordinator:restart_stream(Q, Options) of
@@ -1712,10 +1761,25 @@ restart_stream_off_local(Q, QNameStr, Preferred, Attempts) ->
             restart_stream_off_local(Q, QNameStr, Preferred, Attempts - 1);
         {ok, NewLeader} ->
             ?LOG_DEBUG("Stream ~ts new leader is on node ~tp",
-                       [QNameStr, NewLeader]);
+                       [QNameStr, NewLeader]),
+            transferred;
+        {error, coordinator_unavailable} = Err ->
+            %% Coordinator is already overloaded (all raft members timed out).
+            %% Hammering it with more restart_stream commands makes things
+            %% worse; bail out and let shutdown-time re-election finish.
+            ?LOG_WARNING("Stream coordinator unavailable while transferring "
+                         "leadership of stream ~ts: ~tp",
+                         [QNameStr, Err]),
+            {stop, Err};
+        {timeout, _} = Err ->
+            ?LOG_WARNING("Stream coordinator timed out while transferring "
+                         "leadership of stream ~ts: ~tp",
+                         [QNameStr, Err]),
+            {stop, Err};
         Error ->
             ?LOG_WARNING("Failed to transfer leadership of stream ~ts: ~tp",
-                         [QNameStr, Error])
+                         [QNameStr, Error]),
+            skipped
     end.
 
 queue_vm_stats_sups() ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1764,15 +1764,13 @@ restart_stream_off_local(Q, QNameStr, Preferred, Attempts) ->
                        [QNameStr, NewLeader]),
             transferred;
         {error, coordinator_unavailable} = Err ->
-            %% Coordinator is already overloaded (all raft members timed out).
-            %% Hammering it with more restart_stream commands makes things
-            %% worse; bail out and let shutdown-time re-election finish.
+            %% `rabbit_stream_coordinator:process_command/2` collapses raft
+            %% timeouts across all coordinator members into this single
+            %% error. It means the coordinator is already overloaded, so
+            %% hammering it with more restart_stream commands only makes
+            %% things worse; bail out and let shutdown-time re-election
+            %% finish.
             ?LOG_WARNING("Stream coordinator unavailable while transferring "
-                         "leadership of stream ~ts: ~tp",
-                         [QNameStr, Err]),
-            {stop, Err};
-        {timeout, _} = Err ->
-            ?LOG_WARNING("Stream coordinator timed out while transferring "
                          "leadership of stream ~ts: ~tp",
                          [QNameStr, Err]),
             {stop, Err};

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1676,17 +1676,25 @@ transfer_leadership_of_local_stream_leaders(TransferCandidates) ->
 transfer_leadership_of_stream(Q, TransferCandidates) ->
     %% A stream can only elect a new leader on a node that already hosts a replica.
     Replicas = get_nodes(Q),
-    Options = case [N || N <- TransferCandidates, lists:member(N, Replicas)] of
-                  [] -> #{};
-                  [Preferred | _] -> #{preferred_leader_node => Preferred}
-              end,
     QNameStr = rabbit_misc:rs(amqqueue:get_name(Q)),
-    case rabbit_stream_coordinator:restart_stream(Q, Options) of
-        {ok, NewLeader} ->
-            ?LOG_DEBUG("Stream ~ts new leader is on node ~tp", [QNameStr, NewLeader]);
-        Error ->
-            ?LOG_WARNING("Failed to transfer leadership of stream ~ts: ~tp",
-                         [QNameStr, Error])
+    case [N || N <- TransferCandidates, lists:member(N, Replicas)] of
+        [] ->
+            %% No online, non-maintenance replica for this stream: restarting
+            %% now would risk re-electing the leader onto the draining node (or
+            %% another node under maintenance). Skip and let shutdown-time
+            %% re-election handle it.
+            ?LOG_INFO("Skipping leadership transfer of stream ~ts: no online, "
+                      "non-maintenance replica available", [QNameStr]);
+        [Preferred | _] ->
+            Options = #{preferred_leader_node => Preferred},
+            case rabbit_stream_coordinator:restart_stream(Q, Options) of
+                {ok, NewLeader} ->
+                    ?LOG_DEBUG("Stream ~ts new leader is on node ~tp",
+                               [QNameStr, NewLeader]);
+                Error ->
+                    ?LOG_WARNING("Failed to transfer leadership of stream ~ts: ~tp",
+                                 [QNameStr, Error])
+            end
     end,
     ok.
 

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1672,6 +1672,9 @@ transfer_leadership_of_local_stream_leaders(TransferCandidates) ->
       LocalLeaders),
     ?LOG_INFO("Leadership transfer for streams hosted on this node has been initiated").
 
+-define(STREAM_DRAIN_RESTART_ATTEMPTS, 3).
+-define(STREAM_DRAIN_RESTART_BACKOFF_MS, 500).
+
 -spec transfer_leadership_of_stream(amqqueue:amqqueue(), [node()]) -> ok.
 transfer_leadership_of_stream(Q, TransferCandidates) ->
     %% A stream can only elect a new leader on a node that already hosts a replica.
@@ -1686,17 +1689,34 @@ transfer_leadership_of_stream(Q, TransferCandidates) ->
             ?LOG_INFO("Skipping leadership transfer of stream ~ts: no online, "
                       "non-maintenance replica available", [QNameStr]);
         [Preferred | _] ->
-            Options = #{preferred_leader_node => Preferred},
-            case rabbit_stream_coordinator:restart_stream(Q, Options) of
-                {ok, NewLeader} ->
-                    ?LOG_DEBUG("Stream ~ts new leader is on node ~tp",
-                               [QNameStr, NewLeader]);
-                Error ->
-                    ?LOG_WARNING("Failed to transfer leadership of stream ~ts: ~tp",
-                                 [QNameStr, Error])
-            end
+            restart_stream_off_local(Q, QNameStr, Preferred,
+                                     ?STREAM_DRAIN_RESTART_ATTEMPTS)
     end,
     ok.
+
+restart_stream_off_local(_Q, QNameStr, _Preferred, 0) ->
+    ?LOG_WARNING("Gave up transferring leadership of stream ~ts off ~tp: "
+                 "still local after retries",
+                 [QNameStr, node()]);
+restart_stream_off_local(Q, QNameStr, Preferred, Attempts) ->
+    Options = #{preferred_leader_node => Preferred},
+    case rabbit_stream_coordinator:restart_stream(Q, Options) of
+        {ok, NewLeader} when NewLeader =:= node() ->
+            %% `restart_stream` honours `preferred_leader_node` only when
+            %% the preferred node is tied with the current writer on the
+            %% stopped tail. If the writer just advanced its epoch (as
+            %% happens right after being forced onto this node), the
+            %% replicas need a moment to catch up before another attempt
+            %% can tie them and let the hint win.
+            timer:sleep(?STREAM_DRAIN_RESTART_BACKOFF_MS),
+            restart_stream_off_local(Q, QNameStr, Preferred, Attempts - 1);
+        {ok, NewLeader} ->
+            ?LOG_DEBUG("Stream ~ts new leader is on node ~tp",
+                       [QNameStr, NewLeader]);
+        Error ->
+            ?LOG_WARNING("Failed to transfer leadership of stream ~ts: ~tp",
+                         [QNameStr, Error])
+    end.
 
 queue_vm_stats_sups() ->
     {[stream_queue_procs,

--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -352,6 +352,29 @@ stream_leadership_transfer(Config) ->
          Config, A, rabbit_amqqueue, list_local_stream_leaders, []),
        30000),
 
+    %% Wait until every replica is running as a member under the current
+    %% epoch. Otherwise drain's `restart_stream` fires while B and C are
+    %% still catching up: A has a higher on-disk state than the replicas and
+    %% `select_leader/2` picks A back, ignoring the `preferred_leader_node`
+    %% hint. `members/1` returns `{Pid, Role}` per node; a live replica has
+    %% a non-undefined pid.
+    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, A, rabbit_amqqueue,
+                                           lookup, [QRes]),
+    #{name := StreamId} = rabbit_ct_broker_helpers:rpc(
+                            Config, A, amqqueue, get_type_state, [Q]),
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            case rabbit_ct_broker_helpers:rpc(
+                   Config, A, rabbit_stream_coordinator, members,
+                   [StreamId]) of
+                {ok, Members} when map_size(Members) == 3 ->
+                    lists:all(fun ({Pid, _}) -> is_pid(Pid) end,
+                              maps:values(Members));
+                _ ->
+                    false
+            end
+        end, 30000),
+
     rabbit_ct_broker_helpers:drain_node(Config, A),
     rabbit_ct_helpers:await_condition(
         fun () -> rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),

--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -362,10 +362,7 @@ stream_leadership_transfer(Config) ->
          Config, A, rabbit_amqqueue, list_local_stream_leaders, []),
        30000),
 
-    rabbit_ct_broker_helpers:revive_node(Config, A),
-    amqp_channel:call(Ch, #'queue.delete'{queue = QName}),
-    rabbit_ct_client_helpers:close_channel(Ch),
-    rabbit_ct_client_helpers:close_connection(Conn).
+    rabbit_ct_broker_helpers:revive_node(Config, A).
 
 metadata_store_leadership_transfer(Config) ->
     [A | _] = Nodenames = rabbit_ct_broker_helpers:get_node_configs(

--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -32,6 +32,7 @@ groups() ->
           listener_suspension_status,
           client_connection_closure,
           quorum_queue_leadership_transfer,
+          stream_leadership_transfer,
           metadata_store_leadership_transfer
       ]}
     ].
@@ -314,6 +315,57 @@ quorum_queue_leadership_transfer(Config) ->
     end,
 
     rabbit_ct_broker_helpers:revive_node(Config, A).
+
+%% Regression test for rabbitmq/rabbitmq-server#16340. Draining a node must
+%% move stream leadership off it, or stopping the node forces a re-election
+%% under load and clients see the stream as down for several minutes.
+stream_leadership_transfer(Config) ->
+    [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ct:pal("Picked node ~ts for maintenance tests...", [A]),
+
+    rabbit_ct_helpers:await_condition(
+        fun () -> not rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),
+
+    Conn = rabbit_ct_client_helpers:open_connection(Config, A),
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+    QName = <<"stream.maintenance.1">>,
+    #'queue.declare_ok'{} = amqp_channel:call(
+        Ch, #'queue.declare'{queue = QName, durable = true, arguments = [
+            {<<"x-queue-type">>, longstr, <<"stream">>}
+        ]}),
+
+    QRes = rabbit_misc:r(<<"/">>, queue, QName),
+    %% Force the stream's leader onto A so that draining has work to do.
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            case rabbit_ct_broker_helpers:rpc(
+                   Config, A, rabbit_stream_coordinator, restart_stream,
+                   [QRes, #{preferred_leader_node => A}]) of
+                {ok, A} -> true;
+                _       -> false
+            end
+        end, 60000),
+
+    ?awaitMatch(
+       Leaders when length(Leaders) == 1,
+       rabbit_ct_broker_helpers:rpc(
+         Config, A, rabbit_amqqueue, list_local_stream_leaders, []),
+       30000),
+
+    rabbit_ct_broker_helpers:drain_node(Config, A),
+    rabbit_ct_helpers:await_condition(
+        fun () -> rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),
+
+    ?awaitMatch(
+       Leaders when length(Leaders) == 0,
+       rabbit_ct_broker_helpers:rpc(
+         Config, A, rabbit_amqqueue, list_local_stream_leaders, []),
+       30000),
+
+    rabbit_ct_broker_helpers:revive_node(Config, A),
+    amqp_channel:call(Ch, #'queue.delete'{queue = QName}),
+    rabbit_ct_client_helpers:close_channel(Ch),
+    rabbit_ct_client_helpers:close_connection(Conn).
 
 metadata_store_leadership_transfer(Config) ->
     [A | _] = Nodenames = rabbit_ct_broker_helpers:get_node_configs(

--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -352,29 +352,6 @@ stream_leadership_transfer(Config) ->
          Config, A, rabbit_amqqueue, list_local_stream_leaders, []),
        30000),
 
-    %% Wait until every replica is running as a member under the current
-    %% epoch. Otherwise drain's `restart_stream` fires while B and C are
-    %% still catching up: A has a higher on-disk state than the replicas and
-    %% `select_leader/2` picks A back, ignoring the `preferred_leader_node`
-    %% hint. `members/1` returns `{Pid, Role}` per node; a live replica has
-    %% a non-undefined pid.
-    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, A, rabbit_amqqueue,
-                                           lookup, [QRes]),
-    #{name := StreamId} = rabbit_ct_broker_helpers:rpc(
-                            Config, A, amqqueue, get_type_state, [Q]),
-    rabbit_ct_helpers:await_condition(
-        fun () ->
-            case rabbit_ct_broker_helpers:rpc(
-                   Config, A, rabbit_stream_coordinator, members,
-                   [StreamId]) of
-                {ok, Members} when map_size(Members) == 3 ->
-                    lists:all(fun ({Pid, _}) -> is_pid(Pid) end,
-                              maps:values(Members));
-                _ ->
-                    false
-            end
-        end, 30000),
-
     rabbit_ct_broker_helpers:drain_node(Config, A),
     rabbit_ct_helpers:await_condition(
         fun () -> rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),


### PR DESCRIPTION
Closes #16340 (partially — this covers the missing per-stream leadership transfer; the coordinator starvation scenario is separate).

`rabbit_quorum_queue:drain/1` enumerates every quorum queue with a local leader and stops the local Ra leader so a peer takes over. `rabbit_stream_queue:drain/1` only transferred the stream coordinator's own leadership and left individual stream leaders in place, so re-election for each stream only kicked in when the drained node was actually stopped.

On a cluster with many streams and a lot of clients, that produced a mass reconnect at shutdown time, which starved the stream coordinator and kept streams reported as `down` for minutes — exactly what the reporter in #16340 observed.

## Change

- New `rabbit_amqqueue:list_local_stream_leaders/0`, mirrors `list_local_leaders/0`.
- `rabbit_stream_queue:drain/1` now walks that list and calls `rabbit_stream_coordinator:restart_stream/2` with a `preferred_leader_node` that is both online (not under maintenance) and already a replica of the stream.
- Regression test in `maintenance_mode_SUITE` (cluster_size_3): declare a stream, pin its leader to node A, drain A, assert `list_local_stream_leaders/0` on A becomes empty.

## Scope

This does not touch the coordinator starvation scenario reported in the second half of #16340 (thousands of reconnects contending for a single-threaded coordinator on shutdown). That's a scheduler / backpressure problem in the stream coordinator and belongs in a separate change.