### PR TITLE
Handle concurrent queue or vhost delete race condition on ra cluster shutdown

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1119,11 +1119,14 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
                     Err
             end;
         {error, {shutdown, delete}} ->
-            %% The Ra cluster is already shutting down due to a concurrent
-            %% delete. Clean up queue data and treat as success.
+            ?LOG_INFO(
+              "Quorum queue '~ts' Ra cluster was already shutting down"
+              " due to a concurrent delete, proceeding with cleanup.",
+              [rabbit_misc:rs(QName)]),
             notify_decorators(QName, shutdown),
             case delete_queue_data(Q, ActingUser) of
                 ok ->
+                    rabbit_core_metrics:queue_deleted(QName),
                     {ok, ReadyMsgs};
                 {error, timeout} = Err ->
                     Err

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1118,6 +1118,16 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
                 {error, timeout} = Err ->
                     Err
             end;
+        {error, {shutdown, delete}} ->
+            %% The Ra cluster is already shutting down due to a concurrent
+            %% delete. Clean up queue data and treat as success.
+            notify_decorators(QName, shutdown),
+            case delete_queue_data(Q, ActingUser) of
+                ok ->
+                    {ok, ReadyMsgs};
+                {error, timeout} = Err ->
+                    Err
+            end;
         {error, {no_more_servers_to_try, Errs}} ->
             case lists:all(fun({{error, noproc}, _}) -> true;
                               (_) -> false

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1119,9 +1119,9 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
                     Err
             end;
         {error, {shutdown, delete}} ->
-            ?LOG_INFO(
-              "Quorum queue '~ts' Ra cluster was already shutting down"
-              " due to a concurrent delete, proceeding with cleanup.",
+            ?LOG_WARNING(
+              "While deleting ~ts, the ra cluster was already shutting "
+              "down due to a concurrent delete. Proceeding with cleanup.",
               [rabbit_misc:rs(QName)]),
             notify_decorators(QName, shutdown),
             case delete_queue_data(Q, ActingUser) of

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -86,6 +86,8 @@ groups() ->
                                             delete_declare,
                                             delete_member_during_node_down,
                                             delete_while_publishing,
+                                            delete_ra_cluster_already_shutting_down,
+                                            concurrent_vhost_delete_with_quorum_queue,
                                             metrics_cleanup_on_leadership_takeover,
                                             metrics_cleanup_on_leader_crash,
                                             consume_in_minority,
@@ -3412,6 +3414,75 @@ delete_while_publishing(Config) ->
      || N <- lists:seq(1, 50_000)],
     delete_queues(DeleterChan, [QQ]),
     ?assert(amqp_channel:wait_for_confirms_or_die(PublisherChan, ?TIMEOUT)).
+
+delete_ra_cluster_already_shutting_down(Config) ->
+    [Server | _] = Servers0 = rabbit_ct_broker_helpers:get_node_configs(Config,
+                                                                        nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    RaName = ra_name(QQ),
+    publish(Ch, QQ),
+    publish(Ch, QQ),
+    publish(Ch, QQ),
+    wait_for_messages_ready(Servers0, RaName, 3),
+
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    {ok, Q} = rpc:call(Server, rabbit_amqqueue, lookup, [QName]),
+
+    %% Mock ra:delete_cluster/2 to return {error, {shutdown, delete}} simulating
+    %% a cluster that is already shutting down
+    ok = rpc:call(Server, meck, new, [ra, [passthrough, no_link]]),
+    ok = rpc:call(Server, meck, expect,
+                  [ra, delete_cluster, 2,
+                   {error, {shutdown, delete}}]),
+
+    Result = rpc:call(Server, rabbit_quorum_queue, delete,
+                      [Q, false, false, <<"test-user">>]),
+    ?assertMatch({ok, _}, Result),
+
+    ok = rpc:call(Server, meck, unload, [ra]),
+
+    %% Verify the queue metadata was cleaned up
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
+
+concurrent_vhost_delete_with_quorum_queue(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    VHost = <<"concurrent_delete_vhost">>,
+    User = ?config(rmq_username, Config),
+    ok = rabbit_ct_broker_helpers:add_vhost(Config, Server, VHost, User),
+    ok = rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
+
+    Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, Server, VHost),
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+    [declare(Ch, <<"qq_", (integer_to_binary(N))/binary>>,
+             [{<<"x-queue-type">>, longstr, <<"quorum">>}])
+     || N <- lists:seq(1, 5)],
+    amqp_connection:close(Conn),
+
+    Self = self(),
+    Deleter = fun() ->
+        Res = rpc:call(Server, rabbit_vhost, delete, [VHost, User]),
+        Self ! {delete_result, self(), Res}
+    end,
+    Pid1 = spawn_link(Deleter),
+    Pid2 = spawn_link(Deleter),
+
+    Results = [receive {delete_result, P, R} -> R
+               after ?TIMEOUT -> ct:fail(timeout)
+               end || P <- [Pid1, Pid2]],
+
+    ?assert(lists:member(ok, Results)),
+    [case R of
+         ok -> ok;
+         {error, {no_such_vhost, _}} -> ok;
+         Other -> ct:fail({unexpected_result, Other})
+     end || R <- Results],
+
+    ?assertEqual(false, rpc:call(Server, rabbit_vhost, exists, [VHost])).
 
 sync_queue(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
## Proposed Changes

This fixes the issue discussed https://github.com/rabbitmq/rabbitmq-server/discussions/16765 

The crash (which is being seen in **rabbitmq-4.2.3** via cli-tools):

```
{{:case_clause, {:error, {:shutdown, :delete}}},
 [
   {:rabbit_quorum_queue, :delete, 4,
    [file: ~c"rabbit_quorum_queue.erl", line: 987]},
   {:rabbit_misc, :with_exit_handler, 2, [file: ~c"rabbit_misc.erl", line: 467]},
   {:rabbit_vhost, :"-delete_ignoring_protection/2-lc$^1/1-0-", 3,
    [file: ~c"rabbit_vhost.erl", line: 372]},
   {:rabbit_vhost, :delete_ignoring_protection, 2,
    [file: ~c"rabbit_vhost.erl", line: 373]},
   {:rabbit_vhost, :delete, 2, []}
 ]}
```

(main work and investigation here is by @25schmekles).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
