### PR TITLE
Support if-empty and if-unused checks in quorum queue deletion

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -103,7 +103,7 @@
 -type msg_id() :: undefined | non_neg_integer() | {Priority :: non_neg_integer(), undefined | non_neg_integer()}.
 -type ok_or_errors() ::
         'ok' | {'error', [{'error' | 'exit' | 'throw', any()}]}.
--type absent_reason() :: 'nodedown' | 'crashed' | stopped | timeout.
+-type absent_reason() :: 'nodedown' | 'crashed' | 'stopped' | 'timeout' | 'blocked'.
 -type queue_not_found() :: not_found.
 -type queue_absent() :: {'absent', amqqueue:amqqueue(), absent_reason()}.
 -type not_found_or_absent() :: queue_not_found() | queue_absent().
@@ -606,6 +606,10 @@ with(#resource{} = Name, F, E, RetriesLeft) ->
         {ok, Q} when ?amqqueue_state_is(Q, stopped) ->
             %% The queue was stopped
             E({absent, Q, stopped});
+        %% The queue is being deleted with an if-unused/if-empty precondition
+        %% and is temporarily blocked to fail operations against it.
+        {ok, Q} when ?amqqueue_state_is(Q, blocked) ->
+            E({absent, Q, blocked});
         %% The queue process has crashed with unknown error
         {ok, Q} when ?amqqueue_state_is(Q, crashed) ->
             E({absent, Q, crashed});
@@ -702,6 +706,11 @@ priv_absent(QueueName, _QPid, _IsDurable, crashed) ->
     rabbit_misc:protocol_error(
       not_found,
       "~ts has crashed and failed to restart", [rabbit_misc:rs(QueueName)]);
+
+priv_absent(QueueName, _QPid, _IsDurable, blocked) ->
+    rabbit_misc:protocol_error(
+      resource_locked,
+      "~ts is currently being deleted", [rabbit_misc:rs(QueueName)]);
 
 priv_absent(QueueName, _QPid, _IsDurable, timeout) ->
     rabbit_misc:protocol_error(

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1081,18 +1081,61 @@ restart_server({_, _} = Ref) ->
 -spec delete(amqqueue:amqqueue(),
              boolean(), boolean(),
              rabbit_types:username()) ->
-    {ok, QLen :: non_neg_integer()} |
+    rabbit_types:ok(non_neg_integer()) |
+    rabbit_types:error(in_use | not_empty) |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
-    {ok, ReadyMsgs, Consumers} = stat(Q),
-    if
-        IfEmpty andalso ReadyMsgs > 0 ->
-            {error, not_empty};
-        IfUnused andalso Consumers > 0 ->
-            {error, in_use};
-        true ->
-            do_delete(Q, ReadyMsgs, ActingUser)
+    case delete_precondition(Q, IfUnused, IfEmpty) of
+        {ok, ReadyMsgs} ->
+            do_delete(Q, ReadyMsgs, ActingUser);
+        Error ->
+            Error
     end.
+
+%% The if-unused and if-empty flags gate deletion on the queue's consumer and
+%% message counts, read from the leader via rabbit_fifo_client:stat/1. When a
+%% flag is set, any failure to read the counts is surfaced rather than defaulted
+%% to zero: a queue whose counts cannot be verified must not be deleted, as that
+%% would silently bypass the requested precondition. When no flag is set the read
+%% is best-effort and only supplies the message count reported back to the client.
+delete_precondition(Q, false, false) ->
+    ReadyMsgs = case leader_stat(Q) of
+                    {ok, R, _} ->
+                        R;
+                    _ ->
+                        0
+                end,
+    {ok, ReadyMsgs};
+delete_precondition(Q, IfUnused, IfEmpty) ->
+    QName = amqqueue:get_name(Q),
+    case leader_stat(Q) of
+        {ok, ReadyMsgs, Consumers} ->
+            if
+                IfEmpty andalso ReadyMsgs > 0 ->
+                    {error, not_empty};
+                IfUnused andalso Consumers > 0 ->
+                    {error, in_use};
+                true ->
+                    {ok, ReadyMsgs}
+            end;
+        {_, Reason} ->
+            cannot_verify_delete_flags(QName, Reason)
+    end.
+
+%% Reads the queue's ready message and consumer counts from the leader via
+%% rabbit_fifo_client:stat/1, surfacing any failure to locate or query it.
+leader_stat(Q) ->
+    case find_leader(Q) of
+        {_, _} = Leader ->
+            rabbit_fifo_client:stat(Leader);
+        undefined ->
+            {error, no_leader_available}
+    end.
+
+cannot_verify_delete_flags(QName, Reason) ->
+    {protocol_error, internal_error,
+     "cannot delete ~ts: unable to verify the if-unused/if-empty precondition (~tp)",
+     [rabbit_misc:rs(QName), Reason]}.
 
 do_delete(Q, ReadyMsgs, ActingUser) ->
     {Name, _} = amqqueue:get_pid(Q),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1050,6 +1050,15 @@ recover(_Vhost, Queues) ->
          %% rabbit_durable_queue
          %% So many code paths are dependent on this.
          ok = rabbit_db_queue:set_dirty(Q),
+         %% A queue left in the blocked state means a delete with an
+         %% if-unused/if-empty precondition was interrupted before it could
+         %% restore the state. The queue still exists, so make it usable again.
+         _ = case amqqueue:get_state(Q) =:= blocked of
+                 true ->
+                     set_queue_state(QName, live);
+                 false ->
+                     ok
+             end,
          case Res of
              ok ->
                  {[Q | R0], F0};
@@ -1085,51 +1094,95 @@ restart_server({_, _} = Ref) ->
     rabbit_types:error(in_use | not_empty) |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
-    case delete_precondition(Q, IfUnused, IfEmpty) of
-        {ok, ReadyMsgs} ->
+    case IfUnused orelse IfEmpty of
+        false ->
+            %% Unconditional delete: there is no precondition to protect, so
+            %% no need to block the queue first.
+            {ok, ReadyMsgs, _} = stat(Q),
             do_delete(Q, ReadyMsgs, ActingUser);
-        Error ->
-            Error
+        true ->
+            %% The block-then-delete path below writes the blocked state to the
+            %% cluster metadata store and relies on rejecting publishes. Both
+            %% are unsafe while any node is under a resource alarm, so refuse
+            %% the conditional delete until the alarm clears.
+            case rabbit_alarm:get_alarms() of
+                [] ->
+                    %% Move the queue to the blocked state before checking the
+                    %% preconditions so that publishes and new consumers are
+                    %% rejected while the check and the delete run, closing the
+                    %% window in which an if-empty/if-unused precondition could
+                    %% be violated.
+                    with_queue_blocked(
+                      Q,
+                      fun () ->
+                              case check_delete_flags(Q, IfUnused, IfEmpty) of
+                                  {ok, ReadyMsgs} ->
+                                      do_delete(Q, ReadyMsgs, ActingUser);
+                                  Error ->
+                                      Error
+                              end
+                      end);
+                _Alarms ->
+                    cannot_delete_under_alarm(amqqueue:get_name(Q))
+            end
     end.
+
+cannot_delete_under_alarm(QName) ->
+    {protocol_error, precondition_failed,
+     "cannot delete ~ts with an if-unused/if-empty precondition while the "
+     "cluster is under a resource alarm",
+     [rabbit_misc:rs(QName)]}.
+
+%% Runs Fun with the queue moved to the blocked state. On success the queue
+%% record has already been removed by the delete, so nothing is restored;
+%% otherwise (a failed precondition, an error return or an exception) the
+%% previous state is restored.
+with_queue_blocked(Q, Fun) ->
+    QName = amqqueue:get_name(Q),
+    PrevState = amqqueue:get_state(Q),
+    _ = set_queue_state(QName, blocked),
+    try Fun() of
+        {ok, _} = Ok ->
+            Ok;
+        Other ->
+            _ = set_queue_state(QName, PrevState),
+            Other
+    catch
+        Class:Reason:Stacktrace ->
+            _ = set_queue_state(QName, PrevState),
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
+
+set_queue_state(QName, State) ->
+    rabbit_amqqueue:update(QName,
+                           fun (Q) -> amqqueue:set_state(Q, State) end).
 
 %% The if-unused and if-empty flags gate deletion on the queue's consumer and
-%% message counts, read from the leader via rabbit_fifo_client:stat/1. When a
-%% flag is set, any failure to read the counts is surfaced rather than defaulted
-%% to zero: a queue whose counts cannot be verified must not be deleted, as that
-%% would silently bypass the requested precondition. When no flag is set the read
-%% is best-effort and only supplies the message count reported back to the client.
-delete_precondition(Q, false, false) ->
-    ReadyMsgs = case leader_stat(Q) of
-                    {ok, R, _} ->
-                        R;
-                    _ ->
-                        0
-                end,
-    {ok, ReadyMsgs};
-delete_precondition(Q, IfUnused, IfEmpty) ->
+%% message counts. Both counts come from a single rabbit_fifo_client:stat/1 call
+%% against the leader with any failure surfaced, rather than via
+%% rabbit_quorum_queue:stat/1 which reports zero counts on failure: a queue whose
+%% counts cannot be verified must not be deleted, as that would silently bypass
+%% the requested precondition. On success the ready message count is returned so
+%% the caller can reuse it as the delete result without a second stat call.
+check_delete_flags(Q, IfUnused, IfEmpty) ->
     QName = amqqueue:get_name(Q),
-    case leader_stat(Q) of
-        {ok, ReadyMsgs, Consumers} ->
-            if
-                IfEmpty andalso ReadyMsgs > 0 ->
-                    {error, not_empty};
-                IfUnused andalso Consumers > 0 ->
-                    {error, in_use};
-                true ->
-                    {ok, ReadyMsgs}
-            end;
-        {_, Reason} ->
-            cannot_verify_delete_flags(QName, Reason)
-    end.
-
-%% Reads the queue's ready message and consumer counts from the leader via
-%% rabbit_fifo_client:stat/1, surfacing any failure to locate or query it.
-leader_stat(Q) ->
     case find_leader(Q) of
         {_, _} = Leader ->
-            rabbit_fifo_client:stat(Leader);
+            case rabbit_fifo_client:stat(Leader) of
+                {ok, ReadyMsgs, Consumers} ->
+                    if
+                        IfEmpty andalso ReadyMsgs > 0 ->
+                            {error, not_empty};
+                        IfUnused andalso Consumers > 0 ->
+                            {error, in_use};
+                        true ->
+                            {ok, ReadyMsgs}
+                    end;
+                {_, Reason} ->
+                    cannot_verify_delete_flags(QName, Reason)
+            end;
         undefined ->
-            {error, no_leader_available}
+            cannot_verify_delete_flags(QName, no_leader_available)
     end.
 
 cannot_verify_delete_flags(QName, Reason) ->
@@ -1381,19 +1434,45 @@ deliver(QSs, Msg0, Options) ->
     Msg = mc:prepare(store, Msg0),
     lists:foldl(
       fun({Q, stateless}, Acc) ->
-              QRef = amqqueue:get_pid(Q),
-              ok = rabbit_fifo_client:untracked_enqueue([QRef], Msg),
-              Acc;
+              QName = amqqueue:get_name(Q),
+              case is_blocked(QName) of
+                  true ->
+                      %% The queue is being deleted; drop the message.
+                      Acc;
+                  false ->
+                      QRef = amqqueue:get_pid(Q),
+                      ok = rabbit_fifo_client:untracked_enqueue([QRef], Msg),
+                      Acc
+              end;
          ({Q, S0}, {Qs, Actions}) ->
               QName = amqqueue:get_name(Q),
-              case deliver0(QName, Correlation, Msg, S0) of
-                  {reject_publish, S} ->
-                      {[{Q, S} | Qs],
-                       [{rejected, QName, maxlen, [Correlation]} | Actions]};
-                  {ok, S, As} ->
-                      {[{Q, S} | Qs], As ++ Actions}
+              case is_blocked(QName) of
+                  true ->
+                      %% The queue is being deleted; reject the message so the
+                      %% publisher is notified rather than silently losing it.
+                      {[{Q, S0} | Qs],
+                       [{rejected, QName, blocked, [Correlation]} | Actions]};
+                  false ->
+                      case deliver0(QName, Correlation, Msg, S0) of
+                          {reject_publish, S} ->
+                              {[{Q, S} | Qs],
+                               [{rejected, QName, maxlen, [Correlation]} | Actions]};
+                          {ok, S, As} ->
+                              {[{Q, S} | Qs], As ++ Actions}
+                      end
               end
       end, {[], []}, QSs).
+
+%% A queue is blocked while it is being deleted with an if-unused/if-empty
+%% precondition. Publishing to such a queue must fail. The state is read from
+%% the cluster-consistent full-record projection via a fast ETS lookup.
+is_blocked(QName) ->
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            ?amqqueue_state_is(Q, blocked);
+        _ ->
+            false
+    end.
 
 state_info(S) ->
     #{pending_raft_commands => rabbit_fifo_client:pending_size(S),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -173,6 +173,11 @@
 -define(START_CLUSTER_RPC_TIMEOUT, 60_000). %% needs to be longer than START_CLUSTER_TIMEOUT
 -define(TICK_INTERVAL, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
+%% Default period after which the safety-net timer restores a queue that was
+%% blocked for a conditional delete but never had its previous state restored.
+%% Must comfortably exceed ?DELETE_TIMEOUT so a normally-running delete finishes
+%% first. Configurable via the quorum_queue_blocked_state_restore_timeout env.
+-define(BLOCKED_STATE_RESTORE_TIMEOUT, ?DELETE_TIMEOUT + 1_000).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 %% setting a low default here to allow quorum queues to better chose themselves
@@ -1141,6 +1146,12 @@ with_queue_blocked(Q, Fun) ->
     QName = amqqueue:get_name(Q),
     PrevState = amqqueue:get_state(Q),
     _ = set_queue_state(QName, blocked),
+    %% Safety net: should this process fail to restore the previous state for
+    %% any reason (for example, it is killed mid-delete), an independent timer
+    %% process restores it after a timeout so the queue is not left blocked,
+    %% and rejecting publishes, indefinitely. It is cancelled on the normal
+    %% paths below where the state is restored (or the queue deleted) directly.
+    TimerPid = spawn_state_restore_timer(QName, PrevState),
     try Fun() of
         {ok, _} = Ok ->
             Ok;
@@ -1151,7 +1162,32 @@ with_queue_blocked(Q, Fun) ->
         Class:Reason:Stacktrace ->
             _ = set_queue_state(QName, PrevState),
             erlang:raise(Class, Reason, Stacktrace)
+    after
+        _ = cancel_state_restore_timer(TimerPid)
     end.
+
+%% Spawns an unlinked process that restores State after a configurable timeout
+%% unless it is cancelled first. It must not be linked to the caller: the whole
+%% point is to restore the state even when the caller dies without doing so.
+spawn_state_restore_timer(QName, State) ->
+    Timeout = blocked_state_restore_timeout(),
+    spawn(fun () ->
+                  receive
+                      cancel ->
+                          ok
+                  after Timeout ->
+                          _ = set_queue_state(QName, State),
+                          ok
+                  end
+          end).
+
+cancel_state_restore_timer(Pid) ->
+    Pid ! cancel,
+    ok.
+
+blocked_state_restore_timeout() ->
+    application:get_env(rabbit, quorum_queue_blocked_state_restore_timeout,
+                        ?BLOCKED_STATE_RESTORE_TIMEOUT).
 
 set_queue_state(QName, State) ->
     rabbit_amqqueue:update(QName,

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1083,22 +1083,23 @@ restart_server({_, _} = Ref) ->
              rabbit_types:username()) ->
     {ok, QLen :: non_neg_integer()} |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
-delete(Q, true, _IfEmpty, _ActingUser) when ?amqqueue_is_quorum(Q) ->
-    {protocol_error, not_implemented,
-     "cannot delete ~ts. queue.delete operations with if-unused flag set are not supported by quorum queues",
-     [rabbit_misc:rs(amqqueue:get_name(Q))]};
-delete(Q, _IfUnused, true, _ActingUser) when ?amqqueue_is_quorum(Q) ->
-    {protocol_error, not_implemented,
-     "cannot delete ~ts. queue.delete operations with if-empty flag set are not supported by quorum queues",
-     [rabbit_misc:rs(amqqueue:get_name(Q))]};
-delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
+delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
+    {ok, ReadyMsgs, Consumers} = stat(Q),
+    if
+        IfEmpty andalso ReadyMsgs > 0 ->
+            {error, not_empty};
+        IfUnused andalso Consumers > 0 ->
+            {error, in_use};
+        true ->
+            do_delete(Q, ReadyMsgs, ActingUser)
+    end.
+
+do_delete(Q, ReadyMsgs, ActingUser) ->
     {Name, _} = amqqueue:get_pid(Q),
     QName = amqqueue:get_name(Q),
     QNodes = get_nodes(Q),
-    %% TODO Quorum queue needs to support consumer tracking for IfUnused
     Timeout = ?DELETE_TIMEOUT,
     rabbit_binding:delete_for_destination(QName, ActingUser),
-    {ok, ReadyMsgs, _} = stat(Q),
     Servers = [{Name, Node} || Node <- QNodes],
     case ra:delete_cluster(Servers, Timeout) of
         {ok, {_, LeaderNode} = Leader} ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -38,6 +38,7 @@
 -export([cancel_consumer_handler/2, cancel_consumer/3]).
 -export([become_leader/2, handle_tick/3, spawn_deleter/1]).
 -export([state_restore_timer/3, spawn_state_restore_timers/2]).
+-export([blocked_delete/5]).
 -export([rpc_delete_metrics/1,
          key_metrics_rpc/1]).
 -export([format/2]).
@@ -1107,31 +1108,76 @@ delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
             {ok, ReadyMsgs, _} = stat(Q),
             do_delete(Q, ReadyMsgs, ActingUser);
         true ->
-            %% The block-then-delete path below writes the blocked state to the
-            %% cluster metadata store and relies on rejecting publishes. Both
-            %% are unsafe while any node is under a resource alarm, so refuse
-            %% the conditional delete until the alarm clears.
-            case rabbit_alarm:get_alarms() of
-                [] ->
-                    %% Move the queue to the blocked state before checking the
-                    %% preconditions so that publishes and new consumers are
-                    %% rejected while the check and the delete run, closing the
-                    %% window in which an if-empty/if-unused precondition could
-                    %% be violated.
-                    with_queue_blocked(
-                      Q,
-                      fun () ->
-                              case check_delete_flags(Q, IfUnused, IfEmpty) of
-                                  {ok, ReadyMsgs} ->
-                                      do_delete(Q, ReadyMsgs, ActingUser);
-                                  Error ->
-                                      Error
-                              end
-                      end);
-                _Alarms ->
-                    cannot_delete_under_alarm(amqqueue:get_name(Q))
+            %% The block-then-delete path relies on distinguishing queue
+            %% incarnations by their tracked member UIDs when restoring the
+            %% blocked state (see with_queue_blocked/2). Without them a stray
+            %% restore could clobber a different queue that reuses this name, so
+            %% refuse the conditional delete unless the feature flag is enabled.
+            case rabbit_feature_flags:is_enabled(track_qq_members_uids) of
+                false ->
+                    cannot_delete_without_member_uids(amqqueue:get_name(Q));
+                true ->
+                    %% The block-then-delete path below writes the blocked state
+                    %% to the cluster metadata store and relies on rejecting
+                    %% publishes. Both are unsafe while any node is under a
+                    %% resource alarm, so refuse the conditional delete until the
+                    %% alarm clears.
+                    case rabbit_alarm:get_alarms() of
+                        [] ->
+                            conditional_delete(Q, IfUnused, IfEmpty, ActingUser);
+                        _Alarms ->
+                            cannot_delete_under_alarm(amqqueue:get_name(Q))
+                    end
             end
     end.
+
+%% Resolves the queue's leader and runs the block-then-delete on the leader
+%% node. Blocking, checking the preconditions and deleting all happen where the
+%% leader lives; the resolved leader is passed down so check_delete_flags/4
+%% reuses it instead of resolving it again.
+conditional_delete(Q, IfUnused, IfEmpty, ActingUser) ->
+    QName = amqqueue:get_name(Q),
+    case find_leader(Q) of
+        {_, LeaderNode} = Leader ->
+            try
+                erpc:call(LeaderNode, ?MODULE, blocked_delete,
+                          [Q, IfUnused, IfEmpty, ActingUser, Leader])
+            catch
+                error:{erpc, _} = Reason ->
+                    cannot_verify_delete_flags(QName, Reason)
+            end;
+        undefined ->
+            cannot_verify_delete_flags(QName, no_leader_available)
+    end.
+
+%% Executed on the queue's leader node. Moves the queue to the blocked state
+%% before checking the preconditions so that publishes and new consumers are
+%% rejected while the check and the delete run, closing the window in which an
+%% if-empty/if-unused precondition could be violated. On success the queue has
+%% been deleted; otherwise the previous state is restored (see
+%% with_queue_blocked/2).
+-spec blocked_delete(amqqueue:amqqueue(), boolean(), boolean(),
+                     rabbit_types:username(), ra:server_id()) ->
+    rabbit_types:ok(non_neg_integer()) |
+    rabbit_types:error(in_use | not_empty) |
+    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
+blocked_delete(Q, IfUnused, IfEmpty, ActingUser, Leader) ->
+    with_queue_blocked(
+      Q,
+      fun () ->
+              case check_delete_flags(Q, IfUnused, IfEmpty, Leader) of
+                  {ok, ReadyMsgs} ->
+                      do_delete(Q, ReadyMsgs, ActingUser);
+                  Error ->
+                      Error
+              end
+      end).
+
+cannot_delete_without_member_uids(QName) ->
+    {protocol_error, precondition_failed,
+     "cannot delete ~ts with an if-unused/if-empty precondition until the "
+     "'track_qq_members_uids' feature flag is enabled",
+     [rabbit_misc:rs(QName)]}.
 
 cannot_delete_under_alarm(QName) ->
     {protocol_error, precondition_failed,
@@ -1146,6 +1192,10 @@ cannot_delete_under_alarm(QName) ->
 with_queue_blocked(Q, Fun) ->
     QName = amqqueue:get_name(Q),
     PrevState = amqqueue:get_state(Q),
+    %% Capture the current incarnation's member UIDs so that a restore (below or
+    %% from a safety-net timer) never overwrites the state of a different queue
+    %% that reuses this name after a delete and recreate.
+    Uids = incarnation_uids(Q),
     _ = set_queue_state(QName, blocked),
     %% Safety net: should this process fail to restore the previous state for
     %% any reason (for example, it is killed mid-delete, or its whole node
@@ -1155,16 +1205,16 @@ with_queue_blocked(Q, Fun) ->
     %% restored even if the node running this delete goes down entirely. They
     %% are cancelled on the normal paths below where the state is restored (or
     %% the queue deleted) directly.
-    TimerPids = spawn_state_restore_timers(QName, PrevState),
+    TimerPids = spawn_state_restore_timers(QName, {PrevState, Uids}),
     try Fun() of
         {ok, _} = Ok ->
             Ok;
         Other ->
-            _ = set_queue_state(QName, PrevState),
+            _ = restore_queue_state(QName, PrevState, Uids),
             Other
     catch
         Class:Reason:Stacktrace ->
-            _ = set_queue_state(QName, PrevState),
+            _ = restore_queue_state(QName, PrevState, Uids),
             erlang:raise(Class, Reason, Stacktrace)
     after
         _ = cancel_state_restore_timers(TimerPids)
@@ -1177,19 +1227,19 @@ with_queue_blocked(Q, Fun) ->
 %% than only locally) means the state is restored even if the node running the
 %% delete crashes entirely, since the blocked state lives in the cluster-wide
 %% metadata store and any node can restore it.
-spawn_state_restore_timers(QName, State) ->
+spawn_state_restore_timers(QName, {_State, _Uids} = Restore) ->
     Timeout = blocked_state_restore_timeout(),
-    [spawn(Node, ?MODULE, state_restore_timer, [QName, State, Timeout])
+    [spawn(Node, ?MODULE, state_restore_timer, [QName, Restore, Timeout])
      || Node <- rabbit_nodes:list_running()].
 
 %% Timer body run on each node. Exported so it can be started via spawn/4 on
 %% remote nodes.
-state_restore_timer(QName, State, Timeout) ->
+state_restore_timer(QName, {State, Uids}, Timeout) ->
     receive
         cancel ->
             ok
     after Timeout ->
-            _ = set_queue_state(QName, State),
+            _ = restore_queue_state(QName, State, Uids),
             ok
     end.
 
@@ -1205,32 +1255,74 @@ set_queue_state(QName, State) ->
     rabbit_amqqueue:update(QName,
                            fun (Q) -> amqqueue:set_state(Q, State) end).
 
+%% Restores State only if the record is still blocked and still belongs to the
+%% incarnation identified by CapturedUids. The check runs inside the update fun
+%% so it is atomic with the write: if the queue was deleted the update is a
+%% no-op, and if a different incarnation now holds the name it is left untouched.
+restore_queue_state(QName, State, CapturedUids) ->
+    _ = rabbit_amqqueue:update(
+          QName,
+          fun (Q) ->
+                  case amqqueue:get_state(Q) =:= blocked andalso
+                       same_incarnation(CapturedUids, incarnation_uids(Q)) of
+                      true ->
+                          amqqueue:set_state(Q, State);
+                      false ->
+                          Q
+                  end
+          end),
+    ok.
+
+%% The Ra member UIDs of the queue's current incarnation. Conditional deletes
+%% only reach this code once the track_qq_members_uids feature flag is enabled,
+%% so a freshly declared queue always carries a node => UID map. The empty-list
+%% result is reserved for a legacy record whose type state still holds a plain
+%% nodes list because it has not been repaired to a UID map yet (see
+%% repair_amqqueue_nodes/1). Every UID is regenerated on a delete-and-recreate,
+%% so a change of incarnation replaces the whole set.
+incarnation_uids(Q) ->
+    case amqqueue:get_type_state(Q) of
+        #{nodes := Nodes} when is_map(Nodes) ->
+            maps:values(Nodes);
+        _ ->
+            []
+    end.
+
+%% Records belong to the same incarnation when their tracked member UIDs overlap.
+%% A delete-and-recreate assigns a fresh set of UIDs (the recreated queue is
+%% declared with the feature flag on), so the sets become disjoint, while a mere
+%% membership change within one incarnation still overlaps and a legitimate
+%% restore is never skipped. A legacy record that has not been repaired to a UID
+%% map yet has no UIDs to compare and therefore cannot be told apart; it
+%% conservatively counts as the same incarnation, falling back to the
+%% blocked-state guard alone.
+same_incarnation([], _CurrentUids) ->
+    true;
+same_incarnation(CapturedUids, CurrentUids) ->
+    lists:any(fun (Uid) -> lists:member(Uid, CurrentUids) end, CapturedUids).
+
 %% The if-unused and if-empty flags gate deletion on the queue's consumer and
 %% message counts. Both counts come from a single rabbit_fifo_client:stat/1 call
 %% against the leader with any failure surfaced, rather than via
 %% rabbit_quorum_queue:stat/1 which reports zero counts on failure: a queue whose
 %% counts cannot be verified must not be deleted, as that would silently bypass
 %% the requested precondition. On success the ready message count is returned so
-%% the caller can reuse it as the delete result without a second stat call.
-check_delete_flags(Q, IfUnused, IfEmpty) ->
+%% the caller can reuse it as the delete result without a second stat call. The
+%% leader is resolved once by the caller and passed in so it is reused here.
+check_delete_flags(Q, IfUnused, IfEmpty, Leader) ->
     QName = amqqueue:get_name(Q),
-    case find_leader(Q) of
-        {_, _} = Leader ->
-            case rabbit_fifo_client:stat(Leader) of
-                {ok, ReadyMsgs, Consumers} ->
-                    if
-                        IfEmpty andalso ReadyMsgs > 0 ->
-                            {error, not_empty};
-                        IfUnused andalso Consumers > 0 ->
-                            {error, in_use};
-                        true ->
-                            {ok, ReadyMsgs}
-                    end;
-                {_, Reason} ->
-                    cannot_verify_delete_flags(QName, Reason)
+    case rabbit_fifo_client:stat(Leader) of
+        {ok, ReadyMsgs, Consumers} ->
+            if
+                IfEmpty andalso ReadyMsgs > 0 ->
+                    {error, not_empty};
+                IfUnused andalso Consumers > 0 ->
+                    {error, in_use};
+                true ->
+                    {ok, ReadyMsgs}
             end;
-        undefined ->
-            cannot_verify_delete_flags(QName, no_leader_available)
+        {_, Reason} ->
+            cannot_verify_delete_flags(QName, Reason)
     end.
 
 cannot_verify_delete_flags(QName, Reason) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -37,6 +37,7 @@
 -export([update_consumer_handler/8, update_consumer/9]).
 -export([cancel_consumer_handler/2, cancel_consumer/3]).
 -export([become_leader/2, handle_tick/3, spawn_deleter/1]).
+-export([state_restore_timer/3]).
 -export([rpc_delete_metrics/1,
          key_metrics_rpc/1]).
 -export([format/2]).
@@ -1147,11 +1148,14 @@ with_queue_blocked(Q, Fun) ->
     PrevState = amqqueue:get_state(Q),
     _ = set_queue_state(QName, blocked),
     %% Safety net: should this process fail to restore the previous state for
-    %% any reason (for example, it is killed mid-delete), an independent timer
-    %% process restores it after a timeout so the queue is not left blocked,
-    %% and rejecting publishes, indefinitely. It is cancelled on the normal
-    %% paths below where the state is restored (or the queue deleted) directly.
-    TimerPid = spawn_state_restore_timer(QName, PrevState),
+    %% any reason (for example, it is killed mid-delete, or its whole node
+    %% crashes), independent timer processes restore it after a timeout so the
+    %% queue is not left blocked, and rejecting publishes, indefinitely. One
+    %% timer is spawned on every running cluster node so the state is still
+    %% restored even if the node running this delete goes down entirely. They
+    %% are cancelled on the normal paths below where the state is restored (or
+    %% the queue deleted) directly.
+    TimerPids = spawn_state_restore_timers(QName, PrevState),
     try Fun() of
         {ok, _} = Ok ->
             Ok;
@@ -1163,26 +1167,34 @@ with_queue_blocked(Q, Fun) ->
             _ = set_queue_state(QName, PrevState),
             erlang:raise(Class, Reason, Stacktrace)
     after
-        _ = cancel_state_restore_timer(TimerPid)
+        _ = cancel_state_restore_timers(TimerPids)
     end.
 
-%% Spawns an unlinked process that restores State after a configurable timeout
-%% unless it is cancelled first. It must not be linked to the caller: the whole
-%% point is to restore the state even when the caller dies without doing so.
-spawn_state_restore_timer(QName, State) ->
+%% Spawns one unlinked process per running cluster node, each of which restores
+%% State after a configurable timeout unless it is cancelled first. The timers
+%% must not be linked to the caller: the whole point is to restore the state
+%% even when the caller dies without doing so. Spawning on every node (rather
+%% than only locally) means the state is restored even if the node running the
+%% delete crashes entirely, since the blocked state lives in the cluster-wide
+%% metadata store and any node can restore it.
+spawn_state_restore_timers(QName, State) ->
     Timeout = blocked_state_restore_timeout(),
-    spawn(fun () ->
-                  receive
-                      cancel ->
-                          ok
-                  after Timeout ->
-                          _ = set_queue_state(QName, State),
-                          ok
-                  end
-          end).
+    [spawn(Node, ?MODULE, state_restore_timer, [QName, State, Timeout])
+     || Node <- rabbit_nodes:list_running()].
 
-cancel_state_restore_timer(Pid) ->
-    Pid ! cancel,
+%% Timer body run on each node. Exported so it can be started via spawn/4 on
+%% remote nodes.
+state_restore_timer(QName, State, Timeout) ->
+    receive
+        cancel ->
+            ok
+    after Timeout ->
+            _ = set_queue_state(QName, State),
+            ok
+    end.
+
+cancel_state_restore_timers(Pids) ->
+    _ = [Pid ! cancel || Pid <- Pids],
     ok.
 
 blocked_state_restore_timeout() ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -37,7 +37,7 @@
 -export([update_consumer_handler/8, update_consumer/9]).
 -export([cancel_consumer_handler/2, cancel_consumer/3]).
 -export([become_leader/2, handle_tick/3, spawn_deleter/1]).
--export([state_restore_timer/3, spawn_state_restore_timers/2]).
+-export([state_restore_timer/4, spawn_state_restore_timers/2]).
 -export([blocked_delete/5]).
 -export([rpc_delete_metrics/1,
          key_metrics_rpc/1]).
@@ -180,6 +180,13 @@
 %% Must comfortably exceed ?DELETE_TIMEOUT so a normally-running delete finishes
 %% first. Configurable via the quorum_queue_blocked_state_restore_timeout env.
 -define(BLOCKED_STATE_RESTORE_TIMEOUT, ?DELETE_TIMEOUT + 1_000).
+%% Once the safety-net timeout has elapsed, only the queue's current leader
+%% restores the state. If no leader has been elected yet (for example, an
+%% election is still in progress after the delete node crashed), the timer
+%% re-checks leadership on this interval, for at most this many attempts, before
+%% giving up.
+-define(STATE_RESTORE_POLL_INTERVAL, 1_000).
+-define(STATE_RESTORE_POLL_ATTEMPTS, 10).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 %% setting a low default here to allow quorum queues to better chose themselves
@@ -1202,10 +1209,11 @@ with_queue_blocked(Q, Fun) ->
     %% crashes), independent timer processes restore it after a timeout so the
     %% queue is not left blocked, and rejecting publishes, indefinitely. One
     %% timer is spawned on every running cluster node so the state is still
-    %% restored even if the node running this delete goes down entirely. They
-    %% are cancelled on the normal paths below where the state is restored (or
-    %% the queue deleted) directly.
-    TimerPids = spawn_state_restore_timers(QName, {PrevState, Uids}),
+    %% restored even if the node running this delete goes down entirely, but only
+    %% the timer on the queue's leader at that point performs the restore (see
+    %% state_restore_timer/4). They are cancelled on the normal paths below where
+    %% the state is restored (or the queue deleted) directly.
+    TimerPids = spawn_state_restore_timers(Q, {PrevState, Uids}),
     try Fun() of
         {ok, _} = Ok ->
             Ok;
@@ -1226,21 +1234,58 @@ with_queue_blocked(Q, Fun) ->
 %% even when the caller dies without doing so. Spawning on every node (rather
 %% than only locally) means the state is restored even if the node running the
 %% delete crashes entirely, since the blocked state lives in the cluster-wide
-%% metadata store and any node can restore it.
-spawn_state_restore_timers(QName, {_State, _Uids} = Restore) ->
+%% metadata store and any node can restore it. Although a timer runs on every
+%% node, only the one on the queue's current leader actually restores the state
+%% (see state_restore_timer/4), so a single node performs the write.
+spawn_state_restore_timers(Q, {_State, _Uids} = Restore) ->
+    QName = amqqueue:get_name(Q),
+    {RaName, _} = amqqueue:get_pid(Q),
     Timeout = blocked_state_restore_timeout(),
-    [spawn(Node, ?MODULE, state_restore_timer, [QName, Restore, Timeout])
+    [spawn(Node, ?MODULE, state_restore_timer, [QName, RaName, Restore, Timeout])
      || Node <- rabbit_nodes:list_running()].
 
 %% Timer body run on each node. Exported so it can be started via spawn/4 on
-%% remote nodes.
-state_restore_timer(QName, {State, Uids}, Timeout) ->
+%% remote nodes. Once the timeout elapses the restore is performed by whichever
+%% node is the queue's leader at that point, so the state is written once rather
+%% than from every node at the same time.
+state_restore_timer(QName, RaName, {_State, _Uids} = Restore, Timeout) ->
     receive
         cancel ->
             ok
     after Timeout ->
-            _ = restore_queue_state(QName, State, Uids),
-            ok
+            restore_on_leader(QName, RaName, Restore,
+                              ?STATE_RESTORE_POLL_ATTEMPTS)
+    end.
+
+%% Restores the state only from the node that is the queue's leader. A node that
+%% is not the leader defers to the one that is. If no leader has been elected yet
+%% (an election may still be in progress after the delete node crashed), it waits
+%% and re-checks, up to Attempts times, so the safety net still fires once a
+%% leader emerges. It stops early if the queue is no longer blocked (the state
+%% has already been restored, or the queue deleted, elsewhere). The wait uses a
+%% selective receive so a late cancel is still honoured.
+restore_on_leader(_QName, _RaName, _Restore, 0) ->
+    ok;
+restore_on_leader(QName, RaName, {State, Uids} = Restore, Attempts) ->
+    case is_blocked(QName) of
+        false ->
+            ok;
+        true ->
+            case ra_leaderboard:lookup_leader(RaName) of
+                {_, Node} when Node =:= node() ->
+                    _ = restore_queue_state(QName, State, Uids),
+                    ok;
+                {_, _OtherNode} ->
+                    ok;
+                undefined ->
+                    receive
+                        cancel ->
+                            ok
+                    after ?STATE_RESTORE_POLL_INTERVAL ->
+                            restore_on_leader(QName, RaName, Restore,
+                                              Attempts - 1)
+                    end
+            end
     end.
 
 cancel_state_restore_timers(Pids) ->
@@ -1251,14 +1296,23 @@ blocked_state_restore_timeout() ->
     application:get_env(rabbit, quorum_queue_blocked_state_restore_timeout,
                         ?BLOCKED_STATE_RESTORE_TIMEOUT).
 
+%% Both this and restore_queue_state/3 go through rabbit_amqqueue:update/2, which
+%% is a read-modify-write guarded by a payload-version compare-and-swap committed
+%% by the metadata store leader (with a retry on conflict). It is therefore
+%% linearizable no matter which node runs it: running on a metadata store
+%% follower only adds a forwarding hop, and a stale local read just triggers a
+%% retry, never a wrong write. So these writes are safe from the delete node and
+%% from any safety-net timer node alike.
 set_queue_state(QName, State) ->
     rabbit_amqqueue:update(QName,
                            fun (Q) -> amqqueue:set_state(Q, State) end).
 
 %% Restores State only if the record is still blocked and still belongs to the
-%% incarnation identified by CapturedUids. The check runs inside the update fun
-%% so it is atomic with the write: if the queue was deleted the update is a
-%% no-op, and if a different incarnation now holds the name it is left untouched.
+%% incarnation identified by CapturedUids. The check runs inside the update fun,
+%% so the version compare-and-swap in rabbit_amqqueue:update/2 makes it atomic
+%% with the write (see set_queue_state/2): if the queue was deleted the update is
+%% a no-op, and if a different incarnation now holds the name it is left
+%% untouched.
 restore_queue_state(QName, State, CapturedUids) ->
     _ = rabbit_amqqueue:update(
           QName,

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -37,7 +37,7 @@
 -export([update_consumer_handler/8, update_consumer/9]).
 -export([cancel_consumer_handler/2, cancel_consumer/3]).
 -export([become_leader/2, handle_tick/3, spawn_deleter/1]).
--export([state_restore_timer/3]).
+-export([state_restore_timer/3, spawn_state_restore_timers/2]).
 -export([rpc_delete_metrics/1,
          key_metrics_rpc/1]).
 -export([format/2]).

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -5184,10 +5184,23 @@ delete_if_empty(Config) ->
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
     publish(Ch, QQ),
     wait_for_messages(Config, [[QQ, <<"1">>, <<"1">>, <<"0">>]]),
-    %% Try to delete the quorum queue
-    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
+    %% A non-empty quorum queue cannot be deleted with the if-empty flag set.
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
                 amqp_channel:call(Ch, #'queue.delete'{queue = QQ,
-                                                      if_empty = true})).
+                                                      if_empty = true})),
+    %% The failed deletion left the queue and its message in place.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertMatch(#'queue.purge_ok'{message_count = 1},
+                 amqp_channel:call(Ch1, #'queue.purge'{queue = QQ})),
+    wait_for_messages(Config, [[QQ, <<"0">>, <<"0">>, <<"0">>]]),
+    %% Once empty, the queue can be deleted with the if-empty flag set.
+    ?assertMatch(#'queue.delete_ok'{message_count = 0},
+                 amqp_channel:call(Ch1, #'queue.delete'{queue = QQ,
+                                                        if_empty = true})),
+    %% Ensure queue no longer exists in the broker.
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
 
 delete_if_unused(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
@@ -5196,12 +5209,28 @@ delete_if_unused(Config) ->
     QQ = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', QQ, 0, 0},
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
-    publish(Ch, QQ),
-    wait_for_messages(Config, [[QQ, <<"1">>, <<"1">>, <<"0">>]]),
-    %% Try to delete the quorum queue
-    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
-                amqp_channel:call(Ch, #'queue.delete'{queue = QQ,
-                                                      if_unused = true})).
+    ok = subscribe(Ch, QQ, false),
+    %% A quorum queue with a consumer cannot be deleted with the if-unused flag
+    %% set. Attempt queue.delete on a separate channel to keep consumer alive.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
+                amqp_channel:call(Ch1, #'queue.delete'{queue = QQ,
+                                                       if_unused = true})),
+    %% After the consumer is cancelled, the queue can be deleted with the
+    %% if-unused flag set.
+    ok = cancel(Ch),
+    ?awaitMatch(#'queue.declare_ok'{queue = QQ, message_count = 0,
+                                    consumer_count = 0},
+                amqp_channel:call(Ch, #'queue.declare'{queue = QQ,
+                                                       passive = true}),
+                ?DEFAULT_AWAIT),
+    ?assertMatch(#'queue.delete_ok'{message_count = 0},
+                 amqp_channel:call(Ch, #'queue.delete'{queue = QQ,
+                                                       if_unused = true})),
+    %% Ensure queue no longer exists in the broker.
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
 
 queue_ttl(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -210,6 +210,11 @@ all_tests() ->
      pre_existing_invalid_policy,
      delete_if_empty,
      delete_if_unused,
+     delete_blocks_operations,
+     blocked_state_reset_on_recovery,
+     blocked_state_restore_timer_restores_state_if_empty,
+     blocked_state_restore_timer_restores_state_if_unused,
+     delete_conditional_refused_under_alarm,
      queue_ttl,
      peek,
      oldest_entry_timestamp,
@@ -5232,6 +5237,196 @@ delete_if_unused(Config) ->
     ?assertEqual({error, not_found},
                  rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
 
+delete_blocks_operations(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
+
+    %% Block the queue and wait until the change is visible in the projection
+    %% read by the publish and consume paths.
+    ok = set_queue_state(Config, QName, blocked),
+    ?awaitMatch(blocked, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    %% Publishing to a blocked queue is rejected (nacked).
+    ?assertEqual(fail, publish_confirm(Ch, QQ)),
+
+    %% Consuming from a blocked queue fails and closes the channel.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 405, _}}, _},
+                amqp_channel:call(Ch1, #'basic.get'{queue = QQ})),
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 405, _}}, _},
+                amqp_channel:call(Ch2, #'basic.consume'{queue = QQ})),
+    %% Even a passive re-declaration fails while the queue is blocked.
+    Ch3 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 405, _}}, _},
+                amqp_channel:call(Ch3, #'queue.declare'{queue = QQ,
+                                                        passive = true})),
+
+    %% Once unblocked, the queue works normally again.
+    ok = set_queue_state(Config, QName, live),
+    ?awaitMatch(live, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+    Ch4 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch4, #'confirm.select'{}),
+    ?assertEqual(ok, publish_confirm(Ch4, QQ)),
+    ?assertMatch({#'basic.get_ok'{}, _},
+                 amqp_channel:call(Ch4, #'basic.get'{queue = QQ, no_ack = true})),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch4, #'queue.delete'{queue = QQ})).
+
+blocked_state_reset_on_recovery(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    ok = set_queue_state(Config, QName, blocked),
+    ?awaitMatch(blocked, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Server),
+    ok = rabbit_ct_broker_helpers:start_node(Config, Server),
+
+    %% Recovery has reset the lingering blocked state back to live.
+    ?awaitMatch(live, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    %% The queue is usable again.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch1, #'confirm.select'{}),
+    ?assertEqual(ok, publish_confirm(Ch1, QQ)),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch1, #'queue.delete'{queue = QQ})).
+
+blocked_state_restore_timer_restores_state_if_empty(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    %% if-empty delete (IfUnused = false, IfEmpty = true).
+    assert_restore_timer_recovers_blocked_delete(Config, QName, false, true),
+
+    %% The queue is usable again and can be deleted normally.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch1, #'confirm.select'{}),
+    ?assertEqual(ok, publish_confirm(Ch1, QQ)),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch1, #'queue.delete'{queue = QQ})).
+
+%% As above, but for an interrupted if-unused delete.
+blocked_state_restore_timer_restores_state_if_unused(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    %% if-unused delete (IfUnused = true, IfEmpty = false).
+    assert_restore_timer_recovers_blocked_delete(Config, QName, true, false),
+
+    %% The queue is usable again and can be deleted normally.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch1, #'confirm.select'{}),
+    ?assertEqual(ok, publish_confirm(Ch1, QQ)),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch1, #'queue.delete'{queue = QQ})).
+
+assert_restore_timer_recovers_blocked_delete(Config, QName, IfUnused, IfEmpty) ->
+    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup,
+                                           [QName]),
+
+    %% Use a short restore timeout so the timer fires quickly once the
+    %% deleting process is gone.
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, set_env,
+           [rabbit, quorum_queue_blocked_state_restore_timeout, 500]),
+
+    %% Freeze the delete inside the precondition check, which runs after the
+    %% queue has been moved to the blocked state and the safety-net timer has
+    %% been spawned.
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, new, [rabbit_fifo_client, [passthrough, no_link]]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, expect,
+           [rabbit_fifo_client, stat, fun(_) -> timer:sleep(infinity) end]),
+
+    %% Run the delete in its own process so it can be killed while executing.
+    DeleterPid = rabbit_ct_broker_helpers:rpc(
+                   Config, 0, erlang, spawn,
+                   [rabbit_quorum_queue, delete,
+                    [Q, IfUnused, IfEmpty, <<"test-user">>]]),
+
+    %% Once the queue is blocked, the timer has been spawned and the delete is
+    %% parked in the frozen precondition check.
+    ?awaitMatch(blocked, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    %% Kill the deleting process brutally so its `after` clause never runs: the
+    %% queue is left blocked, exactly as it would be after a crash mid-delete.
+    true = rabbit_ct_broker_helpers:rpc(Config, 0, erlang, exit,
+                                        [DeleterPid, kill]),
+
+    %% The restore timer sets the previous state on its own.
+    ?awaitMatch(live, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, meck, unload,
+                                      [rabbit_fifo_client]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, unset_env,
+           [rabbit, quorum_queue_blocked_state_restore_timeout]),
+    ok.
+
+delete_conditional_refused_under_alarm(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    ok = rabbit_ct_broker_helpers:set_alarm(Config, Server, memory),
+    ?awaitMatch([_ | _], rabbit_ct_broker_helpers:get_alarms(Config, Server),
+                ?DEFAULT_AWAIT),
+
+    %% Both if-empty and if-unused deletes are refused with a 406 while the
+    %% cluster is under a resource alarm.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
+                amqp_channel:call(Ch1, #'queue.delete'{queue = QQ,
+                                                       if_empty = true})),
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
+                amqp_channel:call(Ch2, #'queue.delete'{queue = QQ,
+                                                       if_unused = true})),
+    %% The refused deletes left the queue in place and usable (not stuck in the
+    %% blocked state).
+    ?assertMatch(live, get_queue_state(Config, QName)),
+
+    ok = rabbit_ct_broker_helpers:clear_alarm(Config, Server, memory),
+    ?awaitMatch([], rabbit_ct_broker_helpers:get_alarms(Config, Server),
+                ?DEFAULT_AWAIT),
+
+    %% With the alarm cleared, the conditional delete succeeds.
+    Ch3 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertMatch(#'queue.delete_ok'{message_count = 0},
+                 amqp_channel:call(Ch3, #'queue.delete'{queue = QQ,
+                                                        if_empty = true})),
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
+
 queue_ttl(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
@@ -6627,6 +6822,24 @@ qos(Ch, Prefetch, Global) ->
 cancel(Ch) ->
     ?assertMatch(#'basic.cancel_ok'{consumer_tag = <<"ctag">>},
                  amqp_channel:call(Ch, #'basic.cancel'{consumer_tag = <<"ctag">>})).
+
+set_queue_state(Config, QName, State) ->
+    Fun = fun(Q) -> amqqueue:set_state(Q, State) end,
+    _ = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, update,
+                                     [QName, Fun]),
+    ok.
+
+%% Runs on a broker node via rpc.
+get_queue_state(QName) ->
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            amqqueue:get_state(Q);
+        Err ->
+            Err
+    end.
+
+get_queue_state(Config, QName) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, get_queue_state, [QName]).
 
 receive_basic_deliver(Redelivered) ->
     receive

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -86,7 +86,7 @@ groups() ->
                                             delete_declare,
                                             delete_member_during_node_down,
                                             delete_while_publishing,
-                                            state_restore_timers_restores_state_on_remote_nodes,
+                                            state_restore_timer_restores_state_on_leader,
                                             delete_ra_cluster_already_shutting_down,
                                             concurrent_vhost_delete_with_quorum_queue,
                                             metrics_cleanup_on_leadership_takeover,
@@ -215,7 +215,10 @@ all_tests() ->
      blocked_state_reset_on_recovery,
      blocked_state_restore_timer_restores_state_if_empty,
      blocked_state_restore_timer_restores_state_if_unused,
+     guarded_restore_skips_new_queue_incarnation,
      delete_conditional_refused_under_alarm,
+     delete_conditional_refused_without_member_uids,
+     delete_conditional_executed_on_leader,
      queue_ttl,
      peek,
      oldest_entry_timestamp,
@@ -5390,10 +5393,12 @@ assert_restore_timer_recovers_blocked_delete(Config, QName, IfUnused, IfEmpty) -
     ok.
 
 %% Verifies that spawn_state_restore_timers/2 starts a safety-net timer on every
-%% running cluster node, including the remote nodes, and that a timer on a remote
-%% node restores the previous state on its own (i.e. even when the node that
-%% spawned the timers is not the one that restores the state).
-state_restore_timers_restores_state_on_remote_nodes(Config) ->
+%% running cluster node, but that only the timer on the queue's leader restores
+%% the state: non-leader timers defer to the leader, so the state is written from
+%% a single node. Restoring from the leader (rather than every node) still
+%% survives the node that spawned the timers going down, since a surviving or
+%% newly elected leader performs the restore.
+state_restore_timer_restores_state_on_leader(Config) ->
     [Server0 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
@@ -5401,6 +5406,9 @@ state_restore_timers_restores_state_on_remote_nodes(Config) ->
     QName = rabbit_misc:r(<<"/">>, queue, QQ),
     ?assertEqual({'queue.declare_ok', QQ, 0, 0},
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup,
+                                           [QName]),
+    LeaderNode = leader_node(Config, QName),
 
     %% Move the queue to the blocked state, as the start of a conditional delete
     %% does, then confirm the change is visible cluster-wide.
@@ -5422,18 +5430,20 @@ state_restore_timers_restores_state_on_remote_nodes(Config) ->
                 amqp_channel:call(Ch3, #'queue.declare'{queue = QQ,
                                                         passive = true})),
 
-    %% Use a short restore timeout so the remote timers fire quickly. The
-    %% timeout is read on the spawning node and passed to each timer, so setting
-    %% it on node 0 is enough.
+    %% Use a short restore timeout so the timers fire quickly. The timeout is
+    %% read on the spawning node and passed to each timer, so setting it on
+    %% node 0 is enough.
+    RestoreTimeout = 3000,
     ok = rabbit_ct_broker_helpers:rpc(
            Config, 0, application, set_env,
-           [rabbit, quorum_queue_blocked_state_restore_timeout, 3000]),
+           [rabbit, quorum_queue_blocked_state_restore_timeout, RestoreTimeout]),
 
     %% Spawn the safety-net timers from node 0, asking them to restore the live
-    %% state.
+    %% state. An empty UID set means the restore is guarded on the blocked state
+    %% alone, which is what this test exercises.
     Pids = rabbit_ct_broker_helpers:rpc(
              Config, 0, rabbit_quorum_queue, spawn_state_restore_timers,
-             [QName, live]),
+             [Q, {live, []}]),
 
     %% One timer was started on every running cluster node, including the remote
     %% ones (not just the node that spawned them).
