### PR TITLE
Management stats DB: make `list_queue_stats/4` more defensive

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
@@ -381,10 +381,17 @@ list_queue_stats(Ranges, Objs, Interval, Fun) ->
       [begin
        Id = id_lookup(queue_stats, Obj),
        Pid = pget(pid, Obj),
-       QueueData = maps:get(Id, DataLookup),
-       Props = maps:get(queue_stats, QueueData),
-       Stats = queue_stats(QueueData, Ranges, Interval),
-       {Pid, combine(Props, Obj) ++ Stats}
+       %% A queue deleted before its metrics were collected won't have an entry.
+       %% Return it without any stats rather than throwing an exception.
+       %% See rabbitmq/rabbitmq-server#16989.
+       case maps:find(Id, DataLookup) of
+           {ok, QueueData} ->
+               Props = maps:get(queue_stats, QueueData),
+               Stats = queue_stats(QueueData, Ranges, Interval),
+               {Pid, combine(Props, Obj) ++ Stats};
+           error ->
+               {Pid, Obj}
+       end
        end || Obj <- Objs]).
 
 detail_queue_stats(Ranges, Objs, Interval) ->
@@ -395,20 +402,27 @@ detail_queue_stats(Ranges, Objs, Interval) ->
       [begin
        Id = id_lookup(queue_stats, Obj),
        Pid = pget(pid, Obj),
-       QueueData = maps:get(Id, DataLookup),
-       Props = maps:get(queue_stats, QueueData),
-       Stats = queue_stats(QueueData, Ranges, Interval),
-       ConsumerStats = rabbit_mgmt_data_compat:fill_consumer_active_fields(
-                         maps:get(consumer_stats, QueueData)),
-       Consumers = [{consumer_details, ConsumerStats}],
-       StatsD = [{deliveries,
-                  detail_stats(QueueData, channel_queue_stats_deliver_stats,
-                               deliver_get, second(Id), Ranges, Interval)},
-                 {incoming,
-                  detail_stats(QueueData, queue_exchange_stats_publish,
-                               fine_stats, first(Id), Ranges, Interval)}],
-       Details = augment_details(Obj, []),
-       {Pid, combine(Props, Obj) ++ Stats ++ StatsD ++ Consumers ++ Details}
+       %% See `list_queue_stats/4` and rabbitmq/rabbitmq-server#16989.
+       case maps:find(Id, DataLookup) of
+           {ok, QueueData} ->
+               Props = maps:get(queue_stats, QueueData),
+               Stats = queue_stats(QueueData, Ranges, Interval),
+               ConsumerStats = rabbit_mgmt_data_compat:fill_consumer_active_fields(
+                                 maps:get(consumer_stats, QueueData)),
+               Consumers = [{consumer_details, ConsumerStats}],
+               StatsD = [{deliveries,
+                          detail_stats(QueueData, channel_queue_stats_deliver_stats,
+                                       deliver_get, second(Id), Ranges, Interval)},
+                         {incoming,
+                          detail_stats(QueueData, queue_exchange_stats_publish,
+                                       fine_stats, first(Id), Ranges, Interval)}],
+               Details = augment_details(Obj, []),
+               {Pid, combine(Props, Obj) ++ Stats ++ StatsD ++ Consumers ++ Details};
+           error ->
+               %% consumer_details must be present: the channel detail
+               %% merge below reads it from every entry.
+               {Pid, [{consumer_details, []} | Obj]}
+       end
        end || Obj <- Objs]),
 
    % patch up missing channel details

--- a/deps/rabbitmq_management/test/rabbit_mgmt_test_db_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_test_db_SUITE.erl
@@ -33,6 +33,7 @@ groups() ->
     [
      {non_parallel_tests, [], [
                                queue_coarse_test,
+                               queue_stats_missing_data_test,
                                connection_coarse_test,
                                fine_stats_aggregation_time_test,
                                fine_stats_aggregation_test,
@@ -133,6 +134,43 @@ queue_coarse_test1(_Config) ->
            simple_details(get_overview_q(R2), messages, 0, R2)
        end),
     [rabbit_mgmt_metrics_collector:reset_lookups(T) || {T, _} <- ?CORE_TABLES],
+    ok.
+
+queue_stats_missing_data_test(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE,
+                                      queue_stats_missing_data_test1, [Config]).
+
+%% A queue deleted before its metrics were collected won't have an entry.
+%% Return it without any stats rather than throwing an exception and aborting
+%% the entire HTTP client request.
+%%
+%% See rabbitmq/rabbitmq-server#16989.
+queue_stats_missing_data_test1(_Config) ->
+    ok = meck:new(rabbit_mgmt_data, [passthrough, no_link]),
+    try
+        Empty = fun(_, _, _) -> #{} end,
+        meck:expect(rabbit_mgmt_data, all_list_basic_queue_data, Empty),
+        meck:expect(rabbit_mgmt_data, all_list_queue_data, Empty),
+        meck:expect(rabbit_mgmt_data, all_detail_queue_data, Empty),
+        Obj = [{name, <<"vanished">>},
+               {vhost, <<"/">>},
+               {pid, self()},
+               {state, live}],
+        Now = exometer_slide:timestamp(),
+        R = #range{first = Now - 5000, last = Now, incr = 5000},
+        Ranges = {R, R, R, R},
+        %% Non-empty ranges bypass the listing cache so each mode runs.
+        [Basic] = rabbit_mgmt_db:augment_queues([Obj], Ranges, basic),
+        <<"vanished">> = pget(name, Basic),
+        [Detailed] = rabbit_mgmt_db:augment_queues([Obj], Ranges, detailed),
+        <<"vanished">> = pget(name, Detailed),
+        [Full] = rabbit_mgmt_db:augment_queues([Obj], Ranges, full),
+        <<"vanished">> = pget(name, Full),
+        %% The detail mode always carries consumer_details.
+        [] = pget(consumer_details, Full)
+    after
+        meck:unload(rabbit_mgmt_data)
+    end,
     ok.
 
 %% Generate a well-formed interval from Start using Interval steps


### PR DESCRIPTION
For such now-deleted objects, some stats will be missing. Returning the input is safe and,
for an entity that no longer exists, acceptable: management UI's periodic updates have always
been prone to such timing events.

The "resurrection" of the deleted queue will last only one stats DB update interval.

Closes #16989 #16999.
