### PR TITLE
package-generic-unix: set FULL=1

### DIFF
--- a/packaging/generic-unix/Makefile
+++ b/packaging/generic-unix/Makefile
@@ -57,6 +57,7 @@ dist:
 		PREFIX= RMQ_ROOTDIR= \
 		RMQ_ERLAPP_DIR=`pwd`/$(TARGET_DIR) \
 		MANDIR=`pwd`/$(TARGET_DIR)/share/man \
+		FULL=1 \
 		manpages web-manpages install install-man
 
 	sed -e 's:^SYS_PREFIX=$$:SYS_PREFIX=\$${RABBITMQ_HOME}:' \


### PR DESCRIPTION
Without this change, re-running `make package-generic-unix` could produce strange complilation errors like:
```
== Compilation error in file lib/rabbitmq/cli/formatters/pretty_table.ex ==
** (MatchError) no match of right hand side value:

    false

    lib/rabbitmq/cli/formatters/pretty_table.ex:17: (module)
warning: you must pass return_diagnostics: true when invoking Kernel.ParallelCompiler functions
  (elixir 1.19.5) lib/kernel/parallel_compiler.ex:324: Kernel.ParallelCompiler.spawn_workers/3
  (stdlib 7.3) erl_eval.erl:920: :erl_eval.do_apply/7
  (stdlib 7.3) erl_eval.erl:484: :erl_eval.expr/6
  (mix 1.19.5) lib/mix/project.ex:557: Mix.Project.in_project/4
  (elixir 1.19.5) lib/file.ex:2013: File.cd!/2
  (stdlib 7.3) erl_eval.erl:920: :erl_eval.do_apply/7
```

By disabling erlang.mk's dependency optimisation, we avoid such strange issues.