### PR TITLE
[oauth2] Make exp claim optional if configured 

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/include/oauth2.hrl
+++ b/deps/rabbitmq_auth_backend_oauth2/include/oauth2.hrl
@@ -46,6 +46,7 @@
   id :: resource_server_id(),
   resource_server_type :: binary() | undefined,
   verify_aud :: boolean(),
+  require_exp :: boolean(),
   scope_prefix :: binary(),
   additional_scopes_key :: binary() | undefined,
   preferred_username_claims :: list(),

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -103,6 +103,19 @@
  "rabbitmq_auth_backend_oauth2.verify_aud",
  [{datatype, boolean}]}.
 
+%% Require the exp (expiration time) claim in JWT tokens. When set to true
+%% (the default), tokens without an exp claim are rejected. RFC 7519 treats
+%% exp as optional, but omitting it is a security risk: stolen or leaked tokens
+%% would remain valid indefinitely. Set to false only when your identity
+%% provider issues tokens without an exp claim and you cannot change that behaviour.
+%%
+%% {require_exp, true},
+
+{mapping,
+ "auth_oauth2.require_exp",
+ "rabbitmq_auth_backend_oauth2.require_exp",
+ [{datatype, boolean}]}.
+
 %% How scope patterns match vhost names, resource names, and topic routing keys.
 %% wildcard uses RabbitMQ's legacy *-segment wildcard rules; regex treats each pattern
 %% as a Perl-compatible regular expression matched against the entire string.
@@ -417,6 +430,16 @@
  "auth_oauth2.resource_servers.$name.scope_aliases.$index.scope",
  "rabbitmq_auth_backend_oauth2.resource_servers",
  [{datatype, string}]}.
+
+{mapping,
+ "auth_oauth2.resource_servers.$name.verify_aud",
+ "rabbitmq_auth_backend_oauth2.verify_aud",
+ [{datatype, boolean}]}.
+
+{mapping,
+ "auth_oauth2.resource_servers.$name.require_exp",
+ "rabbitmq_auth_backend_oauth2.require_exp",
+ [{datatype, boolean}]}.
 
 {mapping,
   "auth_oauth2.resource_servers.$name.oauth_provider_id",

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -103,11 +103,11 @@
  "rabbitmq_auth_backend_oauth2.verify_aud",
  [{datatype, boolean}]}.
 
-%% Require the exp (expiration time) claim in JWT tokens. When set to true
-%% (the default), tokens without an exp claim are rejected. RFC 7519 treats
-%% exp as optional, but omitting it is a security risk: stolen or leaked tokens
-%% would remain valid indefinitely. Set to false only when your identity
-%% provider issues tokens without an exp claim and you cannot change that behaviour.
+%% Require the exp (expiration time) claim in JWT tokens. When true (the
+%% default), a token without an exp claim is rejected. RFC 7519 makes exp
+%% optional, but a token without it never expires, so a stolen or leaked token
+%% stays valid forever. Set to false only when your identity provider cannot
+%% issue tokens with an exp claim.
 %%
 %% {require_exp, true},
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -147,7 +147,9 @@ update_state(AuthUser, NewToken) ->
                         ok ->
                             Tags = tags_from(DecodedToken),
                             Token1 = DecodedToken#{<<"x-rmq-scope-pattern-syntax">> =>
-                                                   ResourceServer#resource_server.scope_pattern_syntax},
+                                                   ResourceServer#resource_server.scope_pattern_syntax,
+                                                   <<"x-rmq-require-exp">> =>
+                                                   ResourceServer#resource_server.require_exp},
                             {ok, AuthUser#auth_user{tags = Tags,
                                                     impl = fun() -> Token1 end}};
                         {error, mismatch_username_after_token_refresh} ->
@@ -186,13 +188,26 @@ authenticate(_, AuthProps0) ->
                 {refused, Err} ->
                     {refused, "Authentication using an OAuth 2/JWT token failed: ~tp", [Err]};
                 {ok, DecodedToken} ->
-                    case with_decoded_token(DecodedToken, fun(In) -> auth_user_from_token(In, ResourceServer) end) of
+                    case with_decoded_token(DecodedToken, ResourceServer, fun(In) -> auth_user_from_token(In, ResourceServer) end) of
                         {error, Err} ->
                             {refused, "Authentication using an OAuth 2/JWT token failed: ~tp", [Err]};
                         Else ->
                             Else
                     end
             end