@@ -5441,19 +5451,22 @@ state_restore_timers_restores_state_on_remote_nodes(Config) ->
                                                 list_running, []),
     ?assertEqual(lists:sort(RunningNodes),
                  lists:usort([node(P) || P <- Pids])),
-    RemotePids = [P || P <- Pids, node(P) =/= Server0],
-    ?assert(length(RemotePids) >= 1),
 
-    %% Kill the timer running on the spawning node so that only the timers on the
-    %% remote nodes are left to restore the state. This mimics the spawning node
-    %% going down entirely after it moved the queue to the blocked state.
-    [LocalPid] = [P || P <- Pids, node(P) =:= Server0],
+    %% Kill the timer on the leader node. The non-leader timers must defer to the
+    %% leader rather than restore the state themselves, so the queue stays
+    %% blocked past the timeout.
+    [LeaderPid] = [P || P <- Pids, node(P) =:= LeaderNode],
     true = rabbit_ct_broker_helpers:rpc(Config, 0, erlang, exit,
-                                        [LocalPid, kill]),
-    false = rabbit_ct_broker_helpers:rpc(Config, 0, erlang, is_process_alive,
-                                        [LocalPid]),
+                                        [LeaderPid, kill]),
+    timer:sleep(RestoreTimeout + 1000),
+    ?assertEqual(blocked, get_queue_state(Config, QName)),
 
