### PR TITLE
Reduce connection log noise from AMQP 0.9.1 and 1.0 clients, shovels

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -112,9 +112,20 @@ open(Config0) ->
             {_, Reader, _, _} = lists:keyfind(reader, 1, Children),
             {_, Connection, _, _} = lists:keyfind(connection, 1, Children),
             {_, SessionsSup, _, _} = lists:keyfind(sessions, 1, Children),
-            set_other_procs(Connection, #{sessions_sup => SessionsSup,
-                                          reader => Reader}),
-            {ok, Connection};
+            %% The reader's socket connect (including DNS resolution) is
+            %% deliberately deferred until here, rather than done as part
+            %% of its own init/1: a hostname/connectivity failure is then
+            %% just a normal call reply instead of a supervisor start_error,
+            %% which OTP would otherwise always report.
+            case amqp10_client_frame_reader:connect(Reader) of
+                ok ->
+                    set_other_procs(Connection, #{sessions_sup => SessionsSup,
+                                                  reader => Reader}),
+                    {ok, Connection};
+                {error, _} = Error ->
+                    _ = supervisor:terminate_child(amqp10_client_sup, ConnSup),
+                    Error
+            end;
         Error ->
             Error
     end.

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -419,8 +419,21 @@ terminate(Reason, _StateName, #state{connection_sup = Sup,
                                      config = Config}) ->
     ok = notify_closed(Config, Reason),
     case Reason of