+    end.
+
+-spec with_decoded_token(Token, ResourceServer, Fun) -> Result
+    when Token :: decoded_jwt_token(),
+         ResourceServer :: resource_server(),
+         Fun :: auth_user_extraction_fun(),
+         Result :: {ok, any()} | {'error', any()}.
+with_decoded_token(DecodedToken, ResourceServer, Fun) ->
+    case validate_token_expiry(DecodedToken, ResourceServer) of
+        ok               -> Fun(DecodedToken);
+        {error, Msg} = Err ->
+            ?LOG_ERROR(Msg),
+            Err
     end.
 
 -spec with_decoded_token(Token, Fun) -> Result
@@ -223,7 +238,9 @@ auth_user_from_token(Token0, ResourceServer) ->
         Token0),
     Tags     = tags_from(Token0),
     Token1   = Token0#{<<"x-rmq-scope-pattern-syntax">> =>
-                          ResourceServer#resource_server.scope_pattern_syntax},
+                          ResourceServer#resource_server.scope_pattern_syntax,
+                       <<"x-rmq-require-exp">> =>
+                          ResourceServer#resource_server.require_exp},
     {ok, #auth_user{username = Username,
                     tags = Tags,
                     impl = fun() -> Token1 end}}.
@@ -235,6 +252,12 @@ ensure_same_username(PreferredUsernameClaims, CurrentDecodedToken, NewDecodedTok
         _ -> {error, mismatch_username_after_token_refresh}
     end.
 
+validate_token_expiry(Token, ResourceServer) ->
+    case ResourceServer#resource_server.require_exp of
+        true  -> validate_token_expiry(Token);
+        false -> ok
+    end.
+
 validate_token_expiry(#{<<"exp">> := Exp}) when is_number(Exp) ->
     Now = os:system_time(seconds),
     ExpTs = trunc(Exp),
@@ -244,8 +267,11 @@ validate_token_expiry(#{<<"exp">> := Exp}) when is_number(Exp) ->
     end;
 validate_token_expiry(#{<<"exp">> := _}) ->
     {error, "Provided JWT token has an invalid exp claim: value is not a number"};
-validate_token_expiry(#{}) ->
-    {error, "Provided JWT token has no exp claim"}.
+validate_token_expiry(Token) ->
+    case maps:get(<<"x-rmq-require-exp">>, Token, true) of
+        true  -> {error, "Provided JWT token has no exp claim"};
+        false -> ok
+    end.
 
 -spec check_token(raw_jwt_token(), {resource_server(), internal_oauth_provider()}) ->
           {'ok', decoded_jwt_token()} |
@@ -265,7 +291,6 @@ check_token(Token, {ResourceServer, InternalOAuthProvider}) ->
             end;
         {false, _} -> {refused, signature_invalid}
     end.
-
 extract_scopes_from_scope_claim(Payload) -> 
     case maps:find(?SCOPE_JWT_FIELD, Payload) of
         {ok, Bin} when is_binary(Bin) -> 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -244,7 +244,8 @@ validate_token_expiry(#{<<"exp">> := Exp}) when is_number(Exp) ->
     end;
 validate_token_expiry(#{<<"exp">> := _}) ->
     {error, "Provided JWT token has an invalid exp claim: value is not a number"};
-validate_token_expiry(#{}) -> ok.
+validate_token_expiry(#{}) ->
+    {error, "Provided JWT token has no exp claim"}.
 
 -spec check_token(raw_jwt_token(), {resource_server(), internal_oauth_provider()}) ->
           {'ok', decoded_jwt_token()} |

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -188,26 +188,15 @@ authenticate(_, AuthProps0) ->
                 {refused, Err} ->
                     {refused, "Authentication using an OAuth 2/JWT token failed: ~tp", [Err]};
                 {ok, DecodedToken} ->
-                    case with_decoded_token(DecodedToken, ResourceServer, fun(In) -> auth_user_from_token(In, ResourceServer) end) of
+                    DecodedToken1 = DecodedToken#{<<"x-rmq-require-exp">> =>
+                        ResourceServer#resource_server.require_exp},
+                    case with_decoded_token(DecodedToken1, fun(In) -> auth_user_from_token(In, ResourceServer) end) of
                         {error, Err} ->
                             {refused, "Authentication using an OAuth 2/JWT token failed: ~tp", [Err]};
                         Else ->
                             Else
                     end
             end
-    end.
-
--spec with_decoded_token(Token, ResourceServer, Fun) -> Result
-    when Token :: decoded_jwt_token(),
-         ResourceServer :: resource_server(),
-         Fun :: auth_user_extraction_fun(),
-         Result :: {ok, any()} | {'error', any()}.
-with_decoded_token(DecodedToken, ResourceServer, Fun) ->
-    case validate_token_expiry(DecodedToken, ResourceServer) of
-        ok               -> Fun(DecodedToken);
-        {error, Msg} = Err ->
-            ?LOG_ERROR(Msg),
-            Err
     end.
 
 -spec with_decoded_token(Token, Fun) -> Result
@@ -238,9 +227,7 @@ auth_user_from_token(Token0, ResourceServer) ->
         Token0),
     Tags     = tags_from(Token0),
     Token1   = Token0#{<<"x-rmq-scope-pattern-syntax">> =>
-                          ResourceServer#resource_server.scope_pattern_syntax,
-                       <<"x-rmq-require-exp">> =>
-                          ResourceServer#resource_server.require_exp},
+                          ResourceServer#resource_server.scope_pattern_syntax},
     {ok, #auth_user{username = Username,
                     tags = Tags,
                     impl = fun() -> Token1 end}}.
@@ -251,13 +238,6 @@ ensure_same_username(PreferredUsernameClaims, CurrentDecodedToken, NewDecodedTok
         {CurUsername, CurUsername} -> ok;
         _ -> {error, mismatch_username_after_token_refresh}
     end.
-
-validate_token_expiry(Token, ResourceServer) ->
-    case ResourceServer#resource_server.require_exp of
-        true  -> validate_token_expiry(Token);
-        false -> ok
-    end.
-
 validate_token_expiry(#{<<"exp">> := Exp}) when is_number(Exp) ->
     Now = os:system_time(seconds),
     ExpTs = trunc(Exp),

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_resource_server.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_resource_server.erl
@@ -21,6 +21,7 @@ new_resource_server(ResourceServerId) ->
         id = ResourceServerId,
         resource_server_type = undefined,
         verify_aud = true,
+        require_exp = true,
         scope_prefix = erlang:iolist_to_binary([ResourceServerId, <<".">>]),
         additional_scopes_key = undefined,
         preferred_username_claims = ?DEFAULT_PREFERRED_USERNAME_CLAIMS,
@@ -78,6 +79,8 @@ get_root_resource_server() ->
         get_env(resource_server_type),
     VerifyAud =
         get_boolean_env(verify_aud, true),
+    RequireExp =
+        get_boolean_env(require_exp, true),
     AdditionalScopesKey =
         get_env(extra_scopes_source),
     DefaultScopePrefix =
@@ -98,7 +101,8 @@ get_root_resource_server() ->
         id = ResourceServerId,
         resource_server_type = ResourceServerType,
         verify_aud = VerifyAud,
-        scope_prefix = ScopePrefix,
+        require_exp = RequireExp,
+        scope_prefix = ScopePrefix,         
         additional_scopes_key = AdditionalScopesKey,
         preferred_username_claims = PreferredUsernameClaims,
         scope_aliases = ScopeAliases,
@@ -137,6 +141,9 @@ get_resource_server(ResourceServerId, RootResourseServer) when
     VerifyAud =
         proplists:get_value(verify_aud, ResourceServerProps,
             RootResourseServer#resource_server.verify_aud),
+    RequireExp =
+        proplists:get_value(require_exp, ResourceServerProps,
+            RootResourseServer#resource_server.require_exp),
     AdditionalScopesKey =
         proplists:get_value(extra_scopes_source, ResourceServerProps,
             RootResourseServer#resource_server.additional_scopes_key),
@@ -162,6 +169,7 @@ get_resource_server(ResourceServerId, RootResourseServer) when
         id = ResourceServerId,
         resource_server_type = ResourceServerType,
         verify_aud = VerifyAud,
+        require_exp = RequireExp,
         scope_prefix = ScopePrefix,
         additional_scopes_key = AdditionalScopesKey,
         preferred_username_claims = PreferredUsernameClaims,

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
@@ -106,7 +106,7 @@ token_with_scopes_and_expiration(Scopes, Expiration) ->
 
 token_without_scopes() ->
     %% expiration is a timestamp with precision in seconds
-    #{
+    #{<<"exp">> => default_expiration_moment(),
       <<"iss">> => <<"unit_test">>,
       <<"foo">> => <<"bar">>,
       <<"aud">> => [<<"rabbitmq">>]

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_resource_server_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_resource_server_SUITE.erl
@@ -77,6 +77,10 @@ verify_get_rabbitmq_server_configuration() -> [
     {with_verify_aud_false, [], [
         rabbitmq_verify_aud_is_false
     ]},
+    rabbitmq_require_exp_is_true,
+    {with_require_exp_false, [], [
+        rabbitmq_require_exp_is_false
+    ]},
     rabbitmq_has_default_scope_prefix,
     {with_scope_prefix, [], [
         rabbitmq_has_scope_prefix
@@ -110,6 +114,10 @@ verify_configuration_inheritance_with_rabbitmq2() -> [
     rabbitmq2_verify_aud_is_true,
     {with_verify_aud_false, [], [
         rabbitmq2_verify_aud_is_false
+    ]},
+    rabbitmq2_require_exp_is_true,
+    {with_require_exp_false, [], [
+        rabbitmq2_require_exp_is_false
     ]},
     rabbitmq2_has_default_scope_prefix,
     {with_scope_prefix, [], [
@@ -191,6 +199,10 @@ init_per_group(with_verify_aud_false, Config) ->
     set_env(verify_aud, false),
     Config;
 
+init_per_group(with_require_exp_false, Config) ->
+    set_env(require_exp, false),
+    Config;
+
 init_per_group(with_rabbitmq1_verify_aud_false, Config) ->
     RabbitMQServers = get_env(resource_servers, #{}),
     Resource0 = maps:get(?RABBITMQ_RESOURCE_ONE, RabbitMQServers, []),
@@ -245,6 +257,10 @@ end_per_group(with_scope_pattern_syntax_regex, Config) ->
 
 end_per_group(with_verify_aud_false, Config) ->
     unset_env(verify_aud),
+    Config;
+
+end_per_group(with_require_exp_false, Config) ->
+    unset_env(require_exp),
     Config;
 
 end_per_group(with_two_resource_servers, Config) ->
@@ -351,6 +367,18 @@ rabbitmq_verify_aud_is_false(_) ->
 
 rabbitmq2_verify_aud_is_true(_) ->
     assert_verify_aud(true, ?RABBITMQ_RESOURCE_TWO).
+
+rabbitmq_require_exp_is_true(_) ->
+    assert_require_exp(true, ?RABBITMQ).
+
+rabbitmq_require_exp_is_false(_) ->
+    assert_require_exp(false, ?RABBITMQ).
+
+rabbitmq2_require_exp_is_true(_) ->
+    assert_require_exp(true, ?RABBITMQ_RESOURCE_TWO).
+
+rabbitmq2_require_exp_is_false(_) ->
+    assert_require_exp(false, ?RABBITMQ_RESOURCE_TWO).
 
 both_resources_oauth_provider_id_is_root(_) ->
     assert_oauth_provider_id(root, ?RABBITMQ_RESOURCE_ONE),
@@ -471,6 +499,10 @@ assert_resource_server_id(Expected, Audience) ->
 assert_verify_aud(Expected, Audience) ->
     {ok, Actual} = resolve_resource_server_from_audience(Audience),
     ?assertEqual(Expected, Actual#resource_server.verify_aud).
+
+assert_require_exp(Expected, Audience) ->
+    {ok, Actual} = resolve_resource_server_from_audience(Audience),
+    ?assertEqual(Expected, Actual#resource_server.require_exp).
 
 assert_oauth_provider_id(Expected, Audience) ->
     {ok, Actual} = resolve_resource_server_from_audience(Audience),

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -43,6 +43,8 @@ all() ->
         test_token_expiry_with_float_exp,
         test_token_expiry_with_non_numeric_exp,
         test_token_expiry_with_missing_exp,
+        test_missing_required_exp_claim,
+        test_missing_not_required_exp_claim,
         test_invalid_signature,
         test_incorrect_kid,
         normalize_token_scope_using_multiple_scopes_key,
@@ -76,8 +78,9 @@ groups() ->
           test_successful_access_with_a_token_that_uses_single_scope_alias_in_extra_scope_source_field,
           test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_extra_scope_source_field,
           normalize_token_scope_with_additional_scopes_complex_claims,
-          test_successful_access_with_a_token_that_uses_single_scope_alias_in_scope_field_and_custom_scope_prefix
-
+          test_successful_access_with_a_token_that_uses_single_scope_alias_in_scope_field_and_custom_scope_prefix,
+          test_missing_required_exp_claim_per_resource_server,
+          test_missing_not_required_exp_claim_per_resource_server
       ]}
     ].
 
@@ -1282,11 +1285,112 @@ test_token_expiry_with_missing_exp(_) ->
     Username = <<"username">>,
     set_env(resource_server_id, <<"rabbitmq">>),
 
-    %% A token with no exp claim at all must be refused.
     TokenWithoutExp = maps:remove(<<"exp">>,
         ?UTIL_MOD:token_with_sub(?UTIL_MOD:expirable_token(), Username)),
+
+    %% Default (require_exp = true): a token without exp must be refused.
+    set_env(require_exp, true),
     ?assertMatch({refused, _, _},
-                 user_login_authentication(Username, [{password, TokenWithoutExp}])).
+                 user_login_authentication(Username, [{password, TokenWithoutExp}])),
+
+    %% When require_exp = false, a token without exp is accepted.
+    set_env(require_exp, false),
+    ?assertMatch({ok, _},
+                 user_login_authentication(Username, [{password, TokenWithoutExp}])),
+    unset_env(require_exp).
+
+test_missing_required_exp_claim(_) ->
+    Username = <<"username">>,
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    set_env(key_config, UaaEnv),
+    set_env(resource_server_id, <<"rabbitmq">>),
+
+    %% A signed token with no exp claim must be refused when require_exp = true (the default).
+    TokenData = maps:remove(<<"exp">>,
+        ?UTIL_MOD:token_with_sub(?UTIL_MOD:expirable_token(), Username)),
+    Token = ?UTIL_MOD:sign_token_hs(TokenData, Jwk),
+    ?assertMatch({refused, _, _},
+                 user_login_authentication(Username, [{password, Token}])).
+
+test_missing_not_required_exp_claim(_) ->
+    VHost    = <<"vhost">>,
+    Username = <<"username">>,
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    set_env(key_config, UaaEnv),
+    set_env(resource_server_id, <<"rabbitmq">>),
+
+    %% When require_exp = false, a token without exp must authenticate successfully.
+    set_env(require_exp, false),
+    TokenData = maps:remove(<<"exp">>,
+        ?UTIL_MOD:token_with_sub(?UTIL_MOD:expirable_token(), Username)),
+    Token = ?UTIL_MOD:sign_token_hs(TokenData, Jwk),
+    {ok, #auth_user{username = Username} = User} =
+        user_login_authentication(Username, [{password, Token}]),
+
+    %% expiry_timestamp must return 'never' since there is no exp claim.
+    ?assertEqual(never, rabbit_auth_backend_oauth2:expiry_timestamp(User)),
+
+    %% Resource access checks must also pass: the stored token carries
+    %% x-rmq-require-exp = false so validate_token_expiry/1 returns ok.
+    assert_resource_access_granted(User, VHost, <<"foo">>, configure),
+    assert_resource_access_granted(User, VHost, <<"foo">>, write),
+
+    unset_env(require_exp).
+
+%% Same scenarios as test_missing_required_exp_claim /
+%% test_missing_not_required_exp_claim, but require_exp is configured via the
+%% resource_servers map (indexed by resource server name) rather than through
+%% the top-level require_exp application environment variable.
+test_missing_required_exp_claim_per_resource_server(_) ->
+    Username = <<"username">>,
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    set_env(key_config, UaaEnv),
+
+    %% Route audience resolution through resource_servers, not the root server.
+    unset_env(resource_server_id),
+    set_env(resource_servers, #{<<"rabbitmq">> => [{id, <<"rabbitmq">>}]}),
+
+    %% require_exp defaults to true — a token without exp must be refused.
+    TokenData = maps:remove(<<"exp">>,
+        ?UTIL_MOD:token_with_sub(?UTIL_MOD:expirable_token(), Username)),
+    Token = ?UTIL_MOD:sign_token_hs(TokenData, Jwk),
+    ?assertMatch({refused, _, _},
+                 user_login_authentication(Username, [{password, Token}])),
+
+    set_env(resource_server_id, <<"rabbitmq">>),
+    unset_env(resource_servers).
+
+test_missing_not_required_exp_claim_per_resource_server(_) ->
+    VHost    = <<"vhost">>,
+    Username = <<"username">>,
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    set_env(key_config, UaaEnv),
+
+    %% Route audience resolution through resource_servers, not the root server.
+    %% Set require_exp = false on the named resource server entry.
+    unset_env(resource_server_id),
+    set_env(resource_servers, #{<<"rabbitmq">> => [
+        {id, <<"rabbitmq">>},
+        {require_exp, false}
+    ]}),
+
+    TokenData = maps:remove(<<"exp">>,
+        ?UTIL_MOD:token_with_sub(?UTIL_MOD:expirable_token(), Username)),
+    Token = ?UTIL_MOD:sign_token_hs(TokenData, Jwk),
+    {ok, #auth_user{username = Username} = User} =
+        user_login_authentication(Username, [{password, Token}]),
+
+    ?assertEqual(never, rabbit_auth_backend_oauth2:expiry_timestamp(User)),
+
+    assert_resource_access_granted(User, VHost, <<"foo">>, configure),
+    assert_resource_access_granted(User, VHost, <<"foo">>, write),
+
+    set_env(resource_server_id, <<"rabbitmq">>),
+    unset_env(resource_servers).
 
 test_incorrect_kid(_) ->
     AltKid   = <<"other-token-key">>,

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -42,6 +42,7 @@ all() ->
         test_token_expiration,
         test_token_expiry_with_float_exp,
         test_token_expiry_with_non_numeric_exp,
+        test_token_expiry_with_missing_exp,
         test_invalid_signature,
         test_incorrect_kid,
         normalize_token_scope_using_multiple_scopes_key,
@@ -1276,6 +1277,16 @@ test_token_expiry_with_non_numeric_exp(_) ->
         ?assertMatch({refused, _, _},
                      user_login_authentication(Username, [{password, InvalidToken}]))
     end, [<<"1700000300">>, true, false, null]).
+
+test_token_expiry_with_missing_exp(_) ->
+    Username = <<"username">>,
+    set_env(resource_server_id, <<"rabbitmq">>),
+
+    %% A token with no exp claim at all must be refused.
+    TokenWithoutExp = maps:remove(<<"exp">>,
+        ?UTIL_MOD:token_with_sub(?UTIL_MOD:expirable_token(), Username)),
+    ?assertMatch({refused, _, _},
+                 user_login_authentication(Username, [{password, TokenWithoutExp}])).
 
 test_incorrect_kid(_) ->
     AltKid   = <<"other-token-key">>,

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -1339,7 +1339,7 @@ test_missing_not_required_exp_claim(_) ->
 
     unset_env(require_exp).
 
-%% Same scenarios as test_missing_required_exp_claim /
+%% Same scenarios as test_missing_required_exp_claim and
 %% test_missing_not_required_exp_claim, but require_exp is configured via the
 %% resource_servers map (indexed by resource server name) rather than through
 %% the top-level require_exp application environment variable.
@@ -1353,7 +1353,7 @@ test_missing_required_exp_claim_per_resource_server(_) ->
     unset_env(resource_server_id),
     set_env(resource_servers, #{<<"rabbitmq">> => [{id, <<"rabbitmq">>}]}),
 
-    %% require_exp defaults to true — a token without exp must be refused.
+    %% require_exp defaults to true, so a token without exp must be refused.
     TokenData = maps:remove(<<"exp">>,
         ?UTIL_MOD:token_with_sub(?UTIL_MOD:expirable_token(), Username)),
     Token = ?UTIL_MOD:sign_token_hs(TokenData, Jwk),


### PR DESCRIPTION
## Proposed Changes

Prior to this change, the OAuth 2 authentication backend accepted JWT tokens that lacked an exp (expiration time) claim. This meant that stolen or leaked tokens with no expiry would remain valid indefinitely.

This change introduces a new `require_exp` setting (default: true) that rejects tokens missing the exp claim. The default is intentionally strict: while RFC 7519 treats exp as optional, omitting it is a security risk in practice. Operators who issue tokens without an exp claim can opt out by setting require_exp to false.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
