### PR TITLE
Mergify: remove 4.2 label support

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,37 +6,13 @@ pull_request_rules:
       label:
         add:
           - make
-  - name: Automatically backport to v4.3.x (with cascade to v4.2.x)
+  - name: Automatically backport to v4.3.x based on label
     conditions:
       - base=main
       - label=backport-v4.3.x
-      - label=backport-v4.2.x
     actions:
       backport:
         branches:
           - v4.3.x
-        assignees:
-          - "{{ author }}"
-        labels:
-          - backport-v4.2.x
-  - name: Automatically backport to v4.3.x (without cascade)
-    conditions:
-      - base=main
-      - label=backport-v4.3.x
-      - label!=backport-v4.2.x
-    actions:
-      backport:
-        branches:
-          - v4.3.x
-        assignees:
-          - "{{ author }}"
-  - name: Automatically backport to v4.2.x based on label
-    conditions:
-      - base=v4.3.x
-      - label=backport-v4.2.x
-    actions:
-      backport:
-        branches:
-          - v4.2.x
         assignees:
           - "{{ author }}"


### PR DESCRIPTION
With `4.2.9` shipped this month (July 2026), 4.2 has reached its end of community support
and its future releases will be accessible to the users with a commercial support subscription.
