### PR TITLE
Support claims containing dots in OAuth2 additional_scopes_key

### DIFF
--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -1319,9 +1319,11 @@
 # auth_oauth2.preferred_username_claims.1 = user_name
 # auth_oauth2.preferred_username_claims.2 = preferred_username
 
-## Configure additional fields to look for scopes in the token
+## Configure additional fields to look for scopes in the token.
+## Dots separate nested claim keys; use \. for a literal dot in a claim name.
 ##
 # auth_oauth2.additional_scopes_key = extra_scope
+# auth_oauth2.additional_scopes_key = https://example\.com/claims.roles
 
 ## Custom scope prefix instead of resource_server_id
 ##

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -163,7 +163,7 @@ Note: if both are configured, `jwks_uri` takes precedence over `signing_keys`.
 |------------------------------------------|---------------------------------------------------------------------------
 | `auth_oauth2.resource_server_id`         | [The Resource Server ID](#resource-server-id-and-scope-prefixes)
 | `auth_oauth2.resource_server_type`       | [The Resource Server Type](#rich-authorization-request)
-| `auth_oauth2.additional_scopes_key`      | Key to fetch additional scopes from (maps to `additional_rabbitmq_scopes` in the `advanced.config` format)
+| `auth_oauth2.additional_scopes_key`      | Key to fetch additional scopes from (maps to `additional_rabbitmq_scopes` in the `advanced.config` format). Dots separate nested claim keys; use `\.` for a literal dot in a claim name, e.g. `https://example\.com/claims.roles`
 | `auth_oauth2.default_key`                | ID (name) of the default signing key
 | `auth_oauth2.signing_keys`               | Paths to signing key files
 | `auth_oauth2.jwks_uri`                   | The URL of key server. According to the [JWT Specification](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2) key server URL must be https

--- a/deps/rabbitmq_auth_backend_oauth2/include/oauth2.hrl
+++ b/deps/rabbitmq_auth_backend_oauth2/include/oauth2.hrl
@@ -48,7 +48,7 @@
   verify_aud :: boolean(),
   require_exp :: boolean(),
   scope_prefix :: binary(),
-  additional_scopes_key :: binary() | undefined,
+  additional_scopes_key :: binary() | [[binary()]] | undefined,
   preferred_username_claims :: list(),
   scope_aliases :: map() | undefined,
   oauth_provider_id :: oauth_provider_id(),

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -60,6 +60,9 @@
 
 %% Configure the plugin to also look in other fields using additional_scopes_key (maps to extra_scopes_source in the old format)
 %%
+%% Use \. to address claim keys that contain literal dots, for example:
+%% auth_oauth2.additional_scopes_key = https://example\.com/claims.roles
+%%
 %% {additional_scopes_key, <<"my_custom_scope_key">>},
 
 {mapping,
@@ -70,7 +73,8 @@
 {translation,
  "rabbitmq_auth_backend_oauth2.extra_scopes_source",
  fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("auth_oauth2.additional_scopes_key", Conf))
+    rabbit_oauth2_schema:tokenize_additional_scopes_key(
+        cuttlefish:conf_get("auth_oauth2.additional_scopes_key", Conf))
  end}.
 
 {mapping,

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -423,6 +423,11 @@ extract_scopes_from_additional_scopes_key(
     AdditionalScopes = [ extract_token_value(ResourceServer, 
         Payload, Path, fun extract_scope_list_from_token_value/2) || Path <- Paths],    
     set_scope(lists:flatten(AdditionalScopes) ++ get_scope(Payload), Payload);
+%% Paths is expected to be a list of pre-tokenized paths, each itself a list of
+%% segment binaries, e.g. [[<<"realm">>, <<"roles">>]]. This is the shape produced
+%% by rabbit_oauth2_schema:tokenize_additional_scopes_key/1 from rabbitmq.conf.
+%% A single-level list of binaries is treated as several top-level paths, not one
+%% nested path.
 extract_scopes_from_additional_scopes_key(
         #resource_server{additional_scopes_key = Paths} = ResourceServer, Payload)
           when is_list(Paths) ->

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -353,6 +353,9 @@ extract_scopes_using_scope_aliases(_, Payload) -> Payload.
 extract_token_value(R, Payload, Path, ValueMapperFun) 
         when is_map(Payload), is_binary(Path), is_function(ValueMapperFun) ->
     extract_token_value_from_map(R, Payload, [], split_path(Path), ValueMapperFun);
+extract_token_value(R, Payload, Path, ValueMapperFun)
+        when is_map(Payload), is_list(Path), is_function(ValueMapperFun) ->
+    extract_token_value_from_map(R, Payload, [], Path, ValueMapperFun);
 extract_token_value(_, _, _, _) ->
     [].
 
@@ -419,6 +422,12 @@ extract_scopes_from_additional_scopes_key(
     Paths = binary:split(Key, <<" ">>, [global, trim_all]),
     AdditionalScopes = [ extract_token_value(ResourceServer, 
         Payload, Path, fun extract_scope_list_from_token_value/2) || Path <- Paths],    
+    set_scope(lists:flatten(AdditionalScopes) ++ get_scope(Payload), Payload);
+extract_scopes_from_additional_scopes_key(
+        #resource_server{additional_scopes_key = Paths} = ResourceServer, Payload)
+          when is_list(Paths) ->
+    AdditionalScopes = [ extract_token_value(ResourceServer,
+        Payload, Path, fun extract_scope_list_from_token_value/2) || Path <- Paths],
     set_scope(lists:flatten(AdditionalScopes) ++ get_scope(Payload), Payload);
 extract_scopes_from_additional_scopes_key(_, Payload) -> Payload.
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_schema.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_schema.erl
@@ -25,7 +25,8 @@
     translate_resource_servers/1,
     translate_signing_keys/1,
     translate_endpoint_params/2,
-    translate_scope_aliases/1
+    translate_scope_aliases/1,
+    tokenize_additional_scopes_key/1
 ]).
 
 resource_servers_key_synonym(Key) -> maps:get(Key, ?RESOURCE_SERVERS_SYNONYMS, Key).
@@ -266,6 +267,8 @@ resource_server_property_value(Key, V) ->
     case resource_servers_key_synonym(Key) of
         "scope_pattern_syntax" ->
             parse_scope_pattern_syntax_for_schema(V);
+        "extra_scopes_source" ->
+            tokenize_additional_scopes_key(V);
         _ ->
             resource_server_string_property_value(V)
     end.
@@ -274,6 +277,15 @@ resource_server_string_property_value(V) when is_binary(V) ->
     V;
 resource_server_string_property_value(V) when is_list(V) ->
     list_to_binary(V).
+
+tokenize_additional_scopes_key(V) when is_binary(V) ->
+    tokenize_additional_scopes_key(binary_to_list(V));
+tokenize_additional_scopes_key(V) when is_list(V) ->
+    Paths = string:lexemes(V, " "),
+    [[list_to_binary(Segment)
+      || Segment <- cuttlefish_variable:tokenize(Path),
+         Segment =/= ""]
+     || Path <- Paths].
 
 parse_scope_pattern_syntax_for_schema(wildcard) ->
     wildcard;

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -30,7 +30,7 @@
             {resource_server_id,<<"new_resource_server_id">>},
             {scope_prefix,<<"new_resource_server_id.">>},
             {resource_server_type,<<"new_resource_server_type">>},
-            {extra_scopes_source, <<"my_custom_scope_key">>},
+            {extra_scopes_source, [[<<"my_custom_scope_key">>]]},
             {preferred_username_claims, [<<"user_name">>, <<"username">>, <<"email">>]},
             {verify_aud, true},
             {scope_pattern_syntax, regex},
@@ -86,13 +86,13 @@
         auth_oauth2.resource_servers.1.id = rabbitmq-operations
         auth_oauth2.resource_servers.1.scope_prefix = api://
         auth_oauth2.resource_servers.customers.id = rabbitmq-customers
-        auth_oauth2.resource_servers.customers.additional_scopes_key = roles",
+        auth_oauth2.resource_servers.customers.additional_scopes_key = roles https://example\\.com/claims.roles",
         [
         {rabbitmq_auth_backend_oauth2, [
             {resource_server_id,<<"new_resource_server_id">>},
             {scope_prefix,<<"new_resource_server_id.">>},
             {resource_server_type,<<"new_resource_server_type">>},
-            {extra_scopes_source, <<"my_custom_scope_key">>},
+            {extra_scopes_source, [[<<"my_custom_scope_key">>]]},
             {preferred_username_claims, [<<"user_name">>, <<"username">>, <<"email">>]},
             {verify_aud, true},
             {jwks_uri, "https://my-jwt-issuer/jwks.json"},
@@ -103,7 +103,8 @@
                   {id, <<"rabbitmq-operations">>}
                 ],
                 <<"rabbitmq-customers">> => [
-                  {extra_scopes_source, <<"roles">>},
+                  {extra_scopes_source, [[<<"roles">>],
+                                         [<<"https://example.com/claims">>, <<"roles">>]]},
                   {id, <<"rabbitmq-customers">>}
                 ]
               }
@@ -157,7 +158,7 @@
             {resource_server_id,<<"new_resource_server_id">>},
             {scope_prefix,<<"new_resource_server_id.">>},
             {resource_server_type,<<"new_resource_server_type">>},
-            {extra_scopes_source, <<"my_custom_scope_key">>},
+            {extra_scopes_source, [[<<"my_custom_scope_key">>]]},
             {preferred_username_claims, [<<"user_name">>, <<"username">>, <<"email">>]},
             {verify_aud, true},
             {oauth_providers,
@@ -325,7 +326,17 @@
        [
         {rabbitmq_auth_backend_oauth2, [
             {resource_server_id,<<"new_resource_server_id">>},
-            {extra_scopes_source, <<"roles realm.roles">> }            
+            {extra_scopes_source, [[<<"roles">>], [<<"realm">>, <<"roles">>]] }            
+        ]}
+       ], []
+  },
+  {additional_scopes_key_with_escaped_dots,
+      "auth_oauth2.resource_server_id = new_resource_server_id
+       auth_oauth2.additional_scopes_key = https://example\\.com/claims.roles",
+       [
+        {rabbitmq_auth_backend_oauth2, [
+            {resource_server_id,<<"new_resource_server_id">>},
+            {extra_scopes_source, [[<<"https://example.com/claims">>, <<"roles">>]]}
         ]}
        ], []
   }

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_schema_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_schema_SUITE.erl
@@ -41,7 +41,8 @@ all() ->
         test_without_oauth_providers_with_endpoint_params,
         test_scope_aliases_configured_as_list_of_properties,
         test_scope_aliases_configured_as_map,
-        test_scope_aliases_configured_as_list_of_missing_properties
+        test_scope_aliases_configured_as_list_of_missing_properties,
+        test_tokenize_additional_scopes_key
     ].
 
 
@@ -169,7 +170,7 @@ test_resource_servers_attributes(_) ->
         {["auth_oauth2","resource_servers","rabbitmq1","preferred_username_claims","2"],
             "groupid"}
     ],
-    #{<<"rabbitmq1xxx">> := [{extra_scopes_source, <<"roles">>},
+    #{<<"rabbitmq1xxx">> := [{extra_scopes_source, [[<<"roles">>]]},
                           {id, <<"rabbitmq1xxx">>},
                           {preferred_username_claims, [<<"userid">>, <<"groupid">>]},
                           {scope_prefix, <<"somescope.">>}
@@ -186,12 +187,22 @@ test_resource_servers_attributes(_) ->
         {["auth_oauth2","resource_servers","rabbitmq1","preferred_username_claims","2"],
             "groupid"}
     ],
-    #{<<"rabbitmq1">> := [{extra_scopes_source, <<"roles">>},
+    #{<<"rabbitmq1">> := [{extra_scopes_source, [[<<"roles">>]]},
                           {id, <<"rabbitmq1">>},
                           {preferred_username_claims, [<<"userid">>, <<"groupid">>]},
                           {scope_prefix, <<"somescope.">>}
                         ]
-    } = sort_settings(translate_resource_servers(Conf2)).
+    } = sort_settings(translate_resource_servers(Conf2)),
+
+    Conf3 = [
+        {["auth_oauth2","resource_servers","rabbitmq1","additional_scopes_key"],
+            "https://example\\.com/claims.roles"}
+    ],
+    #{<<"rabbitmq1">> := [{extra_scopes_source,
+                            [[<<"https://example.com/claims">>, <<"roles">>]]},
+                          {id, <<"rabbitmq1">>}
+                        ]
+    } = sort_settings(translate_resource_servers(Conf3)).
 
 test_oauth_providers_attributes_with_invalid_uri(_) ->
     Conf = [
@@ -326,6 +337,32 @@ test_scope_aliases_configured_as_map(_) ->
         <<"developer">> := [<<"rabbitmq.tag:management">>, <<"rabbitmq.read:*/*">>]
     } = rabbit_oauth2_schema:translate_scope_aliases(CuttlefishConf).
 
