### PR TITLE
OAuth 2: introduce a special proxy endpoint, adopt it for the flow that benefits from it

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -8,7 +8,7 @@ export BUILD_WITHOUT_QUIC
 LOCAL_DEPS = inets public_key
 BUILD_DEPS = rabbit_common rabbitmq_cli
 DEPS = rabbit cowlib jose base64url oauth2_client
-TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client rabbitmq_mqtt rabbitmq_web_mqtt emqtt rabbitmq_amqp_client proper
+TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management amqp_client rabbitmq_mqtt rabbitmq_web_mqtt emqtt rabbitmq_amqp_client proper
 
 PLT_APPS += rabbitmq_cli
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/oauth2_mock_http_handler.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/oauth2_mock_http_handler.erl
@@ -1,0 +1,43 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% A mock OpenID provider for rabbit_mgmt_oauth_token_proxy_http_SUITE. The token
+%% endpoint echoes the form parameters it received so a test can assert what the
+%% proxy forwarded.
+-module(oauth2_mock_http_handler).
+
+-export([init/2]).
+
+init(Req, #{kind := discovery, issuer := Issuer,
+            token_endpoint := TokenEndpoint} = State) ->
+    Body = rabbit_json:encode(#{
+        <<"issuer">> => Issuer,
+        <<"authorization_endpoint">> => <<Issuer/binary, "/authorize">>,
+        <<"token_endpoint">> => TokenEndpoint,
+        <<"jwks_uri">> => <<Issuer/binary, "/keys">>,
+        <<"response_types_supported">> => [<<"code">>]}),
+    {ok, reply(200, Req, Body), State};
+init(Req0, #{kind := token} = State) ->
+    {ok, Params, Req1} = cowboy_req:read_urlencoded_body(Req0),
+    {Status, Payload} = token_response(Params),
+    {ok, reply(Status, Req1, rabbit_json:encode(Payload)), State}.
+
+%% A "bad-code" authorization code is rejected, so a test can check that the
+%% proxy relays the provider's error status and body.
+token_response(Params) ->
+    case proplists:get_value(<<"code">>, Params) of
+        <<"bad-code">> ->
+            {400, #{<<"error">> => <<"invalid_grant">>}};
+        _ ->
+            {200, #{<<"access_token">> => <<"mock-access-token">>,
+                    <<"token_type">> => <<"Bearer">>,
+                    <<"received">> => maps:from_list(Params)}}
+    end.
+
+reply(Status, Req, Body) ->
+    cowboy_req:reply(Status, #{<<"content-type">> => <<"application/json">>},
+                     Body, Req).

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_mgmt_oauth_token_proxy_http_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_mgmt_oauth_token_proxy_http_SUITE.erl
@@ -1,0 +1,224 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% Drives rabbit_mgmt_oauth_token_proxy over HTTP against a broker whose
+%% resource server points at a mock OpenID provider.
+-module(rabbit_mgmt_oauth_token_proxy_http_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+-define(SECRET, <<"test-client-secret">>).
+-define(MOCK_LISTENER, oauth2_mock_http_listener).
+
+all() ->
+    [{group, top_level}, {group, per_resource}].
+
+groups() ->
+    %% The core behaviour is checked under both ways of defining a resource
+    %% server: the top-level keys, and an entry in the oauth_resource_servers map.
+    Core = [rewrites_only_the_token_endpoint, injects_client_secret_and_forwards],
+    [{top_level, [], Core ++ [
+        keeps_client_supplied_secret,
+        relays_provider_error,
+        unknown_resource_server_returns_404,
+        token_endpoint_rejects_get,
+        bootstrap_does_not_disclose_secret
+     ]},
+     {per_resource, [], Core ++ [
+        resource_without_secret_returns_404
+     ]}].
+
+%%
+%% Setup
+%%
+
+init_per_suite(Config0) ->
+    rabbit_ct_helpers:log_environment(),
+    inets:start(),
+    {ok, _} = application:ensure_all_started(cowboy),
+    Config1 = rabbit_ct_helpers:set_config(Config0,
+        [{rmq_nodename_suffix, ?MODULE}]),
+    Config2 = rabbit_ct_helpers:run_setup_steps(Config1,
+        rabbit_ct_broker_helpers:setup_steps() ++
+        rabbit_ct_client_helpers:setup_steps()),
+    MockPort = start_mock_provider(),
+    [ok = rabbit_ct_broker_helpers:enable_plugin(Config2, 0, Plugin)
+     || Plugin <- [rabbitmq_management, rabbitmq_auth_backend_oauth2]],
+    rabbit_ct_helpers:set_config(Config2, {mock_port, MockPort}).
+
+end_per_suite(Config) ->
+    _ = cowboy:stop_listener(?MOCK_LISTENER),
+    rabbit_ct_helpers:run_teardown_steps(Config,
+        rabbit_ct_client_helpers:teardown_steps() ++
+        rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_group(Group, Config) ->
+    reset_oauth(Config),
+    configure(Group, Config).
+
+end_per_group(_, Config) ->
+    reset_oauth(Config),
+    Config.
+
+init_per_testcase(_, Config) -> Config.
+end_per_testcase(_, Config) -> Config.
+
+%% The mock runs in the CT node; the broker reaches it over localhost.
+start_mock_provider() ->
+    {ok, _} = cowboy:start_clear(?MOCK_LISTENER, [{port, 0}],
+        #{env => #{dispatch => cowboy_router:compile([{'_', []}])}}),
+    Port = ranch:get_port(?MOCK_LISTENER),
+    Issuer = mock_base(Port),
+    Dispatch = cowboy_router:compile([{'_', [
+        {"/.well-known/openid-configuration", oauth2_mock_http_handler,
+            #{kind => discovery, issuer => Issuer,
+              token_endpoint => <<Issuer/binary, "/token">>}},
+        {"/token", oauth2_mock_http_handler, #{kind => token}}
+    ]}]),
+    cowboy:set_env(?MOCK_LISTENER, dispatch, Dispatch),
+    Port.
+
+configure(top_level, Config) ->
+    ProviderURL = mock_base(?config(mock_port, Config)),
+    set_env(Config, rabbitmq_auth_backend_oauth2, resource_server_id,
+        <<"rabbitmq">>),
+    set_env(Config, rabbitmq_management, oauth_enabled, true),
+    set_env(Config, rabbitmq_management, oauth_client_id, <<"rabbitmq_mgt">>),
+    set_env(Config, rabbitmq_management, oauth_client_secret, ?SECRET),
+    set_env(Config, rabbitmq_management, oauth_provider_url, ProviderURL),
+    set_env(Config, rabbitmq_management, oauth_scopes, <<"openid">>),
+    rabbit_ct_helpers:set_config(Config, {resource, <<"rabbitmq">>});
+configure(per_resource, Config) ->
+    ProviderURL = mock_base(?config(mock_port, Config)),
+    set_env(Config, rabbitmq_auth_backend_oauth2, resource_servers,
+        #{<<"rabbit_prod">> => [{id, <<"rabbit_prod">>}],
+          <<"rabbit_public">> => [{id, <<"rabbit_public">>}]}),
+    set_env(Config, rabbitmq_management, oauth_enabled, true),
+    set_env(Config, rabbitmq_management, oauth_resource_servers,
+        #{<<"rabbit_prod">> =>
+              [{id, <<"rabbit_prod">>},
+               {oauth_client_id, <<"prod_client">>},
+               {oauth_client_secret, ?SECRET},
+               {oauth_provider_url, ProviderURL}],
+          %% rabbit_public has no client secret, so the proxy must refuse it.
+          <<"rabbit_public">> =>
+              [{id, <<"rabbit_public">>},
+               {oauth_client_id, <<"public_client">>},
+               {oauth_provider_url, ProviderURL}]}),
+    rabbit_ct_helpers:set_config(Config, {resource, <<"rabbit_prod">>}).
+
+reset_oauth(Config) ->
+    [unset_env(Config, rabbitmq_management, Key)
+     || Key <- [oauth_enabled, oauth_client_id, oauth_client_secret,
+                oauth_provider_url, oauth_scopes, oauth_resource_servers]],
+    [unset_env(Config, rabbitmq_auth_backend_oauth2, Key)
+     || Key <- [resource_server_id, resource_servers]],
+    ok.
+
+%%
+%% Test cases
+%%
+
+rewrites_only_the_token_endpoint(Config) ->
+    Id = ?config(resource, Config),
+    {200, Map} = get_json(Config, metadata_path(Id)),
+    Issuer = mock_base(?config(mock_port, Config)),
+    ?assertEqual(proxy_token_endpoint(Config, Id),
+        maps:get(<<"token_endpoint">>, Map)),
+    ?assertEqual(Issuer, maps:get(<<"issuer">>, Map)),
+    ?assertEqual(<<Issuer/binary, "/authorize">>,
+        maps:get(<<"authorization_endpoint">>, Map)),
+    ?assertEqual(<<Issuer/binary, "/keys">>, maps:get(<<"jwks_uri">>, Map)).
+
+injects_client_secret_and_forwards(Config) ->
+    Id = ?config(resource, Config),
+    Body = <<"grant_type=authorization_code&code=the-code&code_verifier=v">>,
+    {200, Map} = post_form(Config, token_path(Id), Body),
+    ?assertEqual(<<"mock-access-token">>, maps:get(<<"access_token">>, Map)),
+    %% The mock echoes what it received; it only sees client_secret if the proxy
+    %% injected it server-side.
+    Received = maps:get(<<"received">>, Map),
+    ?assertEqual(?SECRET, maps:get(<<"client_secret">>, Received)),
+    ?assertEqual(<<"the-code">>, maps:get(<<"code">>, Received)),
+    ?assertEqual(<<"authorization_code">>, maps:get(<<"grant_type">>, Received)).
+
+keeps_client_supplied_secret(Config) ->
+    Id = ?config(resource, Config),
+    Body = <<"grant_type=refresh_token&refresh_token=r&client_secret=explicit">>,
+    {200, Map} = post_form(Config, token_path(Id), Body),
+    Received = maps:get(<<"received">>, Map),
+    ?assertEqual(<<"explicit">>, maps:get(<<"client_secret">>, Received)).
+
+relays_provider_error(Config) ->
+    Id = ?config(resource, Config),
+    Body = <<"grant_type=authorization_code&code=bad-code">>,
+    {400, Map} = post_form(Config, token_path(Id), Body),
+    ?assertEqual(<<"invalid_grant">>, maps:get(<<"error">>, Map)).
+
+unknown_resource_server_returns_404(Config) ->
+    {404, _} = get_raw(Config, metadata_path(<<"does-not-exist">>)).
+
+token_endpoint_rejects_get(Config) ->
+    {405, _} = get_raw(Config, token_path(?config(resource, Config))).
+
+bootstrap_does_not_disclose_secret(Config) ->
+    {200, Body} = get_raw(Config, "/js/oidc-oauth/bootstrap.js"),
+    ?assertEqual(nomatch, binary:match(Body, <<"oauth_client_secret">>)),
+    ?assertEqual(nomatch, binary:match(Body, ?SECRET)),
+    ?assertNotEqual(nomatch, binary:match(Body, <<"use_token_endpoint_proxy">>)).
+
+resource_without_secret_returns_404(Config) ->
+    {404, _} = get_raw(Config, metadata_path(<<"rabbit_public">>)).
+
+%%
+%% Helpers
+%%
+
+token_path(Id) ->
+    "/js/oidc-oauth/token-endpoint/" ++ binary_to_list(Id).
+
+metadata_path(Id) ->
+    token_path(Id) ++ "/openid-configuration".
+
+proxy_token_endpoint(Config, Id) ->
+    iolist_to_binary([mgmt_base(Config), token_path(Id)]).
+
+mock_base(Port) ->
+    iolist_to_binary(["http://localhost:", integer_to_list(Port)]).
+
+mgmt_base(Config) ->
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mgmt),
+    "http://localhost:" ++ integer_to_list(Port).
+
+set_env(Config, App, Key, Value) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+        [App, Key, Value]).
+
+unset_env(Config, App, Key) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, unset_env,
+        [App, Key]).
+
+get_raw(Config, Path) ->
+    {ok, {{_, Code, _}, _Headers, Body}} =
+        httpc:request(get, {mgmt_base(Config) ++ Path, []}, [],
+                      [{body_format, binary}]),
+    {Code, Body}.
+
+get_json(Config, Path) ->
+    {Code, Body} = get_raw(Config, Path),
+    {Code, rabbit_json:decode(Body)}.
+
+post_form(Config, Path, Body) ->
+    {ok, {{_, Code, _}, _Headers, RespBody}} =
+        httpc:request(post,
+            {mgmt_base(Config) ++ Path, [],
+             "application/x-www-form-urlencoded", Body},
+            [], [{body_format, binary}]),
+    {Code, rabbit_json:decode(RespBody)}.