-        normal -> sys:terminate(Sup, normal);
-        _      -> ok
+        normal ->
+            %% Tear down the rest of the connection's supervision tree
+            %% (reader, sessions) now that we're done: a quiet (`normal')
+            %% child termination is not cascaded to `one_for_all' siblings.
+            %%
+            %% This must not be a blocking call: `Sup' shutting down this
+            %% very process is part of its own termination, which can
+            %% never complete while we are still executing this callback,
+            %% so calling sys:terminate/2 (or supervisor:terminate_child/2)
+            %% directly here would deadlock both processes until they each
+            %% hit their 5-second timeout.
+            _ = spawn(fun() -> sys:terminate(Sup, normal) end),
+            ok;
+        _ ->
+            ok
     end.
 
 code_change(_OldVsn, StateName, State, _Extra) ->

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -343,6 +343,20 @@ opened(_EvtType, #'v1_0.close'{} = Close, State = #state{config = Config}) ->
         {error, closed} -> {stop, normal, State};
         Error           -> {stop, Error, State}
     end;
+opened(_EvtType, {'EXIT', Pid, Reason}, State) ->
+    %% A linked process (e.g. the application that opened this connection)
+    %% died. Close the connection gracefully instead of lingering silently
+    %% or falling through to the generic "unexpected frame" clause below.
+    ?LOG_WARNING("Connection ~tp closing because dependent process ~tp died: ~tp",
+                 [self(), Pid, Reason]),
+    case send_close(State, Reason) of
+        ok ->
+            {next_state, close_sent, State, {state_timeout, ?TIMEOUT, received_no_close_frame}};
+        {error, closed} ->
+            {stop, normal, State};
+        Error ->
+            {stop, Error, State}
+    end;
 opened({call, From}, begin_session, State) ->
     {Ret, State1} = handle_begin_session(From, State),
     {keep_state, State1, [{reply, From, Ret}]};

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -261,7 +261,7 @@ sasl_init_sent(info, {'DOWN', MRef, process, _Pid, _},
 hdr_sent(_EvtType, {protocol_header_received, 0, 1, 0, 0}, State) ->
     case send_open(State) of
         ok    -> {next_state, open_sent, State};
-        Error -> {stop, Error, State}
+        Error -> {stop, {shutdown, Error}, State}
     end;
 hdr_sent(_EvtType, {protocol_header_received, Protocol, Maj, Min,
                                 Rev}, State) ->
@@ -317,10 +317,11 @@ open_sent(_EvtType, {close, Reason}, State) ->
             %% timeout to give its partner a reasonable time to receive and process the close
             %% before giving up and simply closing the underlying transport mechanism)." [§2.4.3]
             {next_state, close_sent, State, {state_timeout, ?TIMEOUT, received_no_close_frame}};
-        {error, closed} ->
-            {stop, normal, State};
-        Error ->
-            {stop, Error, State}
+        {error, _} ->
+            %% Best-effort: the socket is already gone, for whatever
+            %% reason. There is nobody left to notify and nothing more
+            %% useful to do.
+            {stop, normal, State}
     end;
 open_sent(info, {'DOWN', MRef, process, _, _},
           #state{reader_m_ref = MRef}) ->
@@ -341,18 +342,18 @@ opened(_EvtType, {close, Reason}, State) ->
             %% timeout to give its partner a reasonable time to receive and process the close
             %% before giving up and simply closing the underlying transport mechanism)." [§2.4.3]
             {next_state, close_sent, State, {state_timeout, ?TIMEOUT, received_no_close_frame}};
-        {error, closed} ->
-            {stop, normal, State};
-        Error ->
-            {stop, Error, State}
+        {error, _} ->
+            %% Best-effort: the socket is already gone, for whatever
+            %% reason. There is nobody left to notify and nothing more
+            %% useful to do.
+            {stop, normal, State}
     end;
 opened(_EvtType, #'v1_0.close'{} = Close, State = #state{config = Config}) ->
     %% We receive the first close frame, reply and terminate.
     ok = notify_closed(Config, Close),
     case send_close(State, none) of
-        ok              -> {stop, normal, State};
-        {error, closed} -> {stop, normal, State};
-        Error           -> {stop, Error, State}
+        ok        -> {stop, normal, State};
+        {error, _} -> {stop, normal, State}
     end;
 opened(_EvtType, {'EXIT', Pid, Reason}, State) ->
     %% A linked process (e.g. the application that opened this connection)
@@ -363,10 +364,11 @@ opened(_EvtType, {'EXIT', Pid, Reason}, State) ->
     case send_close(State, Reason) of
         ok ->
             {next_state, close_sent, State, {state_timeout, ?TIMEOUT, received_no_close_frame}};
-        {error, closed} ->
-            {stop, normal, State};
-        Error ->
-            {stop, Error, State}
+        {error, _} ->
+            %% Best-effort: the socket is already gone, for whatever
+            %% reason. There is nobody left to notify and nothing more
+            %% useful to do.
+            {stop, normal, State}
     end;
 opened({call, From}, begin_session, State) ->
     {Ret, State1} = handle_begin_session(From, State),

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -323,6 +323,15 @@ open_sent(_EvtType, {close, Reason}, State) ->
             %% useful to do.
             {stop, normal, State}
     end;
+open_sent(_EvtType, #'v1_0.close'{} = Close,
+          #state{config = Config,
+                 pending_session_reqs = PendingSessionReqs} = State) ->
+    %% The peer refused the connection, e.g. due to an unknown virtual
+    %% host or a connection limit. An expected failure: no OTP-level noise.
+    ok = notify_closed(Config, Close),
+    [gen_statem:reply(From, {error, closed}) || From <- PendingSessionReqs],
+    _ = send_close(State, none),
+    {stop, normal, State};
 open_sent(info, {'DOWN', MRef, process, _, _},
           #state{reader_m_ref = MRef}) ->
     {stop, {shutdown, reader_down}}.

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -327,7 +327,7 @@ open_sent(_EvtType, #'v1_0.close'{} = Close,
           #state{config = Config,
                  pending_session_reqs = PendingSessionReqs} = State) ->
     %% The peer refused the connection, e.g. due to an unknown virtual
-    %% host or a connection limit. An expected failure: no OTP-level noise.
+    %% host or a connection limit.
     ok = notify_closed(Config, Close),
     [gen_statem:reply(From, {error, closed}) || From <- PendingSessionReqs],
     _ = send_close(State, none),

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -221,7 +221,9 @@ sasl_hdr_sent({call, From}, begin_session,
     {keep_state, State1};
 sasl_hdr_sent(info, {'DOWN', MRef, process, _Pid, _},
               #state{reader_m_ref = MRef}) ->
-    {stop, {shutdown, reader_down}}.
+    {stop, {shutdown, reader_down}};
+sasl_hdr_sent(_EvtType, Frame, State) ->
+    unexpected_during_handshake(sasl_hdr_sent, Frame, State).
 
 sasl_hdr_rcvds(_EvtType, #'v1_0.sasl_mechanisms'{
                             sasl_server_mechanisms = {array, symbol, AvailableMechs}},
@@ -233,7 +235,7 @@ sasl_hdr_rcvds(_EvtType, #'v1_0.sasl_mechanisms'{
             ok = send_sasl_init(State, DecryptedSasl),
             {next_state, sasl_init_sent, State};
         false ->
-            {stop, {sasl_not_supported, DecryptedSasl}, State}
+            {stop, {shutdown, {sasl_not_supported, DecryptedSasl}}, State}
     end;
 sasl_hdr_rcvds({call, From}, begin_session,
                #state{pending_session_reqs = PendingSessionReqs} = State) ->
@@ -241,7 +243,9 @@ sasl_hdr_rcvds({call, From}, begin_session,
     {keep_state, State1};
 sasl_hdr_rcvds(info, {'DOWN', MRef, process, _Pid, _},
                #state{reader_m_ref = MRef}) ->
-    {stop, {shutdown, reader_down}}.
+    {stop, {shutdown, reader_down}};
+sasl_hdr_rcvds(_EvtType, Frame, State) ->
+    unexpected_during_handshake(sasl_hdr_rcvds, Frame, State).
 
 sasl_init_sent(_EvtType, #'v1_0.sasl_outcome'{code = {ubyte, 0}},
                #state{socket = Socket} = State) ->
@@ -249,14 +253,16 @@ sasl_init_sent(_EvtType, #'v1_0.sasl_outcome'{code = {ubyte, 0}},
     {next_state, hdr_sent, State};
 sasl_init_sent(_EvtType, #'v1_0.sasl_outcome'{code = {ubyte, C}},
                #state{} = State) when C==1;C==2;C==3;C==4 ->
-    {stop, sasl_auth_failure, State};
+    {stop, {shutdown, sasl_auth_failure}, State};
 sasl_init_sent({call, From}, begin_session,
                #state{pending_session_reqs = PendingSessionReqs} = State) ->
     State1 = State#state{pending_session_reqs = [From | PendingSessionReqs]},
     {keep_state, State1};
 sasl_init_sent(info, {'DOWN', MRef, process, _Pid, _},
                #state{reader_m_ref = MRef}) ->
-    {stop, {shutdown, reader_down}}.
+    {stop, {shutdown, reader_down}};
+sasl_init_sent(_EvtType, Frame, State) ->
+    unexpected_during_handshake(sasl_init_sent, Frame, State).
 
 hdr_sent(_EvtType, {protocol_header_received, 0, 1, 0, 0}, State) ->
     case send_open(State) of
@@ -274,7 +280,9 @@ hdr_sent({call, From}, begin_session,
     {keep_state, State1};
 hdr_sent(info, {'DOWN', MRef, process, _Pid, _},
          #state{reader_m_ref = MRef}) ->
-    {stop, {shutdown, reader_down}}.
+    {stop, {shutdown, reader_down}};
+hdr_sent(_EvtType, Frame, State) ->
+    unexpected_during_handshake(hdr_sent, Frame, State).
 
 open_sent(_EvtType, #'v1_0.open'{max_frame_size = MaybeMaxFrameSize,
                                  idle_time_out = Timeout} = Open,
@@ -417,6 +425,15 @@ close_sent(_EvtType, #'v1_0.open'{}, _Data) ->
     %% Transition from CLOSE_PIPE to CLOSE_SENT in figure 2.23.
     keep_state_and_data.
 
+%% A peer that refuses the connection or misbehaves can send frames out
+%% of the expected handshake sequence. Terminating with a stack trace
+%% would help nobody; log the frame and stop quietly instead.
+unexpected_during_handshake(StateName, Frame, State) ->
+    ?LOG_WARNING("Connection ~tp received an unexpected frame or message "
+                 "~tp during handshake (~ts)",
+                 [self(), Frame, StateName]),
+    {stop, {shutdown, {unexpected_frame, Frame}}, State}.
+
 set_other_procs0(OtherProcs, State) ->
     #{sessions_sup := SessionsSup,
       reader := Reader} = OtherProcs,
@@ -428,7 +445,13 @@ set_other_procs0(OtherProcs, State) ->
 
 terminate(Reason, _StateName, #state{connection_sup = Sup,
                                      config = Config}) ->
-    ok = notify_closed(Config, Reason),
+    %% Expected failures stop this process with a reason wrapped in
+    %% 'shutdown' to avoid massive supervisor reports logged. Notify
+    %% the owner with the specific reason, without the wrapper.
+    ok = notify_closed(Config, case Reason of
+                                   {shutdown, R} -> R;
+                                   _             -> Reason
+                               end),
     case Reason of
         normal ->
             %% Tear down the rest of the connection's supervision tree

--- a/deps/amqp10_client/src/amqp10_client_frame_reader.erl
+++ b/deps/amqp10_client/src/amqp10_client_frame_reader.erl
@@ -18,6 +18,7 @@
 
 %% API
 -export([start_link/2,
+         connect/1,
          set_connection/2,
          register_session/3,
          unregister_session/4]).
@@ -59,6 +60,18 @@ start_link(Sup, Config) ->
 
 %% @private
 %% @doc
+%% Connects the underlying socket (including DNS resolution).
+%%
+%% This is deliberately not done as part of init/1: failing there would
+%% fail amqp10_client_connection_sup's own child startup sequence, which
+%% makes OTP log an unsuppressible supervisor report for what is usually
+%% just an unreachable or misconfigured peer, rather than a bug.
+-spec connect(pid()) -> ok | {error, any()}.
+connect(Reader) ->
+    gen_statem:call(Reader, connect, infinity).
+
+%% @private
+%% @doc
 %% Passes the connection process PID to the reader process.
 %%
 %% This function is called when a connection supervision tree is
@@ -82,22 +95,10 @@ callback_mode() ->
 
 init([Sup, ConnConfig]) when is_map(ConnConfig) ->
     process_flag(trap_exit, true),
-    Port = maps:get(port, ConnConfig, 5672),
-    %% combined the list of `addresses' with the value of the original `address' option if provided
-    Addresses0 = maps:get(addresses, ConnConfig, []),
-    Addresses  = case maps:get(address, ConnConfig, undefined) of
-                     undefined -> Addresses0;
-                     Address   -> Addresses0 ++ [Address]
-                 end,
-    case connect_any(Addresses, Port, ConnConfig) of
-        {ok, Socket} ->
-            State = #state{connection_sup = Sup,
-                           socket = Socket,
-                           connection_config = ConnConfig},
-            {ok, expecting_connection_pid, State};
-        {error, Reason} ->
-            {stop, Reason}
-    end.
+    State = #state{connection_sup = Sup,
+                   socket = closed,
+                   connection_config = ConnConfig},
+    {ok, awaiting_connect, State}.
 
 connect_any([Address], Port, ConnConfig) ->
     amqp10_client_socket:connect(Address, Port, ConnConfig);
@@ -109,6 +110,27 @@ connect_any([Address | Addresses], Port, ConnConfig) ->
             R
     end.
 
+handle_event({call, From}, connect, awaiting_connect,
+             #state{connection_config = ConnConfig} = State) ->
+    Port = maps:get(port, ConnConfig, 5672),
+    %% combined the list of `addresses' with the value of the original `address' option if provided
+    Addresses0 = maps:get(addresses, ConnConfig, []),
+    Addresses  = case maps:get(address, ConnConfig, undefined) of
+                     undefined -> Addresses0;
+                     Address   -> Addresses0 ++ [Address]
+                 end,
+    case connect_any(Addresses, Port, ConnConfig) of
+        {ok, Socket} ->
+            State1 = State#state{socket = Socket},
+            {next_state, expecting_connection_pid, State1, [{reply, From, ok}]};
+        {error, Reason} ->
+            %% Stop quietly: this reader is a `transient' child and `normal'
+            %% is not reported by the supervisor, unlike a start_error would
+            %% have been. amqp10_client_connection:open/1 tears down the
+            %% rest of the connection's supervision tree once it sees the
+            %% `{error, _}' reply.
+            {stop_and_reply, normal, [{reply, From, {error, Reason}}], State}
+    end;
 handle_event(cast, {set_connection, ConnectionPid}, expecting_connection_pid,
              State=#state{socket = Socket}) ->
     ok = amqp10_client_connection:socket_ready(ConnectionPid, Socket),

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -297,8 +297,8 @@ unmapped({call, From}, {attach, Attach},
 unmapped(_EvtType, Msg, _State) ->
     %% Crashing here would take down `amqp10_client_sessions_sup` with this
     %% session, leaving the connection unable to begin any more sessions.
-    ?LOG_WARNING("amqp10_session: unhandled msg in unmapped state ~W",
-                 [Msg, 10]),
+    ?LOG_DEBUG("amqp10_session: unhandled msg in unmapped state ~W",
+               [Msg, 10]),
     keep_state_and_data.
 
 begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
@@ -336,8 +336,8 @@ begin_sent({call, From}, {attach, Attach},
 begin_sent(_EvtType, Msg, _State) ->
     %% Crashing here would take down `amqp10_client_sessions_sup` with this
     %% session, leaving the connection unable to begin any more sessions.
-    ?LOG_WARNING("amqp10_session: unhandled msg in begin_sent state ~W",
-                 [Msg, 10]),
+    ?LOG_DEBUG("amqp10_session: unhandled msg in begin_sent state ~W",
+               [Msg, 10]),
     keep_state_and_data.
 
 mapped(cast, 'end', State) ->

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -286,10 +286,20 @@ unmapped(cast, {socket_ready, Socket}, State) ->
     State1 = State#state{socket = Socket},
     ok = send_begin(State1),
     {next_state, begin_sent, State1};
+unmapped(cast, 'end', State) ->
+    %% The frame reader has not made the socket available yet, so the peer
+    %% never learnt about this session and there is no end frame to send.
+    {stop, normal, State};
 unmapped({call, From}, {attach, Attach},
                       #state{early_attach_requests = EARs} = State) ->
     {keep_state,
-     State#state{early_attach_requests = [{From, Attach} | EARs]}}.
+     State#state{early_attach_requests = [{From, Attach} | EARs]}};
+unmapped(_EvtType, Msg, _State) ->
+    %% Crashing here would take down `amqp10_client_sessions_sup` with this
+    %% session, leaving the connection unable to begin any more sessions.
+    ?LOG_WARNING("amqp10_session: unhandled msg in unmapped state ~W",
+                 [Msg, 10]),
+    keep_state_and_data.
 
 begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
                                next_outgoing_id = {uint, NOI},
@@ -310,10 +320,25 @@ begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
                                       next_incoming_id = NOI,
                                       remote_incoming_window = InWindow,
                                       remote_outgoing_window = OutWindow}};
+begin_sent(cast, 'end', State) ->
+    %% The session was ended before the peer confirmed that it had begun.
+    send_end(State),
+    {next_state, end_sent, State};
+begin_sent(cast, #'v1_0.end'{} = End, State) ->
+    %% `send_end/1` stops this process when the socket is gone, so notify first.
+    ok = notify_session_ended(End, State),
+    _ = send_end(State),
+    {stop, normal, State};
 begin_sent({call, From}, {attach, Attach},
            #state{early_attach_requests = EARs} = State) ->
     {keep_state,
-     State#state{early_attach_requests = [{From, Attach} | EARs]}}.
+     State#state{early_attach_requests = [{From, Attach} | EARs]}};
+begin_sent(_EvtType, Msg, _State) ->
+    %% Crashing here would take down `amqp10_client_sessions_sup` with this
+    %% session, leaving the connection unable to begin any more sessions.
+    ?LOG_WARNING("amqp10_session: unhandled msg in begin_sent state ~W",
+                 [Msg, 10]),
+    keep_state_and_data.
 
 mapped(cast, 'end', State) ->
     %% We send the first end frame and wait for the reply.
@@ -348,9 +373,10 @@ mapped(cast,
     {keep_state, State};
 mapped(cast, #'v1_0.end'{} = End, State) ->
     %% We receive the first end frame, reply and terminate.
-    _ = send_end(State),
-    % TODO: send notifications for links?
+    %% `send_end/1` stops this process when the socket is gone, so notify first.
+    %% TODO: send notifications for links?
     ok = notify_session_ended(End, State),
+    _ = send_end(State),
     {stop, normal, State};
 mapped(cast, #'v1_0.attach'{name = {utf8, Name},
                             handle = {uint, InHandle},

--- a/deps/amqp10_client/test/session_SUITE.erl
+++ b/deps/amqp10_client/test/session_SUITE.erl
@@ -1,0 +1,250 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(session_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp10_common/include/amqp10_framing.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-define(TIMEOUT, 5000).
+
+all() ->
+    [
+     {group, mock},
+     {group, before_mapped}
+    ].
+
+groups() ->
+    [
+     {mock, [], [
+                 end_session_before_begun
+                ]},
+     {before_mapped, [], [
+                          end_before_socket_ready,
+                          end_before_begun,
+                          refused_before_begun,
+                          unexpected_events_before_socket_ready,
+                          unexpected_events_before_begun
+                         ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    ?assertMatch({ok, _}, application:ensure_all_started(amqp10_client)),
+    Config.
+
+end_per_suite(_Config) ->
+    ok = application:stop(amqp10_client).
+
+init_per_group(mock, Config) ->
+    [{mock_host, "localhost"}, {mock_port, 25010} | Config];
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, Config) ->
+    Config.
+
+init_per_testcase(_Test, Config) ->
+    %% Test cases link to the session supervisors they start.
+    process_flag(trap_exit, true),
+    case lists:keyfind(mock_port, 1, Config) of
+        {_, Port} -> [{mock_server, mock_server:start(Port)} | Config];
+        false     -> Config
+    end.
+
+end_per_testcase(_Test, Config) ->
+    case lists:keyfind(mock_server, 1, Config) of
+        {_, M} -> mock_server:stop(M);
+        false  -> ok
+    end,
+    ok.
+
+%% -------------------------------------------------------------------
+%% Test cases.
+%% -------------------------------------------------------------------
+
+%% Ending a session before the connection has confirmed it must leave the
+%% connection able to begin further sessions.
+end_session_before_begun(Config) ->
+    Hostname = ?config(mock_host, Config),
+    Port = ?config(mock_port, Config),
+    OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
+                       {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
+               end,
+    %% Leave the first begin unanswered so that its session cannot map.
+    ParkStep = fun({Ch, #'v1_0.begin'{}, _Pay}) ->
+                       {Ch, []}
+               end,
+    EndStep = fun({Ch, #'v1_0.end'{}, _Pay}) ->
+                      {Ch, []}
+              end,
+    BeginStep = fun({Ch, #'v1_0.begin'{}, _Pay}) ->
+                        {Ch, [#'v1_0.begin'{remote_channel = {ushort, Ch},
+                                            next_outgoing_id = {uint, 1},
+                                            incoming_window = {uint, 1000},
+                                            outgoing_window = {uint, 1000}}]}
+                end,
+    Steps = [fun mock_server:recv_amqp_header_step/1,
+             fun mock_server:send_amqp_header_step/1,
+             mock_server:amqp_step(OpenStep),
+             mock_server:amqp_step(ParkStep),
+             mock_server:amqp_step(EndStep),
+             mock_server:amqp_step(BeginStep)],
+    ok = mock_server:set_steps(?config(mock_server, Config), Steps),
+
+    Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
+    {ok, Connection} = amqp10_client:open_connection(Cfg),
+    {ok, Session} = amqp10_client:begin_session(Connection),
+    ?awaitMatch({begin_sent, _}, sys:get_state(Session), ?TIMEOUT),
+    ok = amqp10_client:end_session(Session),
+    %% Both sessions write to the same socket, so wait for the end frame
+    %% to be sent before the next session sends its begin frame.
+    ?awaitMatch({end_sent, _}, sys:get_state(Session), ?TIMEOUT),
+
+    ?assertMatch({ok, _}, amqp10_client:begin_session_sync(Connection)),
+    ok = amqp10_client:close_connection(Connection).
+
+%% The frame reader makes the socket available asynchronously, so an
+%% application can end a session that is still unmapped.
+end_before_socket_ready(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(unmapped, 0),
+    MRef = erlang:monitor(process, Session),
+    ok = amqp10_client_session:'end'(Session),
+    ?assertEqual(normal, await_down(MRef)),
+    ?assert(is_process_alive(Sup)),
+    ?assert(is_pid(start_session(Sup, 1))),
+    ok = stop_sup(Sup, Sockets).
+
+end_before_begun(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(begin_sent, 0),
+    MRef = erlang:monitor(process, Session),
+    ok = amqp10_client_session:'end'(Session),
+    %% The session waits for the peer's end frame.
+    ?awaitMatch({end_sent, _}, sys:get_state(Session), ?TIMEOUT),
+    ?assert(is_process_alive(Sup)),
+    ?assert(is_pid(start_session(Sup, 1))),
+
+    %% The peer replies and the session ends without ever having been mapped.
+    gen_statem:cast(Session, #'v1_0.end'{}),
+    receive
+        {amqp10_event, {session, Session, {ended, Reason}}} ->
+            ?assertEqual(normal, Reason)
+    after ?TIMEOUT ->
+              ct:fail(missing_ended_event)
+    end,
+    ?assertEqual(normal, await_down(MRef)),
+    ok = stop_sup(Sup, Sockets).
+
+%% A peer refuses a session by ending it with an error.
+refused_before_begun(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(begin_sent, 0),
+    MRef = erlang:monitor(process, Session),
+    Error = #'v1_0.error'{condition = ?V_1_0_AMQP_ERROR_RESOURCE_LIMIT_EXCEEDED,
+                          description = {utf8, <<"too many sessions">>}},
+    gen_statem:cast(Session, #'v1_0.end'{error = Error}),
+    receive
+        {amqp10_event, {session, Session, {ended, Reason}}} ->
+            ?assertEqual(Error, Reason)
+    after ?TIMEOUT ->
+              ct:fail(missing_ended_event)
+    end,
+    ?assertEqual(normal, await_down(MRef)),
+    ?assert(is_process_alive(Sup)),
+    ok = stop_sup(Sup, Sockets).
+
+unexpected_events_before_socket_ready(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(unmapped, 0),
+    [ok = send_unexpected_event(Session, E) || E <- unexpected_events()],
+    ?assertMatch({unmapped, _}, sys:get_state(Session)),
+    ?assert(is_process_alive(Sup)),
+    ok = stop_sup(Sup, Sockets).
+
+unexpected_events_before_begun(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(begin_sent, 0),
+    [ok = send_unexpected_event(Session, E) || E <- unexpected_events()],
+    ?assertMatch({begin_sent, _}, sys:get_state(Session)),
+    ?assert(is_process_alive(Sup)),
+    ok = stop_sup(Sup, Sockets).
+
+%% -------------------------------------------------------------------
+%% Helpers.
+%% -------------------------------------------------------------------
+
+start_session_in(unmapped, Channel) ->
+    Sup = start_sup(),
+    {Sup, start_session(Sup, Channel), none};
+start_session_in(begin_sent, Channel) ->
+    Sup = start_sup(),
+    Session = start_session(Sup, Channel),
+    {Sup, Session, park_in_begin_sent(Session)}.
+
+start_sup() ->
+    {ok, Sup} = amqp10_client_sessions_sup:start_link(),
+    Sup.
+
+stop_sup(Sup, Sockets) ->
+    ok = close_sockets(Sockets),
+    true = unlink(Sup),
+    true = exit(Sup, shutdown),
+    ok.
+
+%% The test process stands in for both the session's owner and the frame
+%% reader.
+start_session(Sup, Channel) ->
+    {ok, Session} = supervisor:start_child(Sup, [self(), Channel, self(), #{}]),
+    Session.
+
+%% Nothing ever replies to the begin frame, so the session stays in
+%% `begin_sent`.
+park_in_begin_sent(Session) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, Port,
+                                   [binary, {active, false}]),
+    {ok, Peer} = gen_tcp:accept(Listener, ?TIMEOUT),
+    ok = amqp10_client_session:socket_ready(Session, {tcp, Socket}),
+    ?assertMatch({begin_sent, _}, sys:get_state(Session)),
+    {Listener, Peer}.
+
+close_sockets(none) ->
+    ok;
+close_sockets({Listener, Peer}) ->
+    ok = gen_tcp:close(Peer),
+    ok = gen_tcp:close(Listener).
+
+%% Events a session cannot handle before it is mapped.
+unexpected_events() ->
+    [{cast, #'v1_0.flow'{}},
+     {info, stray_message},
+     {info, exit_signal}].
+
+send_unexpected_event(Session, {cast, Msg}) ->
+    gen_statem:cast(Session, Msg);
+send_unexpected_event(Session, {info, exit_signal}) ->
+    %% The session is not linked to the test process, so this is an
+    %% ordinary message rather than an exit signal from its parent.
+    Session ! {'EXIT', self(), shutdown},
+    ok;
+send_unexpected_event(Session, {info, Msg}) ->
+    Session ! Msg,
+    ok.
+
+
+await_down(MRef) ->
+    receive
+        {'DOWN', MRef, process, _Pid, Reason} ->
+            Reason
+    after ?TIMEOUT ->
+              ct:fail(session_still_alive)
+    end.

--- a/deps/amqp10_client/test/session_prop_SUITE.erl
+++ b/deps/amqp10_client/test/session_prop_SUITE.erl
@@ -1,0 +1,131 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(session_prop_SUITE).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp10_common/include/amqp10_framing.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-define(TIMEOUT, 5000).
+
+all() ->
+    [
+     survives_events_before_mapping_prop
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    ?assertMatch({ok, _}, application:ensure_all_started(amqp10_client)),
+    Config.
+
+end_per_suite(_Config) ->
+    ok = application:stop(amqp10_client).
+
+init_per_testcase(_Test, Config) ->
+    %% Test cases link to the session supervisors they start.
+    process_flag(trap_exit, true),
+    Config.
+
+end_per_testcase(_Test, _Config) ->
+    ok.
+
+%% -------------------------------------------------------------------
+%% Generators
+%% -------------------------------------------------------------------
+
+%% What an application, the frame reader and unrelated processes can send
+%% a session before it is mapped. The peer's begin frame is left out so
+%% that sessions stay in the states under test.
+event() ->
+    oneof([socket_ready,
+           'end',
+           {cast, #'v1_0.flow'{}},
+           {info, stray_message},
+           {info, exit_signal}]).
+
+%% -------------------------------------------------------------------
+%% Properties
+%% -------------------------------------------------------------------
+
+%% A session must not terminate abnormally in any order these events
+%% arrive: that also takes down `amqp10_client_sessions_sup`, leaving the
+%% connection unable to begin any more sessions.
+survives_events_before_mapping_prop(_Config) ->
+    Prop = ?FORALL(Events, non_empty(list(event())), survives(Events)),
+    ?assert(proper:quickcheck(Prop, [quiet, {numtests, 100}])).
+
+%% -------------------------------------------------------------------
+%% Helpers
+%% -------------------------------------------------------------------
+
+survives(Events) ->
+    {ok, Sup} = amqp10_client_sessions_sup:start_link(),
+    %% The test process stands in for both the session's owner and the
+    %% frame reader.
+    {ok, Session} = supervisor:start_child(Sup, [self(), 0, self(), #{}]),
+    MRef = erlang:monitor(process, Session),
+    {Listener, Peer, Socket} = connected_socket(),
+    try
+        [send_event(Session, E, Socket) || E <- Events],
+        session_survived(Session, MRef) andalso is_process_alive(Sup)
+    after
+        erlang:demonitor(MRef, [flush]),
+        ok = gen_tcp:close(Peer),
+        ok = gen_tcp:close(Listener),
+        true = unlink(Sup),
+        true = exit(Sup, shutdown)
+    end.
+
+%% `sys:get_state/1` is answered only once the session has handled every
+%% event sent before it. No real need to use `await_condition/2` and friends.
+session_survived(Session, MRef) ->
+    try sys:get_state(Session) of
+        {StateName, _Data} ->
+            lists:member(StateName, [unmapped, begin_sent, end_sent])
+    catch
+        exit:_ ->
+            %% Ending a session that was never mapped stops it.
+            normal =:= await_down(MRef)
+    end.
+
+connected_socket() ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, Port,
+                                   [binary, {active, false}]),
+    {ok, Peer} = gen_tcp:accept(Listener, ?TIMEOUT),
+    {Listener, Peer, Socket}.
+
+send_event(Session, socket_ready, Socket) ->
+    amqp10_client_session:socket_ready(Session, {tcp, Socket});
+send_event(Session, 'end', _Socket) ->
+    amqp10_client_session:'end'(Session);
+send_event(Session, {cast, Msg}, _Socket) ->
+    gen_statem:cast(Session, Msg);
+send_event(Session, {info, exit_signal}, _Socket) ->
+    %% The session is not linked to the test process, so this is an
+    %% ordinary message rather than an exit signal from its parent.
+    Session ! {'EXIT', self(), shutdown},
+    ok;
+send_event(Session, {info, Msg}, _Socket) ->
+    Session ! Msg,
+    ok.
+
+await_down(MRef) ->
+    receive
+        {'DOWN', MRef, process, _Pid, Reason} ->
+            Reason
+    after ?TIMEOUT ->
+              ct:fail(session_still_alive)
+    end.

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -52,6 +52,7 @@ groups() ->
       ]},
      {mock, [], [
                  insufficient_credit,
+                 open_refused,
                  attach_refused,
                  incoming_heartbeat,
                  multi_transfer_without_delivery_id
@@ -823,6 +824,31 @@ insufficient_credit(Config) ->
     ok = amqp10_client:end_session(Session),
     ok = amqp10_client:close_connection(Connection),
     ok.
+
+open_refused(Config) ->
+    Hostname = ?config(mock_host, Config),
+    Port = ?config(mock_port, Config),
+    %% Reply to the client's open frame with a close frame, i.e. refuse
+    %% the connection while the client is still in the open_sent state.
+    OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
+                       Err = #'v1_0.error'{
+                                condition = ?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
+                                description = {utf8, <<"virtual host does not exist">>}},
+                       {Ch, [#'v1_0.close'{error = Err}]}
+               end,
+    Steps = [fun mock_server:recv_amqp_header_step/1,
+             fun mock_server:send_amqp_header_step/1,
+             mock_server:amqp_step(OpenStep)],
+    ok = mock_server:set_steps(?config(mock_server, Config), Steps),
+
+    Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
+    {ok, Connection} = amqp10_client:open_connection(Cfg),
+    receive
+        {amqp10_event,
+         {connection, Connection,
+          {closed, {unauthorized_access, <<"virtual host does not exist">>}}}} -> ok
+    after 5000 -> exit(close_timeout)
+    end.
 
 attach_refused(Config) ->
     Hostname = ?config(mock_host, Config),

--- a/deps/amqp_client/src/amqp_main_reader.erl
+++ b/deps/amqp_client/src/amqp_main_reader.erl
@@ -176,4 +176,6 @@ handle_error({malformed_header, Version},  State = #state{connection = Conn}) ->
     {noreply, State};
 handle_error(Reason, State = #state{connection = Conn}) ->
     Conn ! {socket_error, Reason},
-    {stop, {socket_error, Reason}, State}.
+    %% The connection stops as a consequence; a second, abnormal exit
+    %% reason here would only add redundant crash and supervisor reports.
+    {stop, {shutdown, {socket_error, Reason}}, State}.

--- a/deps/amqp_client/src/amqp_network_connection.erl
+++ b/deps/amqp_client/src/amqp_network_connection.erl
@@ -9,6 +9,7 @@
 -module(amqp_network_connection).
 
 -include("amqp_client_internal.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -behaviour(amqp_gen_connection).
 -export([init/0, terminate/2, connect/4, do/2, open_channel_args/1, i/2,
@@ -65,7 +66,9 @@ handle_message(heartbeat_timeout, State) ->
 handle_message(closing_timeout, State = #state{closing_reason = Reason}) ->
     {stop, Reason, State};
 handle_message({'EXIT', Pid, Reason}, State) ->
-    {stop, rabbit_misc:format("stopping because dependent process ~tp died: ~tp", [Pid, Reason]), State};
+    ?LOG_WARNING("Connection (~tp): closing because dependent process ~tp died: ~tp",
+                 [self(), Pid, Reason]),
+    {stop, {shutdown, {dependent_process_died, Pid, Reason}}, State};
 %% see http://erlang.org/pipermail/erlang-bugs/2012-June/002933.html
 handle_message({Ref, {error, Reason}},
                State = #state{waiting_socket_close = Waiting,

--- a/deps/amqp_client/src/amqp_network_connection.erl
+++ b/deps/amqp_client/src/amqp_network_connection.erl
@@ -55,14 +55,17 @@ handle_message(socket_closing_timeout,
 handle_message(socket_closed, State = #state{waiting_socket_close = true,
                                              closing_reason = Reason}) ->
     {stop, {shutdown, Reason}, State};
+%% Expected connection-level failures are wrapped in 'shutdown' so that
+%% neither gen_server nor the supervisor logs them: linked processes and
+%% monitors still observe the specific reason.
 handle_message(socket_closed, State = #state{waiting_socket_close = false}) ->
-    {stop, socket_closed_unexpectedly, State};
+    {stop, {shutdown, socket_closed_unexpectedly}, State};
 handle_message({socket_error, _} = SocketError, State) ->
-    {stop, SocketError, State};
+    {stop, {shutdown, SocketError}, State};
 handle_message({channel_exit, 0, Reason}, State) ->
     {stop, {channel0_died, Reason}, State};
 handle_message(heartbeat_timeout, State) ->
-    {stop, heartbeat_timeout, State};
+    {stop, {shutdown, heartbeat_timeout}, State};
 handle_message(closing_timeout, State = #state{closing_reason = Reason}) ->
     {stop, Reason, State};
 handle_message({'EXIT', Pid, Reason}, State) ->
@@ -76,8 +79,8 @@ handle_message({Ref, {error, Reason}},
   when is_reference(Ref) ->
     {stop, case {Reason, Waiting} of
                {closed,  true} -> {shutdown, CloseReason};
-               {closed, false} -> socket_closed_unexpectedly;
-               {_,          _} -> {socket_error, Reason}
+               {closed, false} -> {shutdown, socket_closed_unexpectedly};
+               {_,          _} -> {shutdown, {socket_error, Reason}}
            end, State}.
 
 closing(_ChannelCloseType, {server_initiated_close, _, _} = Reason, State) ->

--- a/deps/amqp_client/src/amqp_network_connection.erl
+++ b/deps/amqp_client/src/amqp_network_connection.erl
@@ -49,9 +49,11 @@ do2(Method, #state{writer0 = Writer}) ->
     %% Catching because it expects the {channel_exit, _, _} message on error
     catch rabbit_writer:send_command_sync(Writer, Method).
 
+%% We replied to a peer-initiated close but its socket did not close in
+%% time. This is expected teardown, so wrap it like the failures below.
 handle_message(socket_closing_timeout,
                State = #state{closing_reason = Reason}) ->
-    {stop, {socket_closing_timeout, Reason}, State};
+    {stop, {shutdown, {socket_closing_timeout, Reason}}, State};
 handle_message(socket_closed, State = #state{waiting_socket_close = true,
                                              closing_reason = Reason}) ->
     {stop, {shutdown, Reason}, State};
@@ -66,8 +68,10 @@ handle_message({channel_exit, 0, Reason}, State) ->
     {stop, {channel0_died, Reason}, State};
 handle_message(heartbeat_timeout, State) ->
     {stop, {shutdown, heartbeat_timeout}, State};
+%% The peer never replied to our close, matching the reason the
+%% 'connection.close_ok' path would have stopped with.
 handle_message(closing_timeout, State = #state{closing_reason = Reason}) ->
-    {stop, Reason, State};
+    {stop, {shutdown, Reason}, State};
 handle_message({'EXIT', Pid, Reason}, State) ->
     ?LOG_WARNING("Connection (~tp): closing because dependent process ~tp died: ~tp",
                  [self(), Pid, Reason]),

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -348,6 +348,19 @@ error_frame(Condition, Fmt, Args) ->
     #'v1_0.error'{condition = Condition,
                   description = {utf8, Description}}.
 
+handle_exception(State = #v1{connection_state = CS}, _Channel,
+                 Error = #'v1_0.error'{description =
+                                       {utf8, <<"Connection forced: ", Explanation/binary>>}})
+  when ?IS_RUNNING(State) orelse CS =:= closing ->
+    %% Only ever raised by terminate/2 when the connection is deliberately
+    %% closed by an operator or by the broker itself (e.g. rabbitmqctl
+    %% close_connection, the management UI, maintenance mode draining, or
+    %% a node-wide shutdown) - never a client protocol violation, so this
+    %% does not warrant `error'-level logging. Mirrors the equivalent
+    %% AMQP 0-9-1 handling for `connection_forced' in
+    %% rabbit_reader:log_hard_error/3.
+    ?LOG_WARNING("Closing AMQP 1.0 connection ~tp: ~ts", [self(), Explanation]),
+    close(Error, State);
 handle_exception(State = #v1{connection_state = closed}, Channel,
                  #'v1_0.error'{description = {utf8, Desc}}) ->
     ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~tp",

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -394,6 +394,16 @@ handle_frame(Mode, Channel, Body, State) ->
                                ?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
                                "Access for user '~ts' was refused: insufficient permissions",
                                [Username]));
+        _:{inet_error, closed} ->
+            %% Most commonly hit replying to a peer-initiated close: the
+            %% peer's socket is already gone (e.g. it disconnected right
+            %% after sending its own close frame, before we could reply
+            %% with ours). There is nobody left to notify and nothing more
+            %% useful to do, so this does not warrant a full "Reader
+            %% error" stack trace at error level.
+            ?LOG_INFO("AMQP 1.0 connection ~tp: could not reply, "
+                      "peer's socket already closed", [self()]),
+            State#v1{connection_state = closed};
         _:Reason:Trace ->
             handle_exception(State,
                              Channel,

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -858,6 +858,19 @@ format_hard_error(Reason) ->
         false -> rabbit_misc:format("~tp", [Reason])
     end.
 
+%% A connection_forced exception is only ever raised when the connection is
+%% deliberately closed by an operator or by the broker itself (e.g.
+%% `rabbitmqctl close_connection`, the management UI, or maintenance mode
+%% draining) - see terminate/2. It is not a client-triggered protocol error,
+%% so it does not warrant `error`-level logging.
+log_hard_error(#v1{connection = #connection{log_name = ConnName,
+                                            user      = User,
+                                            vhost     = VHost}},
+              _Channel, #amqp_error{name = connection_forced,
+                                    explanation = Explanation}) ->
+    ?LOG_WARNING(
+        "Closing AMQP connection ~tp (~ts, vhost: '~ts', user: '~ts'): ~ts",
+        [self(), ConnName, VHost, User#user.username, Explanation]);
 log_hard_error(#v1{connection_state = CS,
                    connection = #connection{
                                    log_name  = ConnName,

--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -241,6 +241,13 @@ handle_info(check_internal_exchange, State = #state{internal_exchange = IntXName
             {noreply, State#state{internal_exchange_timer = TRef}}
     end;
 
+handle_info({'EXIT', _From, Reason},
+            State = #state{upstream            = Upstream,
+                           upstream_params     = UParams,
+                           downstream_exchange = XName}) ->
+    rabbit_federation_link_util:handle_connection_exit(
+      Reason, Upstream, UParams, XName, State);
+
 handle_info({'EXIT', _From, Reason}, State) ->
     {stop, Reason, State};
 

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
@@ -23,7 +23,7 @@
          connection_close_timeout/0]).
 
 %% temp
--export([connection_error/6]).
+-export([connection_error/6, handle_connection_exit/5]).
 
 -import(rabbit_misc, [pget/2]).
 
@@ -194,6 +194,20 @@ connection_error(local_start, E, Upstream, UParams, XorQName, State) ->
       Upstream, UParams, XorQName, clean_reason(E)),
     ?LOG_WARNING("Federation ~ts did not connect locally~n~tp", [rabbit_misc:rs(XorQName), E]),
     {stop, {shutdown, restart}, State}.
+
+%% The AMQP 0-9-1 client wraps expected connection failures such as
+%% `heartbeat_timeout` in 'shutdown' to avoid massive supervisor reports
+%% logged. `supervisor2` does not restart a transient child that stops
+%% with a `{shutdown, _}` reason, so request an explicit restart.
+handle_connection_exit({shutdown, Reason}, Upstream, UParams, XorQName, State)
+  when Reason =:= heartbeat_timeout;
+       Reason =:= socket_closed_unexpectedly ->
+    connection_error(remote, Reason, Upstream, UParams, XorQName, State);
+handle_connection_exit({shutdown, {socket_error, _} = Reason},
+                       Upstream, UParams, XorQName, State) ->
+    connection_error(remote, Reason, Upstream, UParams, XorQName, State);
+handle_connection_exit(Reason, _Upstream, _UParams, _XorQName, State) ->
+    {stop, Reason, State}.
 
 %% If we terminate due to a gen_server call exploding (almost
 %% certainly due to an amqp_channel:call() exploding) then we do not

--- a/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link.erl
@@ -223,6 +223,14 @@ handle_info({'DOWN', _Ref, process, Pid, Reason},
     QName = amqqueue:get_name(Q),
     handle_down(Pid, Reason, Ch, DCh, {Upstream, UParams, QName}, State);
 
+handle_info({'EXIT', _From, Reason},
+            State = #state{queue           = Q,
+                           upstream        = Upstream,
+                           upstream_params = UParams}) when ?is_amqqueue(Q) ->
+    QName = amqqueue:get_name(Q),
+    rabbit_federation_link_util:handle_connection_exit(
+      Reason, Upstream, UParams, QName, State);
+
 handle_info({'EXIT', _From, Reason}, State) ->
     {stop, Reason, State};
 

--- a/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
@@ -564,12 +564,12 @@ pop_pending(State = #{dest := Dest}) ->
     end.
 
 make_conn_and_chan([], {VHost, Name} = _ShovelName) ->
-    ?LOG_ERROR(
+    ?LOG_WARNING(
           "Shovel '~ts' in vhost '~ts' has no more URIs to try for connection",
           [Name, VHost]),
     erlang:error(failed_to_connect_using_provided_uris);
 make_conn_and_chan([], ShovelName) ->
-    ?LOG_ERROR(
+    ?LOG_WARNING(
           "Shovel '~ts' has no more URIs to try for connection",
           [ShovelName]),
     erlang:error(failed_to_connect_using_provided_uris);
@@ -577,7 +577,7 @@ make_conn_and_chan(URIs, ShovelName) ->
     try do_make_conn_and_chan(URIs, ShovelName) of
         Val -> Val
     catch throw:{error, Reason, URI} ->
-        log_connection_failure(Reason, URI, ShovelName),
+        rabbit_shovel_util:log_connection_failure(Reason, URI, ShovelName),
         make_conn_and_chan(lists:usort(URIs -- [URI]), ShovelName)
     end.
 
@@ -596,38 +596,6 @@ do_make_conn_and_chan(URIs, ShovelName) ->
         {error, Reason} ->
             throw({error, Reason, URI})
     end.
-
-log_connection_failure(Reason, URI, {VHost, Name} = _ShovelName) ->
-    ?LOG_ERROR(
-          "Shovel '~ts' in vhost '~ts' failed to connect (URI: ~ts): ~ts",
-      [Name, VHost, amqp_uri:remove_credentials(URI), human_readable_connection_error(Reason)]);
-log_connection_failure(Reason, URI, ShovelName) ->
-    ?LOG_ERROR(
-          "Shovel '~ts' failed to connect (URI: ~ts): ~ts",
-          [ShovelName, amqp_uri:remove_credentials(URI), human_readable_connection_error(Reason)]).
-
-human_readable_connection_error({auth_failure, Msg}) ->
-    Msg;
-human_readable_connection_error(not_allowed) ->
-    "access to target virtual host was refused";
-human_readable_connection_error(unknown_host) ->
-    "unknown host (failed to resolve hostname)";
-human_readable_connection_error(econnrefused) ->
-    "connection to target host was refused (ECONNREFUSED)";
-human_readable_connection_error(econnreset) ->
-    "connection to target host was reset by peer (ECONNRESET)";
-human_readable_connection_error(etimedout) ->
-    "connection to target host timed out (ETIMEDOUT)";
-human_readable_connection_error(ehostunreach) ->
-    "target host is unreachable (EHOSTUNREACH)";
-human_readable_connection_error(nxdomain) ->
-    "target hostname cannot be resolved (NXDOMAIN)";
-human_readable_connection_error(eacces) ->
-    "connection to target host failed with EACCES. "
-    "This may be due to insufficient RabbitMQ process permissions or "
-    "a reserved IP address used as destination";
-human_readable_connection_error(Other) ->
-    rabbit_misc:format("~tp", [Other]).
 
 get_connection_name(ShovelName) when is_atom(ShovelName) ->
     Prefix = <<"Shovel ">>,

--- a/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
@@ -418,13 +418,20 @@ handle_source(#'basic.cancel'{}, #{name := Name}) ->
 
 handle_source({'EXIT', Conn, Reason},
               #{source := #{current := {Conn, _, _}}}) ->
-    {stop, {inbound_conn_died, Reason}};
+    {stop, {inbound_conn_died, unwrap_shutdown(Reason)}};
 
 handle_source({'EXIT', _Pid, {shutdown, {server_initiated_close, _, Reason}}}, _State) ->
     {stop, {inbound_link_or_channel_closure, Reason}};
 
 handle_source(_Msg, _State) ->
     not_handled.
+
+%% The Erlang AMQP 0-9-1 client wraps expected connection failures
+%% (e.g. `heartbeat_timeout`) in 'shutdown' to avoid massive
+%% supervisor reports logged. Unwrap them so that the specific reason is
+%% matched and logged by `rabbit_shovel_worker`.
+unwrap_shutdown({shutdown, Reason}) -> Reason;
+unwrap_shutdown(Reason)             -> Reason.
 
 handle_dest(#'basic.ack'{delivery_tag = Seq, multiple = Multiple},
             State = #{ack_mode := on_confirm}) ->
@@ -439,7 +446,7 @@ handle_dest(#'basic.nack'{delivery_tag = Seq, multiple = Multiple},
                        end, Seq, Multiple, State);
 
 handle_dest({'EXIT', Conn, Reason}, #{dest := #{current := {Conn, _, _}}}) ->
-    {stop, {outbound_conn_died, Reason}};
+    {stop, {outbound_conn_died, unwrap_shutdown(Reason)}};
 
 handle_dest({'EXIT', _Pid, {shutdown, {server_initiated_close, _, Reason}}}, _State) ->
     {stop, {outbound_link_or_channel_closure, Reason}};

--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -240,7 +240,13 @@ connect(Name, SndSettleMode, Uri, Postfix, Addr, Map, AttachFun, LinkNameOverrid
     %% A better solution would be that the shovel plugin subscribes to event
     %% maintenance_connections_closed to gracefully transfer shovels over to other live nodes.
     Config = Config0#{properties => #{<<"ignore-maintenance">> => {boolean, true}}},
-    {ok, Conn} = amqp10_client:open_connection(Config),
+    Conn = case amqp10_client:open_connection(Config) of
+               {ok, C} ->
+                   C;
+               {error, Reason} ->
+                   rabbit_shovel_util:log_connection_failure(Reason, Uri, Name),
+                   exit({shutdown, {connection_failed, Reason}})
+           end,
     {ok, Sess} = amqp10_client:begin_session(Conn),
     link(Conn),
     LinkName = case LinkNameOverride of

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_config.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_config.erl
@@ -119,8 +119,8 @@ validate_uris0([Uri | Uris]) ->
     case amqp_uri:parse(Uri) of
         {ok, _Params} ->
             validate_uris0(Uris);
-        {error, _} = Err ->
-            throw(Err)
+        {error, {Reason, _Uri}} ->
+            throw({error, Reason})
     end;
 validate_uris0([]) -> ok.
 

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup.erl
@@ -43,13 +43,8 @@ init([Name, Config0]) ->
       {VHost, ShovelName} -> ?LOG_DEBUG("Shovel '~ts' in virtual host '~ts' will use reconnection delay of ~tp", [ShovelName, VHost, Delay]);
       ShovelName          -> ?LOG_DEBUG("Shovel '~ts' will use reconnection delay of ~ts", [ShovelName, Delay])
     end,
-    %% `transient` (rather than `permanent`) is used so that the supervisor
-    %% only logs a SUPERVISOR REPORT for genuinely abnormal terminations.
-    %% Expected disconnects (e.g. maintenance mode) are logged by the shovel
-    %% itself via rabbit_shovel_worker, which exits with {shutdown, restart}
-    %% in that case; `transient` still restarts on that reason, quietly.
     Restart = case Delay of
-        N when is_integer(N) andalso N > 0 -> {transient, N};
+        N when is_integer(N) andalso N > 0 -> {permanent, N};
         %% reconnect-delay = 0 means "do not reconnect"
         _                                  -> temporary
     end,

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup.erl
@@ -43,15 +43,13 @@ init([Name, Config0]) ->
       {VHost, ShovelName} -> ?LOG_DEBUG("Shovel '~ts' in virtual host '~ts' will use reconnection delay of ~tp", [ShovelName, VHost, Delay]);
       ShovelName          -> ?LOG_DEBUG("Shovel '~ts' will use reconnection delay of ~ts", [ShovelName, Delay])
     end,
+    %% `transient` (rather than `permanent`) is used so that the supervisor
+    %% only logs a SUPERVISOR REPORT for genuinely abnormal terminations.
+    %% Expected disconnects (e.g. maintenance mode) are logged by the shovel
+    %% itself via rabbit_shovel_worker, which exits with {shutdown, restart}
+    %% in that case; `transient` still restarts on that reason, quietly.
     Restart = case Delay of
-        N when is_integer(N) andalso N > 0 ->
-          case pget(<<"src-delete-after">>, Config, pget(<<"delete-after">>, Config, <<"never">>)) of
-            %% always try to reconnect
-            <<"never">>                        -> {permanent, N};
-            %% this Shovel is an autodelete one
-              M when is_integer(M) andalso M >= 0 -> {transient, N};
-              <<"queue-length">> -> {transient, N}
-          end;
+        N when is_integer(N) andalso N > 0 -> {transient, N};
         %% reconnect-delay = 0 means "do not reconnect"
         _                                  -> temporary
     end,

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_util.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_util.erl
@@ -23,7 +23,8 @@
          deobfuscated_uris/2,
          obfuscated_uris/2,
          obfuscate_uris/1,
-         deobfuscate_uris/1
+         deobfuscate_uris/1,
+         log_connection_failure/3
         ]).
 
 -export([
@@ -281,3 +282,40 @@ obfuscate_uris(URIs) ->
 deobfuscate_uris(ObfuscatedURIs) ->
     URIs = [credentials_obfuscation:decrypt(ObfuscatedURI) || ObfuscatedURI <- ObfuscatedURIs],
     [rabbit_data_coercion:to_list(URI) || URI <- URIs].
+
+%% Logs a single-line, human-readable connection failure instead of a raw
+%% (and potentially deeply nested) error term. Used by both the AMQP 0-9-1
+%% and AMQP 1.0 shovel implementations.
+log_connection_failure(Reason, URI, {VHost, Name} = _ShovelName) ->
+    ?LOG_WARNING(
+       "Shovel '~ts' in vhost '~ts' failed to connect (URI: ~ts): ~ts",
+       [Name, VHost, amqp_uri:remove_credentials(URI), human_readable_connection_error(Reason)]);
+log_connection_failure(Reason, URI, ShovelName) ->
+    ?LOG_WARNING(
+       "Shovel '~ts' failed to connect (URI: ~ts): ~ts",
+       [ShovelName, amqp_uri:remove_credentials(URI), human_readable_connection_error(Reason)]).
+
+human_readable_connection_error({auth_failure, Msg}) ->
+    Msg;
+human_readable_connection_error(sasl_auth_failure) ->
+    "authentication failure (SASL)";
+human_readable_connection_error(not_allowed) ->
+    "access to target virtual host was refused";
+human_readable_connection_error(unknown_host) ->
+    "unknown host (failed to resolve hostname)";
+human_readable_connection_error(econnrefused) ->
+    "connection to target host was refused (ECONNREFUSED)";
+human_readable_connection_error(econnreset) ->
+    "connection to target host was reset by peer (ECONNRESET)";
+human_readable_connection_error(etimedout) ->
+    "connection to target host timed out (ETIMEDOUT)";
+human_readable_connection_error(ehostunreach) ->
+    "target host is unreachable (EHOSTUNREACH)";
+human_readable_connection_error(nxdomain) ->
+    "target hostname cannot be resolved (NXDOMAIN)";
+human_readable_connection_error(eacces) ->
+    "connection to target host failed with EACCES. "
+    "This may be due to insufficient RabbitMQ process permissions or "
+    "a reserved IP address used as destination";
+human_readable_connection_error(Other) ->
+    rabbit_misc:format("~tp", [Other]).

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -79,9 +79,9 @@ handle_cast(init, State = #state{config = Config0}) ->
         gen_server2:cast(self(), connect_dest),
         {noreply, State#state{config = Config}}
     catch E:R ->
-      ?LOG_ERROR("Shovel ~ts could not connect to source: ~p ~p",
-                 [human_readable_name(maps:get(name, Config0)), E, R]),
-      {stop, {shutdown, inbound_conn_failed}, State}
+      ?LOG_WARNING("Shovel ~ts could not connect to source: ~p ~p",
+                   [human_readable_name(maps:get(name, Config0)), E, R]),
+      {stop, {shutdown, restart}, State}
     end;
 handle_cast(connect_dest, State = #state{config = Config0}) ->
     try rabbit_shovel_behaviour:connect_dest(Config0) of
@@ -90,9 +90,9 @@ handle_cast(connect_dest, State = #state{config = Config0}) ->
         gen_server2:cast(self(), init_shovel),
         {noreply, State#state{config = Config}}
     catch E:R ->
-      ?LOG_ERROR("Shovel ~ts could not connect to destination: ~p ~p",
-                 [human_readable_name(maps:get(name, Config0)), E, R]),
-      {stop, {shutdown, outbond_conn_failed}, State}
+      ?LOG_WARNING("Shovel ~ts could not connect to destination: ~p ~p",
+                   [human_readable_name(maps:get(name, Config0)), E, R]),
+      {stop, {shutdown, restart}, State}
     end;
 handle_cast(init_shovel, State = #state{config = Config}) ->
     %% Don't trap exits until we have established connections so that
@@ -121,42 +121,42 @@ handle_msg(Msg, State = #state{config = Config, name = Name}) ->
                                  [human_readable_name(Name), Msg]),
                     {noreply, State};
                 {stop, {outbound_conn_died, heartbeat_timeout}} ->
-                    ?LOG_ERROR("Shovel ~ts detected missed heartbeats on destination connection",
-                               [human_readable_name(Name)]),
-                    {stop, {shutdown, heartbeat_timeout}, State};
+                    ?LOG_WARNING("Shovel ~ts detected missed heartbeats on destination connection",
+                                 [human_readable_name(Name)]),
+                    {stop, {shutdown, restart}, State};
                 {stop, {outbound_conn_died, Reason}} ->
-                    ?LOG_ERROR("Shovel ~ts detected destination connection failure: ~tp",
-                               [human_readable_name(Name), Reason]),
-                    {stop, Reason, State};
-	            {stop, {outbound_link_or_channel_closure, Reason}} ->
-    		        ?LOG_ERROR("Shovel ~ts detected destination shovel failure: ~tp",
-    		                   [human_readable_name(Name), Reason]),
-    		        {stop, Reason, State};
+                    ?LOG_WARNING("Shovel ~ts detected destination connection failure: ~tp",
+                                 [human_readable_name(Name), Reason]),
+                    {stop, {shutdown, restart}, State};
+                {stop, {outbound_link_or_channel_closure, Reason}} ->
+                    ?LOG_WARNING("Shovel ~ts detected destination shovel failure: ~tp",
+                                 [human_readable_name(Name), Reason]),
+                    {stop, {shutdown, restart}, State};
                 {stop, Reason} ->
                     ?LOG_DEBUG("Shovel ~ts decided to stop due a message from destination: ~tp",
                                [human_readable_name(Name), Reason]),
-                    {stop, Reason, State};
+                    {stop, {shutdown, restart}, State};
                 Config1 ->
                     State1 = State#state{config = Config1},
                     State2 = maybe_report_blocked_status(State1),
                     {noreply, State2}
             end;
         {stop, {inbound_conn_died, heartbeat_timeout}} ->
-            ?LOG_ERROR("Shovel ~ts detected missed heartbeats on source connection",
-                       [human_readable_name(Name)]),
-            {stop, {shutdown, heartbeat_timeout}, State};
+            ?LOG_WARNING("Shovel ~ts detected missed heartbeats on source connection",
+                         [human_readable_name(Name)]),
+            {stop, {shutdown, restart}, State};
         {stop, {inbound_conn_died, Reason}} ->
-            ?LOG_ERROR("Shovel ~ts detected source connection failure: ~tp",
-                       [human_readable_name(Name), Reason]),
-            {stop, Reason, State};
+            ?LOG_WARNING("Shovel ~ts detected source connection failure: ~tp",
+                         [human_readable_name(Name), Reason]),
+            {stop, {shutdown, restart}, State};
         {stop, {inbound_link_or_channel_closure, Reason}} ->
-	        ?LOG_ERROR("Shovel ~ts detected source Shovel (or link,  or channel) failure: ~tp",
-	                   [human_readable_name(Name), Reason]),
-	        {stop, Reason, State};
+            ?LOG_WARNING("Shovel ~ts detected source Shovel (or link,  or channel) failure: ~tp",
+                         [human_readable_name(Name), Reason]),
+            {stop, {shutdown, restart}, State};
         {stop, Reason} ->
-            ?LOG_ERROR("Shovel ~ts decided to stop due a message from source: ~tp",
-                       [human_readable_name(Name), Reason]),
-            {stop, Reason, State};
+            ?LOG_WARNING("Shovel ~ts decided to stop due a message from source: ~tp",
+                         [human_readable_name(Name), Reason]),
+            {stop, {shutdown, restart}, State};
         Config1 ->
             State1 = State#state{config = Config1},
             State2 = maybe_report_blocked_status(State1),
@@ -179,65 +179,24 @@ terminate(shutdown, State = #state{name = Name}) ->
     rabbit_shovel_status:remove(Name),
     ok;
 terminate(socket_closed_unexpectedly, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping because of the socket closed unexpectedly",
-               [human_readable_name(Name)]),
+    ?LOG_WARNING("Shovel ~ts is stopping because of the socket closed unexpectedly",
+                 [human_readable_name(Name)]),
     rabbit_shovel_status:report(State#state.name, State#state.type,
                                 {terminated, "socket closed"}),
     close_connections(State),
     ok;
-terminate({'EXIT', heartbeat_timeout}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping because of a heartbeat timeout",
-               [human_readable_name(Name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "heartbeat timeout"}),
-    close_connections(State),
-    ok;
-terminate({'EXIT', outbound_conn_died}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping because destination connection failed",
-               [human_readable_name(Name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "destination connection failed"}),
-    close_connections(State),
-    ok;
-terminate({'EXIT', inbound_conn_died}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping because destination connection failed",
-               [human_readable_name(Name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "source connection failed"}),
-    close_connections(State),
-    ok;
-terminate({shutdown, heartbeat_timeout}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping because of a heartbeat timeout", [human_readable_name(Name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "heartbeat timeout"}),
-    close_connections(State),
-    ok;
 terminate({shutdown, restart}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping to restart", [human_readable_name(Name)]),
+    ?LOG_WARNING("Shovel ~ts is stopping to restart", [human_readable_name(Name)]),
     rabbit_shovel_status:report(State#state.name, State#state.type,
                                 {terminated, "needed a restart"}),
     close_connections(State),
     ok;
 terminate({{shutdown, {server_initiated_close, Code, Reason}}, _}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping: one of its connections closed "
+    ?LOG_WARNING("Shovel ~ts is stopping: one of its connections closed "
                             "with code ~b, reason: ~ts",
                             [human_readable_name(Name), Code, Reason]),
     rabbit_shovel_status:report(State#state.name, State#state.type,
                                 {terminated, "needed a restart"}),
-    close_connections(State),
-    ok;
-terminate({shutdown, outbond_conn_failed}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping because if failed to connect to destination",
-               [human_readable_name(Name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "failed to connect to destination"}),
-    close_connections(State),
-    ok;
-terminate({shutdown, inbound_conn_failed}, State = #state{name = Name}) ->
-    ?LOG_ERROR("Shovel ~ts is stopping because it failed to connect to source",
-               [human_readable_name(Name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "failed to connect to source"}),
     close_connections(State),
     ok;
 terminate(Reason, State = #state{name = Name}) ->

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -81,6 +81,7 @@ handle_cast(init, State = #state{config = Config0}) ->
     catch E:R ->
       ?LOG_WARNING("Shovel ~ts could not connect to source: ~p ~p",
                    [human_readable_name(maps:get(name, Config0)), E, R]),
+      report_terminated(State, "failed to connect to source"),
       {stop, {shutdown, restart}, State}
     end;
 handle_cast(connect_dest, State = #state{config = Config0}) ->
@@ -92,6 +93,7 @@ handle_cast(connect_dest, State = #state{config = Config0}) ->
     catch E:R ->
       ?LOG_WARNING("Shovel ~ts could not connect to destination: ~p ~p",
                    [human_readable_name(maps:get(name, Config0)), E, R]),
+      report_terminated(State, "failed to connect to destination"),
       {stop, {shutdown, restart}, State}
     end;
 handle_cast(init_shovel, State = #state{config = Config}) ->
@@ -123,18 +125,22 @@ handle_msg(Msg, State = #state{config = Config, name = Name}) ->
                 {stop, {outbound_conn_died, heartbeat_timeout}} ->
                     ?LOG_WARNING("Shovel ~ts detected missed heartbeats on destination connection",
                                  [human_readable_name(Name)]),
+                    report_terminated(State, "heartbeat timeout"),
                     {stop, {shutdown, restart}, State};
                 {stop, {outbound_conn_died, Reason}} ->
                     ?LOG_WARNING("Shovel ~ts detected destination connection failure: ~tp",
                                  [human_readable_name(Name), Reason]),
+                    report_terminated(State, Reason),
                     {stop, {shutdown, restart}, State};
                 {stop, {outbound_link_or_channel_closure, Reason}} ->
                     ?LOG_WARNING("Shovel ~ts detected destination shovel failure: ~tp",
                                  [human_readable_name(Name), Reason]),
+                    report_terminated(State, Reason),
                     {stop, {shutdown, restart}, State};
                 {stop, Reason} ->
                     ?LOG_DEBUG("Shovel ~ts decided to stop due a message from destination: ~tp",
                                [human_readable_name(Name), Reason]),
+                    report_terminated(State, Reason),
                     {stop, {shutdown, restart}, State};
                 Config1 ->
                     State1 = State#state{config = Config1},
@@ -144,18 +150,22 @@ handle_msg(Msg, State = #state{config = Config, name = Name}) ->
         {stop, {inbound_conn_died, heartbeat_timeout}} ->
             ?LOG_WARNING("Shovel ~ts detected missed heartbeats on source connection",
                          [human_readable_name(Name)]),
+            report_terminated(State, "heartbeat timeout"),
             {stop, {shutdown, restart}, State};
         {stop, {inbound_conn_died, Reason}} ->
             ?LOG_WARNING("Shovel ~ts detected source connection failure: ~tp",
                          [human_readable_name(Name), Reason]),
+            report_terminated(State, Reason),
             {stop, {shutdown, restart}, State};
         {stop, {inbound_link_or_channel_closure, Reason}} ->
             ?LOG_WARNING("Shovel ~ts detected source Shovel (or link,  or channel) failure: ~tp",
                          [human_readable_name(Name), Reason]),
+            report_terminated(State, Reason),
             {stop, {shutdown, restart}, State};
         {stop, Reason} ->
             ?LOG_WARNING("Shovel ~ts decided to stop due a message from source: ~tp",
                          [human_readable_name(Name), Reason]),
+            report_terminated(State, Reason),
             {stop, {shutdown, restart}, State};
         Config1 ->
             State1 = State#state{config = Config1},
@@ -186,9 +196,11 @@ terminate(socket_closed_unexpectedly, State = #state{name = Name}) ->
     close_connections(State),
     ok;
 terminate({shutdown, restart}, State = #state{name = Name}) ->
+    %% The specific reason (e.g. "heartbeat timeout", dest_queue_down, ...)
+    %% was already reported by report_terminated/2 at the point of
+    %% detection, before this uniform {shutdown, restart} reason was used
+    %% to stop - reporting a generic status here would just overwrite it.
     ?LOG_WARNING("Shovel ~ts is stopping to restart", [human_readable_name(Name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type,
-                                {terminated, "needed a restart"}),
     close_connections(State),
     ok;
 terminate({{shutdown, {server_initiated_close, Code, Reason}}, _}, State = #state{name = Name}) ->
@@ -246,6 +258,15 @@ maybe_report_blocked_status(#state{config = Config,
             rabbit_shovel_status:report_blocked_status(State#state.name, NewStatus),
             State#state{last_reported_status = NewStatus}
     end.
+
+%% Reports the specific reason a shovel is about to stop and (quietly)
+%% restart, since the OTP-level exit reason is always the uniform
+%% {shutdown, restart} - see the terminate/2 clause for that reason.
+report_terminated(State, {shutdown, restart}) ->
+    report_terminated(State, "needed a restart");
+report_terminated(State, Reason) ->
+    rabbit_shovel_status:report(State#state.name, State#state.type,
+                                {terminated, Reason}).
 
 report_running(#state{config = Config} = State) ->
     InUri = rabbit_shovel_behaviour:source_uri(Config),

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -202,6 +202,8 @@ terminate(shutdown, State = #state{name = Name}) ->
     close_connections(State),
     rabbit_shovel_status:remove(Name),
     ok;
+terminate({shutdown, socket_closed_unexpectedly}, State) ->
+    terminate(socket_closed_unexpectedly, State);
 terminate(socket_closed_unexpectedly, State = #state{name = Name}) ->
     ?LOG_WARNING("Shovel ~ts is stopping because of the socket closed unexpectedly",
                  [human_readable_name(Name)]),

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -101,13 +101,27 @@ handle_cast(init_shovel, State = #state{config = Config}) ->
     %% if we try to shut down while waiting for a connection to be
     %% established then we don't block
     process_flag(trap_exit, true),
-    Config1 = rabbit_shovel_behaviour:init_dest(Config),
-    Config2 = rabbit_shovel_behaviour:init_source(Config1),
-    ?LOG_DEBUG("Shovel ~ts has finished setting up its topology",
-               [human_readable_name(maps:get(name, Config2))]),
-    State1 = State#state{config = Config2},
-    ok = report_running(State1),
-    {noreply, State1};
+    try
+        Config1 = rabbit_shovel_behaviour:init_dest(Config),
+        Config2 = rabbit_shovel_behaviour:init_source(Config1),
+        ?LOG_DEBUG("Shovel ~ts has finished setting up its topology",
+                   [human_readable_name(maps:get(name, Config2))]),
+        State1 = State#state{config = Config2},
+        ok = report_running(State1),
+        {noreply, State1}
+    catch
+        exit:{shutdown, autodelete} ->
+            %% `init_source/1` exits with this reason when a 'delete-after'
+            %% shovel has nothing left to transfer; see `terminate/2`.
+            {stop, {shutdown, autodelete}, State};
+        E:R ->
+            %% Topology setup failed, e.g. a predeclared queue is missing.
+            %% Same handling as the connect phases above.
+            ?LOG_WARNING("Shovel ~ts could not set up its topology: ~p ~p",
+                         [human_readable_name(maps:get(name, Config)), E, R]),
+            report_terminated(State, "failed to set up topology"),
+            {stop, {shutdown, restart}, State}
+    end;
 handle_cast(Msg, State) ->
     handle_msg(Msg, State).
 

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -22,7 +22,8 @@
 
 -record(state, {name :: binary() | {rabbit_types:vhost(), binary()},
                 type :: static | dynamic,
-                config :: rabbit_shovel_behaviour:state(),
+                %% 'undefined' after a dynamic Shovel's parameters fail to parse
+                config :: rabbit_shovel_behaviour:state() | undefined,
                 last_reported_status = {running, #{}} :: {rabbit_shovel_status:blocked_status(), rabbit_shovel_status:metrics()}}).
 
 start_link(Type, Name, Config) ->
@@ -45,20 +46,8 @@ maybe_start_link(_, Type, Name, Config) ->
 %% Gen Server Implementation
 %%---------------------------
 
-init([Type, Name, Config0]) ->
+init([Type, Name, Config]) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_SHOVEL}),
-    Config = case Type of
-                static ->
-                     Config0;
-                dynamic ->
-                    ClusterName = rabbit_nodes:cluster_name(),
-                     %% TODO It could handle errors while parsing
-                     %% (i.e. missing predeclared queues) and stop nicely
-                     %% without long stacktraces
-                    {ok, Mod} = rabbit_registry:lookup_module(runtime_parameter, shovel),
-                    {ok, Conf} = Mod:parse(Name, ClusterName, Config0),
-                    Conf
-            end,
     ?LOG_DEBUG("Initialising a Shovel ~ts of type '~ts'", [human_readable_name(Name), Type]),
     gen_server2:cast(self(), init),
     {ok, #state{name = Name, type = Type, config = Config}}.
@@ -66,23 +55,28 @@ init([Type, Name, Config0]) ->
 handle_call(_Msg, _From, State) ->
     {noreply, State}.
 
-handle_cast(init, State = #state{config = Config0}) ->
-    ?LOG_DEBUG("Shovel ~ts is reporting its status", [human_readable_name(State#state.name)]),
-    rabbit_shovel_status:report(State#state.name, State#state.type, starting),
-    ?LOG_INFO("Shovel ~ts will now try to connect...", [human_readable_name(State#state.name)]),
-    try rabbit_shovel_behaviour:connect_source(Config0) of
-      Config ->
-        ?LOG_DEBUG("Shovel ~ts connected to source", [human_readable_name(maps:get(name, Config))]),
-        %% this makes sure that connection pid is updated in case
-        %% any of the subsequent connection/init steps fail. See
-        %% rabbitmq/rabbitmq-shovel#54 for context.
-        gen_server2:cast(self(), connect_dest),
-        {noreply, State#state{config = Config}}
-    catch E:R ->
-      ?LOG_WARNING("Shovel ~ts could not connect to source: ~p ~p",
-                   [human_readable_name(maps:get(name, Config0)), E, R]),
-      report_terminated(State, "failed to connect to source"),
-      {stop, {shutdown, restart}, State}
+handle_cast(init, State0 = #state{name = Name, type = Type}) ->
+    ?LOG_DEBUG("Shovel ~ts is reporting its status", [human_readable_name(Name)]),
+    rabbit_shovel_status:report(Name, Type, starting),
+    case parse_config(State0) of
+        {ok, State = #state{config = Config0}} ->
+            ?LOG_INFO("Shovel ~ts will now try to connect...", [human_readable_name(Name)]),
+            try rabbit_shovel_behaviour:connect_source(Config0) of
+              Config ->
+                ?LOG_DEBUG("Shovel ~ts connected to source", [human_readable_name(maps:get(name, Config))]),
+                %% this makes sure that connection pid is updated in case
+                %% any of the subsequent connection/init steps fail. See
+                %% rabbitmq/rabbitmq-shovel#54 for context.
+                gen_server2:cast(self(), connect_dest),
+                {noreply, State#state{config = Config}}
+            catch E:R ->
+              ?LOG_WARNING("Shovel ~ts could not connect to source: ~p ~p",
+                           [human_readable_name(Name), E, R]),
+              report_terminated(State, "failed to connect to source"),
+              {stop, {shutdown, restart}, State}
+            end;
+        {stop, _, _} = Stop ->
+            Stop
     end;
 handle_cast(connect_dest, State = #state{config = Config0}) ->
     try rabbit_shovel_behaviour:connect_dest(Config0) of
@@ -245,6 +239,8 @@ format_status(_Opt, [_PDict, State]) ->
 format_state(State = #state{config = Config}) ->
     State#state{config = redact_config(Config)}.
 
+redact_config(undefined) ->
+    undefined;
 redact_config(Config) when is_map(Config) ->
     maps:map(fun(Key, Endpoint) when (Key =:= source orelse Key =:= dest),
                                       is_map(Endpoint) ->
@@ -262,6 +258,25 @@ human_readable_name(Name) ->
     {VHost, ShovelName} -> rabbit_misc:format("'~ts' in virtual host '~ts'", [ShovelName, VHost]);
     ShovelName          -> rabbit_misc:format("'~ts'", [ShovelName])
   end.
+
+%% Dynamic Shovel parameters are parsed here rather than in `init/1` so
+%% that a malformed parameter stops the worker with a reported status
+%% instead of failing the supervisor start with a crash report. Static
+%% Shovels arrive already parsed by `rabbit_shovel_config`.
+parse_config(#state{type = static} = State) ->
+    {ok, State};
+parse_config(#state{type = dynamic, name = Name, config = Config0} = State) ->
+    try
+        ClusterName = rabbit_nodes:cluster_name(),
+        {ok, Mod} = rabbit_registry:lookup_module(runtime_parameter, shovel),
+        {ok, Config} = Mod:parse(Name, ClusterName, Config0),
+        {ok, State#state{config = Config}}
+    catch E:R ->
+        ?LOG_WARNING("Shovel ~ts could not parse its configuration: ~tp:~tp",
+                     [human_readable_name(Name), E, R]),
+        report_terminated(State, "failed to parse configuration"),
+        {stop, {shutdown, restart}, State#state{config = undefined}}
+    end.
 
 maybe_report_blocked_status(#state{config = Config,
                                    last_reported_status = LastStatus} = State) ->
@@ -319,6 +334,9 @@ get_connection_name({_, Name}) when is_binary(Name) ->
 get_connection_name(_) ->
     <<"Shovel">>.
 
+close_connections(#state{config = undefined}) ->
+    %% Configuration parsing failed, so no connection was opened.
+    ok;
 close_connections(#state{config = Conf}) ->
     ok = rabbit_shovel_behaviour:close_source(Conf),
     ok = rabbit_shovel_behaviour:close_dest(Conf).

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker_sup.erl
@@ -22,7 +22,7 @@ init([Name, Config]) ->
                    {rabbit_shovel_worker, start_link, [static, Name, Config]},
                    case Config of
                        #{reconnect_delay := N}
-                         when is_integer(N) andalso N > 0 -> {permanent, N};
+                         when is_integer(N) andalso N > 0 -> {transient, N};
                        _ -> temporary
                    end,
                    16#ffffffff,

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker_sup.erl
@@ -22,7 +22,7 @@ init([Name, Config]) ->
                    {rabbit_shovel_worker, start_link, [static, Name, Config]},
                    case Config of
                        #{reconnect_delay := N}
-                         when is_integer(N) andalso N > 0 -> {transient, N};
+                         when is_integer(N) andalso N > 0 -> {permanent, N};
                        _ -> temporary
                    end,
                    16#ffffffff,

--- a/deps/rabbitmq_shovel/test/amqp091_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_dynamic_SUITE.erl
@@ -39,6 +39,7 @@ groups() ->
           headers,
           restart,
           validation,
+          runtime_parse_failure,
           security_validation,
           get_connection_name,
           credit_flow
@@ -330,6 +331,49 @@ validation(Config) ->
                   [{<<"delete-after">>,    1},
                    {<<"ack-mode">>,        <<"no-ack">>} | QURIs]),
     ok.
+
+%% A definition that fails to parse at worker startup, e.g. one that
+%% declaration-time validation could not reject, must stop the worker
+%% with the quiet `{shutdown, restart}` reason and leave an inspectable
+%% status entry rather than crash with a stack trace.
+runtime_parse_failure(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, ?MODULE, runtime_parse_failure1, []).
+
+runtime_parse_failure1() ->
+    Name = {<<"/">>, <<"runtime-parse-failure">>},
+    %% An unknown publish property fails in rabbit_shovel_parameters:parse/3,
+    %% past the declaration-time validation this definition never went through.
+    Def = #{<<"src-uri">>            => <<"amqp://">>,
+            <<"dest-uri">>           => <<"amqp://">>,
+            <<"src-queue">>          => <<"src">>,
+            <<"dest-queue">>         => <<"dest">>,
+            <<"publish-properties">> => #{<<"nonexistent">> => <<>>}},
+    {ok, Pid} = gen_server2:start(rabbit_shovel_worker, [dynamic, Name, Def], []),
+    MRef = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', MRef, process, Pid, Reason} ->
+            {shutdown, restart} = Reason
+    after 30_000 ->
+            exit(shovel_worker_did_not_stop)
+    end,
+    %% rabbit_shovel_status:report/3 is asynchronous, so the worker's exit
+    %% can be observed before the status entry lands.
+    Expected = {terminated, "failed to parse configuration"},
+    ok = await_status(Name, Expected, 50),
+    ok = rabbit_shovel_status:remove(Name).
+
+await_status(Name, _Expected, 0) ->
+    exit({shovel_status_not_reported, Name, rabbit_shovel_status:status()});
+await_status(Name, Expected, Retries) ->
+    case lists:any(fun(Status) ->
+                           element(1, Status) =:= Name andalso
+                               element(3, Status) =:= Expected
+                   end, rabbit_shovel_status:status()) of
+        true  -> ok;
+        false -> timer:sleep(100),
+                 await_status(Name, Expected, Retries - 1)
+    end.
 
 security_validation(Config) ->
     ok = rabbit_ct_broker_helpers:rpc(Config, 0,

--- a/deps/rabbitmq_shovel/test/amqp091_local_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_local_dynamic_SUITE.erl
@@ -134,6 +134,7 @@ init_per_group(amqp091, Config) ->
     rabbit_ct_helpers:set_config(
       Config,
       [
+       {outer_group, amqp091},
        {src_protocol, <<"amqp091">>},
        {dest_protocol, <<"amqp091">>}
       ]);
@@ -141,6 +142,7 @@ init_per_group(local, Config) ->
     rabbit_ct_helpers:set_config(
       Config,
       [
+       {outer_group, local},
        {src_protocol, <<"local">>},
        {dest_protocol, <<"local">>}
       ]);
@@ -148,6 +150,7 @@ init_per_group(amqp091_to_local, Config) ->
     rabbit_ct_helpers:set_config(
       Config,
       [
+       {outer_group, amqp091_to_local},
        {src_protocol, <<"amqp091">>},
        {dest_protocol, <<"local">>}
       ]);
@@ -155,6 +158,7 @@ init_per_group(local_to_amqp091, Config) ->
     rabbit_ct_helpers:set_config(
       Config,
       [
+       {outer_group, local_to_amqp091},
        {src_protocol, <<"local">>},
        {dest_protocol, <<"amqp091">>}
       ]);
@@ -172,8 +176,15 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(Testcase, Config0) ->
+    %% tc_group_properties only reflects the innermost group (`tests' or
+    %% `predeclared_topology'), which is shared by all four outer groups
+    %% (amqp091, local, amqp091_to_local, local_to_amqp091). Since those
+    %% run in parallel, resource names must also include the outer group,
+    %% otherwise same-named test cases across them collide on the same
+    %% shovel parameter, queues and vhost.
+    OuterGroup = ?config(outer_group, Config0),
     Group = proplists:get_value(name, ?config(tc_group_properties, Config0)),
-    Unique = io_lib:format("~s_~s", [Group, Testcase]),
+    Unique = io_lib:format("~s_~s_~s", [OuterGroup, Group, Testcase]),
     SrcQ = list_to_binary(Unique ++ "_src"),
     DestQ = list_to_binary(Unique ++ "_dest"),
     VHost = list_to_binary(Unique ++ "_vhost"),

--- a/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
@@ -139,13 +139,13 @@ invalid_legacy_configuration1(_Config) ->
     {require_list, brokers, invalid} =
         test_broken_shovel_sources([{brokers, invalid}]),
 
-    {expected_string_uri, 42} =
+    expected_string_uri =
         test_broken_shovel_sources([{brokers, [42]}]),
 
-    {{unexpected_uri_scheme, "invalid"}, "invalid://"} =
+    {unexpected_uri_scheme, "invalid"} =
         test_broken_shovel_sources([{broker, "invalid://"}]),
 
-    {{unable_to_parse_uri, no_scheme}, "invalid"} =
+    {unable_to_parse_uri, no_scheme} =
         test_broken_shovel_sources([{broker, "invalid"}]),
 
     {require_list, invalid} =
@@ -164,14 +164,14 @@ invalid_legacy_configuration1(_Config) ->
           [{broker, "amqp://"},
            {declarations, [{'queue.declare', [invalid]}]}]),
 
-    {{invalid_amqp_params_parameter, heartbeat, "text",
-      [{"heartbeat", "text"}], {not_an_integer, "text"}}, _} =
+    {invalid_amqp_params_parameter, heartbeat, "text",
+     [{"heartbeat", "text"}], {not_an_integer, "text"}} =
         test_broken_shovel_sources(
           [{broker, "amqp://localhost/?heartbeat=text"}]),
 
-    {{invalid_amqp_params_parameter, username, "text",
-      [{"username", "text"}],
-      {parameter_unconfigurable_in_query, username, "text"}}, _} =
+    {invalid_amqp_params_parameter, username, "text",
+     [{"username", "text"}],
+     {parameter_unconfigurable_in_query, username, "text"}} =
         test_broken_shovel_sources([{broker, "amqp://?username=text"}]),
 
     {invalid_parameter_value, prefetch_count,
@@ -197,8 +197,8 @@ invalid_legacy_configuration1(_Config) ->
      {unexpected_fields, [invalid], _}} =
         test_broken_shovel_config([{publish_properties, [invalid]} | Config]),
 
-    {{invalid_ssl_parameter, fail_if_no_peer_cert, "42", _,
-      {require_boolean, "42"}}, _} =
+    {invalid_ssl_parameter, fail_if_no_peer_cert, "42", _,
+     {require_boolean, "42"}} =
         test_broken_shovel_sources([{broker, "amqps://username:password@host:5673/vhost?cacertfile=/path/to/cacert.pem&certfile=/path/to/certfile.pem&keyfile=/path/to/keyfile.pem&verify=verify_peer&fail_if_no_peer_cert=42"}]),
 
     passed.

--- a/deps/rabbitmq_shovel/test/local_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/local_dynamic_SUITE.erl
@@ -152,13 +152,24 @@ local_to_local_stream_no_ack(Config) ->
 local_to_local_delete_dest_queue(Config) ->
     Src = ?config(srcq, Config),
     Dest = ?config(destq, Config),
+    %% With the default (non-predeclared) destination, the shovel
+    %% auto-recreates the deleted queue and goes back to `running'
+    %% on its very next (immediate) reconnect attempt, so the
+    %% `{terminated, dest_queue_down}' status below is never reliably
+    %% observable. Predeclare the destination and tell the shovel not
+    %% to create it itself, so that every reconnect attempt keeps
+    %% failing (with a stable `{terminated, "failed to connect to
+    %% destination"}' status) instead of racing the shovel's own
+    %% automatic recovery.
+    declare_queue(Config, <<"/">>, Dest),
     with_amqp10_session(Config,
       fun (Sess) ->
              shovel_test_utils:set_param(Config, ?PARAM,
                                           [{<<"src-protocol">>, <<"local">>},
                                            {<<"src-queue">>, Src},
                                            {<<"dest-protocol">>, <<"local">>},
-                                           {<<"dest-queue">>, Dest}
+                                           {<<"dest-queue">>, Dest},
+                                           {<<"dest-predeclared">>, true}
                                           ]),
               SrcAddress = rabbitmq_amqp_address:queue(Src),
               DestAddress = rabbitmq_amqp_address:queue(Dest),
@@ -169,7 +180,9 @@ local_to_local_delete_dest_queue(Config) ->
                           30000),
               rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queue,
                                            [Dest, <<"/">>]),
-              ?awaitMatch([{_Name, dynamic, {terminated, dest_queue_down}, _, _}],
+              ?awaitMatch([{_Name, dynamic,
+                            {terminated, "failed to connect to destination"},
+                            _, _}],
                           rabbit_ct_broker_helpers:rpc(Config, 0,
                                                        rabbit_shovel_status, status, []),
                           30000)


### PR DESCRIPTION
Avoid logging stack traces when connections are terminated or cannot be established.
Before these changes, even a graceful rolling restart of a cluster running shovels would lead to numerous errors / stack traces due to maintenance mode connection termination, connection refused while a node is down, etc.