### PR TITLE
[mgt] Hide allow http response header

### DIFF
--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -476,6 +476,17 @@ fun(Conf) ->
 end}.
 
 
+%% Hide the Allow response header from all HTTP responses except 405 Method Not Allowed.
+%% When set to true, the Allow header is omitted from all responses (including 200 OK
+%% responses to OPTIONS requests) to prevent disclosure of supported HTTP methods.
+%% The Allow header is preserved on 405 responses as required by RFC 9110.
+%% This is a security hardening option that is disabled by default.
+%%
+%% {hide_http_allow_header, false},
+
+{mapping, "management.http.hide_allow_header", "rabbitmq_management.hide_http_allow_header",
+    [{datatype, boolean}]}.
+
 {mapping, "management.disable_basic_auth", "rabbitmq_management.disable_basic_auth",
     [{datatype, boolean}]}.
 

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -595,6 +595,19 @@
   },
 
  %%
+ %% Hide Allow header
+ %%
+
+  {hide_allow_header,
+   "management.http.hide_allow_header = true",
+   [
+    {rabbitmq_management, [
+                           {hide_http_allow_header, true}
+                          ]}
+   ], [rabbitmq_management]
+  },
+
+ %%
  %% Exotic options
  %%
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
@@ -28,7 +28,10 @@ groups() ->
                                   ]},
      {sequential_tests, [], [
                               referrer_policy_header_set_when_configured,
-                              referrer_policy_header_absent_when_not_configured
+                              referrer_policy_header_absent_when_not_configured,
+                              allow_header_absent_on_non_405_when_hide_configured,
+                              allow_header_present_on_405_when_hide_configured,
+                              allow_header_present_on_200_when_not_configured
                              ]}
     ].
 
@@ -128,6 +131,26 @@ referrer_policy_header_absent_when_not_configured(_Config) ->
     Req = rabbit_mgmt_headers:set_common_permission_headers(fake_req(), ?MODULE),
     RespHeaders = maps:get(resp_headers, Req),
     ?assertNot(maps:is_key(<<"referrer-policy">>, RespHeaders)).
+
+allow_header_absent_on_non_405_when_hide_configured(_Config) ->
+    application:set_env(rabbitmq_management, hide_http_allow_header, true),
+    Headers = #{<<"allow">> => <<"GET, HEAD, PUT, DELETE, OPTIONS">>,
+                <<"content-type">> => <<"application/json">>},
+    Result = rabbit_cowboy_stream_h:maybe_strip_allow_header(200, Headers),
+    ?assertNot(maps:is_key(<<"allow">>, Result)),
+    ?assert(maps:is_key(<<"content-type">>, Result)).
+
+allow_header_present_on_405_when_hide_configured(_Config) ->
+    application:set_env(rabbitmq_management, hide_http_allow_header, true),
+    Headers = #{<<"allow">> => <<"GET, HEAD, PUT, DELETE, OPTIONS">>},
+    Result = rabbit_cowboy_stream_h:maybe_strip_allow_header(405, Headers),
+    ?assert(maps:is_key(<<"allow">>, Result)).
+
+allow_header_present_on_200_when_not_configured(_Config) ->
+    application:unset_env(rabbitmq_management, hide_http_allow_header),
+    Headers = #{<<"allow">> => <<"GET, HEAD, PUT, DELETE, OPTIONS">>},
+    Result = rabbit_cowboy_stream_h:maybe_strip_allow_header(200, Headers),
+    ?assert(maps:is_key(<<"allow">>, Result)).
 
 %%--------------------------------------------------------------------
 

--- a/deps/rabbitmq_web_dispatch/src/rabbit_cowboy_stream_h.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_cowboy_stream_h.erl
@@ -16,6 +16,7 @@
 -export([terminate/3]).
 -export([early_error/5]).
 -export([set_authenticated_username/2]).
