### PR TITLE
Honor a configurable format depth in RabbitMQ's log formatters

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1659,6 +1659,10 @@ end}.
     {default, off},
     {datatype, flag}
 ]}.
+{mapping, "log.console.formatter.depth", "rabbit.log.console.formatter", [
+    {default, unlimited},
+    {datatype, [{atom, unlimited}, integer]}
+]}.
 {mapping, "log.console.formatter.plaintext.format", "rabbit.log.console.formatter", [
     {default, "$time [$level] $pid $msg"},
     {datatype, string}
@@ -1697,6 +1701,10 @@ end}.
 {mapping, "log.exchange.formatter.single_line", "rabbit.log.exchange.formatter", [
     {default, off},
     {datatype, flag}
+]}.
+{mapping, "log.exchange.formatter.depth", "rabbit.log.exchange.formatter", [
+    {default, unlimited},
+    {datatype, [{atom, unlimited}, integer]}
 ]}.
 {mapping, "log.exchange.formatter.plaintext.format", "rabbit.log.exchange.formatter", [
     {default, "$time [$level] $pid $msg"},
@@ -1752,6 +1760,10 @@ end}.
 {mapping, "log.syslog.formatter.single_line", "rabbit.log.syslog.formatter", [
     {default, off},
     {datatype, flag}
+]}.
+{mapping, "log.syslog.formatter.depth", "rabbit.log.syslog.formatter", [
+    {default, unlimited},
+    {datatype, [{atom, unlimited}, integer]}
 ]}.
 {mapping, "log.syslog.formatter.plaintext.format", "rabbit.log.syslog.formatter", [
     {default, "$msg"},
@@ -1990,6 +2002,10 @@ end}.
 {mapping, "log.file.formatter.single_line", "rabbit.log.file.formatter", [
     {default, off},
     {datatype, flag}
+]}.
+{mapping, "log.file.formatter.depth", "rabbit.log.file.formatter", [
+    {default, unlimited},
+    {datatype, [{atom, unlimited}, integer]}
 ]}.
 {mapping, "log.file.formatter.plaintext.format", "rabbit.log.file.formatter", [
     {default, "$time [$level] $pid $msg"},

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1661,7 +1661,8 @@ end}.
 ]}.
 {mapping, "log.console.formatter.depth", "rabbit.log.console.formatter", [
     {default, unlimited},
-    {datatype, [{atom, unlimited}, integer]}
+    {datatype, [{atom, unlimited}, integer]},
+    {validators, ["formatter_depth"]}
 ]}.
 {mapping, "log.console.formatter.plaintext.format", "rabbit.log.console.formatter", [
     {default, "$time [$level] $pid $msg"},
@@ -1704,7 +1705,8 @@ end}.
 ]}.
 {mapping, "log.exchange.formatter.depth", "rabbit.log.exchange.formatter", [
     {default, unlimited},
-    {datatype, [{atom, unlimited}, integer]}
+    {datatype, [{atom, unlimited}, integer]},
+    {validators, ["formatter_depth"]}
 ]}.
 {mapping, "log.exchange.formatter.plaintext.format", "rabbit.log.exchange.formatter", [
     {default, "$time [$level] $pid $msg"},
@@ -1763,7 +1765,8 @@ end}.
 ]}.
 {mapping, "log.syslog.formatter.depth", "rabbit.log.syslog.formatter", [
     {default, unlimited},
-    {datatype, [{atom, unlimited}, integer]}
+    {datatype, [{atom, unlimited}, integer]},
+    {validators, ["formatter_depth"]}
 ]}.
 {mapping, "log.syslog.formatter.plaintext.format", "rabbit.log.syslog.formatter", [
     {default, "$msg"},
@@ -2005,7 +2008,8 @@ end}.
 ]}.
 {mapping, "log.file.formatter.depth", "rabbit.log.file.formatter", [
     {default, unlimited},
-    {datatype, [{atom, unlimited}, integer]}
+    {datatype, [{atom, unlimited}, integer]},
+    {validators, ["formatter_depth"]}
 ]}.
 {mapping, "log.file.formatter.plaintext.format", "rabbit.log.file.formatter", [
     {default, "$time [$level] $pid $msg"},
@@ -3145,6 +3149,12 @@ end}.
 {validator, "non_zero_positive_integer", "number should be greater or equal to one",
 fun(Int) when is_integer(Int) ->
     Int >= 1
+end}.
+
+{validator, "formatter_depth", "should be positive integer or 'unlimited'",
+fun(unlimited) -> true;
+   (Int) when is_integer(Int) -> Int >= 1;
+   (_) -> false
 end}.
 
 {validator, "positive_16_bit_unsigned_integer", "number should be between 1 and 65535",

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1839,5 +1839,16 @@ credential_validator.regexp = ^abc\\d+",
        {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
        {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
        {psk_identity, "my_identity"}]}]}],
