### PR TITLE
Refactor how user tags are recalculated on JWT token refresh

### DIFF
--- a/deps/rabbit/src/rabbit_access_control.erl
+++ b/deps/rabbit/src/rabbit_access_control.erl
@@ -414,25 +414,38 @@ check_user_id0(ClaimedUserName, #user{username = ActualUserName,
 update_state(User = #user{authz_backends = Backends0}, NewState) ->
     %% N.B.: we use foldl/3 and prepending, so the final list of
     %% backends is in reverse order from the original list.
+    %%
+    %% Rebuild `#user.tags` from the refreshed backends. A refresh can revoke a
+    %% tag, for example `impersonator`, which is honoured by `check_user_id/2`,
+    %% so a stale tag set must not survive the refresh.
     Backends = lists:foldl(
-                fun({Module, Impl}, {ok, Acc}) ->
+                fun({Module, Impl}, {ok, Acc, TagsAcc, Refreshed}) ->
                         AuthUser = auth_user(User, Impl),
                         case Module:expiry_timestamp(AuthUser) of
                           never ->
-                            {ok, [{Module, Impl} | Acc]};
+                            {ok, [{Module, Impl} | Acc], TagsAcc, Refreshed};
                           _  ->
                             case Module:update_state(AuthUser, NewState) of
-                              {ok, #auth_user{impl = Impl1}} ->
-                                {ok, [{Module, Impl1} | Acc]};
+                              {ok, #auth_user{impl = Impl1, tags = Tags1}} ->
+                                {ok, [{Module, Impl1} | Acc], TagsAcc ++ Tags1, true};
                               Else -> Else
                             end
                         end;
                    (_, {error, _} = Err)      -> Err;
                    (_, {refused, _, _} = Err) -> Err
-                end, {ok, []}, Backends0),
+                end, {ok, [], [], false}, Backends0),
     case Backends of
-      {ok, Pairs} -> {ok, User#user{authz_backends = lists:reverse(Pairs)}};
-      Else        -> Else
+      {ok, Pairs, RefreshedTags, Refreshed} ->
+        %% This branches on `Refreshed` rather than on the tag list being
+        %% empty, because a refresh to a token with no tags must still clear the
+        %% old tags.
+        Tags = case Refreshed of
+                   true  -> RefreshedTags;
+                   false -> User#user.tags
+               end,
+        {ok, User#user{authz_backends = lists:reverse(Pairs), tags = Tags}};
+      Else ->
+        Else
     end.
 
 -spec permission_cache_can_expire(User :: rabbit_types:user()) -> boolean().

--- a/deps/rabbit/test/rabbit_access_control_SUITE.erl
+++ b/deps/rabbit/test/rabbit_access_control_SUITE.erl
@@ -25,6 +25,7 @@
          end_per_testcase/2,
 
          expiry_timestamp/1,
+         update_state_rebuilds_tags/1,
          with_enabled_plugin/1,
          with_enabled_plugin_plus_internal/1,
          with_missing_plugin/1,
@@ -43,7 +44,8 @@ all() ->
      {group, integration_tests}].
 
 groups() ->
-    [{unit_tests, [], [expiry_timestamp]},
+    [{unit_tests, [], [expiry_timestamp,
+                       update_state_rebuilds_tags]},
      {integration_tests, [], [with_enabled_plugin,
                               with_enabled_plugin_plus_internal,
                               with_missing_plugin,
@@ -175,6 +177,47 @@ expiry_timestamp(_) ->
     User7 = #user{authz_backends = [{rabbit_no_expiry_backend, unused},
                                     {rabbit_expiry_backend, unused}]},
     ?assertEqual(Now, rabbit_access_control:expiry_timestamp(User7)),
+    ok.
+
+%% A refresh must rebuild `#user.tags`. Without this a tag that the new
+%% credential revoked, for example `impersonator`, would survive and still be
+%% honoured by `check_user_id/2`.
+update_state_rebuilds_tags(_) ->
+    Mod = rabbit_refresh_backend,
+    ok = meck:new(Mod, [non_strict]),
+    meck:expect(Mod, expiry_timestamp, fun(_) -> os:system_time(seconds) + 60 end),
+    %% This stands in for a refresh-capable backend. It returns a fresh tag set
+    %% from the new credential, as OAuth's `update_state/2` does.
+    meck:expect(Mod, update_state,
+                fun(AuthUser, NewTags) ->
+                        {ok, AuthUser#auth_user{tags = NewTags,
+                                                impl = fun() -> NewTags end}}
+                end),
+
+    User = #user{username = <<"u">>,
+                 tags = [impersonator, management],
+                 authz_backends = [{Mod, unused}]},
+
+    {ok, U1} = rabbit_access_control:update_state(User, [management]),
+    ?assertEqual([management], U1#user.tags),
+    ?assertNot(lists:member(impersonator, U1#user.tags)),
+
+    %% A refresh to a credential with no tags clears them; keeping the old set
+    %% here would leave impersonator behind.
+    {ok, U2} = rabbit_access_control:update_state(User, []),
+    ?assertEqual([], U2#user.tags),
+
+    {ok, U3} = rabbit_access_control:update_state(User, [impersonator, management]),
+    ?assert(lists:member(impersonator, U3#user.tags)),
+
+    %% A backend without expiry is not refreshed and leaves the tags as they are.
+    ok = meck:new(rabbit_static_backend, [non_strict]),
+    meck:expect(rabbit_static_backend, expiry_timestamp, fun(_) -> never end),
+    Static = #user{username = <<"u">>,
+                   tags = [administrator],
+                   authz_backends = [{rabbit_static_backend, unused}]},
+    {ok, U4} = rabbit_access_control:update_state(Static, ignored),
+    ?assertEqual([administrator], U4#user.tags),
     ok.
 
 with_enabled_plugin(Config) ->


### PR DESCRIPTION
On JWT token refresh, `update_state/2` reinstalled the backend state but discarded the refreshed `#auth_user.tags`.

This rebuilds `#user.tags` from what each refreshed backend returns. This would allow tag removals to be reflected in the computed state.
