### PR TITLE
Federation: isolate upstream URI parse errors at link init

### DIFF
--- a/deps/amqp_client/src/amqp_uri.erl
+++ b/deps/amqp_client/src/amqp_uri.erl
@@ -20,21 +20,30 @@
 -spec remove_credentials(URI :: string() | binary()) -> string().
 remove_credentials(URI) ->
     UriString = rabbit_data_coercion:to_list(URI),
-    Props = uri_parser:parse(UriString,
-                             [{host, undefined}, {path, undefined},
-                              {port, undefined}, {'query', []}]),
-    PortPart = case proplists:get_value(port, Props) of
-                   undefined -> "";
-                   Port      -> rabbit_misc:format(":~B", [Port])
-               end,
-    PGet = fun(K, P) -> case proplists:get_value(K, P) of
-                            undefined -> "";
-                            R         -> R
-                        end
-           end,
-    rabbit_misc:format(
-      "~ts://~ts~ts~ts", [proplists:get_value(scheme, Props), PGet(host, Props),
-                      PortPart,                           PGet(path, Props)]).
+    case uri_parser:parse(UriString,
+                          [{host, undefined}, {path, undefined},
+                           {port, undefined}, {'query', []}]) of
+        {error, _} ->
+            %% `uri_parser:parse/2` cannot parse a structurally malformed URI.
+            %% Since this function is used to sanitize a URI before logging it,
+            %% and is therefore routinely called on invalid input, fall back to
+            %% a best-effort strip of the `user:password@` userinfo rather than
+            %% crashing.
+            re:replace(UriString, "://[^@/]*@", "://", [{return, list}]);
+        Props ->
+            PortPart = case proplists:get_value(port, Props) of
+                           undefined -> "";
+                           Port      -> rabbit_misc:format(":~B", [Port])
+                       end,
+            PGet = fun(K, P) -> case proplists:get_value(K, P) of
+                                    undefined -> "";
+                                    R         -> R
+                                end
+                   end,
+            rabbit_misc:format(
+              "~ts://~ts~ts~ts", [proplists:get_value(scheme, Props), PGet(host, Props),
+                              PortPart,                           PGet(path, Props)])
+    end.
 
 %% @spec (Uri) -> {ok, #amqp_params_network{} | #amqp_params_direct{}} |
 %%                {error, {Info, Uri}}

--- a/deps/amqp_client/test/unit_SUITE.erl
+++ b/deps/amqp_client/test/unit_SUITE.erl
@@ -222,6 +222,12 @@ amqp_uri_remove_credentials(_Config) ->
     [?assertMatch("amqp://host:10000/vhost",
                   amqp_uri:remove_credentials(Uri))
         || Uri <- string_binaries_uris()],
+    %% A structurally malformed URI must not crash: `remove_credentials/1`
+    %% sanitizes URIs for logging and is routinely called on invalid input.
+    %% The userinfo must still be stripped so credentials do not leak.
+    Sanitized = amqp_uri:remove_credentials("amqp://alice:s3cret@:::"),
+    ?assertEqual(nomatch, string:find(Sanitized, "s3cret")),
+    ?assertEqual(nomatch, string:find(Sanitized, "alice")),
     ok.
 
 uri_parser_accepts_string_and_binaries(_Config) ->

--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -86,13 +86,27 @@ init_link({Upstream, XName}) ->
     case rabbit_exchange:lookup(XName) of
         {ok, X} ->
             DeobfuscatedUpstream = rabbit_federation_util:deobfuscate_upstream(Upstream),
-            DeobfuscatedUParams = rabbit_federation_upstream:to_params(DeobfuscatedUpstream, X),
-            UParams = rabbit_federation_util:obfuscate_upstream_params(DeobfuscatedUParams),
-            rabbit_federation_status:report(Upstream, UParams, XName, starting),
-            join(rabbit_federation_exchanges),
-            join({rabbit_federation_exchange, XName}),
-            gen_server2:cast(self(), maybe_go),
-            {ok, {not_started, {Upstream, UParams, XName}}};
+            case rabbit_federation_upstream:to_params(DeobfuscatedUpstream, X) of
+                {ok, DeobfuscatedUParams} ->
+                    UParams = rabbit_federation_util:obfuscate_upstream_params(DeobfuscatedUParams),
+                    rabbit_federation_status:report(Upstream, UParams, XName, starting),
+                    join(rabbit_federation_exchanges),
+                    join({rabbit_federation_exchange, XName}),
+                    gen_server2:cast(self(), maybe_go),
+                    {ok, {not_started, {Upstream, UParams, XName}}};
+                {error, {_Info, SafeURI} = Reason} ->
+                    %% Unable to parse upstream URI. Return `ignore` so this
+                    %% link's supervisor keeps its siblings and does not fail
+                    %% broker startup. Publish an entry to the status table
+                    %% so the link is visible via `federation_status`.
+                    ?LOG_ERROR(
+                       "Skipping federation link for ~ts, upstream ~ts: ~tp",
+                       [rabbit_misc:rs(XName), Upstream#upstream.name, Reason]),
+                    rabbit_federation_status:report(
+                      Upstream, #upstream_params{safe_uri = SafeURI}, XName,
+                      {invalid_upstream_uri, Reason}),
+                    ignore
+            end;
         {error, not_found} ->
             ?LOG_WARNING("not found, stopping link", []),
             {stop, gone}

--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -99,9 +99,8 @@ init_link({Upstream, XName}) ->
                     %% link's supervisor keeps its siblings and does not fail
                     %% broker startup. Publish an entry to the status table
                     %% so the link is visible via `federation_status`.
-                    ?LOG_ERROR(
-                       "Skipping federation link for ~ts, upstream ~ts: ~tp",
-                       [rabbit_misc:rs(XName), Upstream#upstream.name, Reason]),
+                    rabbit_federation_util:log_skipped_link(
+                      XName, Upstream#upstream.name, Reason),
                     rabbit_federation_status:report(
                       Upstream, #upstream_params{safe_uri = SafeURI}, XName,
                       {invalid_upstream_uri, Reason}),

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -97,6 +97,10 @@ sanitize_parse_error({invalid_ssl_parameter, Key, _Value, _Query, Reason}) ->
     {invalid_ssl_parameter, Key, redacted, redacted, Reason};
 sanitize_parse_error({invalid_amqp_params_parameter, Field, _Value, _Query, Reason}) ->
     {invalid_amqp_params_parameter, Field, redacted, redacted, Reason};
+sanitize_parse_error({unable_to_parse_uri, _Detail}) ->
+    %% The detail embeds the raw URI (with credentials) and an exit stack
+    %% trace. Neither is safe to log; the sanitized URI is reported separately.
+    unable_to_parse_uri;
 sanitize_parse_error(Info) ->
     Info.
 

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -67,9 +67,15 @@ remove_credentials(URI) ->
     list_to_binary(amqp_uri:remove_credentials(binary_to_list(URI))).
 
 %% Returns `{ok, #upstream_params{}}` on success or `{error, {Info, SafeURI}}`
-%% (credentials stripped) when the upstream URI cannot be parsed.
+%% (credentials stripped) when none of the upstream URIs can be parsed. The
+%% URIs of an upstream are interchangeable failover endpoints, so each is
+%% tried, in a random order to spread load, until one parses.
 to_params(Upstream = #upstream{uris = URIs}, XorQ) ->
-    URI = lists:nth(rand:uniform(length(URIs)), URIs),
+    to_params(shuffle(URIs), Upstream, XorQ, undefined).
+
+to_params([], _Upstream, _XorQ, LastError) ->
+    LastError;
+to_params([URI | Rest], Upstream, XorQ, _LastError) ->
     case amqp_uri:parse(binary_to_list(URI), vhost(XorQ)) of
         {ok, Params} ->
             XorQ1 = with_name(Upstream, vhost(Params), XorQ),
@@ -80,8 +86,23 @@ to_params(Upstream = #upstream{uris = URIs}, XorQ) ->
                                   safe_uri = SafeURI,
                                   table    = params_table(SafeURI, XorQ)}};
         {error, {Info, _UnsafeURI}} ->
-            {error, {Info, remove_credentials(URI)}}
+            Error = {error, {sanitize_parse_error(Info), remove_credentials(URI)}},
+            to_params(Rest, Upstream, XorQ, Error)
     end.
+
+%% `amqp_uri:parse/2` embeds the full query string in some error `Info`
+%% shapes, and a TLS `password` (or other secret) can appear there. Redact
+%% the offending value and query before the error reaches the logs.
+sanitize_parse_error({invalid_ssl_parameter, Key, _Value, _Query, Reason}) ->
+    {invalid_ssl_parameter, Key, redacted, redacted, Reason};
+sanitize_parse_error({invalid_amqp_params_parameter, Field, _Value, _Query, Reason}) ->
+    {invalid_amqp_params_parameter, Field, redacted, redacted, Reason};
+sanitize_parse_error(Info) ->
+    Info.
+
+%% Random permutation, used to spread load across an upstream's URIs.
+shuffle(List) ->
+    [X || {_, X} <- lists:sort([{rand:uniform(), X} || X <- List])].
 
 print(Fmt, Args) -> iolist_to_binary(io_lib:format(Fmt, Args)).
 

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -66,16 +66,22 @@ params_to_string(#upstream_params{safe_uri = SafeURI,
 remove_credentials(URI) ->
     list_to_binary(amqp_uri:remove_credentials(binary_to_list(URI))).
 
+%% Returns `{ok, #upstream_params{}}` on success or `{error, {Info, SafeURI}}`
+%% (credentials stripped) when the upstream URI cannot be parsed.
 to_params(Upstream = #upstream{uris = URIs}, XorQ) ->
     URI = lists:nth(rand:uniform(length(URIs)), URIs),
-    {ok, Params} = amqp_uri:parse(binary_to_list(URI), vhost(XorQ)),
-    XorQ1 = with_name(Upstream, vhost(Params), XorQ),
-    SafeURI = remove_credentials(URI),
-    #upstream_params{params   = Params,
-                     uri      = URI,
-                     x_or_q   = XorQ1,
-                     safe_uri = SafeURI,
-                     table    = params_table(SafeURI, XorQ)}.
+    case amqp_uri:parse(binary_to_list(URI), vhost(XorQ)) of
+        {ok, Params} ->
+            XorQ1 = with_name(Upstream, vhost(Params), XorQ),
+            SafeURI = remove_credentials(URI),
+            {ok, #upstream_params{params   = Params,
+                                  uri      = URI,
+                                  x_or_q   = XorQ1,
+                                  safe_uri = SafeURI,
+                                  table    = params_table(SafeURI, XorQ)}};
+        {error, {Info, _UnsafeURI}} ->
+            {error, {Info, remove_credentials(URI)}}
+    end.
 
 print(Fmt, Args) -> iolist_to_binary(io_lib:format(Fmt, Args)).
 

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_util.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_util.erl
@@ -9,11 +9,13 @@
 
 -include_lib("rabbit/include/amqqueue.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("kernel/include/logger.hrl").
 -include("rabbit_federation.hrl").
 
 -export([should_forward/4, find_upstreams/2, already_seen/3]).
 -export([validate_arg/3, fail/2, name/1, vhost/1, r/1, pgname/1]).
 -export([obfuscate_upstream/1, deobfuscate_upstream/1, obfuscate_upstream_params/1, deobfuscate_upstream_params/1]).
+-export([log_skipped_link/3]).
 
 -import(rabbit_misc, [pget_or_die/2, pget/3]).
 
@@ -86,6 +88,14 @@ obfuscate_upstream_params(#upstream_params{uri = Uri, params = #amqp_params_dire
         uri = credentials_obfuscation:encrypt(Uri),
         params = Params#amqp_params_direct{password = credentials_obfuscation:encrypt(rabbit_data_coercion:to_binary(Password))}
     }.
+
+%% Logged when an upstream URI cannot be parsed. The link init returns
+%% `ignore` so the link's supervisor keeps its siblings and node startup
+%% does not fail. `Reason` has already had its credentials stripped by
+%% `rabbit_federation_upstream:to_params/2`.
+log_skipped_link(Resource, UpstreamName, Reason) ->
+    ?LOG_ERROR("Skipping federation link for ~ts, upstream ~ts: ~tp",
+               [rabbit_misc:rs(Resource), UpstreamName, Reason]).
 
 deobfuscate_upstream(#upstream{uris = EncryptedUris} = Upstream) ->
     Upstream#upstream{uris = [credentials_obfuscation:decrypt(EncryptedUri) || EncryptedUri <- EncryptedUris]}.

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -28,7 +28,10 @@ all() -> [
     terminate_all_paced_batching,
     terminate_all_timeout_kills_remaining_batches,
     to_params_returns_error_on_unparseable_uri,
-    to_params_error_strips_credentials
+    to_params_error_strips_credentials,
+    to_params_error_on_malformed_uri_strips_credentials,
+    to_params_falls_back_to_valid_uri,
+    to_params_error_redacts_query_secrets
 ].
 
 init_per_suite(Config) ->
@@ -208,4 +211,47 @@ to_params_error_strips_credentials(_Config) ->
         rabbit_federation_upstream:to_params(Upstream, XorQ),
     ?assertEqual(nomatch, binary:match(SafeURI, <<"s3cret">>)),
     ?assertEqual(nomatch, binary:match(SafeURI, <<"alice">>)),
+    ok.
+
+%% A structurally malformed URI must not crash `to_params/2`. Such URIs also
+%% crash `amqp_uri:remove_credentials/1`, so the error branch has to strip
+%% credentials without relying on it.
+to_params_error_on_malformed_uri_strips_credentials(_Config) ->
+    BadURI = <<"amqp://alice:s3cret@:::">>,
+    Upstream = #upstream{uris = [BadURI], name = <<"u">>},
+    XorQ = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"x">>},
+    {error, {_Info, SafeURI}} =
+        rabbit_federation_upstream:to_params(Upstream, XorQ),
+    ?assertEqual(nomatch, binary:match(SafeURI, <<"s3cret">>)),
+    ?assertEqual(nomatch, binary:match(SafeURI, <<"alice">>)),
+    ok.
+
+%% The URIs of an upstream are interchangeable failover endpoints, so a single
+%% unparseable URI must not prevent the link from using a valid one.
+to_params_falls_back_to_valid_uri(_Config) ->
+    BadURI = <<"amqp://guest:guest@localhost/?auth_mechanism=zzz_no_such_mech">>,
+    GoodURI = <<"amqp://guest:guest@localhost">>,
+    X = #exchange{name = #resource{virtual_host = <<"/">>,
+                                   kind = exchange, name = <<"x">>}},
+    %% Try both orderings since `to_params/2` shuffles the URIs.
+    lists:foreach(
+      fun(URIs) ->
+              Upstream = #upstream{uris = URIs, name = <<"u">>,
+                                   exchange_name = <<"x">>},
+              ?assertMatch({ok, _},
+                           rabbit_federation_upstream:to_params(Upstream, X))
+      end,
+      [[BadURI, GoodURI], [GoodURI, BadURI]]),
+    ok.
+
+%% Some `amqp_uri:parse/2` error shapes embed the full query string, which can
+%% carry a TLS `password` or other secret. The error tuple must not leak it.
+to_params_error_redacts_query_secrets(_Config) ->
+    BadURI = <<"amqps://guest:guest@localhost/?depth=notanumber&password=s3cret">>,
+    Upstream = #upstream{uris = [BadURI], name = <<"u">>},
+    XorQ = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"x">>},
+    {error, {Info, _SafeURI}} =
+        rabbit_federation_upstream:to_params(Upstream, XorQ),
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(io_lib:format("~tp", [Info])),
+                                       <<"s3cret">>)),
     ok.

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -220,10 +220,16 @@ to_params_error_on_malformed_uri_strips_credentials(_Config) ->
     BadURI = <<"amqp://alice:s3cret@:::">>,
     Upstream = #upstream{uris = [BadURI], name = <<"u">>},
     XorQ = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"x">>},