+  []},
+ %% This snippet only asserts that the schema ACCEPTS
+ %% `log.file.formatter.depth'. The generated `rabbit.log' subtree is
+ %% stripped by `rabbit_ct_config_schema:without_rabbit_log/1' before
+ %% comparison, so the expected config is `[]' and the resulting `depth'
+ %% value cannot be checked here. That the value is carried into the
+ %% formatter config is covered by
+ %% `rabbit_prelaunch_early_logging_SUITE'.
+ {log_file_formatter_depth,
+  "log.file.formatter.depth = 20",
+  [],
   []}
 ].

--- a/deps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
@@ -148,8 +148,41 @@ format_msg1({string, Chardata}, Meta, Config) ->
 format_msg1({report, Report}, Meta, Config) ->
     FormattedReport = format_report(Report, Meta, Config),
     format_msg1(FormattedReport, Meta, Config);
-format_msg1({Format, Args}, _, _) ->
-    io_lib:format(Format, Args).
+format_msg1({Format, Args}, _, Config) ->
+    Depth = maps:get(depth, Config, unlimited),
+    SingleLine = maps:get(single_line, Config, false),
+    format_msg_with_depth(Format, Args, Depth, SingleLine).
+
+%% With no configured depth (the default), format exactly as before.
+format_msg_with_depth(Format, Args, unlimited, _SingleLine) ->
+    io_lib:format(Format, Args);
+%% Otherwise apply the configured format depth the same way OTP's
+%% `logger_formatter' does: rewrite the ~p/~w control sequences to
+%% ~P/~W with the depth appended, so deep sub-terms are truncated to
+%% `...'. See `format_msg/4' and `reformat/3' in:
+%% https://github.com/erlang/otp/blob/OTP-27.3.4.14/lib/kernel/src/logger_formatter.erl
+format_msg_with_depth(Format0, Args, Depth, SingleLine) ->
+    Format1 = io_lib:scan_format(Format0, Args),
+    Format2 = reformat(Format1, Depth, SingleLine),
+    io_lib:build_text(Format2).
+
+reformat([#{control_char := C} = M | T], Depth, true) when C =:= $p ->
+    [limit_depth(M#{width => 0}, Depth) | reformat(T, Depth, true)];
+reformat([#{control_char := C} = M | T], Depth, true) when C =:= $P ->
+    [M#{width => 0} | reformat(T, Depth, true)];
+reformat([#{control_char := C} = M | T], Depth, SingleLine)
+  when C =:= $p; C =:= $w ->
+    [limit_depth(M, Depth) | reformat(T, Depth, SingleLine)];
+reformat([H | T], Depth, SingleLine) ->
+    [H | reformat(T, Depth, SingleLine)];
+reformat([], _, _) ->
+    [].
+
+limit_depth(#{control_char := C0, args := Args} = M0, Depth) ->
+    %% Uppercase the control char (~p -> ~P, ~w -> ~W) and append the
+    %% depth to its argument list.
+    C = C0 - ($a - $A),
+    M0#{control_char := C, args := Args ++ [Depth]}.
 
 format_report(
   #{label := {application_controller, _}} = Report, Meta, Config) ->

--- a/deps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
@@ -195,7 +195,15 @@ format_report(
     try
         case erlang:fun_info(Cb, arity) of
             {arity, 1} -> Cb(Report);
-            {arity, 2} -> {"~ts", [Cb(Report, #{})]}
+            %% Pass the depth-limiting keys through to the callback, the
+            %% same way OTP's `logger_formatter' does. This lets report
+            %% callbacks such as `proc_lib:report_cb/2' truncate large
+            %% crash reports. See `format_msg/3' in:
+            %% https://github.com/erlang/otp/blob/OTP-27.3.4.14/lib/kernel/src/logger_formatter.erl
+            {arity, 2} ->
+                Extra = maps:with(
+                          [depth, chars_limit, single_line], Config),
+                {"~ts", [Cb(Report, Extra)]}
         end
     catch
         _:_:_ ->

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -269,7 +269,8 @@ translate_generic_conf(Var, Conf) ->
     %% sub-terms to `...'. `unlimited' (or an unset key) means "no
     %% explicit depth"; in that case we fall back to the deprecated
     %% `error_logger_format_depth' kernel variable, the same way OTP's
-    %% `logger_formatter:get_depth/1' does.
+    %% `logger_formatter:get_depth/1' does. As in OTP, an explicit depth
+    %% is floored at 5, so configured values below 5 are raised to 5.
     Depth = case cuttlefish:conf_get(Var ++ ".depth", Conf, unlimited) of
                 unlimited -> error_logger:get_format_depth();
                 D         -> max(5, D)

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -285,6 +285,7 @@ translate_generic_conf(Var, Conf) ->
 -type formatter_plaintext_conf() :: #{time_format := time_format(),
                                       level_format := level_format(),
                                       single_line := boolean(),
+                                      depth := unlimited | pos_integer(),
                                       prefix_format := line_format(),
                                       line_format := line_format(),
                                       use_colors := boolean(),
@@ -414,6 +415,7 @@ translate_colors_conf(_, _) ->
 -type formatter_json_conf() :: #{time_format := time_format(),
                                  level_format := level_format(),
                                  single_line := boolean(),
+                                 depth := unlimited | pos_integer(),
                                  field_map := json_field_map(),
                                  verbosity_map := json_verbosity_map()}.
 

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -27,7 +27,8 @@
 
 %% For internal testing purpose only.
 -export([levels/0,
-         determine_prefix/1]).
+         determine_prefix/1,
+         translate_generic_conf/2]).
 
 -define(CONFIGURED_KEY, {?MODULE, configured}).
 
@@ -218,7 +219,8 @@ translate_formatter_conf(Var, Conf) when is_list(Var) ->
 -type level_format() :: lc | uc | lc3 | uc3 | lc4 | uc4.
 -type formatter_generic_conf() :: #{time_format := time_format(),
                                     level_format := level_format(),
-                                    single_line := boolean()}.
+                                    single_line := boolean(),
+                                    depth := unlimited | pos_integer()}.
 
 -spec translate_generic_conf(string(), cuttlefish_conf:conf()) ->
     formatter_generic_conf().
@@ -262,9 +264,21 @@ translate_generic_conf(Var, Conf) ->
     %% stay on a single line.
     SingleLine = cuttlefish:conf_get(Var ++ ".single_line", Conf),
 
+    %% log.*.formatter.depth
+    %% It caps the depth to which terms are printed, truncating deeper
+    %% sub-terms to `...'. `unlimited' (or an unset key) means "no
+    %% explicit depth"; in that case we fall back to the deprecated
+    %% `error_logger_format_depth' kernel variable, the same way OTP's
+    %% `logger_formatter:get_depth/1' does.
+    Depth = case cuttlefish:conf_get(Var ++ ".depth", Conf, unlimited) of
+                unlimited -> error_logger:get_format_depth();
+                D         -> max(5, D)
+            end,
+
     #{time_format => TimeFormat,
       level_format => LevelFormat,
-      single_line => SingleLine}.
+      single_line => SingleLine,
+      depth => Depth}.
 
 -type line_format() :: [atom() | string()].
 -type color_esc_seqs() :: #{logger:level() => string()}.

--- a/deps/rabbitmq_prelaunch/test/rabbit_logger_fmt_helpers_SUITE.erl
+++ b/deps/rabbitmq_prelaunch/test/rabbit_logger_fmt_helpers_SUITE.erl
@@ -1,0 +1,79 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_logger_fmt_helpers_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [{group, tests}].
+
+all_tests() ->
+    [format_args_depth_truncates,
+     format_args_depth_unlimited_is_full].
+
+groups() ->
+    [{tests, [], all_tests()}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+%% A term deeply nested past a small depth limit.
+deep_term() ->
+    [{level1, [{level2, [{level3, [{level4, [{level5, secret}]}]}]}]}].
+
+format(Msg, Config) ->
+    Meta = #{},
+    lists:flatten(rabbit_logger_fmt_helpers:format_msg(Msg, Meta, Config)).
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+%% A `{Format, Args}' message formatted with a small `depth' must be
+%% truncated. OTP's logger_formatter rewrites ~p/~w to ~P/~W with the
+%% configured depth, which renders deep sub-terms as `...'.
+format_args_depth_truncates(_Config) ->
+    Config = #{single_line => false, depth => 3},
+    Formatted = format({"~p", [deep_term()]}, Config),
+    ?assertNotEqual(nomatch, string:find(Formatted, "...")),
+    ?assertEqual(nomatch, string:find(Formatted, "secret")).
+
+%% With `depth => unlimited' the full term is rendered, including the
+%% deepest element.
+format_args_depth_unlimited_is_full(_Config) ->
+    Config = #{single_line => false, depth => unlimited},
+    Formatted = format({"~p", [deep_term()]}, Config),
+    ?assertNotEqual(nomatch, string:find(Formatted, "secret")),
+    ?assertEqual(nomatch, string:find(Formatted, "...")).

--- a/deps/rabbitmq_prelaunch/test/rabbit_logger_fmt_helpers_SUITE.erl
+++ b/deps/rabbitmq_prelaunch/test/rabbit_logger_fmt_helpers_SUITE.erl
@@ -22,7 +22,9 @@ all() ->
 
 all_tests() ->
     [format_args_depth_truncates,
-     format_args_depth_unlimited_is_full].
+     format_args_depth_unlimited_is_full,
+     report_cb_depth_truncates,
+     report_cb_depth_unlimited_is_full].
 
 groups() ->
     [{tests, [], all_tests()}].
@@ -77,3 +79,36 @@ format_args_depth_unlimited_is_full(_Config) ->
     Formatted = format({"~p", [deep_term()]}, Config),
     ?assertNotEqual(nomatch, string:find(Formatted, "secret")),
     ?assertEqual(nomatch, string:find(Formatted, "...")).
+
+%% A `{report, Report}' message whose meta carries an arity-2
+%% `report_cb' must have the configured `depth' passed through to that
+%% callback (in the `Extra' map), so the callback can truncate. This
+%% mirrors how OTP's `logger_formatter' invokes report callbacks and is
+%% what `proc_lib:report_cb/2' relies on to limit crash reports.
+report_cb_depth_truncates(_Config) ->
+    Config = #{single_line => false, depth => 3},
+    Formatted = format_report_with_cb(deep_term(), Config),
+    ?assertNotEqual(nomatch, string:find(Formatted, "...")),
+    ?assertEqual(nomatch, string:find(Formatted, "secret")).
+
+report_cb_depth_unlimited_is_full(_Config) ->
+    Config = #{single_line => false, depth => unlimited},
+    Formatted = format_report_with_cb(deep_term(), Config),
+    ?assertNotEqual(nomatch, string:find(Formatted, "secret")),
+    ?assertEqual(nomatch, string:find(Formatted, "...")).
+
+%% Build a `{report, Report}' message with an arity-2 `report_cb' that
+%% honors the `depth' key from its `Extra' argument, exactly as
+%% `proc_lib:report_cb/2' does.
+format_report_with_cb(Term, Config) ->
+    Report = #{term => Term},
+    Cb = fun(#{term := T}, Extra) ->
+                 Depth = maps:get(depth, Extra, unlimited),
+                 case Depth of
+                     unlimited -> io_lib:format("~p", [T]);
+                     D         -> io_lib:format("~P", [T, D])
+                 end
+         end,
+    Meta = #{report_cb => Cb},
+    lists:flatten(
+      rabbit_logger_fmt_helpers:format_msg({report, Report}, Meta, Config)).

--- a/deps/rabbitmq_prelaunch/test/rabbit_logger_json_fmt_SUITE.erl
+++ b/deps/rabbitmq_prelaunch/test/rabbit_logger_json_fmt_SUITE.erl
@@ -1,0 +1,105 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_logger_json_fmt_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [{group, tests}].
+
+all_tests() ->
+    [msg_args_depth_truncates,
+     msg_args_depth_unlimited_is_full,
+     msg_report_depth_truncates].
+
+groups() ->
+    [{tests, [], all_tests()}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+deep_term() ->
+    [{level1, [{level2, [{level3, [{level4, [{level5, secret}]}]}]}]}].
+
+config(Depth) ->
+    #{single_line => false,
+      depth => Depth,
+      time_format => {rfc3339, $\s, ""},
+      level_format => lc}.
+
+format(Msg, Config) ->
+    Event = #{msg => Msg, level => error, meta => #{time => 0}},
+    iolist_to_binary(rabbit_logger_json_fmt:format(Event, Config)).
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+%% The JSON formatter renders the `msg' field through the shared
+%% `format_msg/3', so a `{Format, Args}' message honors the configured
+%% depth: deep sub-terms are truncated to `...' and the produced line is
+%% still valid JSON.
+msg_args_depth_truncates(_Config) ->
+    Formatted = format({"~p", [deep_term()]}, config(3)),
+    ?assertMatch(#{}, rabbit_json:decode(Formatted)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"...">>)),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"secret">>)).
+
+msg_args_depth_unlimited_is_full(_Config) ->
+    Formatted = format({"~p", [deep_term()]}, config(unlimited)),
+    ?assertMatch(#{}, rabbit_json:decode(Formatted)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"secret">>)),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"...">>)).
+
+%% Crash reports are logged as `{report, Report}' messages with an
+%% arity-2 `report_cb'. They too flow through `format_msg/3', so the
+%% depth is passed to the callback and the report is truncated.
+msg_report_depth_truncates(_Config) ->
+    Report = #{term => deep_term()},
+    Cb = fun(#{term := T}, Extra) ->
+                 Depth = maps:get(depth, Extra, unlimited),
+                 case Depth of
+                     unlimited -> io_lib:format("~p", [T]);
+                     D         -> io_lib:format("~P", [T, D])
+                 end
+         end,
+    Event = #{msg => {report, Report},
+              level => error,
+              meta => #{time => 0, report_cb => Cb}},
+    Formatted = iolist_to_binary(
+                  rabbit_logger_json_fmt:format(Event, config(3))),
+    ?assertMatch(#{}, rabbit_json:decode(Formatted)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"...">>)),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"secret">>)).

--- a/deps/rabbitmq_prelaunch/test/rabbit_prelaunch_early_logging_SUITE.erl
+++ b/deps/rabbitmq_prelaunch/test/rabbit_prelaunch_early_logging_SUITE.erl
@@ -1,0 +1,95 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_prelaunch_early_logging_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [{group, tests}].
+
+all_tests() ->
+    [generic_conf_explicit_depth,
+     generic_conf_unlimited_falls_back_to_error_logger,
+     generic_conf_missing_depth_falls_back_to_error_logger].
+
+groups() ->
+    [{tests, [], all_tests()}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Saved = application:get_env(kernel, error_logger_format_depth),
+    [{saved_format_depth, Saved} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    case ?config(saved_format_depth, Config) of
+        {ok, V}   -> application:set_env(kernel, error_logger_format_depth, V);
+        undefined -> application:unset_env(kernel, error_logger_format_depth)
+    end,
+    ok.
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+%% A minimal plaintext-formatter cuttlefish conf. `Extra' entries are
+%% appended so individual tests can add or omit the `depth' key.
+base_conf(Extra) ->
+    [{["log", "file"], plaintext},
+     {["log", "file", "time_format"], rfc3339_space},
+     {["log", "file", "level_format"], lc},
+     {["log", "file", "single_line"], false}
+     | Extra].
+
+depth_of(Conf) ->
+    Generic = rabbit_prelaunch_early_logging:translate_generic_conf(
+                "log.file", Conf),
+    maps:get(depth, Generic).
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+%% An explicit integer `depth' is carried into the generic formatter
+%% config.
+generic_conf_explicit_depth(_Config) ->
+    Conf = base_conf([{["log", "file", "depth"], 20}]),
+    ?assertEqual(20, depth_of(Conf)).
+
+%% `depth = unlimited' means "no explicit depth"; fall back to the
+%% deprecated `error_logger_format_depth' kernel variable, matching
+%% OTP's `logger_formatter:get_depth/1'.
+generic_conf_unlimited_falls_back_to_error_logger(_Config) ->
+    application:set_env(kernel, error_logger_format_depth, 10),
+    Conf = base_conf([{["log", "file", "depth"], unlimited}]),
+    ?assertEqual(10, depth_of(Conf)).
+
+%% A missing `depth' key behaves the same as `unlimited': fall back to
+%% the kernel variable.
+generic_conf_missing_depth_falls_back_to_error_logger(_Config) ->
+    application:set_env(kernel, error_logger_format_depth, 10),
+    Conf = base_conf([]),
+    ?assertEqual(10, depth_of(Conf)).


### PR DESCRIPTION
## Why

Follow-up to #14349 and the work that shipped in #14523 / #14555.

Those changes shrink the *queue process state* via `format_state/1` before it is logged, which stops the largest offender (the backing-queue state) from being dumped on a crash. They do not, however, cap the depth of everything else a crash report prints: the `Last message`, the exit `Reason`, and the full `crasher:` SASL report from `proc_lib`. A crash in a process with a large mailbox or large arguments (for example a `gen_batch_server` such as `ra_log_wal`, as @the-mikedavis noted in the discussion) can still produce a multi-hundred-KB to multi-MB log entry containing message bodies, and in the worst case OOM the node.

OTP's own `logger_formatter` already solves this with its [`depth` config value](https://www.erlang.org/doc/apps/kernel/logger_formatter#t:config/0), which rewrites `~p`/`~w` to `~P`/`~W` so deep sub-terms are truncated to `...`. RabbitMQ ships its own formatters (`rabbit_logger_text_fmt` and `rabbit_logger_json_fmt`), which did not honor any depth, so the deprecated `kernel.error_logger_format_depth` setting mentioned in #14349 was not reflected in RabbitMQ's formatted output.

## What

Make RabbitMQ's formatters honor a format depth, exposed as a per-output formatter setting:

```ini
log.file.formatter.depth = 20
log.console.formatter.depth = 20
log.exchange.formatter.depth = 20
log.syslog.formatter.depth = 20
```

Behavior:

- The depth is applied the same way OTP's `logger_formatter` does: `~p`/`~w` control sequences are rewritten to `~P`/`~W` with the depth appended, truncating deeper sub-terms to `...`. This covers both `{Format, Args}` messages and reports formatted through an arity-2 `report_cb` (which is how `proc_lib` crash reports are logged), so the crash report itself is truncated, not just the server state.
- When unset (the default), the value is `unlimited`, and RabbitMQ falls back to the deprecated `error_logger_format_depth` kernel variable via `error_logger:get_format_depth/0`, exactly as OTP's `logger_formatter:get_depth/1` does. This keeps the deprecated setting working for anyone relying on it today, with no behavior change for users who set neither.
- An explicit depth is floored at 5, matching OTP's `logger_formatter` semantics.

This is complementary to #14523 / #14555, not a replacement: `format_state/1` removes the bulk of the state, and this bounds whatever remains across all crash-report fields.

## Testing

- `deps/rabbitmq_prelaunch`: new CT suites `rabbit_logger_fmt_helpers_SUITE` (text/report paths), `rabbit_logger_json_fmt_SUITE` (JSON path, asserting output remains valid JSON), and `rabbit_prelaunch_early_logging_SUITE` (config resolution and the `error_logger_format_depth` fallback). All green.
- `deps/rabbit`: `config_schema_SUITE` covers the new mappings; green.
- `make dialyze` and `make xref` pass on `deps/rabbitmq_prelaunch`; `make dialyze` passes on `deps/rabbit`.

## Related

- #14349 (discussion)
- #14523 / #14548 (shrink queue process state)
- #14555 / #14558 (`format_state/1` for `rabbit_priority_queue`)
