### PR TITLE
rabbitmq-plugins: tolerate plugins enabled but not installed

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -72,7 +72,10 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
 
     mode = PluginHelpers.mode(opts)
 
-    case PluginHelpers.set_enabled_plugins(MapSet.to_list(plugins_to_set), opts) do
+    case PluginHelpers.set_enabled_plugins(
+           MapSet.to_list(plugins_to_set),
+           Map.put(opts, :keep_missing_plugins, true)
+         ) do
       {:ok, enabled_plugins} ->
         {:stream,
          Stream.concat([

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -79,7 +79,10 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
 
         mode = PluginHelpers.mode(opts)
 
-        case PluginHelpers.set_enabled_plugins(MapSet.to_list(plugins_to_set), opts) do
+        case PluginHelpers.set_enabled_plugins(
+               MapSet.to_list(plugins_to_set),
+               Map.put(opts, :keep_missing_plugins, true)
+             ) do
           {:ok, enabled_plugins} ->
             {:stream,
              Stream.concat([

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -7,7 +7,7 @@
 defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   import RabbitCommon.Records
 
-  alias RabbitMQ.CLI.Core.{Config, DocGuide, Validators}
+  alias RabbitMQ.CLI.Core.{DocGuide, Validators}
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
   import RabbitMQ.CLI.Core.{CodePath, Paths}
 
@@ -58,22 +58,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
     all = PluginHelpers.list(opts)
     enabled = PluginHelpers.read_enabled(opts)
 
-    missing = MapSet.difference(MapSet.new(enabled), MapSet.new(PluginHelpers.plugin_names(all)))
-
-    case Enum.empty?(missing) do
-      true ->
-        :ok
-
-      false ->
-        case Config.output_less?(opts) do
-          false ->
-            names = Enum.join(Enum.to_list(missing), ", ")
-            IO.puts("WARNING - plugins currently enabled but missing: #{names}\n")
-
-          true ->
-            :ok
-        end
-    end
+    missing = PluginHelpers.missing_plugins(enabled, all)
+    PluginHelpers.warn_about_missing_plugins(missing, opts)
 
     implicit = :rabbit_plugins.dependencies(false, enabled, all)
     enabled_implicitly = implicit -- enabled

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -371,7 +371,7 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     end
   end
 
-  # `enable`/`disable` set `keep_missing_plugins` to tolerate an enabled but
+  # `enable` and `disable` commands set `keep_missing_plugins` to tolerate an enabled but
   # no longer installed plugin instead of failing; `set` still rejects it.
   defp check_missing_plugins(missing, opts) do
     if Enum.empty?(missing) or Map.get(opts, :keep_missing_plugins, false) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -266,6 +266,22 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     end
   end
 
+  def missing_plugins(plugins, all) do
+    all_plugin_names = Enum.map(all, &plugin_name/1)
+    MapSet.difference(MapSet.new(plugins), MapSet.new(all_plugin_names))
+  end
+
+  def warn_about_missing_plugins(missing, opts) do
+    case Enum.empty?(missing) or Config.output_less?(opts) do
+      true ->
+        :ok
+
+      false ->
+        names = Enum.join(Enum.to_list(missing), ", ")
+        IO.puts("WARNING - plugins currently enabled but missing: #{names}\n")
+    end
+  end
+
   def plugin_name(plugin) when is_binary(plugin) do
     plugin
   end
@@ -305,13 +321,12 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
 
   defp write_enabled_plugins(plugins, plugins_file, opts) do
     all = list_local(opts)
-    all_plugin_names = Enum.map(all, &plugin_name/1)
-    missing = MapSet.difference(MapSet.new(plugins), MapSet.new(all_plugin_names))
+    missing = missing_plugins(plugins, all)
 
-    hard_write = Map.get(opts, :hard_write, false)
+    case check_missing_plugins(missing, opts) do
+      :ok ->
+        warn_about_missing_plugins(missing, opts)
 
-    case Enum.empty?(missing) or hard_write do
-      true ->
         case :rabbit_file.write_term_file(to_charlist(plugins_file), [plugins]) do
           :ok ->
             all_enabled = :rabbit_plugins.dependencies(false, plugins, all)
@@ -321,21 +336,20 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
             {:error, {:cannot_write_enabled_plugins_file, plugins_file, reason}}
         end
 
-      false ->
-        {:error, {:plugins_not_found, Enum.to_list(missing)}}
+      {:error, _} = err ->
+        err
     end
   end
 
   defp write_enabled_plugins_on_remote(node_name, plugins, opts) do
     with {:ok, all} <- list_remote(node_name),
          {:ok, remote_file} <- rpc_enabled_plugins_file(node_name) do
-      all_plugin_names = Enum.map(all, &plugin_name/1)
-      missing = MapSet.difference(MapSet.new(plugins), MapSet.new(all_plugin_names))
+      missing = missing_plugins(plugins, all)
 
-      hard_write = Map.get(opts, :hard_write, false)
+      case check_missing_plugins(missing, opts) do
+        :ok ->
+          warn_about_missing_plugins(missing, opts)
 
-      case Enum.empty?(missing) or hard_write do
-        true ->
           case :rabbit_misc.rpc_call(node_name, :rabbit_file, :write_term_file, [
                  remote_file,
                  [plugins]
@@ -351,9 +365,19 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
               {:error, {:cannot_write_enabled_plugins_file, remote_file, reason}}
           end
 
-        false ->
-          {:error, {:plugins_not_found, Enum.to_list(missing)}}
+        {:error, _} = err ->
+          err
       end
+    end
+  end
+
+  # `enable`/`disable` set `keep_missing_plugins` to tolerate an enabled but
+  # no longer installed plugin instead of failing; `set` still rejects it.
+  defp check_missing_plugins(missing, opts) do
+    if Enum.empty?(missing) or Map.get(opts, :keep_missing_plugins, false) do
+      :ok
+    else
+      {:error, {:plugins_not_found, Enum.to_list(missing)}}
     end
   end
 

--- a/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
@@ -7,6 +7,7 @@
 defmodule DisablePluginsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
+  import ExUnit.CaptureIO
 
   alias RabbitMQ.CLI.Core.ExitCodes
 
@@ -84,6 +85,30 @@ defmodule DisablePluginsCommandTest do
 
   defp assert_lists_equal(expected, actual) do
     assert Enum.sort(expected) == Enum.sort(actual)
+  end
+
+  test "run: keeps a missing enabled plugin in the file and still disables another plugin",
+       context do
+    # rabbitmq_non_existent is enabled but not installed.
+    set_enabled_plugins(
+      [:rabbitmq_stomp, :rabbitmq_federation, :rabbitmq_non_existent],
+      :online,
+      context[:opts][:node],
+      Map.put(context[:opts], :keep_missing_plugins, true)
+    )
+
+    warning =
+      capture_io(fn ->
+        assert {:stream, stream} = @command.run(["rabbitmq_stomp"], context[:opts])
+        Enum.to_list(stream)
+      end)
+
+    assert warning =~ "WARNING - plugins currently enabled but missing: rabbitmq_non_existent"
+
+    {:ok, [enabled]} = :file.consult(context[:opts][:enabled_plugins_file])
+    assert Enum.member?(enabled, :rabbitmq_non_existent)
+    assert Enum.member?(enabled, :rabbitmq_federation)
+    refute Enum.member?(enabled, :rabbitmq_stomp)
   end
 
   test "validate: specifying both --online and --offline is reported as invalid", context do

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -7,6 +7,7 @@
 defmodule EnablePluginsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
+  import ExUnit.CaptureIO
 
   alias RabbitMQ.CLI.Core.ExitCodes
 
@@ -291,6 +292,32 @@ defmodule EnablePluginsCommandTest do
       ],
       currently_active_plugins(context)
     )
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+  end
+
+  test "run: keeps a missing enabled plugin in the file and still enables another plugin",
+       context do
+    # rabbitmq_non_existent is enabled but not installed.
+    set_enabled_plugins(
+      [:rabbitmq_federation, :rabbitmq_non_existent],
+      :online,
+      context[:opts][:node],
+      Map.put(context[:opts], :keep_missing_plugins, true)
+    )
+
+    warning =
+      capture_io(fn ->
+        assert {:stream, stream} = @command.run(["rabbitmq_stomp"], context[:opts])
+        Enum.to_list(stream)
+      end)
+
+    assert warning =~ "WARNING - plugins currently enabled but missing: rabbitmq_non_existent"
+
+    {:ok, [enabled]} = :file.consult(context[:opts][:enabled_plugins_file])
+    assert Enum.member?(enabled, :rabbitmq_non_existent)
+    assert Enum.member?(enabled, :rabbitmq_stomp)
+    assert Enum.member?(enabled, :rabbitmq_federation)
 
     reset_enabled_plugins_to_preconfigured_defaults(context)
   end

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -456,7 +456,7 @@ defmodule ListPluginsCommandTest do
     opts =
       context[:opts]
       |> Map.put_new(:silent, true)
-      |> Map.put_new(:hard_write, true)
+      |> Map.put_new(:keep_missing_plugins, true)
 
     context = Map.replace(context, :opts, opts)
 
@@ -475,7 +475,7 @@ defmodule ListPluginsCommandTest do
       opts =
         context[:opts]
         |> Map.delete(:silent)
-        |> Map.delete(:hard_write)
+        |> Map.delete(:keep_missing_plugins)
 
       context = Map.replace(context, :opts, opts)
 
@@ -517,7 +517,7 @@ defmodule ListPluginsCommandTest do
     opts =
       context[:opts]
       |> Map.put_new(:quiet, true)
-      |> Map.put_new(:hard_write, true)
+      |> Map.put_new(:keep_missing_plugins, true)
 
     context = Map.replace(context, :opts, opts)
 
@@ -536,7 +536,7 @@ defmodule ListPluginsCommandTest do
       opts =
         context[:opts]
         |> Map.delete(:quiet)
-        |> Map.delete(:hard_write)
+        |> Map.delete(:keep_missing_plugins)
 
       context = Map.replace(context, :opts, opts)
 


### PR DESCRIPTION
`enable`/`disable` fail today if `enabled_plugins` contains a plugin that isn't installed (e.g. a discontinued plugin left over from before an upgrade), because both commands carry the existing enabled list, including the stale name, into the new list they write, and the write is rejected wholesale with `{:plugins_not_found, [...]}`. The only way out was editing the file by hand.
Not specific to one plugin, see :- https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/issues/119

`enable`/`disable` now keep such names in the file, warn about them the same way `list` already does, and proceed with the rest of the operation instead of failing. `set` is unchanged and still rejects unknown names, since it replaces the whole list explicitly.
