### PR TITLE
QQ: handle aux state upgrades from aux v1.

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1299,11 +1299,12 @@ init_aux(Name) when is_atom(Name) ->
                                       messages_total = 0,
                                       min_reclaimable = MinReclaimable}}.
 
-handle_aux(RaftState, Tag, Cmd, AuxV2, RaAux)
-  when element(1, AuxV2) == aux_v2 ->
-    Name = element(2, AuxV2),
-    AuxV3 = init_aux(Name),
-    handle_aux(RaftState, Tag, Cmd, AuxV3, RaAux);
+handle_aux(RaftState, Tag, Cmd, AuxPre, RaAux)
+  when element(1, AuxPre) == aux_v2 orelse
+       element(1, AuxPre) == aux ->
+    Name = element(2, AuxPre),
+    Aux = init_aux(Name),
+    handle_aux(RaftState, Tag, Cmd, Aux, RaAux);
 handle_aux(RaftState, Tag, Cmd, AuxV3, RaAux)
   when element(1, AuxV3) == aux_v3 ->
     AuxV4 = #?AUX{name = element(2, AuxV3),

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -4051,6 +4051,29 @@ aux_upgrade_from_v2_test(_) ->
     meck:unload(),
     ok.
 
+aux_upgrade_from_v3_test(_) ->
+    _ = ra_machine_ets:start_link(),
+    Name = ?FUNCTION_NAME,
+    %% shape of the aux state as used by an earlier version of rabbit_fifo
+    AuxV3 = {aux_v3, Name, unused_last_decorators_state, unused_capacity,
+             {aux_gc, 0}, unused_tick_pid, unused_cache, unused_last_checkpoint,
+             unused_bytes_in, unused_bytes_out},
+    LastApplied = 0,
+    State0 = #{machine_state =>
+               init(#{name => Name,
+                      queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+                      single_active_consumer_on => false}),
+               log => mock_log,
+               cfg => #cfg{},
+               last_applied => LastApplied},
+    ok = meck:new(ra_log, []),
+    meck:expect(ra_log, last_index_term, fun (_) -> {0, 0} end),
+    {no_reply, Aux, _, []} = handle_aux(leader, cast, tick, AuxV3, State0),
+    ?assertEqual(aux_v4, element(1, Aux)),
+    ?assertEqual(Name, element(2, Aux)),
+    meck:unload(),
+    ok.
+
 %% machine version conversion test
 
 machine_version_test(Config) ->

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -4007,6 +4007,50 @@ aux_test(_) ->
     meck:unload(),
     ok.
 
+%% covers upgrades from aux states as old as 3.13, e.g. 3.13 -> 4.2 -> 4.3
+aux_upgrade_from_v1_test(_) ->
+    _ = ra_machine_ets:start_link(),
+    Name = ?FUNCTION_NAME,
+    %% shape of the aux state as used by rabbit_fifo_v0 / rabbit_fifo_v1
+    AuxV1 = {aux, Name, unused_capacity, unused_gc},
+    LastApplied = 0,
+    State0 = #{machine_state =>
+               init(#{name => Name,
+                      queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+                      single_active_consumer_on => false}),
+               log => mock_log,
+               cfg => #cfg{},
+               last_applied => LastApplied},
+    ok = meck:new(ra_log, []),
+    meck:expect(ra_log, last_index_term, fun (_) -> {0, 0} end),
+    {no_reply, Aux, _, []} = handle_aux(leader, cast, tick, AuxV1, State0),
+    ?assertEqual(aux_v4, element(1, Aux)),
+    ?assertEqual(Name, element(2, Aux)),
+    meck:unload(),
+    ok.
+
+aux_upgrade_from_v2_test(_) ->
+    _ = ra_machine_ets:start_link(),
+    Name = ?FUNCTION_NAME,
+    %% shape of the aux state as used by an earlier version of rabbit_fifo
+    AuxV2 = {aux_v2, Name, unused_last_decorators_state, unused_capacity,
+              unused_gc, unused_tick_pid, unused_cache},
+    LastApplied = 0,
+    State0 = #{machine_state =>
+               init(#{name => Name,
+                      queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+                      single_active_consumer_on => false}),
+               log => mock_log,
+               cfg => #cfg{},
+               last_applied => LastApplied},
+    ok = meck:new(ra_log, []),
+    meck:expect(ra_log, last_index_term, fun (_) -> {0, 0} end),
+    {no_reply, Aux, _, []} = handle_aux(leader, cast, tick, AuxV2, State0),
+    ?assertEqual(aux_v4, element(1, Aux)),
+    ?assertEqual(Name, element(2, Aux)),
+    meck:unload(),
+    ok.
+
 %% machine version conversion test
 
 machine_version_test(Config) ->


### PR DESCRIPTION
If this isn't done and a system is upgraded as: 3.13 -> 4.2 -> 4.3
then the aux state will initialise as aux v1 which the current version
of rabbit_fifo.erl does not handle. The aux state will never be
upgraded and thus the queue(s) will never emit metrics or take
snapshots.

Fixes #16974 

