### PR TITLE
OTP 26 has reached EOL

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -23,7 +23,7 @@ on:
       otp_version:
         # a tag of the erlang image, see https://hub.docker.com/_/erlang for available tags
         # also used in the setup-beam step (same tag should work for both)
-        description: OTP version (eg. `26`, `26.2.5.6`)
+        description: OTP version (eg. `27`, `27.3.4.1`)
         default: 28
       build_arm:
         description: Build for ARM64 as well?

--- a/.github/workflows/test-make.yaml
+++ b/.github/workflows/test-make.yaml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - '26'
         - '27'
         - '28'
         elixir_version:

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
@@ -7,9 +7,9 @@
 -export([check/1]).
 
 %% minimum Erlang/OTP version supported
--define(OTP_MINIMUM, "26.0").
+-define(OTP_MINIMUM, "27.0").
 %% the ERTS version provided by the minimum Erlang/OTP version supported
--define(ERTS_MINIMUM, "14.0").
+-define(ERTS_MINIMUM, "15.0").
 
 check(_Context) ->
     ?LOG_DEBUG(


### PR DESCRIPTION
OTP 26's security support ended in May 2026 - https://endoflife.date/erlang
Set OTP 27 as minimum required OTP version.

Change to be backported to `v4.2.x`

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
