### PR TITLE
Match exact symbol length when detecting AMQP 1.0 body sections

### DIFF
--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -274,17 +274,17 @@ pm(<<?DESCRIBED, ?CODE_ULONG, ?DESCRIPTOR_CODE_AMQP_SEQUENCE:64, _Rest/binary>>,
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_SEQUENCE);
 pm(<<?DESCRIBED, ?CODE_ULONG, ?DESCRIPTOR_CODE_AMQP_VALUE:64, _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_VALUE);
-pm(<<?DESCRIBED, ?CODE_SYM_8, _S:8, "amqp:data:binary", _Rest/binary>>, true, B) ->
+pm(<<?DESCRIBED, ?CODE_SYM_8, 16:8, "amqp:data:binary", _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_DATA);
-pm(<<?DESCRIBED, ?CODE_SYM_8, _S:8, "amqp:amqp-sequence:list", _Rest/binary>>, true, B) ->
+pm(<<?DESCRIBED, ?CODE_SYM_8, 23:8, "amqp:amqp-sequence:list", _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_SEQUENCE);
-pm(<<?DESCRIBED, ?CODE_SYM_8, _S:8, "amqp:amqp-value:*", _Rest/binary>>, true, B) ->
+pm(<<?DESCRIBED, ?CODE_SYM_8, 17:8, "amqp:amqp-value:*", _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_VALUE);
-pm(<<?DESCRIBED, ?CODE_SYM_32, _S:32, "amqp:data:binary", _Rest/binary>>, true, B) ->
+pm(<<?DESCRIBED, ?CODE_SYM_32, 16:32, "amqp:data:binary", _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_DATA);
-pm(<<?DESCRIBED, ?CODE_SYM_32, _S:32, "amqp:amqp-sequence:list", _Rest/binary>>, true, B) ->
+pm(<<?DESCRIBED, ?CODE_SYM_32, 23:32, "amqp:amqp-sequence:list", _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_SEQUENCE);
-pm(<<?DESCRIBED, ?CODE_SYM_32, _S:32, "amqp:amqp-value:*", _Rest/binary>>, true, B) ->
+pm(<<?DESCRIBED, ?CODE_SYM_32, 17:32, "amqp:amqp-value:*", _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_VALUE);
 pm(<<?DESCRIBED, ?CODE_ULONG, ?DESCRIPTOR_CODE_PROPERTIES:64, Rest0/binary>>, O = true, B) ->
     [Value | Rest] = pm(Rest0, O, B+10),

--- a/deps/amqp10_common/test/binary_parser_SUITE.erl
+++ b/deps/amqp10_common/test/binary_parser_SUITE.erl
@@ -25,6 +25,8 @@ all_tests() ->
      array_of_zero_width_elements,
      array_of_described_zero_width_elements_unsupported,
      unsupported_type,
+     server_mode_symbolic_body_descriptors,
+     server_mode_body_descriptor_prefix_collision,
      peek_described_section_total_sizes,
      peek_described_section,
      peek_non_described_throws,
@@ -165,6 +167,48 @@ unsupported_type(_Config) ->
     Bin = <<UnsupportedType, "hey">>,
     Expected = {primitive_type_unsupported, UnsupportedType, {position, 0}},
     ?assertThrow(Expected, amqp10_binary_parser:parse_many(Bin, [])).
+
+%% A symbolic body descriptor of the exact registered length is classified as
+%% the corresponding standard body section in server_mode.
+server_mode_symbolic_body_descriptors(_Config) ->
+    Data8 = <<0, 16#a3, 16, "amqp:data:binary", 16#a0, 1, "x">>,
+    Seq8 = <<0, 16#a3, 23, "amqp:amqp-sequence:list", 16#45>>,
+    Value8 = <<0, 16#a3, 17, "amqp:amqp-value:*", 16#a1, 1, "x">>,
+    ?assertEqual([{{pos, 0}, {body, 16#75}}],
+                 amqp10_binary_parser:parse_many(Data8, [server_mode])),
+    ?assertEqual([{{pos, 0}, {body, 16#76}}],
+                 amqp10_binary_parser:parse_many(Seq8, [server_mode])),
+    ?assertEqual([{{pos, 0}, {body, 16#77}}],
+                 amqp10_binary_parser:parse_many(Value8, [server_mode])),
+    %% The sym32 forms must be classified identically.
+    Data32 = <<0, 16#b3, 16:32, "amqp:data:binary", 16#a0, 1, "x">>,
+    Seq32 = <<0, 16#b3, 23:32, "amqp:amqp-sequence:list", 16#45>>,
+    Value32 = <<0, 16#b3, 17:32, "amqp:amqp-value:*", 16#a1, 1, "x">>,
+    ?assertEqual([{{pos, 0}, {body, 16#75}}],
+                 amqp10_binary_parser:parse_many(Data32, [server_mode])),
+    ?assertEqual([{{pos, 0}, {body, 16#76}}],
+                 amqp10_binary_parser:parse_many(Seq32, [server_mode])),
+    ?assertEqual([{{pos, 0}, {body, 16#77}}],
+                 amqp10_binary_parser:parse_many(Value32, [server_mode])).
+
+server_mode_body_descriptor_prefix_collision(_Config) ->
+    %% Well-formed but unknown descriptor "amqp:data:binary@" (length 17).
+    Collision8 = <<0, 16#a3, 17, "amqp:data:binary", $@, 16#a0, 3, "abc">>,
+    ?assertEqual(
+       [{described, {symbol, <<"amqp:data:binary@">>}, {binary, <<"abc">>}}],
+       amqp10_binary_parser:parse_many(Collision8, [server_mode])),
+
+    %% The same collision via the sym32 constructor.
+    Collision32 = <<0, 16#b3, 17:32, "amqp:data:binary", $@, 16#a0, 3, "abc">>,
+    ?assertEqual(
+       [{described, {symbol, <<"amqp:data:binary@">>}, {binary, <<"abc">>}}],
+       amqp10_binary_parser:parse_many(Collision32, [server_mode])),
+
+    %% A prefix collision on the amqp-value descriptor.
+    ValueCollision = <<0, 16#a3, 18, "amqp:amqp-value:*!", 16#a1, 1, "x">>,
+    ?assertEqual(
+       [{described, {symbol, <<"amqp:amqp-value:*!">>}, {utf8, <<"x">>}}],
+       amqp10_binary_parser:parse_many(ValueCollision, [server_mode])).
 
 %%%===================================================================
 %%% peek/1 (exercises peek_value_size internally via described types)


### PR DESCRIPTION
In server_mode, the parser recognised the symbolic message body descriptors (amqp:data:binary, amqp:amqp-sequence:list and amqp:amqp-value:*) by their textual prefix only, ignoring the encoded symbol length. A described value whose descriptor merely started with one of these names was therefore classified as the corresponding standard body section.