-    %% A timer on a remote node restores the previous state on its own.
+    %% Spawn the timers afresh and this time leave the leader's timer running:
+    %% the leader is the one that restores the previous state, even though the
+    %% timers were spawned from node 0.
+    _ = rabbit_ct_broker_helpers:rpc(
+          Config, 0, rabbit_quorum_queue, spawn_state_restore_timers,
+          [Q, {live, []}]),
     ?awaitMatch(live, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
 
     ok = rabbit_ct_broker_helpers:rpc(
@@ -5466,6 +5479,97 @@ state_restore_timers_restores_state_on_remote_nodes(Config) ->
     ?assertEqual(ok, publish_confirm(Ch4, QQ)),
     ?assertMatch(#'queue.delete_ok'{},
                  amqp_channel:call(Ch4, #'queue.delete'{queue = QQ})).
+
+%% The node that is the queue's Ra leader, from node 0's leaderboard view.
+leader_node(Config, QName) ->
+    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup,
+                                           [QName]),
+    {RaName, _} = amqqueue:get_pid(Q),
+    {_, Node} = rabbit_ct_broker_helpers:rpc(
+                  Config, 0, ra_leaderboard, lookup_leader, [RaName]),
+    Node.
+
+%% A safety-net restore left over from an interrupted conditional delete must
+%% not overwrite the state of a different queue that reuses the name after a
+%% delete and recreate. Telling incarnations apart relies on tracked member
+%% UIDs, so the test is skipped when that feature flag is disabled.
+guarded_restore_skips_new_queue_incarnation(Config) ->
+    case rabbit_ct_broker_helpers:is_feature_flag_enabled(
+           Config, track_qq_members_uids) of
+        false ->
+            {skip, "guarded restore relies on the track_qq_members_uids ff"};
+        true ->
+            guarded_restore_skips_new_queue_incarnation0(Config)
+    end.
+
+guarded_restore_skips_new_queue_incarnation0(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+
+    %% Incarnation A.
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    UidsA = incarnation_uids(Config, QName),
+    ?assert(UidsA =/= []),
+
+    %% Delete A and recreate the same name: incarnation B, with fresh UIDs.
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch, #'queue.delete'{queue = QQ})),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    UidsB = incarnation_uids(Config, QName),
+    ?assert(UidsB =/= []),
+    %% The two incarnations share no member UID.
+    ?assertEqual([], [U || U <- UidsA, lists:member(U, UidsB)]),
+
+    %% Put B into the blocked state so a wrongful restore-to-live is observable.
+    ok = set_queue_state(Config, QName, blocked),
+    ?awaitMatch(blocked, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+    {ok, QB} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup,
+                                            [QName]),
+
+    %% Use a short restore timeout so the stray timers fire quickly.
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, set_env,
+           [rabbit, quorum_queue_blocked_state_restore_timeout, 500]),
+
+    %% Fire safety-net timers carrying incarnation A's UIDs, as one left behind
+    %% by an interrupted conditional delete of A would. They must not touch B.
+    _ = rabbit_ct_broker_helpers:rpc(
+          Config, 0, rabbit_quorum_queue, spawn_state_restore_timers,
+          [QB, {live, UidsA}]),
+
+    %% Wait past the restore timeout and confirm B is still blocked.
+    timer:sleep(1500),
+    ?assertEqual(blocked, get_queue_state(Config, QName)),
+
+    %% Control: timers carrying B's own UIDs do restore B to live.
+    _ = rabbit_ct_broker_helpers:rpc(
+          Config, 0, rabbit_quorum_queue, spawn_state_restore_timers,
+          [QB, {live, UidsB}]),
+    ?awaitMatch(live, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, unset_env,
+           [rabbit, quorum_queue_blocked_state_restore_timeout]),
+
+    %% The queue is usable again and can be deleted normally.
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch, #'queue.delete'{queue = QQ})).
+
+%% The Ra member UIDs of the queue's current incarnation, or an empty list when
+%% member UIDs are not tracked.
+incarnation_uids(Config, QName) ->
+    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup,
+                                           [QName]),
+    case amqqueue:get_type_state(Q) of
+        #{nodes := Nodes} when is_map(Nodes) ->
+            maps:values(Nodes);
+        _ ->
+            []
+    end.
 
 delete_conditional_refused_under_alarm(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
@@ -5505,6 +5609,142 @@ delete_conditional_refused_under_alarm(Config) ->
                                                         if_empty = true})),
     ?assertEqual({error, not_found},
                  rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
+
+%% Conditional (if-empty/if-unused) deletes rely on the block-then-delete path,
+%% which is only safe when queue incarnations can be told apart by their tracked
+%% member UIDs. When the track_qq_members_uids feature flag is disabled the
+%% conditional delete must be refused rather than silently run unguarded.
+delete_conditional_refused_without_member_uids(Config) ->
+    case rabbit_ct_broker_helpers:is_feature_flag_enabled(
+           Config, track_qq_members_uids) of
+        false ->
+            {skip, "test simulates disabling an otherwise enabled ff"};
+        true ->
+            delete_conditional_refused_without_member_uids0(Config)
+    end.
+
+delete_conditional_refused_without_member_uids0(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    %% Simulate a cluster where the feature flag has not been enabled yet, while
+    %% leaving every other feature flag untouched.
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, new,
+           [rabbit_feature_flags, [passthrough, no_link]]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, expect,
+           [rabbit_feature_flags, is_enabled,
+            fun (track_qq_members_uids) -> false;
+                (FeatureName) -> meck:passthrough([FeatureName])
+            end]),
+
+    %% Both if-empty and if-unused deletes are refused with a 406.
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
+                amqp_channel:call(Ch1, #'queue.delete'{queue = QQ,
+                                                       if_empty = true})),
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
+                amqp_channel:call(Ch2, #'queue.delete'{queue = QQ,
+                                                       if_unused = true})),
+    %% The refused deletes left the queue in place and usable (not stuck in the
+    %% blocked state).
+    ?assertMatch(live, get_queue_state(Config, QName)),
+
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, meck, unload,
+                                      [rabbit_feature_flags]),
+
+    %% With the flag enabled again, the conditional delete succeeds.
+    Ch3 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?assertMatch(#'queue.delete_ok'{message_count = 0},
+                 amqp_channel:call(Ch3, #'queue.delete'{queue = QQ,
+                                                        if_empty = true})),
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
+
+%% A conditional (if-empty/if-unused) delete resolves the queue's leader and
+%% runs the block-then-delete step (blocked_delete/5) on the leader node itself
+%% (see conditional_delete/4). This drives the delete from a non-leader node
+%% whenever the cluster has more than one node and asserts that blocked_delete/5
+%% executed on the leader node, and nowhere else.
+delete_conditional_executed_on_leader(Config) ->
+    case rabbit_ct_broker_helpers:is_feature_flag_enabled(
+           Config, track_qq_members_uids) of
+        false ->
+            {skip, "conditional delete relies on the track_qq_members_uids ff"};
+        true ->
+            delete_conditional_executed_on_leader0(Config)
+    end.
+
+delete_conditional_executed_on_leader0(Config) ->
+    Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server0 | _] = Nodes,
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    %% Resolve the queue's leader node.
+    RaName = ra_name(QQ),
+    {ok, _, {_, LeaderNode}} = ra:members({RaName, Server0}),
+
+    %% Drive the delete from a non-leader node when the cluster has one, so that
+    %% "runs on the leader" is a non-trivial assertion (in a single-node cluster
+    %% the only node is the leader).
+    InitiatorNode = case [N || N <- Nodes, N =/= LeaderNode] of
+                        [NonLeader | _] ->
+                            NonLeader;
+                        [] ->
+                            LeaderNode
+                    end,
+
+    %% Track where blocked_delete/5 actually runs by mecking it on every node
+    %% with passthrough so the real delete still happens. rpc/5 over a list of
+    %% nodes returns one result per node, so we expect a list of oks.
+    ?assertEqual([ok || _ <- Nodes],
+                 rabbit_ct_broker_helpers:rpc(Config, Nodes, meck, new,
+                                              [rabbit_quorum_queue,
+                                               [passthrough, no_link]])),
+    ?assertEqual(
+       [ok || _ <- Nodes],
+       rabbit_ct_broker_helpers:rpc(
+         Config, Nodes, meck, expect,
+         [rabbit_quorum_queue, blocked_delete,
+          fun(Q, IfUnused, IfEmpty, ActingUser, Leader) ->
+                  meck:passthrough([Q, IfUnused, IfEmpty, ActingUser, Leader])
+          end])),
+    try
+        Ch1 = rabbit_ct_client_helpers:open_channel(Config, InitiatorNode),
+        ?assertMatch(#'queue.delete_ok'{message_count = 0},
+                     amqp_channel:call(Ch1, #'queue.delete'{queue = QQ,
+                                                            if_empty = true})),
+
+        %% blocked_delete/5 ran exactly once, on the leader node, and on no
+        %% other node (in particular not on the node that initiated the delete).
+        Calls = [{N, rabbit_ct_broker_helpers:rpc(
+                       Config, N, meck, num_calls,
+                       [rabbit_quorum_queue, blocked_delete,
+                        ['_', '_', '_', '_', '_']])}
+                 || N <- Nodes],
+        ?assertEqual(1, proplists:get_value(LeaderNode, Calls)),
+        ?assertEqual([{N, 0} || N <- Nodes, N =/= LeaderNode],
+                     [{N, C} || {N, C} <- Calls, N =/= LeaderNode])
+    after
+        _ = rabbit_ct_broker_helpers:rpc(Config, Nodes, meck, unload,
+                                         [rabbit_quorum_queue])
+    end,
+
+    %% Ensure the queue no longer exists in the broker.
+    ?assertEqual({error, not_found},
+                 rabbit_ct_broker_helpers:rpc(Config, Server0, rabbit_amqqueue,
+                                              lookup, [QName])).
 
 queue_ttl(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -86,6 +86,7 @@ groups() ->
                                             delete_declare,
                                             delete_member_during_node_down,
                                             delete_while_publishing,
+                                            state_restore_timers_restores_state_on_remote_nodes,
                                             delete_ra_cluster_already_shutting_down,
                                             concurrent_vhost_delete_with_quorum_queue,
                                             metrics_cleanup_on_leadership_takeover,
@@ -5387,6 +5388,84 @@ assert_restore_timer_recovers_blocked_delete(Config, QName, IfUnused, IfEmpty) -
            Config, 0, application, unset_env,
            [rabbit, quorum_queue_blocked_state_restore_timeout]),
     ok.
