### PR TITLE
Restore the pre-login page after an idp_initiated OAuth login

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -48,8 +48,6 @@ function removeDuplicates(array){
 
 
 function startWithOAuthLogin (oauth) {
-  store_pref("oauth-return-to", window.location.hash);
-
   if (!oauth.logged_in) {
     hasAnyResourceServerReady(oauth, (oauth, warnings) => {  render_login_oauth(oauth, warnings); start_app_login(); })
   } else {
@@ -192,14 +190,22 @@ function start_app() {
     var url = this.location.toString();
     var hash = this.location.hash;
     var pathname = this.location.pathname;
+
+    var return_to = '#/';
+    if (get_pref("oauth-idp-pending")) {
+        clear_pref("oauth-idp-pending");
+        return_to = get_pref("oauth-return-to") || '#/';
+        clear_pref("oauth-return-to");
+    }
+
     if (url.indexOf('#') == -1) {
-        this.location = url + '#/';
+        this.location = url + return_to;
     } else if (hash.indexOf('#token_type') != - 1 && pathname == '/') {
         // This is equivalent to previous `if` clause when uaa authorisation is used.
         // Tokens are passed in the url hash, so the url always contains a #.
         // We need to check the current path is `/` and token is present,
         // so we can redirect to `/#/`
-        this.location = url.replace(/#token_type.+/gi, '#/');
+        this.location = url.replace(/#token_type.+/gi, return_to);
     }
 
     app = new Sammy.Application(dispatcher);

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -256,6 +256,8 @@ export function oauth_initiateLogin(resource_server_id) {
   if (!resource_server) return;
   set_auth_resource(resource_server_id)
 
+  store_pref("oauth-return-to", window.location.hash);
+
   oauth.sp_initiated = resource_server.sp_initiated
   oauth.authority = resource_server.oauth_provider_url
 
@@ -268,6 +270,7 @@ export function oauth_initiateLogin(resource_server_id) {
         _management_logger.error(err)
     })
   } else {
+    store_pref("oauth-idp-pending", "true")
     location.href = resource_server.oauth_provider_url
   }
 }

--- a/selenium/test/oauth/with-idp-initiated/oauth-return-to.js
+++ b/selenium/test/oauth/with-idp-initiated/oauth-return-to.js
@@ -1,0 +1,130 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+const assert = require('assert')
+const { buildDriver, goToHome, goToExchanges, goToQueues, captureScreensFor, teardown } = require('../../utils')
+
+const SSOHomePage = require('../../pageobjects/SSOHomePage')
+const FakePortalPage = require('../../pageobjects/FakePortalPage')
+const ExchangesPage = require('../../pageobjects/ExchangesPage')
+const QueuesAndStreamsPage = require('../../pageobjects/QueuesAndStreamsPage')
+const OverviewPage = require('../../pageobjects/OverviewPage')
+
+// Exercises the oauth-return-to behaviour for the idp_initiated flow: after
+// logging in, the user should land back on the page they were on when they
+// clicked "log in", and a plain visit to "/" must never be hijacked to a saved
+// page. Each describe uses a fresh browser so it starts logged out.
+
+describe('A user who logs in from the home page', function () {
+  let driver
+  let homePage
+  let fakePortal
+  let overview
+  let captureScreen
+
+  before(async function () {
+    driver = buildDriver()
+    homePage = new SSOHomePage(driver)
+    fakePortal = new FakePortalPage(driver)
+    overview = new OverviewPage(driver)
+    await goToHome(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+  })
+
+  it('should land on the home page', async function () {
+    await homePage.clickToLogin()
+    if (!await fakePortal.isLoaded()) {
+      throw new Error('Failed to load fakePortal')
+    }
+    await fakePortal.login()
+    if (!await overview.isLoaded()) {
+      throw new Error('Home page did not load after login')
+    }
+    const url = await driver.driver.getCurrentUrl()
+    assert.ok(url.endsWith('#/'),
+      'Expected to land on the home page (#/) but got ' + url)
+  })
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})
+
+describe('A user who accesses a protected page before logging in', function () {
+  let driver
+  let homePage
+  let fakePortal
+  let exchanges
+  let overview
+  let captureScreen
+
+  before(async function () {
+    driver = buildDriver()
+    homePage = new SSOHomePage(driver)
+    fakePortal = new FakePortalPage(driver)
+    exchanges = new ExchangesPage(driver)
+    overview = new OverviewPage(driver)
+    await goToExchanges(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+  })
+
+  it('should be redirected back to that page after logging in', async function () {
+    await homePage.clickToLogin()
+    if (!await fakePortal.isLoaded()) {
+      throw new Error('Failed to load fakePortal')
+    }
+    await fakePortal.login()
+    if (!await exchanges.isLoaded()) {
+      throw new Error('Was not redirected back to the exchanges page after login')
+    }
+    await exchanges.getPagingSectionHeaderText()
+  })
+
+  it('should go to the home page when later visiting "/" directly', async function () {
+    await goToHome(driver)
+    if (!await overview.isLoaded()) {
+      throw new Error('Home page did not load')
+    }
+    const url = await driver.driver.getCurrentUrl()
+    assert.ok(url.endsWith('#/'),
+      'Expected to land on the home page (#/) but got ' + url)
+  })
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})
+
+describe('A user who visits several pages before logging in', function () {
+  let driver
+  let homePage
+  let fakePortal
+  let queuesAndStreams
+  let captureScreen
+
+  before(async function () {
+    driver = buildDriver()
+    homePage = new SSOHomePage(driver)
+    fakePortal = new FakePortalPage(driver)
+    queuesAndStreams = new QueuesAndStreamsPage(driver)
+    // Access exchanges first, then move to queues while still logged out. Queues
+    // is the page the user ends up on, so that is the page that must be restored.
+    await goToExchanges(driver)
+    await goToQueues(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+  })
+
+  it('should be redirected to the last page it visited', async function () {
+    await homePage.clickToLogin()
+    if (!await fakePortal.isLoaded()) {
+      throw new Error('Failed to load fakePortal')
+    }
+    await fakePortal.login()
+    if (!await queuesAndStreams.isLoaded()) {
+      throw new Error('Was not redirected back to the queues page after login')
+    }
+    await queuesAndStreams.getPagingSectionHeaderText()
+  })
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})


### PR DESCRIPTION
## Background

In #9820 `oauth-return-to` was added for the management UI to remember the page a user was on before the OAuth login. This worked only for the `sp_initiated` flow and not the `idp_initiated` flow. In #9820 `startWithOAuthLogin()` stores the path in `oauth-return-to` but because the identity provider posts the token to `/login` that path is overwritten to '' and UI does not have a path to return to. But also there was no logic to return to `oauth-return-to` path for IDP. It was in `oauth_redirectToHome()` for SP Flow. 

## Proposed Changes

- Do not store `oauth-return-to` in `startWithOAuthLogin()` but instead do it in `oauth_initiateLogin()` this way the path is only stored when OAuth is initiated, and not when the we are returning back from OAuth. 
  - Also helps in the case when user opens `#/exchanges` and changes the url manually to `#/queues` and hit login, the return to path is correctly set to `#/queues` and not `#/exchanges` because we do not set `oauth-return-to` when the page loaded. 
- Store `oauth-idp-pending` in IDP flow in `oauth_initiateLogin()` to know if we are coming to `start_app()` after login. If we are, we can return to `oauth-return-to` path, or if not, just keep the existing `#/` path we have today
- Clean up `oauth-return-to` which stayed set and unused for IDP flow along with `oauth-idp-pending`

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I have signed the CLA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Manual Testing 
| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | Normal login — open `/`, click log in | land on home `#/` | ✅ |
| 2 | Login with a path — open `/#/queues`, click log in | land back on `#/queues` | ✅ |
| 3 | Open with a path, change it, then log in — open `/#/queues`, navigate to `#/channels`, then log in | land back on `#/channels` | ✅ |
| 4 | Open URL when already logged in — visit `/` or `/#/exchanges` with a live session | No redirect to a oauth-return-to page; `/` → home; `/#/exchanges` → exchanges;  | ✅ |

https://github.com/user-attachments/assets/da441091-98e7-424e-ab18-967f7207cc81


