### PR TITLE
Log mirrored_supervisor roster wipe and successful failover at info

### DIFF
--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -284,7 +284,12 @@ handle_call({init, Overall}, _From,
     %% leave any genuinely orphaned records to the reconciliation loop.
     case Rest =:= [] andalso rabbit_nodes:list_reachable() =:= [node()] of
         true ->
-            ?LOG_DEBUG("Mirrored supervisor: no known peer members in group ~tp and no other reachable cluster members, will delete all child records for it", [Group]),
+            %% Logged at info because this wipes the entire child-record roster
+            %% for the group. It is expected on a genuine single-node (re)start,
+            %% but it is the most destructive operation here, so a wrong wipe
+            %% (e.g. a node that transiently sees no peers) should leave a trace
+            %% above debug level.
+            ?LOG_INFO("Mirrored supervisor: this node is the sole reachable member, deleting all child records for group ~tp", [Group]),
             delete_all(Group);
         false -> ok
     end,
@@ -402,6 +407,15 @@ handle_info({'DOWN', _Ref, process, Pid, _Reason},
                                            || ChildSpec <- restore_child_order(
                                                              ChildSpecs, ChildOrder)],
                                 case errors(Results) of
+                                    [] when ChildSpecs =/= [] ->
+                                        %% Log a successful failover: this is a
+                                        %% rare, high-consequence event (a peer
+                                        %% died and this node re-homed and started
+                                        %% its children). The failure branches are
+                                        %% already logged; without this the
+                                        %% success case was silent.
+                                        ?LOG_INFO("Mirrored supervisor: failover in group ~tp re-homed and started ~b child(ren) from dead peer on node ~tp",
+                                                  [Group, length(ChildSpecs), node(Pid)]);
                                     []     -> ok;
                                     Errors ->
                                         ?LOG_WARNING("Mirrored supervisor: failover in group ~tp could not start some children, reconciliation will retry: ~tp",


### PR DESCRIPTION
## Proposed Changes

`mirrored_supervisor` logs failover failures at warning and reconciliation actions at notice, but two high-consequence lifecycle events are silent or at debug:

1. The `delete_all` branch in init (this node is the sole reachable member, so it wipes the group's child-record roster) is at debug. If it ever fires wrongly, there is no trace at info level to diagnose. Promoted to info.

2. A successful failover (peer dies, this node re-homes and starts its children) logs nothing. Added one info line with the group, child count, and dead peer's node, symmetric with the existing failure logging.

Both are per-event (not per-child), so no steady-state noise. No behavior change.

Related: #11495 (federation links lost after rolling restart). These two events are exactly where the silent failure lived.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
