### PR TITLE
Make AMQP message parsing stricter

### DIFF
--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -30,17 +30,31 @@
 -define(CODE_SYM_8, 16#a3).
 -define(CODE_SYM_32, 16#b3).
 %% §3.2
+-define(DESCRIPTOR_CODE_HEADER, 16#70).
+-define(DESCRIPTOR_CODE_DELIVERY_ANNOTATIONS, 16#71).
+-define(DESCRIPTOR_CODE_MESSAGE_ANNOTATIONS, 16#72).
 -define(DESCRIPTOR_CODE_PROPERTIES, 16#73).
 -define(DESCRIPTOR_CODE_APPLICATION_PROPERTIES, 16#74).
 -define(DESCRIPTOR_CODE_DATA, 16#75).
 -define(DESCRIPTOR_CODE_AMQP_SEQUENCE, 16#76).
 -define(DESCRIPTOR_CODE_AMQP_VALUE, 16#77).
+-define(DESCRIPTOR_CODE_FOOTER, 16#78).
+
+%% The spec does not limit how many body sections a message may consist of.
+%% Since a message must be validated section by section, an unlimited number of
+%% tiny sections would let a single message consume disproportionate CPU time.
+%% No real world sender should come anywhere near this limit.
+-define(MAX_MSG_SECTIONS, 10_000).
 
 %% server_mode is a special parsing mode used by RabbitMQ when parsing
 %% AMQP message sections from an AMQP client. This mode:
 %% 1. stops parsing when the body starts, and
 %% 2. returns the start byte position of each parsed bare message section.
--type opts() :: [server_mode].
+%%
+%% If Validate is true, the order and cardinality of all message sections is
+%% additionally validated as defined in §3.2.
+-type opt() :: {server_mode, Validate :: boolean()}.
+-type opts() :: [opt()].
 
 -export_type([opts/0]).
 
@@ -209,7 +223,11 @@ parse_array_primitive(ElementType, Data) ->
 mapify([]) ->
     [];
 mapify([Key, Value | Rest]) ->
-    [{Key, Value} | mapify(Rest)].
+    [{Key, Value} | mapify(Rest)];
+mapify([_]) ->
+    %% "Map encodings MUST contain an even number of items
+    %% (i.e. an equal number of keys and values)." [1.6.23]
+    throw(map_with_odd_number_of_elements).
 
 %% Parses all AMQP types (or, in server_mode, stops when the body is reached).
 %% This is an optimisation over calling parse/1 repeatedly.
@@ -219,8 +237,13 @@ mapify([Key, Value | Rest]) ->
      {{pos, non_neg_integer()},
       amqp10_binary_generator:amqp10_type() | {body, pos_integer()}}].
 parse_many(Binary, Opts) ->
-    OptionServerMode = lists:member(server_mode, Opts),
-    pm(Binary, OptionServerMode, 0).
+    case lists:keyfind(server_mode, 1, Opts) of
+        {server_mode, Validate} ->
+            Validate andalso validate_msg_sections(Binary),
+            pm(Binary, true, 0);
+        false ->
+            pm(Binary, false, 0)
+    end.
 
 pm(<<>>, _, _) ->
     [];
@@ -246,9 +269,9 @@ pm(<<?CODE_SYM_8, S:8, V:S/binary,R/binary>>, O, B)      -> [{symbol, V} | pm(R,
 pm(<<16#45, R/binary>>, O, B) ->
     [{list, []} | pm(R, O, B+1)];
 pm(<<16#c0, S:8,CountAndValue:S/binary,R/binary>>, O, B) ->
-    [{list, pm_compound(8, CountAndValue, O, B+2)} | pm(R, O, B+2+S)];
+    [{list, pm_compound(8, CountAndValue, B+2)} | pm(R, O, B+2+S)];
 pm(<<16#c1, S:8,CountAndValue:S/binary,R/binary>>, O, B) ->
-    List = pm_compound(8, CountAndValue, O, B+2),
+    List = pm_compound(8, CountAndValue, B+2),
     [{map, mapify(List)} | pm(R, O, B+2+S)];
 
 %% We avoid guard tests: they improve readability, but result in worse performance.
@@ -333,9 +356,9 @@ pm(<<16#b0, S:32,V:S/binary,R/binary>>, O, B)        -> [{binary, V} | pm(R, O, 
 pm(<<16#b1, S:32,V:S/binary,R/binary>>, O, B)        -> [{utf8, V} | pm(R, O, B+5+S)];
 %% Compounds
 pm(<<16#d0, S:32,CountAndValue:S/binary,R/binary>>, O, B) ->
-    [{list, pm_compound(32, CountAndValue, O, B+5)} | pm(R, O, B+5+S)];
+    [{list, pm_compound(32, CountAndValue, B+5)} | pm(R, O, B+5+S)];
 pm(<<16#d1, S:32,CountAndValue:S/binary,R/binary>>, O, B) ->
-    List = pm_compound(32, CountAndValue, O, B+5),
+    List = pm_compound(32, CountAndValue, B+5),
     [{map, mapify(List)} | pm(R, O, B+5+S)];
 %% Arrays
 pm(<<16#e0, S:8,CountAndV:S/binary,R/binary>>, O, B) ->
@@ -357,12 +380,170 @@ pm(<<16#94, V:16/binary, R/binary>>, O, B) ->
 pm(<<Type, _Bin/binary>>, _O, B) ->
     throw({primitive_type_unsupported, Type, {position, B}}).
 
-pm_compound(UnitSize, Bin, O, B) ->
-    <<_IgnoreCount:UnitSize, Value/binary>> = Bin,
-    pm(Value, O, B + UnitSize div 8).
+pm_compound(UnitSize, Bin, B) ->
+    case Bin of
+        <<_IgnoreCount:UnitSize, Value/binary>> ->
+            pm(Value, false, B + UnitSize div 8);
+        _ ->
+            throw({invalid_compound_size, {position, B}})
+    end.
 
 reached_body(Position, DescriptorCode) ->
     [{{pos, Position}, {body, DescriptorCode}}].
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% "Altogether a message consists of the following sections:
+%%  * Zero or one header sections.
+%%  * Zero or one delivery-annotation sections.
+%%  * Zero or one message-annotation sections.
+%%  * Zero or one properties sections.
+%%  * Zero or one application-properties sections.
+%%  * The body consists of one of the following three choices: one or more data
+%%    sections, one or more amqp-sequence sections, or a single amqp-value
+%%    section.
+%%  * Zero or one footer sections." [§3.2]
+%%
+%% The descriptor codes of these sections are assigned in exactly the order in
+%% which the sections must appear. Therefore, validating the order and the
+%% cardinality of all sections preceding the body reduces to requiring strictly
+%% increasing descriptor codes.
+%%
+%% This validation jumps from one section to the next without building any
+%% Erlang term. erlang:binary_part/2,3 is avoided to avoid creating sub binaries.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+validate_msg_sections(Binary) ->
+    validate(Binary, 0, ?DESCRIPTOR_CODE_HEADER, ?MAX_MSG_SECTIONS).
+
+%% While the sections preceding the body are validated, State is the lowest
+%% descriptor code that is still allowed. From the first body section onwards,
+%% State is the atom 'data', 'sequence' or 'value', and 'eof' after the footer.
+%% Left is the number of sections that may still follow.
+validate(<<>>, _Pos, _State, _Left) ->
+    %% A missing body section will be reported by the caller.
+    ok;
+validate(<<_, _/binary>>, Pos, _State, 0) ->
+    throw({too_many_message_sections, ?MAX_MSG_SECTIONS, {position, Pos}});
+validate(<<?DESCRIBED, ?CODE_SMALL_ULONG, Code:8, R/binary>>, Pos, State, Left) ->
+    State1 = validate_state(Code, State, Pos),
+    validate_value(R, Pos+3, State1, section_value_kind(Code), Left-1);
+validate(<<?DESCRIBED, ?CODE_ULONG, Code:64, R/binary>>, Pos, State, Left) ->
+    State1 = validate_state(Code, State, Pos),
+    validate_value(R, Pos+10, State1, section_value_kind(Code), Left-1);
+validate(<<?DESCRIBED, ?CODE_SYM_8, Size:8, Symbol:Size/binary, R/binary>>, Pos, State, Left) ->
+    Code = descriptor_code(Symbol),
+    State1 = validate_state(Code, State, Pos),
+    validate_value(R, Pos+3+Size, State1, section_value_kind(Code), Left-1);
+validate(<<?DESCRIBED, ?CODE_SYM_32, Size:32, Symbol:Size/binary, R/binary>>, Pos, State, Left) ->
+    Code = descriptor_code(Symbol),
+    State1 = validate_state(Code, State, Pos),
+    validate_value(R, Pos+6+Size, State1, section_value_kind(Code), Left-1);
+validate(_, Pos, _State, _Left) ->
+    throw({not_a_message_section, {position, Pos}}).
+
+%% Rejects an unknown section descriptor as well as a known section that
+%% violates the section order or cardinality.
+validate_state(?DESCRIPTOR_CODE_HEADER, State, _Pos)
+  when State =< ?DESCRIPTOR_CODE_HEADER ->
+    ?DESCRIPTOR_CODE_HEADER + 1;
+validate_state(?DESCRIPTOR_CODE_DELIVERY_ANNOTATIONS, State, _Pos)
+  when State =< ?DESCRIPTOR_CODE_DELIVERY_ANNOTATIONS ->
+    ?DESCRIPTOR_CODE_DELIVERY_ANNOTATIONS + 1;
+validate_state(?DESCRIPTOR_CODE_MESSAGE_ANNOTATIONS, State, _Pos)
+  when State =< ?DESCRIPTOR_CODE_MESSAGE_ANNOTATIONS ->
+    ?DESCRIPTOR_CODE_MESSAGE_ANNOTATIONS + 1;
+validate_state(?DESCRIPTOR_CODE_PROPERTIES, State, _Pos)
+  when State =< ?DESCRIPTOR_CODE_PROPERTIES ->
+    ?DESCRIPTOR_CODE_PROPERTIES + 1;
+validate_state(?DESCRIPTOR_CODE_APPLICATION_PROPERTIES, State, _Pos)
+  when State =< ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES ->
+    ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES + 1;
+validate_state(?DESCRIPTOR_CODE_DATA, State, _Pos)
+  when is_integer(State) orelse State =:= data ->
+    data;
+validate_state(?DESCRIPTOR_CODE_AMQP_SEQUENCE, State, _Pos)
+  when is_integer(State) orelse State =:= sequence ->
+    sequence;
+validate_state(?DESCRIPTOR_CODE_AMQP_VALUE, State, _Pos)
+  when is_integer(State) ->
+    value;
+validate_state(?DESCRIPTOR_CODE_FOOTER, State, _Pos)
+  when State =:= data orelse
+       State =:= sequence orelse
+       State =:= value ->
+    eof;
+validate_state(Descriptor, _State, Pos) ->
+    throw({unexpected_message_section, section_name(Descriptor), {position, Pos}}).
+
+section_value_kind(?DESCRIPTOR_CODE_HEADER) -> list;
+section_value_kind(?DESCRIPTOR_CODE_DELIVERY_ANNOTATIONS) -> map;
+section_value_kind(?DESCRIPTOR_CODE_MESSAGE_ANNOTATIONS) -> map;
+section_value_kind(?DESCRIPTOR_CODE_PROPERTIES) -> list;
+section_value_kind(?DESCRIPTOR_CODE_APPLICATION_PROPERTIES) -> map;
+section_value_kind(?DESCRIPTOR_CODE_DATA) -> binary;
+section_value_kind(?DESCRIPTOR_CODE_AMQP_SEQUENCE) -> list;
+section_value_kind(?DESCRIPTOR_CODE_AMQP_VALUE) -> any;
+section_value_kind(?DESCRIPTOR_CODE_FOOTER) -> map.
+
+%% Jumps over the section value: neither an Erlang term nor a sub binary is created.
+validate_value(<<16#45, R/binary>>, Pos, State, Kind, Left)
+  when Kind =:= list orelse Kind =:= any ->
+    validate(R, Pos+1, State, Left);
+validate_value(<<16#c0, Size:8, _:Size/binary, R/binary>>, Pos, State, Kind, Left)
+  when Kind =:= list orelse Kind =:= any ->
+    validate(R, Pos+2+Size, State, Left);
+validate_value(<<16#d0, Size:32, _:Size/binary, R/binary>>, Pos, State, Kind, Left)
+  when Kind =:= list orelse Kind =:= any ->
+    validate(R, Pos+5+Size, State, Left);
+validate_value(<<16#c1, Size:8, _:Size/binary, R/binary>>, Pos, State, Kind, Left)
+  when Kind =:= map orelse Kind =:= any ->
+    validate(R, Pos+2+Size, State, Left);
+validate_value(<<16#d1, Size:32, _:Size/binary, R/binary>>, Pos, State, Kind, Left)
+  when Kind =:= map orelse Kind =:= any ->
+    validate(R, Pos+5+Size, State, Left);
+validate_value(<<16#a0, Size:8, _:Size/binary, R/binary>>, Pos, State, Kind, Left)
+  when Kind =:= binary orelse Kind =:= any ->
+    validate(R, Pos+2+Size, State, Left);
+validate_value(<<16#b0, Size:32, _:Size/binary, R/binary>>, Pos, State, Kind, Left)
+  when Kind =:= binary orelse Kind =:= any ->
+    validate(R, Pos+5+Size, State, Left);
+%% Any other AMQP type is valid only as the value of an amqp-value section.
+%% Its size is determined without building any Erlang term either.
+validate_value(Bin, Pos, State, any, Left) ->
+    validate_skip(Bin, Pos, State, Left, peek_value_size(Bin));
+validate_value(_, Pos, _State, Kind, _Left) ->
+    throw({invalid_section_value, Kind, {position, Pos}}).
+
+validate_skip(Bin, Pos, State, Left, Size) ->
+    case Bin of
+        <<_:Size/binary, R/binary>> ->
+            validate(R, Pos+Size, State, Left);
+        _ ->
+            throw({invalid_section_value, any, {position, Pos}})
+    end.
+
+descriptor_code(<<"amqp:header:list">>) -> ?DESCRIPTOR_CODE_HEADER;
+descriptor_code(<<"amqp:delivery-annotations:map">>) -> ?DESCRIPTOR_CODE_DELIVERY_ANNOTATIONS;
+descriptor_code(<<"amqp:message-annotations:map">>) -> ?DESCRIPTOR_CODE_MESSAGE_ANNOTATIONS;
+descriptor_code(<<"amqp:properties:list">>) -> ?DESCRIPTOR_CODE_PROPERTIES;
+descriptor_code(<<"amqp:application-properties:map">>) -> ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES;
+descriptor_code(<<"amqp:data:binary">>) -> ?DESCRIPTOR_CODE_DATA;
+descriptor_code(<<"amqp:amqp-sequence:list">>) -> ?DESCRIPTOR_CODE_AMQP_SEQUENCE;
+descriptor_code(<<"amqp:amqp-value:*">>) -> ?DESCRIPTOR_CODE_AMQP_VALUE;
+descriptor_code(<<"amqp:footer:map">>) -> ?DESCRIPTOR_CODE_FOOTER;
+descriptor_code(_UnknownSymbol) -> unknown_section_descriptor.
+
+%% Only used to report an error.
+section_name(?DESCRIPTOR_CODE_HEADER) -> header;
+section_name(?DESCRIPTOR_CODE_DELIVERY_ANNOTATIONS) -> delivery_annotations;
+section_name(?DESCRIPTOR_CODE_MESSAGE_ANNOTATIONS) -> message_annotations;
+section_name(?DESCRIPTOR_CODE_PROPERTIES) -> properties;
+section_name(?DESCRIPTOR_CODE_APPLICATION_PROPERTIES) -> application_properties;
+section_name(?DESCRIPTOR_CODE_DATA) -> data;
+section_name(?DESCRIPTOR_CODE_AMQP_SEQUENCE) -> amqp_sequence;
+section_name(?DESCRIPTOR_CODE_AMQP_VALUE) -> amqp_value;
+section_name(?DESCRIPTOR_CODE_FOOTER) -> footer;
+section_name(UnknownDescriptor) -> UnknownDescriptor.
 
 %% Returns the descriptor and total byte size (1 + B1 + B2) of the described type
 %% at the start of the binary, without parsing the value.
@@ -377,7 +558,17 @@ peek(<<Type, _/binary>>) ->
     throw({not_described_type, Type}).
 
 %% Returns the byte size of the AMQP value at the start of the binary
-%% without parsing it (no term construction). Used by peek/1.
+%% without parsing it (no term construction).
+peek_value_size(<<?DESCRIBED, Rest/binary>>) ->
+    %% "The descriptor portion of a described format code is itself any valid AMQP
+    %% encoded value, including other described values." [§1.2]
+    DescriptorSize = peek_value_size(Rest),
+    case Rest of
+        <<_:DescriptorSize/binary, Value/binary>> ->
+            1 + DescriptorSize + peek_value_size(Value);
+        _ ->
+            throw({insufficient_input, described_type, peek_value_size})
+    end;
 peek_value_size(<<16#40, _/binary>>) -> 1;
 peek_value_size(<<16#41, _/binary>>) -> 1;
 peek_value_size(<<16#42, _/binary>>) -> 1;

--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -179,9 +179,37 @@ parse_array2(0, Type, Bin, Acc) ->
 parse_array2(Count, Type, <<>>, Acc) when Count > 0 ->
     exit({failed_to_parse_array_insufficient_input, Type, Count, Acc});
 parse_array2(Count, Type, Bin, Acc) ->
-    {Value, B} = parse_array_primitive(Type, Bin),
-    <<_ParsedValue:B/binary, Rest/binary>> = Bin,
-    parse_array2(Count - 1, Type, Rest, [Value | Acc]).
+    Size = array_element_size(Type, Bin),
+    case Bin of
+        <<Element:Size/binary, Rest/binary>> ->
+            TotalSize = Size + 1,
+            %% assertion
+            {Value, TotalSize} = parse(<<Type, Element/binary>>),
+            parse_array2(Count - 1, Type, Rest, [Value | Acc]);
+        _ ->
+            exit({failed_to_parse_array_insufficient_input, Type, Count, Acc})
+    end.
+
+%% Returns the byte size of a single array element, excluding the constructor
+%% that all elements of the array share.
+array_element_size(Type, _Bin) when Type >= 16#40 andalso Type =< 16#4f -> 0;
+array_element_size(Type, _Bin) when Type >= 16#50 andalso Type =< 16#5f -> 1;
+array_element_size(Type, _Bin) when Type >= 16#60 andalso Type =< 16#6f -> 2;
+array_element_size(Type, _Bin) when Type >= 16#70 andalso Type =< 16#7f -> 4;
+array_element_size(Type, _Bin) when Type >= 16#80 andalso Type =< 16#8f -> 8;
+array_element_size(Type, _Bin) when Type >= 16#90 andalso Type =< 16#9f -> 16;
+array_element_size(Type, <<Size:8, _/binary>>)
+  when Type >= 16#a0 andalso Type =< 16#af;
+       Type >= 16#c0 andalso Type =< 16#cf;
+       Type >= 16#e0 andalso Type =< 16#ef ->
+    1 + Size;
+array_element_size(Type, <<Size:32, _/binary>>)
+  when Type >= 16#b0 andalso Type =< 16#bf;
+       Type >= 16#d0 andalso Type =< 16#df;
+       Type >= 16#f0 andalso Type =< 16#ff ->
+    4 + Size;
+array_element_size(Type, _Bin) ->
+    exit({failed_to_parse_array_element_size, Type}).
 
 parse_constructor(?CODE_SYM_8) -> symbol;
 parse_constructor(?CODE_SYM_32) -> symbol;
@@ -215,10 +243,6 @@ parse_constructor(16#f0) -> array;
 parse_constructor(0) -> described;
 parse_constructor(X) ->
     exit({failed_to_parse_constructor, X}).
-
-parse_array_primitive(ElementType, Data) ->
-    {Val, B} = parse(<<ElementType, Data/binary>>),
-    {Val, B-1}.
 
 mapify([]) ->
     [];

--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -132,11 +132,17 @@ parse(<<16#84, V:8/binary, _/binary>>, B) ->
 parse(<<16#94, V:16/binary, _/binary>>, B) ->
     {{as_is, 16#94, V}, B+17};
 parse(<<Type, _/binary>>, B) ->
-    throw({primitive_type_unsupported, Type, {position, B}}).
+    throw({primitive_type_unsupported, Type, {position, B}});
+parse(<<>>, B) ->
+    throw({insufficient_input, {position, B}}).
 
 parse_array(UnitSize, Bin) ->
-    <<Count:UnitSize, Bin1/binary>> = Bin,
-    parse_array1(UnitSize, Count, Bin1).
+    case Bin of
+        <<Count:UnitSize, Bin1/binary>> ->
+            parse_array1(UnitSize, Count, Bin1);
+        _ ->
+            throw({failed_to_parse_array_count, {size, byte_size(Bin)}})
+    end.
 
 parse_array1(UnitSize, Count, <<?DESCRIBED, Rest/binary>>) ->
     {Descriptor, B1} = parse(Rest),
@@ -147,7 +153,7 @@ parse_array1(UnitSize, Count, <<?DESCRIBED, Rest/binary>>) ->
             % this format cannot represent an empty array of described types
             {array, {described, Descriptor, Type}, Values};
         {as_is, _, _} ->
-            exit({array_of_described_zero_width_elements_unsupported, Count})
+            throw({array_of_described_zero_width_elements_unsupported, Count})
     end;
 parse_array1(UnitSize, Count, <<Type, ArrayBin/binary>>)
   when Type >= 16#40 andalso Type =< 16#45 ->
@@ -164,20 +170,22 @@ parse_array1(UnitSize, Count, <<Type, ArrayBin/binary>>)
                 32 -> {as_is, 16#f0, <<5:32, Count:32, Type>>}
             end;
         Size ->
-            exit({failed_to_parse_array_extra_input_remaining, Type, Size})
+            throw({failed_to_parse_array_extra_input_remaining, Type, Size})
     end;
 parse_array1(_UnitSize, Count, <<Type, ArrayBin/binary>>)
   when Count > byte_size(ArrayBin) ->
-    exit({failed_to_parse_array_count_exceeds_input, Type, Count, byte_size(ArrayBin)});
+    throw({failed_to_parse_array_count_exceeds_input, Type, Count, byte_size(ArrayBin)});
 parse_array1(_UnitSize, Count, <<Type, ArrayBin/binary>>) ->
-    parse_array2(Count, Type, ArrayBin, []).
+    parse_array2(Count, Type, ArrayBin, []);
+parse_array1(_UnitSize, Count, <<>>) ->
+    throw({failed_to_parse_array_element_constructor, Count}).
 
 parse_array2(0, Type, <<>>, Acc) ->
     {array, parse_constructor(Type), lists:reverse(Acc)};
 parse_array2(0, Type, Bin, Acc) ->
-    exit({failed_to_parse_array_extra_input_remaining, Type, Bin, Acc});
+    throw({failed_to_parse_array_extra_input_remaining, Type, Bin, Acc});
 parse_array2(Count, Type, <<>>, Acc) when Count > 0 ->
-    exit({failed_to_parse_array_insufficient_input, Type, Count, Acc});
+    throw({failed_to_parse_array_insufficient_input, Type, Count, Acc});
 parse_array2(Count, Type, Bin, Acc) ->
     Size = array_element_size(Type, Bin),
     case Bin of
@@ -187,7 +195,7 @@ parse_array2(Count, Type, Bin, Acc) ->
             {Value, TotalSize} = parse(<<Type, Element/binary>>),
             parse_array2(Count - 1, Type, Rest, [Value | Acc]);
         _ ->
-            exit({failed_to_parse_array_insufficient_input, Type, Count, Acc})
+            throw({failed_to_parse_array_insufficient_input, Type, Count, Acc})
     end.
 
 %% Returns the byte size of a single array element, excluding the constructor
@@ -209,7 +217,7 @@ array_element_size(Type, <<Size:32, _/binary>>)
        Type >= 16#f0 andalso Type =< 16#ff ->
     4 + Size;
 array_element_size(Type, _Bin) ->
-    exit({failed_to_parse_array_element_size, Type}).
+    throw({failed_to_parse_array_element_size, Type}).
 
 parse_constructor(?CODE_SYM_8) -> symbol;
 parse_constructor(?CODE_SYM_32) -> symbol;
@@ -242,7 +250,7 @@ parse_constructor(16#d1) -> map;
 parse_constructor(16#f0) -> array;
 parse_constructor(0) -> described;
 parse_constructor(X) ->
-    exit({failed_to_parse_constructor, X}).
+    throw({failed_to_parse_constructor, X}).
 
 mapify([]) ->
     [];
@@ -310,11 +318,9 @@ pm(<<?DESCRIBED, ?CODE_SMALL_ULONG, ?DESCRIPTOR_CODE_AMQP_SEQUENCE, _Rest/binary
 pm(<<?DESCRIBED, ?CODE_SMALL_ULONG, ?DESCRIPTOR_CODE_AMQP_VALUE, _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_VALUE);
 pm(<<?DESCRIBED, ?CODE_SMALL_ULONG, ?DESCRIPTOR_CODE_PROPERTIES, Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+3),
-    [{{pos, B}, {described, {ulong, ?DESCRIPTOR_CODE_PROPERTIES}, Value}} | Rest];
+    pm_bare_section({ulong, ?DESCRIPTOR_CODE_PROPERTIES}, B, pm(Rest0, O, B+3));
 pm(<<?DESCRIBED, ?CODE_SMALL_ULONG, ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES, Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+3),
-    [{{pos, B}, {described, {ulong, ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES}, Value}} | Rest];
+    pm_bare_section({ulong, ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES}, B, pm(Rest0, O, B+3));
 pm(<<?DESCRIBED, ?CODE_ULONG, ?DESCRIPTOR_CODE_DATA:64, _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_DATA);
 pm(<<?DESCRIBED, ?CODE_ULONG, ?DESCRIPTOR_CODE_AMQP_SEQUENCE:64, _Rest/binary>>, true, B) ->
@@ -334,28 +340,21 @@ pm(<<?DESCRIBED, ?CODE_SYM_32, 23:32, "amqp:amqp-sequence:list", _Rest/binary>>,
 pm(<<?DESCRIBED, ?CODE_SYM_32, 17:32, "amqp:amqp-value:*", _Rest/binary>>, true, B) ->
     reached_body(B, ?DESCRIPTOR_CODE_AMQP_VALUE);
 pm(<<?DESCRIBED, ?CODE_ULONG, ?DESCRIPTOR_CODE_PROPERTIES:64, Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+10),
-    [{{pos, B}, {described, {ulong, ?DESCRIPTOR_CODE_PROPERTIES}, Value}} | Rest];
+    pm_bare_section({ulong, ?DESCRIPTOR_CODE_PROPERTIES}, B, pm(Rest0, O, B+10));
 pm(<<?DESCRIBED, ?CODE_ULONG, ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES:64, Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+10),
-    [{{pos, B}, {described, {ulong, ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES}, Value}} | Rest];
+    pm_bare_section({ulong, ?DESCRIPTOR_CODE_APPLICATION_PROPERTIES}, B, pm(Rest0, O, B+10));
 pm(<<?DESCRIBED, ?CODE_SYM_8, 20, "amqp:properties:list", Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+23),
-    [{{pos, B}, {described, {symbol, <<"amqp:properties:list">>}, Value}} | Rest];
+    pm_bare_section({symbol, <<"amqp:properties:list">>}, B, pm(Rest0, O, B+23));
 pm(<<?DESCRIBED, ?CODE_SYM_8, 31, "amqp:application-properties:map", Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+34),
-    [{{pos, B}, {described, {symbol, <<"amqp:application-properties:map">>}, Value}} | Rest];
+    pm_bare_section({symbol, <<"amqp:application-properties:map">>}, B, pm(Rest0, O, B+34));
 pm(<<?DESCRIBED, ?CODE_SYM_32, 20:32, "amqp:properties:list", Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+26),
-    [{{pos, B}, {described, {symbol, <<"amqp:properties:list">>}, Value}} | Rest];
+    pm_bare_section({symbol, <<"amqp:properties:list">>}, B, pm(Rest0, O, B+26));
 pm(<<?DESCRIBED, ?CODE_SYM_32, 31:32, "amqp:application-properties:map", Rest0/binary>>, O = true, B) ->
-    [Value | Rest] = pm(Rest0, O, B+37),
-    [{{pos, B}, {described, {symbol, <<"amqp:application-properties:map">>}, Value}} | Rest];
+    pm_bare_section({symbol, <<"amqp:application-properties:map">>}, B, pm(Rest0, O, B+37));
 
 %% Described Types
 pm(<<?DESCRIBED, Rest0/binary>>, O, B) ->
-    [Descriptor, Value | Rest] = pm(Rest0, O, B+1),
-    [{described, Descriptor, Value} | Rest];
+    pm_described(B, pm(Rest0, O, B+1));
 
 %% Primitives Types
 %%
@@ -403,6 +402,16 @@ pm(<<16#94, V:16/binary, R/binary>>, O, B) ->
     [{as_is, 16#94, V} | pm(R, O, B+17)];
 pm(<<Type, _Bin/binary>>, _O, B) ->
     throw({primitive_type_unsupported, Type, {position, B}}).
+
+pm_described(_Pos, [Descriptor, Value | Rest]) ->
+    [{described, Descriptor, Value} | Rest];
+pm_described(Pos, _TooShort) ->
+    throw({described_type_incomplete, {position, Pos}}).
+
+pm_bare_section(Descriptor, Pos, [Value | Rest]) ->
+    [{{pos, Pos}, {described, Descriptor, Value}} | Rest];
+pm_bare_section(_Descriptor, Pos, []) ->
+    throw({described_type_incomplete, {position, Pos}}).
 
 pm_compound(UnitSize, Bin, B) ->
     case Bin of
@@ -579,7 +588,9 @@ peek(<<?DESCRIBED, Rest/binary>>) ->
     B2 = peek_value_size(Rest1),
     {Descriptor, 1 + B1 + B2};
 peek(<<Type, _/binary>>) ->
-    throw({not_described_type, Type}).
+    throw({not_described_type, Type});
+peek(<<>>) ->
+    throw({insufficient_input, peek}).
 
 %% Returns the byte size of the AMQP value at the start of the binary
 %% without parsing it (no term construction).
@@ -633,7 +644,9 @@ peek_value_size(<<16#d1, Size:32, _/binary>>) -> 5 + Size;
 peek_value_size(<<16#e0, S:8, _/binary>>) -> 2 + S;
 peek_value_size(<<16#f0, S:32, _/binary>>) -> 5 + S;
 peek_value_size(<<Type, _/binary>>) ->
-    throw({primitive_type_unsupported, Type, peek_value_size}).
+    throw({primitive_type_unsupported, Type, peek_value_size});
+peek_value_size(<<>>) ->
+    throw({insufficient_input, peek_value_size}).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/deps/amqp10_common/test/binary_parser_SUITE.erl
+++ b/deps/amqp10_common/test/binary_parser_SUITE.erl
@@ -6,6 +6,7 @@
          ]).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp10_common/include/amqp10_framing.hrl").
 
 %%%===================================================================
 %%% Common Test callbacks
@@ -27,6 +28,18 @@ all_tests() ->
      unsupported_type,
      server_mode_symbolic_body_descriptors,
      server_mode_body_descriptor_prefix_collision,
+     validate_valid_messages,
+     validate_section_after_body,
+     validate_section_out_of_order,
+     validate_duplicate_sections,
+     validate_body_sections,
+     validate_too_many_sections,
+     validate_footer,
+     validate_unknown_section,
+     validate_section_value_type,
+     validate_nested_section_descriptor,
+     validate_malformed_encodings,
+     validate_symbolic_descriptors,
      peek_described_section_total_sizes,
      peek_described_section,
      peek_non_described_throws,
@@ -175,40 +188,411 @@ server_mode_symbolic_body_descriptors(_Config) ->
     Seq8 = <<0, 16#a3, 23, "amqp:amqp-sequence:list", 16#45>>,
     Value8 = <<0, 16#a3, 17, "amqp:amqp-value:*", 16#a1, 1, "x">>,
     ?assertEqual([{{pos, 0}, {body, 16#75}}],
-                 amqp10_binary_parser:parse_many(Data8, [server_mode])),
+                 amqp10_binary_parser:parse_many(Data8, [{server_mode, false}])),
     ?assertEqual([{{pos, 0}, {body, 16#76}}],
-                 amqp10_binary_parser:parse_many(Seq8, [server_mode])),
+                 amqp10_binary_parser:parse_many(Seq8, [{server_mode, false}])),
     ?assertEqual([{{pos, 0}, {body, 16#77}}],
-                 amqp10_binary_parser:parse_many(Value8, [server_mode])),
+                 amqp10_binary_parser:parse_many(Value8, [{server_mode, false}])),
     %% The sym32 forms must be classified identically.
     Data32 = <<0, 16#b3, 16:32, "amqp:data:binary", 16#a0, 1, "x">>,
     Seq32 = <<0, 16#b3, 23:32, "amqp:amqp-sequence:list", 16#45>>,
     Value32 = <<0, 16#b3, 17:32, "amqp:amqp-value:*", 16#a1, 1, "x">>,
     ?assertEqual([{{pos, 0}, {body, 16#75}}],
-                 amqp10_binary_parser:parse_many(Data32, [server_mode])),
+                 amqp10_binary_parser:parse_many(Data32, [{server_mode, false}])),
     ?assertEqual([{{pos, 0}, {body, 16#76}}],
-                 amqp10_binary_parser:parse_many(Seq32, [server_mode])),
+                 amqp10_binary_parser:parse_many(Seq32, [{server_mode, false}])),
     ?assertEqual([{{pos, 0}, {body, 16#77}}],
-                 amqp10_binary_parser:parse_many(Value32, [server_mode])).
+                 amqp10_binary_parser:parse_many(Value32, [{server_mode, false}])).
 
 server_mode_body_descriptor_prefix_collision(_Config) ->
     %% Well-formed but unknown descriptor "amqp:data:binary@" (length 17).
     Collision8 = <<0, 16#a3, 17, "amqp:data:binary", $@, 16#a0, 3, "abc">>,
     ?assertEqual(
        [{described, {symbol, <<"amqp:data:binary@">>}, {binary, <<"abc">>}}],
-       amqp10_binary_parser:parse_many(Collision8, [server_mode])),
+       amqp10_binary_parser:parse_many(Collision8, [{server_mode, false}])),
 
     %% The same collision via the sym32 constructor.
     Collision32 = <<0, 16#b3, 17:32, "amqp:data:binary", $@, 16#a0, 3, "abc">>,
     ?assertEqual(
        [{described, {symbol, <<"amqp:data:binary@">>}, {binary, <<"abc">>}}],
-       amqp10_binary_parser:parse_many(Collision32, [server_mode])),
+       amqp10_binary_parser:parse_many(Collision32, [{server_mode, false}])),
 
     %% A prefix collision on the amqp-value descriptor.
     ValueCollision = <<0, 16#a3, 18, "amqp:amqp-value:*!", 16#a1, 1, "x">>,
     ?assertEqual(
        [{described, {symbol, <<"amqp:amqp-value:*!">>}, {utf8, <<"x">>}}],
-       amqp10_binary_parser:parse_many(ValueCollision, [server_mode])).
+       amqp10_binary_parser:parse_many(ValueCollision, [{server_mode, false}])).
+
+%%%===================================================================
+%%% Strict server mode: message section order and cardinality [§3.2]
+%%%===================================================================
+
+%% Descriptor codes of the message sections [§3.2].
+-define(HEADER, 16#70).
+-define(DELIVERY_ANNOTATIONS, 16#71).
+-define(MESSAGE_ANNOTATIONS, 16#72).
+-define(PROPERTIES, 16#73).
+-define(APPLICATION_PROPERTIES, 16#74).
+-define(DATA, 16#75).
+-define(AMQP_SEQUENCE, 16#76).
+-define(AMQP_VALUE, 16#77).
+-define(FOOTER, 16#78).
+
+validate_valid_messages(_Config) ->
+    Messages = [
+                [data()],
+                [data(), data(), data()],
+                [sequence()],
+                [sequence(), sequence()],
+                [value()],
+                [data(), footer()],
+                [value(), footer()],
+                [sequence(), sequence(), footer()],
+                [header(), data()],
+                [delivery_annotations(), data()],
+                [message_annotations(), data()],
+                [properties(), data()],
+                [application_properties(), data()],
+                [header(), delivery_annotations(), message_annotations(),
+                 properties(), application_properties(), data(), footer()],
+                [header(), message_annotations(), properties(), value()],
+                %% Sections in between may be omitted.
+                [header(), properties(), data()],
+                [delivery_annotations(), application_properties(), sequence()]
+               ],
+    lists:foreach(
+      fun(Sections) ->
+              Bin = iolist_to_binary(Sections),
+              %% Strict mode accepts the message and returns exactly what the
+              %% non-strict server mode returns.
+              ?assertEqual(amqp10_binary_parser:parse_many(Bin, [{server_mode, false}]),
+                           amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
+      end, Messages),
+    %% An empty payload is left to the caller to report: no body section is
+    %% returned, but parsing itself does not fail.
+    ?assertEqual([], amqp10_binary_parser:parse_many(<<>>, [{server_mode, true}])).
+
+%% The security relevant case: RabbitMQ stops parsing at the body, so a section
+%% that follows the body would be invisible to the broker while remaining
+%% visible to a consumer whose parser tolerates it. The prime example is a
+%% properties section carrying a forged user-id.
+validate_section_after_body(_Config) ->
+    ForgedProperties = section(?PROPERTIES,
+                               list([<<16#40>>, binary(<<"admin">>)])),
+    lists:foreach(
+      fun({Body, Late}) ->
+              Bin = iolist_to_binary([Body, Late]),
+              %% The non-strict server mode neither sees nor rejects it.
+              ?assertMatch([{{pos, 0}, {body, _}}],
+                           amqp10_binary_parser:parse_many(Bin, [{server_mode, false}])),
+              ?assertThrow({unexpected_message_section, _, _},
+                           amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
+      end,
+      [{Body, Late} || Body <- [data(), sequence(), value()],
+                       Late <- [ForgedProperties,
+                                header(),
+                                delivery_annotations(),
+                                message_annotations(),
+                                properties(),
+                                application_properties()]]).
+
+validate_section_out_of_order(_Config) ->
+    OutOfOrder = [
+                  [delivery_annotations(), header(), data()],
+                  [message_annotations(), header(), data()],
+                  [message_annotations(), delivery_annotations(), data()],
+                  [properties(), header(), data()],
+                  [properties(), message_annotations(), data()],
+                  [application_properties(), properties(), data()],
+                  [application_properties(), header(), data()]
+                 ],
+    lists:foreach(
+      fun(Sections) ->
+              Bin = iolist_to_binary(Sections),
+              ?assertThrow({unexpected_message_section, _, _},
+                           amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
+      end, OutOfOrder).
+
+validate_duplicate_sections(_Config) ->
+    Duplicated = [header(),
+                  delivery_annotations(),
+                  message_annotations(),
+                  properties(),
+                  application_properties()],
+    lists:foreach(
+      fun(Section) ->
+              Bin = iolist_to_binary([Section, Section, data()]),
+              ?assertThrow({unexpected_message_section, _, _},
+                           amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
+      end, Duplicated).
+
+%% "The body consists of one of the following three choices: one or more data
+%% sections, one or more amqp-sequence sections, or a single amqp-value
+%% section." [§3.2]
+validate_body_sections(_Config) ->
+    Invalid = [
+               [data(), sequence()],
+               [data(), value()],
+               [sequence(), data()],
+               [sequence(), value()],
+               [value(), data()],
+               [value(), sequence()],
+               [value(), value()],
+               %% The body is mandatory, so a footer alone is not a message.
+               [footer()],
+               [message_annotations(), footer()]
+              ],
+    lists:foreach(
+      fun(Sections) ->
+              Bin = iolist_to_binary(Sections),
+              ?assertThrow({unexpected_message_section, _, _},
+                           amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
+      end, Invalid),
+    %% A message without any body section is left to the caller to report.
+    NoBody = iolist_to_binary([header(), message_annotations()]),
+    ?assertEqual(amqp10_binary_parser:parse_many(NoBody, [{server_mode, false}]),
+                 amqp10_binary_parser:parse_many(NoBody, [{server_mode, true}])).
+
+%% The spec does not limit how many body sections a message may consist of.
+%% Since every section has to be validated, the total number of sections is
+%% capped so that a single message cannot consume disproportionate CPU time.
+validate_too_many_sections(_Config) ->
+    Data = iolist_to_binary(data()),
+    Sections = fun(N) -> binary:copy(Data, N) end,
+    %% The limit is part of the error, so this test does not duplicate it.
+    Max = try amqp10_binary_parser:parse_many(Sections(100_000), [{server_mode, true}]) of
+              _ -> ct:fail(expected_too_many_message_sections)
+          catch throw:{too_many_message_sections, M, {position, _}} ->
+                    M
+          end,
+    ?assertMatch([{{pos, 0}, {body, ?DATA}}],
+                 amqp10_binary_parser:parse_many(Sections(Max), [{server_mode, true}])),
+    ?assertThrow({too_many_message_sections, Max, _},
+                 amqp10_binary_parser:parse_many(Sections(Max + 1), [{server_mode, true}])),
+    %% Every section counts towards the limit, not only the body sections.
+    Prefix = iolist_to_binary([header(), properties()]),
+    ?assertMatch([_Header, {{pos, _}, _Properties}, {{pos, _}, {body, ?DATA}}],
+                 amqp10_binary_parser:parse_many(
+                   <<Prefix/binary, (Sections(Max - 2))/binary>>, [{server_mode, true}])),
+    ?assertThrow({too_many_message_sections, Max, _},
+                 amqp10_binary_parser:parse_many(
+                   <<Prefix/binary, (Sections(Max - 1))/binary>>, [{server_mode, true}])),
+    %% Without strict mode, parsing stops at the body: there is nothing to cap.
+    ?assertMatch([{{pos, 0}, {body, ?DATA}}],
+                 amqp10_binary_parser:parse_many(Sections(100_000), [{server_mode, false}])).
+
+%% "Zero or one footer sections." [§3.2] The footer terminates the message.
+validate_footer(_Config) ->
+    ?assertThrow({unexpected_message_section, footer, _},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([data(), footer(), footer()]), [{server_mode, true}])),
+    ?assertThrow({unexpected_message_section, data, _},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([data(), footer(), data()]), [{server_mode, true}])),
+    ?assertThrow({not_a_message_section, _},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([data(), footer(), <<16#40>>]), [{server_mode, true}])),
+    %% Trailing bytes that are not a section are rejected as well.
+    ?assertThrow({not_a_message_section, _},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([data(), <<16#40>>]), [{server_mode, true}])).
+
+validate_unknown_section(_Config) ->
+    %% A numeric descriptor that is not a message section descriptor.
+    ?assertThrow({unexpected_message_section, 16#7f, {position, 0}},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([section(16#7f, <<16#40>>), data()]),
+                   [{server_mode, true}])),
+    %% A symbolic descriptor that is not a message section descriptor.
+    Unknown = <<0, 16#a3, 3, "URL", 16#40>>,
+    ?assertThrow({unexpected_message_section, unknown_section_descriptor,
+                  {position, 0}},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([Unknown, data()]), [{server_mode, true}])),
+    %% A descriptor that is neither a ulong nor a symbol.
+    ?assertThrow({not_a_message_section, {position, 0}},
+                 amqp10_binary_parser:parse_many(<<0, 16#40, 16#40>>, [{server_mode, true}])).
+
+%% Every section value has a fixed outer type: a list, a map or, for the data
+%% section, a binary. Only the amqp-value section holds any AMQP type [§3.2].
+validate_section_value_type(_Config) ->
+    Map = <<16#c1, 1, 0>>,
+    List = <<16#c0, 1, 0>>,
+    Bin = <<16#a0, 0>>,
+    Null = <<16#40>>,
+    %% A described value would let a section descriptor hide inside a section
+    %% that must hold a list, a map or a binary.
+    Described = iolist_to_binary(section(?PROPERTIES, List)),
+    WrongTypes = [{?HEADER, Map}, {?HEADER, Bin}, {?HEADER, Null},
+                  {?HEADER, Described},
+                  {?DELIVERY_ANNOTATIONS, List}, {?DELIVERY_ANNOTATIONS, Null},
+                  {?MESSAGE_ANNOTATIONS, List}, {?MESSAGE_ANNOTATIONS, Bin},
+                  {?MESSAGE_ANNOTATIONS, Described},
+                  {?PROPERTIES, Map}, {?PROPERTIES, Null},
+                  {?PROPERTIES, Described},
+                  {?APPLICATION_PROPERTIES, List},
+                  {?DATA, List}, {?DATA, Map}, {?DATA, Null},
+                  {?DATA, Described},
+                  {?AMQP_SEQUENCE, Map}, {?AMQP_SEQUENCE, Bin}],
+    lists:foreach(
+      fun({Code, Value}) ->
+              Payload = iolist_to_binary([section(Code, Value), data()]),
+              ?assertThrow({invalid_section_value, _, _},
+                           amqp10_binary_parser:parse_many(Payload, [{server_mode, true}]))
+      end, WrongTypes),
+    %% The footer value must be a map too.
+    ?assertThrow({invalid_section_value, map, _},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([data(), section(?FOOTER, List)]), [{server_mode, true}])),
+    %% An amqp-value section accepts any AMQP type, including a described one.
+    lists:foreach(
+      fun(Value) ->
+              Payload = iolist_to_binary(section(?AMQP_VALUE, Value)),
+              ?assertEqual([{{pos, 0}, {body, ?AMQP_VALUE}}],
+                           amqp10_binary_parser:parse_many(Payload, [{server_mode, true}]))
+      end, [Null, Bin, List, Map,
+            <<16#45>>,
+            <<16#a1, 2, "hi">>,
+            <<16#83, 0:64>>,
+            <<16#98, 0:128>>,
+            <<16#f0, 5:32, 3:32, 16#40>>,
+            <<0, 16#a1, 3, "URL", 16#a1, 1, $x>>,
+            <<0, 0, 16#a1, 3, "URL", 16#40, 16#a1, 1, $x>>]).
+
+%% "The descriptor portion of a described format code is itself any valid AMQP
+%% encoded value, including other described values." [§1.2] A section
+%% descriptor nested inside a section value must not be taken for a section:
+%% otherwise a properties section hidden inside a message-annotations map could
+%% become the properties of the message.
+validate_nested_section_descriptor(_Config) ->
+    Nested = [iolist_to_binary(data()),
+              iolist_to_binary(properties()),
+              iolist_to_binary(header()),
+              iolist_to_binary(footer())],
+    %% Nested inside a message-annotations map.
+    Key = <<16#a3, 2, "x-">>,
+    lists:foreach(
+      fun(N) ->
+              Bin = iolist_to_binary(
+                      [section(?MESSAGE_ANNOTATIONS, map([Key, N])), data()]),
+              [{described, {ulong, ?MESSAGE_ANNOTATIONS}, {map, Content}},
+               {{pos, _}, {body, ?DATA}}] =
+                  amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]),
+              %% The nested described type stays the annotation value.
+              ?assertMatch([{{symbol, <<"x-">>}, {described, _, _}}], Content)
+      end, Nested),
+    %% Nested inside the properties list, that is as the message-id.
+    lists:foreach(
+      fun(N) ->
+              Bin = iolist_to_binary(
+                      [section(?PROPERTIES, list([N])), data()]),
+              [{{pos, 0}, {described, {ulong, ?PROPERTIES}, {list, Fields}}},
+               {{pos, _}, {body, ?DATA}}] =
+                  amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]),
+              ?assertMatch([{described, _, _}], Fields)
+      end, Nested).
+
+validate_malformed_encodings(_Config) ->
+    %% A compound whose size is too small to hold its count field.
+    ?assertThrow({invalid_compound_size, _},
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary([section(?MESSAGE_ANNOTATIONS, <<16#c1, 0>>),
+                                     data()]), [{server_mode, true}])),
+    %% A map with an odd number of elements.
+    ?assertThrow(map_with_odd_number_of_elements,
+                 amqp10_binary_parser:parse_many(
+                   iolist_to_binary(
+                     [section(?MESSAGE_ANNOTATIONS,
+                              <<16#c1, 5, 1, 16#a3, 2, "x-">>),
+                      data()]), [{server_mode, true}])),
+    %% A data section whose declared size exceeds the remaining input.
+    ?assertThrow({invalid_section_value, binary, _},
+                 amqp10_binary_parser:parse_many(
+                   <<0, 16#53, ?DATA, 16#a0, 200, "short">>, [{server_mode, true}])),
+    %% An amqp-value section whose declared size exceeds the remaining input.
+    ?assertThrow({invalid_section_value, any, _},
+                 amqp10_binary_parser:parse_many(
+                   <<0, 16#53, ?AMQP_VALUE, 16#a1, 200, "short">>, [{server_mode, true}])),
+    %% A truncated section descriptor.
+    ?assertThrow({not_a_message_section, _},
+                 amqp10_binary_parser:parse_many(<<0, 16#53>>, [{server_mode, true}])).
+
+%% All four descriptor encodings are validated identically.
+validate_symbolic_descriptors(_Config) ->
+    Symbols = #{?HEADER => <<"amqp:header:list">>,
+                ?DELIVERY_ANNOTATIONS => <<"amqp:delivery-annotations:map">>,
+                ?MESSAGE_ANNOTATIONS => <<"amqp:message-annotations:map">>,
+                ?PROPERTIES => <<"amqp:properties:list">>,
+                ?APPLICATION_PROPERTIES => <<"amqp:application-properties:map">>,
+                ?DATA => <<"amqp:data:binary">>,
+                ?AMQP_SEQUENCE => <<"amqp:amqp-sequence:list">>,
+                ?AMQP_VALUE => <<"amqp:amqp-value:*">>,
+                ?FOOTER => <<"amqp:footer:map">>},
+    Encode = fun(Descriptor, Code, Value) ->
+                     Sym = maps:get(Code, Symbols),
+                     Size = byte_size(Sym),
+                     D = case Descriptor of
+                             small_ulong -> <<16#53, Code>>;
+                             ulong -> <<16#80, Code:64>>;
+                             sym8 -> <<16#a3, Size:8, Sym/binary>>;
+                             sym32 -> <<16#b3, Size:32, Sym/binary>>
+                         end,
+                     <<0, D/binary, Value/binary>>
+             end,
+    lists:foreach(
+      fun(Descriptor) ->
+              E = fun(Code, Value) -> Encode(Descriptor, Code, Value) end,
+              Data = E(?DATA, <<16#a0, 1, "x">>),
+              Props = E(?PROPERTIES, <<16#c0, 1, 0>>),
+              Valid = <<(E(?HEADER, <<16#c0, 1, 0>>))/binary,
+                        (E(?MESSAGE_ANNOTATIONS, <<16#c1, 1, 0>>))/binary,
+                        Props/binary,
+                        Data/binary,
+                        (E(?FOOTER, <<16#c1, 1, 0>>))/binary>>,
+              %% Strict mode validates the sections. Which of the four
+              %% descriptor encodings was used on the wire is preserved by
+              %% the parsed sections, just like in non-strict server mode.
+              Parsed = amqp10_binary_parser:parse_many(Valid, [{server_mode, true}]),
+              ?assertEqual(amqp10_binary_parser:parse_many(Valid, [{server_mode, false}]),
+                           Parsed),
+              ?assertMatch([#'v1_0.header'{},
+                            #'v1_0.message_annotations'{},
+                            {{pos, _}, #'v1_0.properties'{}},
+                            {{pos, _}, {body, ?DATA}}],
+                           amqp10_framing:decode_bin(Valid, [{server_mode, true}])),
+              %% Properties after the body are rejected for every encoding.
+              ?assertThrow({unexpected_message_section, properties, _},
+                           amqp10_binary_parser:parse_many(
+                             <<Data/binary, Props/binary>>, [{server_mode, true}]))
+      end, [small_ulong, ulong, sym8, sym32]).
+
+%%%===================================================================
+%%% Section encoding helpers
+%%%===================================================================
+
+section(Code, Value) ->
+    [<<0, 16#53, Code>>, Value].
+
+list(Elements) ->
+    Bin = iolist_to_binary(Elements),
+    <<16#c0, (byte_size(Bin) + 1), (length(Elements)), Bin/binary>>.
+
+map(Elements) ->
+    Bin = iolist_to_binary(Elements),
+    <<16#c1, (byte_size(Bin) + 1), (length(Elements)), Bin/binary>>.
+
+binary(Bin) ->
+    <<16#a0, (byte_size(Bin)), Bin/binary>>.
+
+header() -> section(?HEADER, list([<<16#41>>])).
+delivery_annotations() -> section(?DELIVERY_ANNOTATIONS, map([])).
+message_annotations() -> section(?MESSAGE_ANNOTATIONS, map([])).
+properties() -> section(?PROPERTIES, list([])).
+application_properties() -> section(?APPLICATION_PROPERTIES, map([])).
+data() -> section(?DATA, binary(<<"body">>)).
+sequence() -> section(?AMQP_SEQUENCE, <<16#45>>).
+value() -> section(?AMQP_VALUE, <<16#a1, 2, "hi">>).
+footer() -> section(?FOOTER, map([])).
 
 %%%===================================================================
 %%% peek/1 (exercises peek_value_size internally via described types)

--- a/deps/amqp10_common/test/binary_parser_SUITE.erl
+++ b/deps/amqp10_common/test/binary_parser_SUITE.erl
@@ -25,6 +25,7 @@ all_tests() ->
      array32_count_exceeds_data,
      array_of_zero_width_elements,
      array_of_described_zero_width_elements_unsupported,
+     array_element_widths,
      unsupported_type,
      server_mode_symbolic_body_descriptors,
      server_mode_body_descriptor_prefix_collision,
@@ -174,6 +175,52 @@ array_of_described_zero_width_elements_unsupported(_Config) ->
     Bin = <<16#f0, (byte_size(CountAndV)):32, CountAndV/binary>>,
     ?assertExit({array_of_described_zero_width_elements_unsupported, Count},
                 amqp10_binary_parser:parse(Bin)).
+
+%% Array elements are cut out of the array by the width that their shared
+%% constructor implies [§1.6.1]. Cover one element type per subcategory, that is
+%% per width class, including the ones whose width is a size prefix.
+array_element_widths(_Config) ->
+    Arrays = [
+              %% 0x4X: zero-width elements
+              {array, boolean, [true, false, true]},
+              %% 0x5X: 1 octet
+              {array, ubyte, [{ubyte, 0}, {ubyte, 255}]},
+              {array, byte, [{byte, -128}, {byte, 127}]},
+              %% 0x6X: 2 octets
+              {array, ushort, [{ushort, 0}, {ushort, 16#ff_ff}]},
+              {array, short, [{short, -1}, {short, 1}]},
+              %% 0x7X: 4 octets
+              {array, uint, [{uint, 0}, {uint, 16#ff_ff_ff_ff}]},
+              {array, float, [{float, 1.5}, {float, -1.5}]},
+              {array, char, [{char, $a}]},
+              %% 0x8X: 8 octets
+              {array, ulong, [{ulong, 0}, {ulong, 16#ff_ff_ff_ff_ff}]},
+              {array, double, [{double, 1.25}]},
+              {array, timestamp, [{timestamp, 1}]},
+              %% 0x9X: 16 octets
+              {array, uuid, [{uuid, <<0:128>>}, {uuid, <<1:128>>}]},
+              %% 0xAX: 1 octet of size
+              {array, binary, [{binary, <<>>}, {binary, <<1, 2, 3>>}]},
+              {array, utf8, [{utf8, <<"a">>}, {utf8, <<"bb">>}]},
+              {array, symbol, [{symbol, <<"s">>}]},
+              %% 0xBX: 4 octets of size
+              {array, binary, [{binary, binary:copy(<<7>>, 300)}]},
+              {array, utf8, [{utf8, binary:copy(<<$x>>, 300)}]},
+              %% 0xDX: 4 octets of size and count
+              {array, list, [{list, [{ubyte, 1}]}, {list, []}]},
+              {array, map, [{map, [{{utf8, <<"k">>}, {ubyte, 1}}]}]},
+              %% 0xFX: 4 octets of size and count
+              {array, array, [{array, ubyte, [{ubyte, 9}]}]},
+              %% Described elements share their descriptor as well.
+              {array, {described, {utf8, <<"URL">>}, utf8},
+               [{described, {utf8, <<"URL">>}, {utf8, <<"u">>}}]}
+             ],
+    lists:foreach(
+      fun(Array) ->
+              Bin = iolist_to_binary(amqp10_binary_generator:generate(Array)),
+              ?assertEqual({Array, byte_size(Bin)},
+                           amqp10_binary_parser:parse(Bin))
+      end, Arrays).
 
 unsupported_type(_Config) ->
     UnsupportedType = 16#02,

--- a/deps/amqp10_common/test/binary_parser_SUITE.erl
+++ b/deps/amqp10_common/test/binary_parser_SUITE.erl
@@ -106,7 +106,7 @@ array_with_extra_input(_Config) ->
                 %% element type, remaining input size
                 65, 12},
 
-    ?assertExit(Expected, amqp10_binary_parser:parse_many(Bin, [])).
+    ?assertThrow(Expected, amqp10_binary_parser:parse_many(Bin, [])).
 
 array32_count_exceeds_data(_Config) ->
     TypeArray32 = 16#f0,
@@ -115,8 +115,8 @@ array32_count_exceeds_data(_Config) ->
     Count = 10,
     Payload = <<Count:32, TypeUByte, 1, 2, 3>>,
     Bin = <<TypeArray32, (byte_size(Payload)):32, Payload/binary>>,
-    ?assertExit({failed_to_parse_array_count_exceeds_input, TypeUByte, Count, 3},
-                amqp10_binary_parser:parse(Bin)).
+    ?assertThrow({failed_to_parse_array_count_exceeds_input, TypeUByte, Count, 3},
+                 amqp10_binary_parser:parse(Bin)).
 
 %% Zero-width array elements (null, booleans, uint0, ulong0, list0) cost zero
 %% octets on the wire no matter how large Count is. Rather than materializing
@@ -173,17 +173,12 @@ array_of_described_zero_width_elements_unsupported(_Config) ->
     Count = 16#FFFFFFFF,
     CountAndV = <<Count:32, DescribedNull/binary>>,
     Bin = <<16#f0, (byte_size(CountAndV)):32, CountAndV/binary>>,
-    ?assertExit({array_of_described_zero_width_elements_unsupported, Count},
-                amqp10_binary_parser:parse(Bin)).
+    ?assertThrow({array_of_described_zero_width_elements_unsupported, Count},
+                 amqp10_binary_parser:parse(Bin)).
 
-%% Array elements are cut out of the array by the width that their shared
-%% constructor implies [§1.6.1]. Cover one element type per subcategory, that is
-%% per width class, including the ones whose width is a size prefix.
 array_element_widths(_Config) ->
     Arrays = [
-              %% 0x4X: zero-width elements
               {array, boolean, [true, false, true]},
-              %% 0x5X: 1 octet
               {array, ubyte, [{ubyte, 0}, {ubyte, 255}]},
               {array, byte, [{byte, -128}, {byte, 127}]},
               %% 0x6X: 2 octets
@@ -314,24 +309,13 @@ validate_valid_messages(_Config) ->
               %% non-strict server mode returns.
               ?assertEqual(amqp10_binary_parser:parse_many(Bin, [{server_mode, false}]),
                            amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
-      end, Messages),
-    %% An empty payload is left to the caller to report: no body section is
-    %% returned, but parsing itself does not fail.
-    ?assertEqual([], amqp10_binary_parser:parse_many(<<>>, [{server_mode, true}])).
+      end, Messages).
 
-%% The security relevant case: RabbitMQ stops parsing at the body, so a section
-%% that follows the body would be invisible to the broker while remaining
-%% visible to a consumer whose parser tolerates it. The prime example is a
-%% properties section carrying a forged user-id.
 validate_section_after_body(_Config) ->
-    ForgedProperties = section(?PROPERTIES,
-                               list([<<16#40>>, binary(<<"admin">>)])),
+    ForgedProperties = section(?PROPERTIES, list([<<16#40>>, binary(<<"admin">>)])),
     lists:foreach(
       fun({Body, Late}) ->
               Bin = iolist_to_binary([Body, Late]),
-              %% The non-strict server mode neither sees nor rejects it.
-              ?assertMatch([{{pos, 0}, {body, _}}],
-                           amqp10_binary_parser:parse_many(Bin, [{server_mode, false}])),
               ?assertThrow({unexpected_message_section, _, _},
                            amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
       end,
@@ -361,17 +345,17 @@ validate_section_out_of_order(_Config) ->
       end, OutOfOrder).
 
 validate_duplicate_sections(_Config) ->
-    Duplicated = [header(),
-                  delivery_annotations(),
-                  message_annotations(),
-                  properties(),
-                  application_properties()],
+    Sections = [header(),
+                delivery_annotations(),
+                message_annotations(),
+                properties(),
+                application_properties()],
     lists:foreach(
       fun(Section) ->
               Bin = iolist_to_binary([Section, Section, data()]),
               ?assertThrow({unexpected_message_section, _, _},
                            amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
-      end, Duplicated).
+      end, Sections).
 
 %% "The body consists of one of the following three choices: one or more data
 %% sections, one or more amqp-sequence sections, or a single amqp-value
@@ -394,11 +378,7 @@ validate_body_sections(_Config) ->
               Bin = iolist_to_binary(Sections),
               ?assertThrow({unexpected_message_section, _, _},
                            amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
-      end, Invalid),
-    %% A message without any body section is left to the caller to report.
-    NoBody = iolist_to_binary([header(), message_annotations()]),
-    ?assertEqual(amqp10_binary_parser:parse_many(NoBody, [{server_mode, false}]),
-                 amqp10_binary_parser:parse_many(NoBody, [{server_mode, true}])).
+      end, Invalid).
 
 %% The spec does not limit how many body sections a message may consist of.
 %% Since every section has to be validated, the total number of sections is
@@ -508,9 +488,7 @@ validate_section_value_type(_Config) ->
 
 %% "The descriptor portion of a described format code is itself any valid AMQP
 %% encoded value, including other described values." [§1.2] A section
-%% descriptor nested inside a section value must not be taken for a section:
-%% otherwise a properties section hidden inside a message-annotations map could
-%% become the properties of the message.
+%% descriptor nested inside a section value must not be taken for a section.
 validate_nested_section_descriptor(_Config) ->
     Nested = [iolist_to_binary(data()),
               iolist_to_binary(properties()),
@@ -599,9 +577,8 @@ validate_symbolic_descriptors(_Config) ->
               %% Strict mode validates the sections. Which of the four
               %% descriptor encodings was used on the wire is preserved by
               %% the parsed sections, just like in non-strict server mode.
-              Parsed = amqp10_binary_parser:parse_many(Valid, [{server_mode, true}]),
               ?assertEqual(amqp10_binary_parser:parse_many(Valid, [{server_mode, false}]),
-                           Parsed),
+                           amqp10_binary_parser:parse_many(Valid, [{server_mode, true}])),
               ?assertMatch([#'v1_0.header'{},
                             #'v1_0.message_annotations'{},
                             {{pos, _}, #'v1_0.properties'{}},

--- a/deps/amqp10_common/test/prop_SUITE.erl
+++ b/deps/amqp10_common/test/prop_SUITE.erl
@@ -27,6 +27,8 @@ groups() ->
        prop_server_mode_body,
        prop_server_mode_bare_message,
        prop_strict_server_mode,
+       prop_strict_server_mode_rejects_malformed,
+       prop_strict_server_mode_never_errors,
        prop_frame,
        prop_array32_terminates
       ]}
@@ -165,6 +167,41 @@ prop_strict_server_mode(_Config) ->
                        end)
       end, [], 300).
 
+%% Strict mode must reject every message that violates the AMQP 1.0 Core Spec, Part 3 §3.2 section
+%% order and cardinality.
+%%
+%% A valid message is mutated in one of these illegal ways and
+%% must be rejected with `unexpected_message_section`.
+prop_strict_server_mode_rejects_malformed(_Config) ->
+    run_proper(
+      fun() -> ?FORALL(Sections,
+                       annotated_message(),
+                       ?FORALL(Mutated,
+                               mutate(Sections),
+                               begin
+                                   Bin = iolist_to_binary(
+                                           [amqp10_framing:encode_bin(S) || S <- Mutated]),
+                                   try amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]) of
+                                       _ -> false
+                                   catch
+                                       throw:{unexpected_message_section, _, _} -> true
+                                   end
+                               end))
+      end, [], 1000).
+
+%% Strict parsing of any binary must either succeed or throw. It must never let
+%% an error or a process exit escape, since only throws are caught on the ingress path.
+prop_strict_server_mode_never_errors(_Config) ->
+    run_proper(
+      fun() -> ?FORALL(Bin,
+                       binary(),
+                       try amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]) of
+                           L when is_list(L) -> true
+                       catch
+                           throw:_ -> true
+                       end)
+      end, [], 5000).
+
 prop_frame(_Config) ->
     run_proper(
       fun() -> ?FORALL(Frame,
@@ -205,6 +242,48 @@ parse(Bin, Parsed, PosVal)
     BinPart = binary_part(Bin, Parsed, size(Bin) - Parsed),
     {Val, NumBytes} = amqp10_binary_parser:parse(BinPart),
     parse(Bin, Parsed + NumBytes, [{Parsed, Val} | PosVal]).
+
+is_body_section(#'v1_0.data'{}) -> true;
+is_body_section(#'v1_0.amqp_sequence'{}) -> true;
+is_body_section(#'v1_0.amqp_value'{}) -> true;
+is_body_section(_) -> false.
+
+%% Turns a valid annotated message into one that violates the AMQP 1.0 Core Spec, Part 3 §3.2 section
+%% order and cardinality. Every result is illegal and must be rejected with
+%% `unexpected_message_section`.
+%%
+%% More specifically:
+%%
+%%  * a section that must precede the body, or a second body, placed at the end
+%%  * a footer placed before the body
+%%  * the leading pre-body section is duplicated
+%%  * the first two pre-body sections swapped
+mutate(Sections) ->
+    IllegalTrailer = oneof([header_section(),
+                            delivery_annotation_section(),
+                            message_annotation_section(),
+                            properties_section(),
+                            application_properties_section(),
+                            amqp_value_section()]),
+    Duplicate = case Sections of
+                    [First | _] ->
+                        case is_body_section(First) of
+                            false -> [[First | Sections]];
+                            true -> []
+                        end;
+                    _ -> []
+                end,
+    Swap = case Sections of
+               [A, B | Rest] ->
+                   case (not is_body_section(A)) andalso (not is_body_section(B)) of
+                       true -> [[B, A | Rest]];
+                       false -> []
+                   end;
+               _ -> []
+           end,
+    oneof([?LET(S, IllegalTrailer, Sections ++ [S]),
+           ?LET(S, footer_section(), [S | Sections])
+          ] ++ Duplicate ++ Swap).
 
 %%%%%%%%%%%%%%%%%%
 %%% Generators %%%

--- a/deps/amqp10_common/test/prop_SUITE.erl
+++ b/deps/amqp10_common/test/prop_SUITE.erl
@@ -26,6 +26,7 @@ groups() ->
        prop_annotated_message,
        prop_server_mode_body,
        prop_server_mode_bare_message,
+       prop_strict_server_mode,
        prop_frame,
        prop_array32_terminates
       ]}
@@ -102,7 +103,7 @@ prop_server_mode_body(_Config) ->
                            Bin = iolist_to_binary([amqp10_framing:encode_bin(S) || S <- Sections]),
                            %% Invariant 1: Decoder should us return the correct
                            %% byte position of the first body section.
-                           Decoded = amqp10_framing:decode_bin(Bin, [server_mode]),
+                           Decoded = amqp10_framing:decode_bin(Bin, [{server_mode, false}]),
                            {value,
                             {{pos, Pos},
                              {body, Code}}} = lists:search(fun(({{pos, _Pos}, {body, _Code}})) ->
@@ -137,7 +138,7 @@ prop_server_mode_bare_message(_Config) ->
                            Bin = iolist_to_binary([amqp10_framing:encode_bin(S) || S <- Sections]),
                            %% Invariant: Decoder should us return the correct
                            %% byte position of the first bare message section.
-                           Decoded = amqp10_framing:decode_bin(Bin, [server_mode]),
+                           Decoded = amqp10_framing:decode_bin(Bin, [{server_mode, false}]),
                            {value,
                             {{pos, Pos}, _Sect}} = lists:search(fun(({{pos, _Pos}, _Sect})) ->
                                                                         true;
@@ -149,6 +150,20 @@ prop_server_mode_bare_message(_Config) ->
                            equals(FirstBareMsgSection, amqp10_framing:decode(Section))
                        end)
       end, [], 1000).
+
+%% Strict mode must accept every message whose sections comply with §3.2 and
+%% return exactly what the non-strict server mode returns.
+prop_strict_server_mode(_Config) ->
+    run_proper(
+      fun() -> ?FORALL(Sections,
+                       annotated_message(),
+                       begin
+                           Bin = iolist_to_binary(
+                                   [amqp10_framing:encode_bin(S) || S <- Sections]),
+                           equals(amqp10_binary_parser:parse_many(Bin, [{server_mode, false}]),
+                                  amqp10_binary_parser:parse_many(Bin, [{server_mode, true}]))
+                       end)
+      end, [], 300).
 
 prop_frame(_Config) ->
     run_proper(

--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -129,7 +129,7 @@
 -spec init_from_stream(binary(), mc:annotations()) ->
     mc:state().
 init_from_stream(Payload, #{} = Anns0) ->
-    Sections = amqp10_framing:decode_bin(Payload, [server_mode]),
+    Sections = amqp10_framing:decode_bin(Payload, [{server_mode, false}]),
     Msg = msg_body_encoded(Sections, Payload, #msg_body_encoded{}),
     %% when initalising from stored stream data the recovered
     %% annotations take precendence over the ones provided
@@ -141,7 +141,7 @@ init_from_stream(Payload, #{} = Anns0) ->
 init(#msg_body_encoded{} = Msg) ->
     {Msg, #{}};
 init(Payload) ->
-    Sections = amqp10_framing:decode_bin(Payload, [server_mode]),
+    Sections = amqp10_framing:decode_bin(Payload, [{server_mode, true}]),
     Msg = msg_body_encoded(Sections, Payload, #msg_body_encoded{}),
     Anns = essential_properties(Msg, new),
     {Msg, Anns}.

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -2545,9 +2545,9 @@ incoming_link_transfer(
     rabbit_msg_size_metrics:observe(?PROTOCOL, PayloadSize),
     messages_received(Settled),
     Mc0 = try mc:init(mc_amqp, PayloadBin, #{})
-          catch missing_amqp_message_body ->
+          catch throw:Reason0 ->
                     link_error(?V_1_0_AMQP_ERROR_DECODE_ERROR,
-                               "message has no body", [])
+                               "failed to parse message: ~tp", [Reason0])
           end,
     case lookup_target(LinkExchange, LinkRKey, Mc0, Vhost, User, PermCache0) of
         {ok, X, RoutingKeys, Mc1, PermCache} ->

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -127,6 +127,7 @@ groups() ->
        trace_classic_queue,
        trace_stream,
        user_id,
+       sections_out_of_order,
        message_ttl,
        plugin,
        idle_time_out_on_server,
@@ -5123,6 +5124,116 @@ user_id(Config) ->
     ok = end_session_sync(Session),
     ok = close_connection_sync(Connection).
 
+%% RabbitMQ should reject any message whose sections violate the order or
+%% cardinality mandated by §3.2.
+sections_out_of_order(Config) ->
+    QName = atom_to_binary(?FUNCTION_NAME),
+    Address = rabbitmq_amqp_address:queue(QName),
+    OpnConf = connection_config(Config),
+    {ok, Connection} = amqp10_client:open_connection(OpnConf),
+    {ok, Session} = amqp10_client:begin_session_sync(Connection),
+    {ok, LinkPair} = rabbitmq_amqp_client:attach_management_link_pair_sync(
+                       Session, <<"management link pair">>),
+    {ok, _} = rabbitmq_amqp_client:declare_queue(LinkPair, QName, #{}),
+
+    Encode = fun(Section) -> iolist_to_binary(amqp10_framing:encode_bin(Section)) end,
+    Header = Encode(#'v1_0.header'{durable = true}),
+    MessageAnnotations = Encode(#'v1_0.message_annotations'{
+                                   content = [{{symbol, <<"x-forged">>}, {utf8, <<"v">>}}]}),
+    ForgedProperties = Encode(#'v1_0.properties'{user_id = {binary, <<"fake user">>}}),
+    AppProperties = Encode(#'v1_0.application_properties'{
+                              content = [{{utf8, <<"k">>}, {utf8, <<"v">>}}]}),
+    Data = Encode(#'v1_0.data'{content = <<"m1">>}),
+    Sequence = Encode(#'v1_0.amqp_sequence'{content = [{utf8, <<"m1">>}]}),
+    Value = Encode(#'v1_0.amqp_value'{content = {utf8, <<"m1">>}}),
+    Footer = Encode(#'v1_0.footer'{content = [{{symbol, <<"x-f">>}, {utf8, <<"v">>}}]}),
+
+    InvalidPayloads =
+    [
+     %% A section that must precede the body follows it instead.
+     <<Data/binary, Header/binary>>,
+     <<Data/binary, MessageAnnotations/binary>>,
+     <<Data/binary, ForgedProperties/binary>>,
+     <<Data/binary, AppProperties/binary>>,
+     <<Sequence/binary, ForgedProperties/binary>>,
+     <<Value/binary, ForgedProperties/binary>>,
+     %% Sections that precede the body appear more than once or out of order.
+     <<ForgedProperties/binary, ForgedProperties/binary, Data/binary>>,
+     <<MessageAnnotations/binary, Header/binary, Data/binary>>,
+     %% The body mixes section kinds or repeats an amqp-value section.
+     <<Data/binary, Sequence/binary>>,
+     <<Value/binary, Value/binary>>,
+     %% A section follows the footer.
+     <<Data/binary, Footer/binary, Footer/binary>>,
+     <<Data/binary, Footer/binary, Data/binary>>
+    ],
+
+    lists:foreach(
+      fun({N, Payload}) ->
+              LinkName = <<"sender ", (integer_to_binary(N))/binary>>,
+              {ok, Sender} = amqp10_client:attach_sender_link(
+                               Session, LinkName, Address, settled),
+              ok = wait_for_credit(Sender),
+              ok = amqp10_client:send_msg(
+                     Sender, amqp10_raw_msg:new(true, 0, Payload)),
+              receive
+                  {amqp10_event,
+                   {link, Sender,
+                    {detached, #'v1_0.error'{condition = Condition}}}} ->
+                      ?assertEqual(?V_1_0_AMQP_ERROR_DECODE_ERROR, Condition)
+              after 9000 ->
+                        flush(missing_detached),
+                        ct:fail({"expected the link to be detached for payload",
+                                 Payload})
+              end,
+              flush(detached)
+      end, lists:enumerate(InvalidPayloads)),
+
+    %% The very same forged user-id in a legal position is refused as well,
+    %% but by the user-id validation rather than by the parser.
+    {ok, Sender1} = amqp10_client:attach_sender_link(
+                      Session, <<"sender1">>, Address, settled),
+    ok = wait_for_credit(Sender1),
+    ok = amqp10_client:send_msg(
+           Sender1, amqp10_raw_msg:new(true, 0, <<ForgedProperties/binary, Data/binary>>)),
+    receive
+        {amqp10_event,
+         {link, Sender1, {detached, #'v1_0.error'{condition = Cond}}}} ->
+            ?assertEqual(?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS, Cond)
+    after 9000 -> flush(missing_detached),
+                  ct:fail("expected the link to be detached")
+    end,
+    flush(detached),
+
+    %% A message whose sections are in order is accepted, and the user-id the
+    %% consumer sees is the one RabbitMQ validated.
+    Properties = Encode(#'v1_0.properties'{user_id = {binary, <<"guest">>}}),
+    Valid = <<Header/binary, MessageAnnotations/binary, Properties/binary,
+              AppProperties/binary, Data/binary, Footer/binary>>,
+    {ok, Sender2} = amqp10_client:attach_sender_link(
+                      Session, <<"sender2">>, Address, unsettled),
+    ok = wait_for_credit(Sender2),
+    ok = amqp10_client:send_msg(
+           Sender2, amqp10_raw_msg:new(false, 0, Valid)),
+    ok = wait_for_accepts(1),
+    ok = detach_link_sync(Sender2),
+
+    {ok, Receiver} = amqp10_client:attach_receiver_link(
+                       Session, <<"receiver">>, Address, settled),
+    {ok, Msg} = amqp10_client:get_msg(Receiver),
+    ?assertEqual(<<"m1">>, amqp10_msg:body_bin(Msg)),
+    ?assertMatch(#{user_id := <<"guest">>},
+                 amqp10_msg:properties(Msg)),
+    ok = detach_link_sync(Receiver),
+
+    %% None of the rejected messages was queued.
+    ?assertMatch({ok, #{message_count := 0}},
+                 rabbitmq_amqp_client:delete_queue(LinkPair, QName)),
+    ok = rabbitmq_amqp_client:detach_management_link_pair_sync(LinkPair),
+
+    ok = end_session_sync(Session),
+    ok = close_connection_sync(Connection).
+
 message_ttl(Config) ->
     QName = atom_to_binary(?FUNCTION_NAME),
     Address = rabbitmq_amqp_address:queue(QName),
@@ -6934,13 +7045,16 @@ reserved_annotation(Config) ->
     ok = amqp10_client:send_msg(Sender, Msg),
     receive
         {amqp10_event,
-         {session, Session,
-          {ended,
-           #'v1_0.error'{description = {utf8, Description}}}}} ->
+         {link, Sender,
+          {detached,
+           #'v1_0.error'{condition = Condition,
+                         description = {utf8, Description}}}}} ->
+            ?assertEqual(?V_1_0_AMQP_ERROR_DECODE_ERROR, Condition),
             ?assertMatch(
-               <<"{reserved_annotation_key,{symbol,<<\"reserved-key\">>}}", _/binary>>,
+               <<"failed to parse message: {reserved_annotation_key,",
+                 "{symbol,<<\"reserved-key\">>}}", _/binary>>,
                Description)
-    after 30000 -> flush(missing_ended),
+    after 9000 -> flush(missing_detached),
                   ct:fail({missing_event, ?LINE})
     end,
     ok = close_connection_sync(Connection).

--- a/deps/rabbit/test/amqp_dotnet_SUITE_data/fsharp-tests/Program.fs
+++ b/deps/rabbit/test/amqp_dotnet_SUITE_data/fsharp-tests/Program.fs
@@ -608,7 +608,7 @@ module Test =
         assertNotNull linkError
         assertEqual (Symbol "amqp:decode-error") linkError.Condition
         assertNotNull linkError.Description
-        assertTrue (linkError.Description.Contains("message has no body"))
+        assertTrue (linkError.Description.Contains("missing_amqp_message_body"))
 
 let (|AsLower|) (s: string) =
     match s with


### PR DESCRIPTION
This PR introduces improvements to the AMQP message parsing layer ensuring stricter adherence to the protocol specification. The parser now explicitly rejects and throws errors on malformed AMQP encodings such as wrong order or cardinality of message sections, ensuring that invalid payloads fail fast.

The performance regression is negligible in the default case where the message contains a single data section. Validating the message is O(N) where N is the number of sections. No sub binaries or Erlang terms are constructed however during validation. We cap the maximum number of sections within an AMQP message to 10k. This should be sufficient for any real world use case.