--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -25,7 +25,7 @@ endef
 
 DEPS = rabbit_common rabbit amqp_client cowboy cowlib rabbitmq_web_dispatch rabbitmq_management_agent oauth2_client
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers proper rabbitmq_amqp_client
-LOCAL_DEPS += ranch ssl crypto public_key
+LOCAL_DEPS += ranch ssl crypto public_key inets
 
 # FIXME: Add Ranch as a BUILD_DEPS to be sure the correct version is picked.
 # See rabbitmq-components.mk.

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -53,10 +53,6 @@ function auth_settings_apply_defaults(authSettings) {
         if (!resource_server.oauth_client_id) {
           resource_server.oauth_client_id = authSettings.oauth_client_id
         }
-        if (!resource_server.oauth_client_secret && resource_server.oauth_client_id
-            && authSettings.oauth_client_secret) {
-          resource_server.oauth_client_secret = authSettings.oauth_client_secret
-        }
         if (!resource_server.oauth_initiated_logon_type) {
           if (authSettings.oauth_initiated_logon_type) {
             resource_server.oauth_initiated_logon_type = authSettings.oauth_initiated_logon_type
@@ -164,8 +160,11 @@ export function oidc_settings_from(resource_server) {
       end_session_endpoint: resource_server.end_session_endpoint
     }
   }
-  if (resource_server.oauth_client_secret != "") {
-    oidcSettings.client_secret = resource_server.oauth_client_secret
+  if (resource_server.use_token_endpoint_proxy) {
+    // The client secret stays server-side. Discover through the proxy so that
+    // token requests carrying the secret are sent to RabbitMQ, not the provider.
+    oidcSettings.metadataUrl = rabbit_base_uri() + "/js/oidc-oauth/token-endpoint/"
+      + encodeURIComponent(resource_server.id) + "/openid-configuration"
   }
   if (resource_server.oauth_authorization_endpoint_params) {
     oidcSettings.extraQueryParams = resource_server.oauth_authorization_endpoint_params

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -28,12 +28,13 @@ build_routes(Ignore) ->
     LocalPaths = [{module_app(M), "www"} || M <- modules(Ignore)],
     LocalStaticRte = {"/[...]", rabbit_mgmt_wm_static, LocalPaths},
     OauthBootstrap = build_oauth_bootstrap_route(Prefix),
+    OauthTokenProxy = build_oauth_token_proxy_routes(Prefix),
     % NB: order is significant in the routing list
     Routes0 = build_module_routes(Ignore) ++
         [ApiRdrRte, CliRdrRte, MgmtRdrRte, StatsRdrRte1, StatsRdrRte2, LocalStaticRte],
     Routes1 = maybe_add_path_prefix(Routes0, Prefix),
     % NB: ensure the root routes are first
-    Routes2 = RootIdxRtes ++ OauthBootstrap ++ maybe_add_path_prefix([{"/login", rabbit_mgmt_login, []}], Prefix) ++ Routes1,
+    Routes2 = RootIdxRtes ++ OauthBootstrap ++ OauthTokenProxy ++ maybe_add_path_prefix([{"/login", rabbit_mgmt_login, []}], Prefix) ++ Routes1,
     [{'_', Routes2}].
 
 build_root_index_routes("", ManagementApp) ->
@@ -47,6 +48,11 @@ build_oauth_bootstrap_route("") ->
 build_oauth_bootstrap_route(Prefix) ->
     [{"/js/oidc-oauth/bootstrap.js", rabbit_mgmt_wm_redirect, Prefix ++ "/js/oidc-oauth/bootstrap.js"},
      {Prefix ++ "/js/oidc-oauth/bootstrap.js", rabbit_mgmt_oauth_bootstrap, #{}}].
+
+build_oauth_token_proxy_routes(Prefix) ->
+    Base = Prefix ++ "/js/oidc-oauth/token-endpoint/",
+    [{Base ++ ":id", rabbit_mgmt_oauth_token_proxy, #{op => token}},
+     {Base ++ ":id/openid-configuration", rabbit_mgmt_oauth_token_proxy, #{op => metadata}}].
 
 build_redirect_route(Path, Location) ->
     {Path, rabbit_mgmt_wm_redirect, Location}.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_oauth_token_proxy.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_oauth_token_proxy.erl
@@ -1,0 +1,257 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_mgmt_oauth_token_proxy).
+
+-export([init/2]).
+%% exported for testing
+-export([inject_client_secret/2, rewrite_token_endpoint/2]).
+
+-include_lib("oauth2_client/include/oauth2_client.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%%--------------------------------------------------------------------
+%% Server-side proxy for the OAuth 2 token endpoint.
+%%
+%% It exists so that management.oauth_client_secret is never sent to the
+%% browser. Resource servers that need a client secret point the OAuth 2
+%% client at this proxy instead of the identity provider. The proxy adds the
+%% secret and forwards the request to the provider's real token endpoint.
+%%
+%% The token endpoint the browser must use is advertised through a rewritten
+%% OpenID configuration document (the metadata operation), which is the real
+%% document with only token_endpoint replaced.
+%%
+%% The provider is resolved the same way the browser resolves it, from the
+%% management resource server settings, so the proxy always targets the
+%% identity provider the browser was told to use. The proxy is an HTTPS client
+%% towards that provider, so it verifies the peer using the OAuth 2 backend's
+%% TLS options, which default to the system trust store.
+%%--------------------------------------------------------------------
+
+init(Req, #{op := metadata} = State) ->
+    handle_metadata(Req, State);
+init(Req, #{op := token} = State) ->
+    handle_token(Req, State).
+
+handle_metadata(Req0, State) ->
+    Id = cowboy_req:binding(id, Req0),
+    case resolve(Id) of
+        {ok, _Secret, MetadataURL, HttpOpts} ->
+            case http_get(MetadataURL, HttpOpts) of
+                {ok, 200, _Headers, Body} ->
+                    ProxyTokenURL = proxy_token_url(Req0, Id),
+                    Rewritten = rewrite_token_endpoint(Body, ProxyTokenURL),
+                    {ok, reply_json(200, Rewritten, Req0), State};
+                Other ->
+                    ?LOG_ERROR("OAuth 2 token proxy could not fetch ~ts: ~tp",
+                               [MetadataURL, Other]),
+                    {ok, cowboy_req:reply(502, Req0), State}
+            end;
+        {error, _} ->
+            {ok, cowboy_req:reply(404, Req0), State}
+    end.
+
+handle_token(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"POST">> ->
+            Id = cowboy_req:binding(id, Req0),
+            case resolve(Id) of
+                {ok, Secret, MetadataURL, HttpOpts} ->
+                    forward_token_request(Req0, State, Secret, MetadataURL,
+                                          HttpOpts);
+                {error, _} ->
+                    {ok, cowboy_req:reply(404, Req0), State}
+            end;
+        _ ->
+            {ok, cowboy_req:reply(405, #{<<"allow">> => <<"POST">>}, Req0), State}
+    end.
+
+forward_token_request(Req0, State, Secret, MetadataURL, HttpOpts) ->
+    case token_endpoint(MetadataURL, HttpOpts) of
+        {ok, TokenEndpoint} ->
+            {ok, Params, Req1} = cowboy_req:read_urlencoded_body(Req0),
+            Body = uri_string:compose_query(inject_client_secret(Params, Secret)),
+            case http_post(TokenEndpoint, Body, HttpOpts) of
+                {ok, Status, Headers, RespBody} ->
+                    {ok, reply_json(Status, content_type(Headers), RespBody,
+                                    Req1), State};
+                {error, Reason} ->
+                    ?LOG_ERROR("OAuth 2 token proxy request to ~ts failed: ~tp",
+                               [TokenEndpoint, Reason]),
+                    {ok, cowboy_req:reply(502, Req1), State}
+            end;
+        {error, Reason} ->
+            ?LOG_ERROR("OAuth 2 token proxy could not resolve token endpoint "
+                       "from ~ts: ~tp", [MetadataURL, Reason]),
+            {ok, cowboy_req:reply(502, Req0), State}
+    end.
+
+%% Only add the secret when the request does not already carry one, so an
+%% explicit client_secret_post from the client is never overwritten.
+inject_client_secret(Params, Secret) ->
+    case lists:keymember(<<"client_secret">>, 1, Params) of
+        true -> Params;
+        false -> Params ++ [{<<"client_secret">>, Secret}]
+    end.
+
+rewrite_token_endpoint(MetadataJson, ProxyTokenURL) ->
+    Map = rabbit_json:decode(MetadataJson),
+    rabbit_json:encode(maps:put(<<"token_endpoint">>, ProxyTokenURL, Map)).
+
+%%--------------------------------------------------------------------
+%% helpers
+%%--------------------------------------------------------------------
+
+%% A resource server is only served by the proxy when a secret is configured
+%% for it, which also prevents the proxy from relaying to arbitrary providers.
+resolve(Id) ->
+    ManagementProps = application:get_all_env(rabbitmq_management),
+    ResourceServers = proplists:get_value(oauth_resource_servers,
+                                          ManagementProps, #{}),
+    case maps:find(Id, ResourceServers) of
+        {ok, Props} ->
+            build(Id,
+                  secret([proplists:get_value(oauth_client_secret, Props),
+                          proplists:get_value(oauth_client_secret, ManagementProps)]),
+                  proplists:get_value(oauth_provider_id, Props));
+        error ->
+            case is_root_resource_server(Id) of
+                true ->
+                    build(Id,
+                          secret([proplists:get_value(oauth_client_secret,
+                                                      ManagementProps)]),
+                          undefined);
+                false ->
+                    {error, unknown_resource_server}
+            end
+    end.
+
+build(_Id, undefined, _ProviderId) ->
+    {error, no_client_secret};
+build(Id, Secret, ProviderId) ->
+    case metadata_url(Id) of
+        undefined ->
+            {error, no_provider_url};
+        MetadataURL ->
+            case tls_options(ProviderId) of
+                {ok, HttpOpts} ->
+                    {ok, rabbit_data_coercion:to_binary(Secret), MetadataURL,
+                     HttpOpts};
+                {error, _} = Error ->
+                    Error
+            end
+    end.
+
+%% Resolve the provider the same way the browser does, from the settings served
+%% to it, so the proxy targets the identity provider the browser was told to use.
+metadata_url(Id) ->
+    Settings = rabbit_mgmt_wm_auth:authSettings(),
+    case proplists:get_value(oauth_resource_servers, Settings, #{}) of
+        ResourceServers when is_map(ResourceServers) ->
+            case maps:find(Id, ResourceServers) of
+                {ok, ResourceServer} -> metadata_url_of(ResourceServer);
+                error -> undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+metadata_url_of(ResourceServer) ->
+    case proplists:get_value(oauth_metadata_url, ResourceServer) of
+        undefined ->
+            case proplists:get_value(oauth_provider_url, ResourceServer) of
+                undefined -> undefined;
+                ProviderURL -> well_known_url(ProviderURL)
+            end;
+        MetadataURL ->
+            MetadataURL
+    end.
+
+well_known_url(ProviderURL) ->
+    Trimmed = string:trim(rabbit_data_coercion:to_binary(ProviderURL),
+                          trailing, "/"),
+    <<Trimmed/binary, "/.well-known/openid-configuration">>.
+
+%% The OAuth 2 backend provider's TLS options, as an `httpc` `{ssl, _}` option.
+%% `get_oauth_provider/2` with no required attributes returns them without
+%% contacting the provider; they default to the system trust store.
+tls_options(ProviderId) ->
+    Result = case ProviderId of
+                 undefined -> oauth2_client:get_oauth_provider([]);
+                 _ -> oauth2_client:get_oauth_provider(ProviderId, [])
+             end,
+    case Result of
+        {ok, #oauth_provider{ssl_options = undefined}} -> {ok, []};
+        {ok, #oauth_provider{ssl_options = SslOptions}} -> {ok, [{ssl, SslOptions}]};
+        {error, _} = Error -> Error
+    end.
+
+token_endpoint(MetadataURL, HttpOpts) ->
+    case oauth2_client:get_openid_configuration(MetadataURL, HttpOpts) of
+        {ok, #openid_configuration{token_endpoint = TokenEndpoint}} ->
+            {ok, TokenEndpoint};
+        {error, _} = Error ->
+            Error
+    end.
+
+secret(Candidates) ->
+    case [V || V <- Candidates, is_valid(V)] of
+        [Secret | _] -> Secret;
+        [] -> undefined
+    end.
+
+is_valid(undefined) -> false;
+is_valid("") -> false;
+is_valid(<<>>) -> false;
+is_valid(_) -> true.
+
+is_root_resource_server(Id) ->
+    Id =:= rabbit_data_coercion:to_binary(
+        application:get_env(rabbitmq_auth_backend_oauth2, resource_server_id,
+                            undefined)).
+
+proxy_token_url(Req, Id) ->
+    Scheme = cowboy_req:scheme(Req),
+    Host = cowboy_req:host(Req),
+    Prefix = rabbit_mgmt_util:get_path_prefix(),
+    iolist_to_binary([Scheme, "://", Host, port(Req, Scheme), Prefix,
+                      "/js/oidc-oauth/token-endpoint/",
+                      cow_uri:urlencode(Id)]).
+
+port(Req, Scheme) ->
+    case {cowboy_req:port(Req), Scheme} of
+        {80, <<"http">>} -> "";
+        {443, <<"https">>} -> "";
+        {Port, _} -> [":", integer_to_binary(Port)]
+    end.
+
+http_get(URL, HttpOpts) ->
+    request(get, {URL, []}, HttpOpts).
+
+http_post(URL, Body, HttpOpts) ->
+    request(post, {URL, [], "application/x-www-form-urlencoded", Body},
+            HttpOpts).
+
+request(Method, Request, HttpOpts) ->
+    case httpc:request(Method, Request, HttpOpts, [{body_format, binary}]) of
+        {ok, {{_, Status, _}, Headers, Body}} -> {ok, Status, Headers, Body};
+        {error, _} = Error -> Error
+    end.
+
+content_type(Headers) ->
+    case lists:keyfind("content-type", 1, Headers) of
+        {_, Value} -> list_to_binary(Value);
+        false -> <<"application/json">>
+    end.
+
+reply_json(Status, Body, Req) ->
+    reply_json(Status, <<"application/json">>, Body, Req).
+
+reply_json(Status, ContentType, Body, Req) ->
+    cowboy_req:reply(Status, #{<<"content-type">> => ContentType,
+                               <<"cache-control">> => <<"no-store">>}, Body, Req).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
@@ -7,7 +7,9 @@
 
 -module(rabbit_mgmt_wm_auth).
 
--export([authSettings/0]). %% for testing only
+%% authSettings/0 is also used by rabbit_mgmt_oauth_token_proxy to resolve the
+%% same provider the browser was served.
+-export([authSettings/0]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("oauth2_client/include/oauth2_client.hrl").
@@ -167,10 +169,17 @@ produce_auth_settings(MgtResourceServers, ManagementProps) ->
             {K1, ensure_oauth_resource_server_properties_are_binaries(K1, V1)}
             || {K1,V1} <- maps:to_list(V)
         ] end,
-    FilteredMgtResourceServers =
+    FilteredMgtResourceServers0 =
         filter_mgt_resource_servers_without_oauth_provider_url(
             filter_out_invalid_mgt_resource_servers(MgtResourceServers,
                 ManagementProps)),
+    %% The OAuth 2 client secret must never reach the browser. Resource servers
+    %% that need one are served through a server-side token endpoint proxy
+    %% instead; see rabbit_mgmt_oauth_token_proxy.
+    FilteredMgtResourceServers =
+        maps:map(fun(_K, V) ->
+            adjust_client_secret(V, ManagementProps)
+        end, FilteredMgtResourceServers0),
 
     case maps:size(FilteredMgtResourceServers) of
         0 ->
@@ -183,7 +192,6 @@ produce_auth_settings(MgtResourceServers, ManagementProps) ->
                 to_tuple(oauth_disable_basic_auth, ManagementProps,
                     fun to_binary/1, true),
                 to_tuple(oauth_client_id, ManagementProps),
-                to_tuple(oauth_client_secret, ManagementProps),
                 to_tuple(oauth_scopes, ManagementProps),
                 case proplists:get_value(oauth_initiated_logon_type,
                     ManagementProps, sp_initiated) of
@@ -198,6 +206,28 @@ produce_auth_settings(MgtResourceServers, ManagementProps) ->
                     undefined, undefined)
             ])
   end.
+
+adjust_client_secret(ResourceServer, ManagementProps) ->
+    Stripped = maps:remove(oauth_client_secret, ResourceServer),
+    case requires_client_secret(ResourceServer, ManagementProps) of
+        true -> maps:put(use_token_endpoint_proxy, true, Stripped);
+        false -> Stripped
+    end.
+
+%% Mirrors how helper.js resolves the effective secret: a resource server's own
+%% secret, or the top-level secret when the resource server has a client id.
+requires_client_secret(ResourceServer, ManagementProps) ->
+    HasOwnSecret =
+        is_valid_value(maps:get(oauth_client_secret, ResourceServer, undefined)),
+    HasTopSecret =
+        is_valid_value(proplists:get_value(oauth_client_secret, ManagementProps)),
+    HasClientId =
+        is_valid_value(maps:get(oauth_client_id, ResourceServer, undefined)) orelse
+        is_valid_value(proplists:get_value(oauth_client_id, ManagementProps)),
+    HasOwnSecret orelse (HasTopSecret andalso HasClientId).
+
+is_valid_value(Value) ->
+    not is_invalid([Value]).
 
 filter_empty_properties(ListOfProperties) ->
     lists:filter(fun(Prop) ->

--- a/deps/rabbitmq_management/test/rabbit_mgmt_oauth_token_proxy_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_oauth_token_proxy_SUITE.erl
@@ -1,0 +1,49 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_mgmt_oauth_token_proxy_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+     inject_client_secret_when_absent,
+     does_not_override_client_secret_when_present,
+     rewrite_replaces_only_token_endpoint
+    ].
+
+inject_client_secret_when_absent(_Config) ->
+    Params = [{<<"grant_type">>, <<"authorization_code">>},
+              {<<"code">>, <<"abc">>}],
+    Result = rabbit_mgmt_oauth_token_proxy:inject_client_secret(Params, <<"s3cret">>),
+    ?assertEqual(<<"s3cret">>,
+                 proplists:get_value(<<"client_secret">>, Result)),
+    ?assertEqual(<<"abc">>, proplists:get_value(<<"code">>, Result)).
+
+does_not_override_client_secret_when_present(_Config) ->
+    Params = [{<<"grant_type">>, <<"refresh_token">>},
+              {<<"client_secret">>, <<"from-client">>}],
+    Result = rabbit_mgmt_oauth_token_proxy:inject_client_secret(Params, <<"s3cret">>),
+    ?assertEqual(<<"from-client">>,
+                 proplists:get_value(<<"client_secret">>, Result)).
+
+rewrite_replaces_only_token_endpoint(_Config) ->
+    Metadata = rabbit_json:encode(#{
+        <<"issuer">> => <<"https://idp">>,
+        <<"authorization_endpoint">> => <<"https://idp/authorize">>,
+        <<"token_endpoint">> => <<"https://idp/token">>,
+        <<"jwks_uri">> => <<"https://idp/keys">>}),
+    Proxy = <<"https://rabbit/js/oidc-oauth/token-endpoint/rabbitmq">>,
+    Rewritten = rabbit_json:decode(
+        rabbit_mgmt_oauth_token_proxy:rewrite_token_endpoint(Metadata, Proxy)),
+    ?assertEqual(Proxy, maps:get(<<"token_endpoint">>, Rewritten)),
+    ?assertEqual(<<"https://idp/authorize">>,
+                 maps:get(<<"authorization_endpoint">>, Rewritten)),
+    ?assertEqual(<<"https://idp/keys">>, maps:get(<<"jwks_uri">>, Rewritten)).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_wm_auth_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_wm_auth_SUITE.erl
@@ -66,7 +66,8 @@ groups() ->
                 should_not_return_oauth_client_secret,
                 {with_mgt_oauth_client_secret_q, [], [
                   should_return_oauth_enabled,
-                  should_return_oauth_client_secret_q
+                  should_not_return_oauth_client_secret,
+                  should_use_token_endpoint_proxy_for_rabbit
                 ]}
               ]}
             ]},
@@ -79,7 +80,8 @@ groups() ->
                   should_return_oauth_resource_server_a_with_client_id_x
                 ]},
                 {with_mgt_resource_server_a_with_client_secret_w, [], [
-                  should_return_oauth_resource_server_a_with_client_secret_w
+                  should_not_return_oauth_resource_server_a_with_client_secret,
+                  should_use_token_endpoint_proxy_for_a
                 ]}
               ]}
             ]}
@@ -640,15 +642,13 @@ end_per_group(_, Config) ->
 should_not_return_oauth_client_secret(_Config) ->
   Actual = authSettings(),
   ?assertEqual(false, proplists:is_defined(oauth_client_secret, Actual)).
-should_return_oauth_client_secret_q(Config) ->
-  Actual = authSettings(),
-  ?assertEqual(?config(q, Config), proplists:get_value(oauth_client_secret, Actual)).
+should_use_token_endpoint_proxy_for_rabbit(Config) ->
+  assert_uses_token_endpoint_proxy(authSettings(), Config, rabbit).
+should_use_token_endpoint_proxy_for_a(Config) ->
+  assert_uses_token_endpoint_proxy(authSettings(), Config, a).
 should_return_oauth_resource_server_a_with_client_id_x(Config) ->
   assertEqual_on_attribute_for_oauth_resource_server(authSettings(),
     Config, a, oauth_client_id, x).
-should_return_oauth_resource_server_a_with_client_secret_w(Config) ->
-  assertEqual_on_attribute_for_oauth_resource_server(authSettings(),
-    Config, a, oauth_client_secret, w).
 should_not_return_oauth_resource_server_a_with_client_secret(Config) ->
   assert_attribute_not_defined_for_oauth_resource_server(authSettings(),
     Config, a, oauth_client_secret).
@@ -881,6 +881,13 @@ assert_attribute_not_defined_for_oauth_resource_server(Actual, Config, ConfigKey
   OAuthResourceServers =  proplists:get_value(oauth_resource_servers, Actual),
   OauthResource = maps:get(?config(ConfigKey, Config), OAuthResourceServers),
   ?assertEqual(false, proplists:is_defined(Attribute, OauthResource)).
+
+assert_uses_token_endpoint_proxy(Actual, Config, ConfigKey) ->
+  log(Actual),
+  OAuthResourceServers = proplists:get_value(oauth_resource_servers, Actual),
+  OauthResource = maps:get(?config(ConfigKey, Config), OAuthResourceServers),
+  ?assertEqual(true, proplists:get_value(use_token_endpoint_proxy, OauthResource)),
+  ?assertEqual(false, proplists:is_defined(oauth_client_secret, OauthResource)).
 
 assert_not_defined_oauth_resource_server(Actual, Config, ConfigKey) ->
   log(Actual),

--- a/selenium/test/oauth/rabbitmq.uaa-mgt-oauth-provider.conf
+++ b/selenium/test/oauth/rabbitmq.uaa-mgt-oauth-provider.conf
@@ -3,3 +3,6 @@ management.oauth_client_secret = ${OAUTH_CLIENT_SECRET}
 
 # uaa requires a secret in order to renew tokens
 management.oauth_provider_url = ${UAA_URL}
+
+# the token endpoint proxy uses this CA to verify UAA's certificate
+auth_oauth2.https.cacertfile = ${OAUTH_SERVER_CONFIG_DIR}/ca_uaa_certificate.pem

--- a/selenium/test/oauth/with-sp-initiated/token-endpoint-proxy.js
+++ b/selenium/test/oauth/with-sp-initiated/token-endpoint-proxy.js
@@ -1,11 +1,9 @@
 const assert = require('assert')
 const { buildDriver, goToHome, captureScreensFor, teardown } = require('../../utils')
 
-// Regression test for the OAuth 2 client secret disclosure (GHSA-f9f2-q3jf-wfj3).
-// The unauthenticated bootstrap script must not carry management.oauth_client_secret;
-// resource servers that need it are served through the server-side token endpoint proxy.
-// The script is fetched through the browser so it uses the browser's trust of the
-// management UI's TLS certificate.
+// The unauthenticated bootstrap script must not expose
+// management.oauth_client_secret. Fetched through the browser so it uses the
+// browser's trust of the management UI's TLS certificate.
 describe('The unauthenticated OAuth 2 bootstrap script', function () {
   let driver
   let captureScreen
@@ -17,26 +15,16 @@ describe('The unauthenticated OAuth 2 bootstrap script', function () {
     captureScreen = captureScreensFor(driver, __filename)
   })
 
-  async function fetchBootstrap () {
-    return driver.driver.executeAsyncScript(function () {
+  it('does not disclose the client secret', async function () {
+    const body = await driver.driver.executeAsyncScript(function () {
       const callback = arguments[arguments.length - 1]
       fetch('js/oidc-oauth/bootstrap.js')
         .then(function (response) { return response.text() })
         .then(callback)
         .catch(function (err) { callback('FETCH_ERROR: ' + err) })
     })
-  }
-
-  it('does not disclose the client secret', async function () {
-    const body = await fetchBootstrap()
     assert.ok(!body.includes('oauth_client_secret'),
       'bootstrap.js must not contain the oauth_client_secret field')
-  })
-
-  it('advertises the token endpoint proxy instead', async function () {
-    const body = await fetchBootstrap()
-    assert.ok(body.includes('use_token_endpoint_proxy'),
-      'bootstrap.js must mark the resource server as using the token endpoint proxy')
   })
 
   after(async function () {

--- a/selenium/test/oauth/with-sp-initiated/token-endpoint-proxy.js
+++ b/selenium/test/oauth/with-sp-initiated/token-endpoint-proxy.js
@@ -1,24 +1,45 @@
 const assert = require('assert')
-const { getOAuthBootstrap } = require('../../utils')
+const { buildDriver, goToHome, captureScreensFor, teardown } = require('../../utils')
 
 // Regression test for the OAuth 2 client secret disclosure (GHSA-f9f2-q3jf-wfj3).
 // The unauthenticated bootstrap script must not carry management.oauth_client_secret;
 // resource servers that need it are served through the server-side token endpoint proxy.
+// The script is fetched through the browser so it uses the browser's trust of the
+// management UI's TLS certificate.
 describe('The unauthenticated OAuth 2 bootstrap script', function () {
-  this.timeout(20000)
+  let driver
+  let captureScreen
+  this.timeout(30000)
 
-  // The secret value is not checked directly because in this suite the
-  // configured client id equals the client secret; the settings must not carry
-  // the oauth_client_secret field at all.
-  it('does not disclose the client secret', function () {
-    const body = getOAuthBootstrap()
+  before(async function () {
+    driver = buildDriver()
+    await goToHome(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+  })
+
+  async function fetchBootstrap () {
+    return driver.driver.executeAsyncScript(function () {
+      const callback = arguments[arguments.length - 1]
+      fetch('js/oidc-oauth/bootstrap.js')
+        .then(function (response) { return response.text() })
+        .then(callback)
+        .catch(function (err) { callback('FETCH_ERROR: ' + err) })
+    })
+  }
+
+  it('does not disclose the client secret', async function () {
+    const body = await fetchBootstrap()
     assert.ok(!body.includes('oauth_client_secret'),
       'bootstrap.js must not contain the oauth_client_secret field')
   })
 
-  it('advertises the token endpoint proxy instead', function () {
-    const body = getOAuthBootstrap()
+  it('advertises the token endpoint proxy instead', async function () {
+    const body = await fetchBootstrap()
     assert.ok(body.includes('use_token_endpoint_proxy'),
       'bootstrap.js must mark the resource server as using the token endpoint proxy')
+  })
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
   })
 })

--- a/selenium/test/oauth/with-sp-initiated/token-endpoint-proxy.js
+++ b/selenium/test/oauth/with-sp-initiated/token-endpoint-proxy.js
@@ -1,0 +1,24 @@
+const assert = require('assert')
+const { getOAuthBootstrap } = require('../../utils')
+
+// Regression test for the OAuth 2 client secret disclosure (GHSA-f9f2-q3jf-wfj3).
+// The unauthenticated bootstrap script must not carry management.oauth_client_secret;
+// resource servers that need it are served through the server-side token endpoint proxy.
+describe('The unauthenticated OAuth 2 bootstrap script', function () {
+  this.timeout(20000)
+
+  // The secret value is not checked directly because in this suite the
+  // configured client id equals the client secret; the settings must not carry
+  // the oauth_client_secret field at all.
+  it('does not disclose the client secret', function () {
+    const body = getOAuthBootstrap()
+    assert.ok(!body.includes('oauth_client_secret'),
+      'bootstrap.js must not contain the oauth_client_secret field')
+  })
+
+  it('advertises the token endpoint proxy instead', function () {
+    const body = getOAuthBootstrap()
+    assert.ok(body.includes('use_token_endpoint_proxy'),
+      'bootstrap.js must mark the resource server as using the token endpoint proxy')
+  })
+})

--- a/selenium/test/utils.js
+++ b/selenium/test/utils.js
@@ -306,6 +306,20 @@ module.exports = {
       default: new Error("Unsupported ipd " + preferredIdp)
     }
   },
+  getOAuthBootstrap: (url = baseUrl) => {
+    const target = url.replace(/\/+$/, '') + '/js/oidc-oauth/bootstrap.js'
+    const req = new XMLHttpRequest()
+    try {
+      req.open('GET', target, false)
+      req.send()
+    } catch (e) {
+      module.exports.error("GET " + target + " failed: " + e.message)
+      throw e
+    }
+    if (req.status == 200) return req.responseText
+    module.exports.error("GET " + target + " returned " + req.status)
+    throw new Error("getOAuthBootstrap failed with status " + req.status)
+  },
   openIdConfiguration: (url) => {
     const target = url + "/.well-known/openid-configuration"
     const req = new XMLHttpRequest()

--- a/selenium/test/utils.js
+++ b/selenium/test/utils.js
@@ -306,20 +306,6 @@ module.exports = {
       default: new Error("Unsupported ipd " + preferredIdp)
     }
   },
-  getOAuthBootstrap: (url = baseUrl) => {
-    const target = url.replace(/\/+$/, '') + '/js/oidc-oauth/bootstrap.js'
-    const req = new XMLHttpRequest()
-    try {
-      req.open('GET', target, false)
-      req.send()
-    } catch (e) {
-      module.exports.error("GET " + target + " failed: " + e.message)
-      throw e
-    }
-    if (req.status == 200) return req.responseText
-    module.exports.error("GET " + target + " returned " + req.status)
-    throw new Error("getOAuthBootstrap failed with status " + req.status)
-  },
   openIdConfiguration: (url) => {
     const target = url + "/.well-known/openid-configuration"
     const req = new XMLHttpRequest()


### PR DESCRIPTION
Specifically for the flow that uses a client secret, which is a minority of deployments.

This allows us to keep the client secret value on
the server and pass it on to the IDP.

In this case RabbitMQ acts as an HTTPS client.
The trusted CA bundle can be configured via
`auth_oauth2.https.cacertfile` or system-wide
(Erlang/OTP's HTTP client should pick up
the system-wide bundle per RabbitMQ defaults).

This change tries very hard to be backwards compatible and meaningfully modernize that one
rare client secret flow we see used with only one IDP.