### PR TITLE
Add negative-auth canary tests for the internal loopback backend

### DIFF
--- a/deps/rabbitmq_auth_backend_internal_loopback/test/rabbit_auth_backend_internal_loopback_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_internal_loopback/test/rabbit_auth_backend_internal_loopback_SUITE.erl
@@ -21,6 +21,13 @@
         "loopback/localhost, which is prohibited by the internal loopback authN "
         "backend.").
 
+-define(BLANK_PASSWORD_REJECTION_MESSAGE,
+        "user '~ts' attempted to log in with a blank password, which is prohibited by the internal authN backend. "
+        "To use TLS/x509 certificate-based authentication, see the rabbitmq_auth_mechanism_ssl plugin and configure the client to use the EXTERNAL authentication mechanism. "
+        "Alternatively change the password for the user to be non-blank.").
+
+-define(INVALID_CREDENTIALS_REJECTION_MESSAGE, "user '~ts' - invalid credentials").
+
 -define(LOOPBACK_USER, #{username => <<"TestLoopbackUser">>,
                         password => <<"TestLoopbackUser">>,
                         expected_credentials => [username, password],
@@ -43,7 +50,11 @@ groups() ->
     [
         {localhost_connection, [], [
             login_from_localhost_with_loopback_user,
-            login_from_localhost_with_nonloopback_user
+            login_from_localhost_with_nonloopback_user,
+            login_from_localhost_with_wrong_password_is_refused,
+            login_from_localhost_with_blank_password_is_refused,
+            login_from_localhost_with_unknown_user_is_refused,
+            login_without_loopback_info_is_refused
         ]},
         {nonlocalhost_connection, [], [
             login_from_nonlocalhost_with_loopback_user,
@@ -84,6 +95,39 @@ login_from_localhost_with_nonloopback_user(Config) ->
     AuthProps = build_auth_props(maps:get(password, ?NONLOOPBACK_USER), ?LOCALHOST_ADDR),
     {ok, _AuthUser} = rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
         [maps:get(username, ?NONLOOPBACK_USER), AuthProps]).
+
+%% Security canary: a loopback connection presenting the wrong password
+%% must be refused with an invalid-credentials error. Guards the salted-hash
+%% comparison against an accidental fail-open regression.
+login_from_localhost_with_wrong_password_is_refused(Config) ->
+    AuthProps = build_auth_props(<<"not-the-right-password">>, ?LOCALHOST_ADDR),
+    {refused, ?INVALID_CREDENTIALS_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [maps:get(username, ?LOOPBACK_USER), AuthProps]).
+
+%% Security canary: a loopback connection with a blank password must be
+%% refused, even though the address is trusted.
+login_from_localhost_with_blank_password_is_refused(Config) ->
+    AuthProps = build_auth_props(<<"">>, ?LOCALHOST_ADDR),
+    {refused, ?BLANK_PASSWORD_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [maps:get(username, ?LOOPBACK_USER), AuthProps]).
+
+%% Security canary: a loopback connection for a user that does not exist
+%% must be refused with an invalid-credentials error.
+login_from_localhost_with_unknown_user_is_refused(Config) ->
+    AuthProps = build_auth_props(<<"any-password">>, ?LOCALHOST_ADDR),
+    {refused, ?INVALID_CREDENTIALS_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [<<"NoSuchUser">>, AuthProps]).
+
+%% Security canary: when no socket or address is provided, the backend cannot
+%% determine whether the connection is from localhost and must fail closed.
+login_without_loopback_info_is_refused(Config) ->
+    AuthProps = [{password, maps:get(password, ?LOOPBACK_USER)}],
+    {refused, ?NO_SOCKET_OR_ADDRESS_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [maps:get(username, ?LOOPBACK_USER), AuthProps]).
 
 % Test cases for non-localhost connections
 login_from_nonlocalhost_with_loopback_user(Config) ->


### PR DESCRIPTION
## What

The internal loopback authN backend's `user_login_authentication/2` has several fail-closed branches, but the existing suite only exercised the positive login paths and the `is_loopback=false` gate. Both pre-existing "refused" cases refused on the address gate before ever reaching password verification, so the salted-hash comparison, the blank-password rejection, and the fail-closed default when no socket or address is provided had no coverage.

This change adds four negative-auth canaries to the `localhost_connection` group, each asserting the specific refusal message so a regression that short-circuits on the wrong branch is caught (the pre-existing cases used a wildcard for the message):

- wrong password is refused with invalid credentials
- blank password is refused
- unknown user is refused with invalid credentials
- missing socket/address info fails closed

## Why

These branches are the security-critical part of the backend: they are what keeps a loopback connection from authenticating without valid credentials. A future change that made any of them fail open would be silent today because nothing asserts on them. Asserting on the exact refusal reason (rather than just "some refusal happened") ensures each test proves the branch it is meant to guard actually fired.

## Scope

Test-only. No production code changes. The new cases pass against the current implementation.

## Testing

Ran the suite locally:

```
gmake -C deps/rabbitmq_auth_backend_internal_loopback ct-rabbit_auth_backend_internal_loopback
```

Result: 8 Ok, 0 Failed, 0 Skipped (4 pre-existing plus the 4 new canaries).