+
+test_tokenize_additional_scopes_key(_) ->
+    %% Simple dotless key.
+    [[<<"roles">>]] =
+        rabbit_oauth2_schema:tokenize_additional_scopes_key("roles"),
+    %% Nested dotted path.
+    [[<<"resource_access">>, <<"account">>, <<"roles">>]] =
+        rabbit_oauth2_schema:tokenize_additional_scopes_key("resource_access.account.roles"),
+    %% Escaped dots in a URI-namespaced claim name followed by a nested path.
+    [[<<"https://example.com/claims">>, <<"request_tags">>, <<"scope">>]] =
+        rabbit_oauth2_schema:tokenize_additional_scopes_key(
+            "https://example\\.com/claims.request_tags.scope"),
+    %% Flat namespaced claim, escaped dots only.
+    [[<<"https://myapp.example.com/roles">>]] =
+        rabbit_oauth2_schema:tokenize_additional_scopes_key(
+            "https://myapp\\.example\\.com/roles"),
+    %% Multiple space-separated paths.
+    [[<<"roles">>], [<<"permissions">>]] =
+        rabbit_oauth2_schema:tokenize_additional_scopes_key("roles permissions"),
+    %% Multiple paths with escaped dots.
+    [[<<"https://example.com/claims">>, <<"scope">>], [<<"roles">>]] =
+        rabbit_oauth2_schema:tokenize_additional_scopes_key(
+            "https://example\\.com/claims.scope roles"),
+    %% Per-resource-server: value arrives as binary from proplists.
+    [[<<"cognito:groups">>]] =
+        rabbit_oauth2_schema:tokenize_additional_scopes_key(<<"cognito:groups">>).
 
 cert_filename(Conf) ->
     string:concat(?config(data_dir, Conf), "certs/server_certificate.pem").

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -78,6 +78,7 @@ groups() ->
           test_successful_access_with_a_token_that_uses_single_scope_alias_with_var_expansion,
           test_successful_access_with_a_token_that_uses_single_scope_alias_in_extra_scope_source_field,
           test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_extra_scope_source_field,
