### PR TITLE
Adopt `rabbit_re` in more places

### DIFF
--- a/deps/rabbit/src/rabbit_credential_validator_password_regexp.erl
+++ b/deps/rabbit/src/rabbit_credential_validator_password_regexp.erl
@@ -34,7 +34,7 @@ validate(Username, Password) ->
 -spec validate(rabbit_types:username(), rabbit_types:password(), string()) -> 'ok' | {'error', string(), [any()]}.
 
 validate(_Username, Password, Pattern) ->
-    case re:run(rabbit_data_coercion:to_list(Password), Pattern) of
-        {match, _} -> ok;
-        nomatch    -> {error, "provided password does not match the validator regular expression"}
+    case rabbit_re:run(rabbit_data_coercion:to_list(Password), Pattern) of
+        match   -> ok;
+        nomatch -> {error, "provided password does not match the validator regular expression"}
     end.

--- a/deps/rabbit/src/rabbit_db_vhost_defaults.erl
+++ b/deps/rabbit/src/rabbit_db_vhost_defaults.erl
@@ -71,7 +71,7 @@ list_limits(VHost) ->
     Match = lists:search(
         fun({_, Ss}) ->
             RE = proplists:get_value(<<"pattern">>, Ss, ".*"),
-            re:run(VHost, RE, [{capture, none}]) =:= match
+            rabbit_re:matches(VHost, RE)
         end,
         VHostLimits
     ),
@@ -91,8 +91,8 @@ list_operator_policies(VHost) ->
     lists:filtermap(
         fun({PolicyName, Ss}) ->
             RE = proplists:get_value(<<"vhost_pattern">>, Ss, ".*"),
-            case re:run(VHost, RE, [{capture, none}]) of
-                match ->
+            case rabbit_re:matches(VHost, RE) of
+                true ->
                     QPattern = proplists:get_value(<<"queue_pattern">>, Ss, <<".*">>),
                     ApplyTo = proplists:get_value(<<"apply_to">>, Ss, <<"all">>),
                     Ss1 = proplists:delete(<<"queue_pattern">>, Ss),
@@ -118,8 +118,8 @@ list_users(VHost) ->
     lists:filtermap(
         fun({Username, Ss}) ->
             RE = proplists:get_value(<<"vhost_pattern">>, Ss, ".*"),
-            case re:run(VHost, RE, [{capture, none}]) of
-                match ->
+            case rabbit_re:matches(VHost, RE) of
+                true ->
                     C = rabbit_data_coercion:to_binary(
                               proplists:get_value(<<"configure">>, Ss, <<".*">>)
                             ),

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -428,14 +428,9 @@ safe_eval(_F, _,          {error, _}) -> false;
 safe_eval(F,  V1,         V2)         -> F(V1, V2).
 
 do_match(S1, S2) ->
-    case re:run(S1, S2) of
-        {match, _} ->
-            log_match(S1, S2, R = true),
-            R;
-        nomatch ->
-            log_match(S1, S2, R = false),
-            R
-    end.
+    R = rabbit_re:matches(S1, S2),
+    log_match(S1, S2, R),
+    R.
 
 %% In some cases when fetching regular expressions, LDAP evalution()
 %% returns a list of strings, so we need to wrap guards around that.
@@ -444,11 +439,11 @@ do_match_multi(S1, []) ->
     log_match(S1, [], R = false),
     R;
 do_match_multi(S1 = [H1|_], [H2|Tail]) when is_list(H2) and not is_list(H1) ->
-    case re:run(S1, H2) of
-        {match, _} ->
+    case rabbit_re:matches(S1, H2) of
+        true ->
             log_match(S1, H2, R = true),
             R;
-        _ ->
+        false ->
             log_match(S1,H2, false),
             do_match_multi(S1, Tail)
     end;
@@ -456,11 +451,11 @@ do_match_multi([], S2) ->
     log_match([], S2, R = false),
     R;
 do_match_multi([H1|Tail], S2 = [H2|_] ) when is_list(H1) and not is_list(H2) ->
-    case re:run(H1, S2) of
-        {match, _} ->
+    case rabbit_re:matches(H1, S2) of
+        true ->
             log_match(H1, S2, R = true),
             R;
-        _ ->
+        false ->
             log_match(H1, S2, false),
             do_match_multi(Tail, S2)
     end;

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
@@ -631,7 +631,7 @@ maybe_insert_entry_ops(Name, Pattern, Table, Id, Incr, Entry, Ops, Policies) ->
 needs_filtering_out(_, undefined) ->
     false;
 needs_filtering_out(#resource{name = Name}, Pattern) ->
-    match == re:run(Name, Pattern, [{capture, none}]).
+    rabbit_re:matches(Name, Pattern).
 
 insert_entry_ops(Table, Id, Incr, Entry, Ops, Policies) ->
     lists:foldl(fun({Size, Interval}, Acc) ->


### PR DESCRIPTION
For consistency, even if some of them do not
deal with external inputs or the inputs
would require very elevated privileges.

## Backporting

I suggest that we backport this after `4.3.3` ships.