-    {error, {_Info, SafeURI}} =
+    {error, {Info, SafeURI}} =
         rabbit_federation_upstream:to_params(Upstream, XorQ),
     ?assertEqual(nomatch, binary:match(SafeURI, <<"s3cret">>)),
     ?assertEqual(nomatch, binary:match(SafeURI, <<"alice">>)),
+    %% The parse-error `Info` for a malformed URI embeds the raw URI, so it
+    %% must be sanitized as well or the credentials leak into the logs.
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(io_lib:format("~tp", [Info])),
+                                       <<"s3cret">>)),
+    ?assertEqual(nomatch, binary:match(iolist_to_binary(io_lib:format("~tp", [Info])),
+                                       <<"alice">>)),
     ok.
 
 %% The URIs of an upstream are interchangeable failover endpoints, so a single

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -26,7 +26,9 @@ all() -> [
     terminate_all_shutdown_kills_non_trapping_processes,
     terminate_all_timeout_force_kill,
     terminate_all_paced_batching,
-    terminate_all_timeout_kills_remaining_batches
+    terminate_all_timeout_kills_remaining_batches,
+    to_params_returns_error_on_unparseable_uri,
+    to_params_error_strips_credentials
 ].
 
 init_per_suite(Config) ->
@@ -174,3 +176,36 @@ await_all_dead(Pids, AttemptsLeft) ->
             timer:sleep(10),
             await_all_dead(Pids, AttemptsLeft - 1)
     end.