+          test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_extra_scope_source_field_list_form,
           normalize_token_scope_with_additional_scopes_complex_claims,
           test_successful_access_with_a_token_that_uses_single_scope_alias_in_scope_field_and_custom_scope_prefix,
           test_missing_required_exp_claim_per_resource_server,
@@ -1080,6 +1081,55 @@ test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_extra_sc
     Token    = ?UTIL_MOD:sign_token_hs(?UTIL_MOD:token_with_sub(
         ?UTIL_MOD:token_with_scope_alias_in_claim_field(Claims, [<<"unrelated">>]),
             Username), Jwk),
+
+    {ok, AuthUser} = user_login_authentication(Username, [{password, Token}]),
+    assert_vhost_access_granted(AuthUser, VHost),
+    assert_vhost_access_denied(AuthUser, <<"some-other-vhost">>),
+
+    assert_resource_access_granted(AuthUser, VHost, <<"one">>, configure),
+    assert_resource_access_granted(AuthUser, VHost, <<"one">>, read),
+    assert_resource_access_granted(AuthUser, VHost, <<"two">>, read),
+    assert_resource_access_granted(AuthUser, VHost, <<"two">>, write),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, configure),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, read),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, write),
+
+    application:unset_env(rabbitmq_auth_backend_oauth2, scope_aliases),
+    application:unset_env(rabbitmq_auth_backend_oauth2, key_config).
+
+test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_extra_scope_source_field_list_form(_) ->
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    set_env(key_config, UaaEnv),
+    set_env(extra_scopes_source, [[<<"https://example.com/claims">>, <<"scope">>],
+                                  [<<"claims">>]]),
+    Role1 = <<"client-aliases-1">>,
+    Role2 = <<"client-aliases-2">>,
+    Role3 = <<"client-aliases-3">>,
+    set_env(scope_aliases, #{
+        Role1 => [
+            <<"rabbitmq.configure:vhost/one">>
+        ],
+        Role2 => [
+            <<"rabbitmq.write:vhost/two">>
+        ],
+        Role3 => [
+            <<"rabbitmq.read:vhost/one">>,
+            <<"rabbitmq.read:vhost/two">>,
+            <<"rabbitmq.read:vhost/two/abc">>
+        ]
+    }),
+
+    VHost = <<"vhost">>,
+    Username = <<"username">>,
+    %% Role1 lives under the URI-namespaced nested claim,
+    %% Role2 and Role3 live under the flat `claims` claim.
+    Token0   = ?UTIL_MOD:token_with_sub(
+        ?UTIL_MOD:token_with_scope_alias_in_claim_field([Role2, Role3], [<<"unrelated">>]),
+        Username),
+    Token1   = maps:put(<<"https://example.com/claims">>,
+                        #{<<"scope">> => [Role1]}, Token0),
+    Token    = ?UTIL_MOD:sign_token_hs(Token1, Jwk),
 
     {ok, AuthUser} = user_login_authentication(Username, [{password, Token}]),
     assert_vhost_access_granted(AuthUser, VHost),

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -48,6 +48,7 @@ all() ->
         test_invalid_signature,
         test_incorrect_kid,
         normalize_token_scope_using_multiple_scopes_key,
+        normalize_token_scope_with_escaped_dot_additional_scopes_key,
         normalize_token_scope_with_requesting_party_token_scopes,
         normalize_token_scope_with_rich_auth_request,
         normalize_token_scope_with_rich_auth_request_using_regular_expression_with_cluster,
@@ -197,6 +198,22 @@ normalize_token_scope_using_multiple_scopes_key(_) ->
         {ok, Token} = normalize_token_scope(ResourceServer, Token0),
         ?assertEqual(lists:sort(ExpectedScope), lists:sort(uaa_jwt:get_scope(Token)), Case)
         end, Pairs).