+
+%% Verifies that spawn_state_restore_timers/2 starts a safety-net timer on every
+%% running cluster node, including the remote nodes, and that a timer on a remote
+%% node restores the previous state on its own (i.e. even when the node that
+%% spawned the timers is not the one that restores the state).
+state_restore_timers_restores_state_on_remote_nodes(Config) ->
+    [Server0 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    %% Move the queue to the blocked state, as the start of a conditional delete
+    %% does, then confirm the change is visible cluster-wide.
+    ok = set_queue_state(Config, QName, blocked),
+    ?awaitMatch(blocked, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    %% While blocked, the queue is not usable: publishing is rejected and
+    %% consuming or passively re-declaring it fails and closes the channel.
+    #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
+    ?assertEqual(fail, publish_confirm(Ch, QQ)),
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    ?assertExit({{shutdown, {server_initiated_close, 405, _}}, _},
+                amqp_channel:call(Ch1, #'basic.get'{queue = QQ})),
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    ?assertExit({{shutdown, {server_initiated_close, 405, _}}, _},
+                amqp_channel:call(Ch2, #'basic.consume'{queue = QQ})),
+    Ch3 = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    ?assertExit({{shutdown, {server_initiated_close, 405, _}}, _},
+                amqp_channel:call(Ch3, #'queue.declare'{queue = QQ,
+                                                        passive = true})),
+
+    %% Use a short restore timeout so the remote timers fire quickly. The
+    %% timeout is read on the spawning node and passed to each timer, so setting
+    %% it on node 0 is enough.
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, set_env,
+           [rabbit, quorum_queue_blocked_state_restore_timeout, 3000]),
+
+    %% Spawn the safety-net timers from node 0, asking them to restore the live
+    %% state.
+    Pids = rabbit_ct_broker_helpers:rpc(
+             Config, 0, rabbit_quorum_queue, spawn_state_restore_timers,
+             [QName, live]),
+
+    %% One timer was started on every running cluster node, including the remote
+    %% ones (not just the node that spawned them).
+    RunningNodes = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_nodes,
+                                                list_running, []),
+    ?assertEqual(lists:sort(RunningNodes),
+                 lists:usort([node(P) || P <- Pids])),
+    RemotePids = [P || P <- Pids, node(P) =/= Server0],
+    ?assert(length(RemotePids) >= 1),
+
+    %% Kill the timer running on the spawning node so that only the timers on the
+    %% remote nodes are left to restore the state. This mimics the spawning node
+    %% going down entirely after it moved the queue to the blocked state.
+    [LocalPid] = [P || P <- Pids, node(P) =:= Server0],
+    true = rabbit_ct_broker_helpers:rpc(Config, 0, erlang, exit,
+                                        [LocalPid, kill]),
+    false = rabbit_ct_broker_helpers:rpc(Config, 0, erlang, is_process_alive,
+                                        [LocalPid]),
+
+    %% A timer on a remote node restores the previous state on its own.
+    ?awaitMatch(live, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, unset_env,
+           [rabbit, quorum_queue_blocked_state_restore_timeout]),
+
+    %% The queue is usable again and can be deleted normally.
+    Ch4 = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch4, #'confirm.select'{}),
+    ?assertEqual(ok, publish_confirm(Ch4, QQ)),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch4, #'queue.delete'{queue = QQ})).
 
 delete_conditional_refused_under_alarm(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -3669,8 +3669,15 @@ publish_confirm_timeout_test(Config) ->
     passed.
 
 if_empty_unused_test(Config) ->
+    ok = if_empty_unused_test0(Config, <<"classic">>),
+    ok = if_empty_unused_test0(Config, <<"quorum">>),
+    passed.
+
+if_empty_unused_test0(Config, QueueType) ->
     http_put(Config, "/exchanges/%2F/test", #{}, {group, '2xx'}),
-    http_put(Config, "/queues/%2F/test", #{durable => true}, {group, '2xx'}),
+    http_put(Config, "/queues/%2F/test",
+             #{durable => true,
+               arguments => #{'x-queue-type' => QueueType}}, {group, '2xx'}),
     http_post(Config, "/bindings/%2F/e/test/q/test", #{}, {group, '2xx'}),
     http_post(Config, "/exchanges/%2F/amq.default/publish",
               msg(<<"test">>, #{}, <<"Hello world">>), ?OK),
@@ -3686,7 +3693,7 @@ if_empty_unused_test(Config) ->
 
     http_delete(Config, "/queues/%2F/test?if-empty=true", {group, '2xx'}),
     http_delete(Config, "/exchanges/%2F/test?if-unused=true", {group, '2xx'}),
-    passed.
+    ok.
 
 parameters_test(Config) ->
     register_parameters_and_policy_validator(Config),

--- a/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
@@ -1740,8 +1740,15 @@ columns_test(Config) ->
     passed.
 
 if_empty_unused_test(Config) ->
+    ok = if_empty_unused_test0(Config, <<"classic">>),
+    ok = if_empty_unused_test0(Config, <<"quorum">>),
+    passed.
+
+if_empty_unused_test0(Config, QueueType) ->
     http_put(Config, "/exchanges/%2F/test", #{}, {group, '2xx'}),
-    http_put(Config, "/queues/%2F/test", #{durable => true}, {group, '2xx'}),
+    http_put(Config, "/queues/%2F/test",
+             #{durable => true,
+               arguments => #{'x-queue-type' => QueueType}}, {group, '2xx'}),
     http_post(Config, "/bindings/%2F/e/test/q/test", #{}, {group, '2xx'}),
     http_post(Config, "/exchanges/%2F/amq.default/publish",
               msg(<<"test">>, #{}, <<"Hello world">>), ?OK),
@@ -1757,7 +1764,7 @@ if_empty_unused_test(Config) ->
 
     http_delete(Config, "/queues/%2F/test?if-empty=true", {group, '2xx'}),
     http_delete(Config, "/exchanges/%2F/test?if-unused=true", {group, '2xx'}),
-    passed.
+    ok.
 
 invalid_config_test(Config) ->
     {Conn, _Ch} = open_connection_and_channel(Config),


### PR DESCRIPTION
## Proposed Changes

This change implements: https://github.com/rabbitmq/rabbitmq-server/issues/10543 for quorum queues. A `rabbit_quorum_queue:stat/1`
call is carried out to get ready message count and consumer count, for checking the queue
`if-empty` and `if-unused`, respectively, before the deletion is carried out.

We are keen to have this feature supported in QQs (for both AMQP `queue.delete` and
operator tools QQ deletions / compatibility with CQ behaviour). 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