+
+%% -------------------------------------------------------------------
+%% rabbit_federation_upstream:to_params/2 error handling
+%% -------------------------------------------------------------------
+
+%% Regression test for the boot-time crash observed when a persisted
+%% federation-upstream URI contains an `auth_mechanism` value that is not an
+%% existing atom (for example, an invisible U+2028 injected by a copy-paste).
+%% Before the fix, `amqp_uri:parse/2` returning `{error, _}` would badmatch
+%% inside `to_params/2` and crash the link's supervisor. It must now return
+%% an error tuple that callers can handle.
+to_params_returns_error_on_unparseable_uri(_Config) ->
+    %% "external" + U+2028 (UTF-8: E2 80 A8) + "connect" is not a SASL mechanism
+    %% atom, matching the value seen in production.
+    BadURI = <<"amqp://guest:guest@localhost/?auth_mechanism=external",
+               16#E2, 16#80, 16#A8, "connect">>,
+    Upstream = #upstream{uris = [BadURI], name = <<"u">>},
+    XorQ = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"x">>},
+    ?assertMatch({error, {{unknown_mechanism, _}, _SafeURI}},
+                 rabbit_federation_upstream:to_params(Upstream, XorQ)),
+    ok.
+
+%% The URI returned inside the error tuple must have credentials removed so
+%% that error logs cannot leak the upstream password.
+to_params_error_strips_credentials(_Config) ->
+    BadURI = <<"amqp://alice:s3cret@localhost/?auth_mechanism=zzz_no_such_mech">>,
+    Upstream = #upstream{uris = [BadURI], name = <<"u">>},
+    XorQ = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"x">>},
+    {error, {_Info, SafeURI}} =
+        rabbit_federation_upstream:to_params(Upstream, XorQ),
+    ?assertEqual(nomatch, binary:match(SafeURI, <<"s3cret">>)),
+    ?assertEqual(nomatch, binary:match(SafeURI, <<"alice">>)),
+    ok.