+
+
+normalize_token_scope_with_escaped_dot_additional_scopes_key(_) ->
+    ResourceServer0 = new_resource_server(<<"rabbitmq-resource">>),
+    ResourceServer = ResourceServer0#resource_server{
+        additional_scopes_key = [[<<"https://example.com/claims">>, <<"request_tags">>, <<"scope">>]]
+    },
+    Token0 = #{
+        <<"https://example.com/claims">> => #{
+            <<"request_tags">> => #{
+                <<"scope">> => <<"rabbitmq-resource.read:all">>
+            }
+        }
+    },
+    {ok, Token} = normalize_token_scope(ResourceServer, Token0),
+    ?assertEqual([<<"read:all">>], uaa_jwt:get_scope(Token)).
 
 normalize_token_scope_with_requesting_party_token_scopes(_) ->
     Pairs = [


### PR DESCRIPTION
## Proposed Changes

Implements changes for #16947 

OAuth2 `additional_scopes_key` currently supports nested claims separated by dots. This prevents it from accessing claims whose names contain dots such as URIs.

This PR uses `cuttlefish_variable:tokenize/1` for the value, which treats `\`. as a literal dot. The path is now tokenized once at config parse time and not per-token. Keys set directly via `advanced.config` as binaries keep the current behavior.

```
auth_oauth2.additional_scopes_key = https://example\.com/claims.roles
```

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

**Breaking case**: Claim names that end with a `\` followed by nesting work today but will be treated as a single token after this change. This does seem unlikely to affect anyone in practice, and any affected users can get the old behavior by setting the key in `advanced.config` directly.