+-export([maybe_strip_allow_header/2]).
 
 -record(state, {
     next :: any(),
@@ -46,11 +47,13 @@ info(StreamId, Response, State = #state{next = Next, req = Req}) ->
         {response, Status, Headers0, Body} ->
             log_response(Response, Req),
             H1 = unset_authenticated_username(Headers0),
-            {response, Status, H1, Body};
+            H2 = maybe_strip_allow_header(Status, H1),
+            {response, Status, H2, Body};
         {headers, Status, Headers0} ->
             log_stream_response(Response, Req),
             H1 = unset_authenticated_username(Headers0),
-            {headers, Status, H1};
+            H2 = maybe_strip_allow_header(Status, H1),
+            {headers, Status, H2};
         _ ->
             Response
     end,
@@ -69,6 +72,19 @@ set_authenticated_username(Username, Req) ->
 
 unset_authenticated_username(Headers) ->
     maps:remove(?AUTH_USER_HEADER, Headers).
+
+%% Removes the Allow response header from all responses except 405 Method Not Allowed,
+%% when management.http.hide_allow_header is set to true in the management plugin configuration.
+%% This prevents disclosure of supported HTTP methods via responses to normal requests
+%% (including OPTIONS), while still preserving the Allow header on 405 responses as required
+%% by RFC 9110.
+maybe_strip_allow_header(405, Headers) ->
+    Headers;
+maybe_strip_allow_header(_Status, Headers) ->
+    case application:get_env(rabbitmq_management, hide_http_allow_header, false) of
+        true  -> maps:remove(<<"allow">>, Headers);
+        false -> Headers
+    end.
 
 get_authenticated_username(Headers) ->
     maps:get(?AUTH_USER_HEADER, Headers, <<"-">>).
@@ -157,6 +173,31 @@ escape_for_quoted_log(Value) ->
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+maybe_strip_allow_header_preserves_on_405_test() ->
+    Headers = #{<<"allow">> => <<"GET, HEAD, PUT, DELETE, OPTIONS">>},
+    application:set_env(rabbitmq_management, hide_http_allow_header, true),
+    ?assertEqual(Headers, maybe_strip_allow_header(405, Headers)),
+    application:unset_env(rabbitmq_management, hide_http_allow_header).
+
+maybe_strip_allow_header_strips_on_200_when_enabled_test() ->
+    Headers = #{<<"allow">> => <<"GET, HEAD, PUT, DELETE, OPTIONS">>,
+                <<"content-type">> => <<"application/json">>},
+    application:set_env(rabbitmq_management, hide_http_allow_header, true),
+    ?assertEqual(#{<<"content-type">> => <<"application/json">>},
+                 maybe_strip_allow_header(200, Headers)),
+    application:unset_env(rabbitmq_management, hide_http_allow_header).
+
+maybe_strip_allow_header_preserves_on_200_when_disabled_test() ->
+    Headers = #{<<"allow">> => <<"GET, HEAD, PUT, DELETE, OPTIONS">>},
+    application:unset_env(rabbitmq_management, hide_http_allow_header),
+    ?assertEqual(Headers, maybe_strip_allow_header(200, Headers)).
+
+maybe_strip_allow_header_no_allow_header_test() ->
+    Headers = #{<<"content-type">> => <<"application/json">>},
+    application:set_env(rabbitmq_management, hide_http_allow_header, true),
+    ?assertEqual(Headers, maybe_strip_allow_header(200, Headers)),
+    application:unset_env(rabbitmq_management, hide_http_allow_header).
 
 sanitize_test() ->
     ?assertEqual(<<"hello">>, sanitize(<<"hello">>)),

--- a/selenium/full-suite-management-ui
+++ b/selenium/full-suite-management-ui
@@ -24,3 +24,4 @@ mgt/limits.sh
 mgt/mgt-only-exchanges.sh
 mgt/queuesAndStreams.sh
 mgt/feature-flags.sh
+mgt/hide-allow-header.sh

--- a/selenium/suites/mgt/hide-allow-header.sh
+++ b/selenium/suites/mgt/hide-allow-header.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TEST_CASES_PATH=/queuesAndStreams
+TEST_CONFIG_PATH=/basic-auth
+PROFILES="hide-allow-header"
+
+source $SCRIPT/../../bin/suite_template $@
+run

--- a/selenium/test/basic-auth/rabbitmq.hide-allow-header.conf
+++ b/selenium/test/basic-auth/rabbitmq.hide-allow-header.conf
@@ -1,0 +1,1 @@
+management.http.hide_allow_header = true


### PR DESCRIPTION
## Proposed Changes

Hide allow http response header except for 405 responses. This behaviour is configurable. By default, RabbitMQ keeps sending this header.
This is a requested security improvement. 

Accompanied by docs PR: https://github.com/rabbitmq/rabbitmq-website/pull/2562

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