--- a/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link.erl
@@ -116,9 +116,8 @@ init_link({Upstream, Queue}) when ?is_amqqueue(Queue) ->
                     %% link's supervisor keeps its siblings and does not fail
                     %% broker startup. Publish an entry to the status table
                     %% so the link is visible via `federation_status`.
-                    ?LOG_ERROR(
-                       "Skipping federation link for ~ts, upstream ~ts: ~tp",
-                       [rabbit_misc:rs(QName), Upstream#upstream.name, Reason]),
+                    rabbit_federation_util:log_skipped_link(
+                      QName, Upstream#upstream.name, Reason),
                     rabbit_federation_status:report(
                       Upstream, #upstream_params{safe_uri = SafeURI}, QName,
                       {invalid_upstream_uri, Reason}),

--- a/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_queue_federation/src/rabbit_federation_queue_link.erl
@@ -99,17 +99,31 @@ init_link({Upstream, Queue}) when ?is_amqqueue(Queue) ->
     case rabbit_amqqueue:lookup(QName) of
         {ok, Q} ->
             DeobfuscatedUpstream = rabbit_federation_util:deobfuscate_upstream(Upstream),
-            DeobfuscatedUParams = rabbit_federation_upstream:to_params(DeobfuscatedUpstream, Queue),
-            UParams = rabbit_federation_util:obfuscate_upstream_params(DeobfuscatedUParams),
-            rabbit_federation_status:report(Upstream, UParams, QName, starting),
-            join(rabbit_federation_queues),
-            join({rabbit_federation_queue, QName}),
-            gen_server2:cast(self(), maybe_go),
-            rabbit_amqqueue:notify_decorators(Q),
-            {ok, #not_started{queue           = Queue,
-                              run             = false,
-                              upstream        = Upstream,
-                              upstream_params = UParams}};
+            case rabbit_federation_upstream:to_params(DeobfuscatedUpstream, Queue) of
+                {ok, DeobfuscatedUParams} ->
+                    UParams = rabbit_federation_util:obfuscate_upstream_params(DeobfuscatedUParams),
+                    rabbit_federation_status:report(Upstream, UParams, QName, starting),
+                    join(rabbit_federation_queues),
+                    join({rabbit_federation_queue, QName}),
+                    gen_server2:cast(self(), maybe_go),
+                    rabbit_amqqueue:notify_decorators(Q),
+                    {ok, #not_started{queue           = Queue,
+                                      run             = false,
+                                      upstream        = Upstream,
+                                      upstream_params = UParams}};
+                {error, {_Info, SafeURI} = Reason} ->
+                    %% Unable to parse upstream URI. Return `ignore` so this
+                    %% link's supervisor keeps its siblings and does not fail
+                    %% broker startup. Publish an entry to the status table
+                    %% so the link is visible via `federation_status`.
+                    ?LOG_ERROR(
+                       "Skipping federation link for ~ts, upstream ~ts: ~tp",
+                       [rabbit_misc:rs(QName), Upstream#upstream.name, Reason]),
+                    rabbit_federation_status:report(
+                      Upstream, #upstream_params{safe_uri = SafeURI}, QName,
+                      {invalid_upstream_uri, Reason}),
+                    ignore
+            end;
         {error, not_found} ->
             ?LOG_WARNING("not found, stopping link", []),
             {stop, gone}


### PR DESCRIPTION
When a federation upstream URI fails to parse, `to_params/2` badmatched `{ok, Params}` and crashed link initialisation. The crash propagated through the link supervisor into broker recovery, so one malformed upstream took the whole broker down on every cold boot.

The trigger is c3b950b3 (atom-table exhaustion hardening), which now rejects unknown atom parameters (`auth_mechanism`, `verify`, ...) via `list_to_existing_atom/1`. That hardening is kept as is; the regression is that upstream definitions accepted by the older parser can now return `{error, _}` and turn a per-link problem into a broker-wide boot failure.

Make `to_params/2` return `{ok, _} | {error, {Info, SafeURI}}` with credentials stripped, and have `init_link/1` log and return `ignore` so one bad upstream cannot fail broker startup. Add unit tests covering the parse-error return and the credential-stripping guarantee.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [ ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
