### PR TITLE
[mgt] Remove LOGIN_SESSION_TIMEOUT from the m Cookie

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -293,6 +293,9 @@ function oauth_redirectToLogin(error) {
 }
 export function oauth_completeLogin() {
     mgr.signinRedirectCallback().then(function(user) {
+      // Clear the stored timeout so a fresh login re-applies the configured
+      // value; the silent token renewal path in addUserLoaded must not.
+      clear_local_pref(LOGIN_SESSION_TIMEOUT)
       set_token_auth(user.access_token);
       oauth_redirectToHome();
     }).catch(function(err) {

--- a/deps/rabbitmq_management/priv/www/js/prefs.js
+++ b/deps/rabbitmq_management/priv/www/js/prefs.js
@@ -44,7 +44,7 @@ function get_auth_scheme() {
 function clear_auth() {
     clear_local_pref(CREDENTIALS)
     clear_local_pref(AUTH_SCHEME)
-    clear_cookie_value(LOGIN_SESSION_TIMEOUT)
+    clear_local_pref(LOGIN_SESSION_TIMEOUT)
     clear_cookie_value(LOGGED_IN)
     clear_local_pref(AUTH_RESOURCE)
 }
@@ -76,25 +76,14 @@ function default_hard_session_timeout() {
 }
 
 function update_login_session_timeout(login_session_timeout) {
-    //var auth_info = get_cookie_value('auth');
-    if (get_cookie_value(LOGIN_SESSION_TIMEOUT) != undefined || !has_auth_credentials()) {
+    if (get_local_pref(LOGIN_SESSION_TIMEOUT) != undefined || !has_auth_credentials()) {
       return;
     }
     var date = new Date();
     date.setMinutes(date.getMinutes() + login_session_timeout);
-    store_cookie_value(LOGIN_SESSION_TIMEOUT, login_session_timeout);
+    store_local_pref(LOGIN_SESSION_TIMEOUT, login_session_timeout);
     store_cookie_value_with_expiration(LOGGED_IN, "true", date)
 }
-
-function print_logging_session_info (user_login_session_timeout) {
-  let var_has_auth_cookie_value = has_auth_credentials()
-  let login_session_timeout = get_login_session_timeout()
-  console.log('user_login_session_timeout: ' + user_login_session_timeout)
-  console.log('has_auth_cookie_value: ' + var_has_auth_cookie_value)
-  console.log('login_session_timeout: ' + login_session_timeout)
-  console.log('isNaN(user_login_session_timeout): ' + isNaN(user_login_session_timeout))
-}
-
 
 /// End Credential Management
 
@@ -243,15 +232,7 @@ function parse_cookie() {
 }
 
 function store_cookie(dict) {
-    var sessionTimeout = dict[short_key(LOGIN_SESSION_TIMEOUT)];
-    var date;
-    if (sessionTimeout != undefined) {
-        date = new Date();
-        date.setMinutes(date.getMinutes() + parseInt(sessionTimeout, 10));
-    } else {
-        date = default_hard_session_timeout();
-    }
-    store_cookie_with_expiration(dict, date);
+    store_cookie_with_expiration(dict, default_hard_session_timeout());
 }
 
 function store_cookie_with_expiration(dict, expiration_date) {

--- a/deps/rabbitmq_management/priv/www/js/prefs.js
+++ b/deps/rabbitmq_management/priv/www/js/prefs.js
@@ -49,6 +49,8 @@ function clear_auth() {
     clear_local_pref(AUTH_RESOURCE)
 }
 function set_basic_auth(username, password) {
+    // Clear the stored timeout so a fresh login re-applies the configured value.
+    clear_local_pref(LOGIN_SESSION_TIMEOUT)
     set_auth("Basic", b64_encode_utf8(username + ":" + password), default_hard_session_timeout())
 }
 function set_token_auth(token) {


### PR DESCRIPTION
## Proposed Changes

Remove unnecessary pseudo-cookie (entry stored within the m cookie) .
This change is part of an effort of securing cookies. All cookies that exists in the management ui are now owned by the server and fully secured with the right attributes. The only cookie left is m, controlled by the client side, which only exists for the pseudo-cookie LOGGED_IN which has a TTL that controls the lifespan of the client-side session. This cookie has no value hence it is fine that it is not fully secured because javascript created cookies cannot be fully secured. 
Also, this pseudo-cookie needs to be accessed by javascript hence it cannot be owned by the server.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
