### PR TITLE
Stream: clamp frame_max before authentication and authorization

### DIFF
--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -880,3 +880,8 @@ The client answers with a `Tune` frame with the settings he agrees on, possibly 
 from the server's suggestions.
 * Open: the client sends an `Open` frame to pick a virtual host to connect to. The server
 answers whether it accepts the access or not.
+
+Until `Open` completes successfully, the server enforces a low, fixed `frame_max` ceiling
+(8192 bytes) on incoming frames, regardless of the value negotiated (or yet to be negotiated)
+with `Tune`. This ceiling is high enough to accommodate realistic
+https://www.rabbitmq.com/docs/oauth2[JWT tokens] carried as the SASL PLAIN password.

--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -881,7 +881,8 @@ from the server's suggestions.
 * Open: the client sends an `Open` frame to pick a virtual host to connect to. The server
 answers whether it accepts the access or not.
 
-Until `Open` completes successfully, the server enforces a low, fixed `frame_max` ceiling
-(8192 bytes) on incoming frames, regardless of the value negotiated (or yet to be negotiated)
-with `Tune`. This ceiling is high enough to accommodate realistic
+Until `Open` completes successfully, the server enforces a low `frame_max` ceiling
+(8192 bytes by default, configurable via `stream.initial_frame_max`) on incoming frames,
+regardless of the value negotiated (or yet to be negotiated) with `Tune`. This ceiling is
+high enough to accommodate realistic
 https://www.rabbitmq.com/docs/oauth2[JWT tokens] carried as the SASL PLAIN password.

--- a/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
+++ b/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
@@ -102,6 +102,15 @@ end}.
     {datatype, integer}
 ]}.
 
+%% Max frame size the server accepts before a connection is
+%% authenticated and authorized (a successful `open`).
+%%
+%% {initial_frame_max, 8192},
+
+{mapping, "stream.initial_frame_max", "rabbitmq_stream.initial_frame_max", [
+    {datatype, integer}
+]}.
+
 {mapping, "stream.heartbeat", "rabbitmq_stream.heartbeat", [
     {datatype, integer}
 ]}.

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -85,6 +85,11 @@
 -define(SILENT_CLOSE_DELAY, 3_000).
 -define(METADATA_TIMEOUT, 10_000).
 -define(SAC_MOD, rabbit_stream_sac_coordinator).
+%% Ceiling for the wire parser before authentication and authorization
+%% (i.e. before a successful `open`) complete, regardless of the
+%% configured frame_max, so an unauthenticated peer can't make the
+%% server commit to a large per-connection buffer.
+-define(PRE_AUTH_FRAME_MAX, 8192).
 
 -import(rabbit_stream_utils, [check_write_permitted/2,
                               check_read_permitted/3,
@@ -199,7 +204,8 @@ init([KeepaliveSup,
                 #stream_connection_state{consumers = #{},
                                          blocked = false,
                                          data =
-                                             rabbit_stream_core:init(#{frame_max => FrameMax})},
+                                             rabbit_stream_core:init(#{frame_max =>
+                                                                           negotiate_frame_max(?PRE_AUTH_FRAME_MAX, FrameMax)})},
             Transport:setopts(RealSocket, [{active, once}]),
             _ = rabbit_alarm:register(self(), {?MODULE, resource_alarm, []}),
             ConnectionNegotiationStepTimeout =
@@ -1549,15 +1555,14 @@ handle_frame_pre_auth(_Transport,
                                          name = ConnectionName,
                                          frame_max = ConfiguredFrameMax} =
                           Connection,
-                      #stream_connection_state{blocked = Blocked,
-                                               data = CoreState0} = State,
+                      #stream_connection_state{blocked = Blocked} = State,
                       {tune, FrameMax, Heartbeat}) ->
     ?LOG_DEBUG("Tuning response ~tp ~tp ",
                                 [FrameMax, Heartbeat]),
     %% 0 on either side means "no limit" and must not be clamped to 0.
+    %% The parser stays clamped to ?PRE_AUTH_FRAME_MAX until `open`
+    %% succeeds; only Connection.frame_max is updated here.
     NegotiatedFrameMax = negotiate_frame_max(FrameMax, ConfiguredFrameMax),
-    CoreState = rabbit_stream_core:set_frame_max(NegotiatedFrameMax,
-                                                 CoreState0),
     Parent = self(),
     %% sending a message to the main process so the heartbeat frame is sent from this main process
     %% otherwise heartbeat frames can interleave with chunk delivery
@@ -1587,17 +1592,17 @@ handle_frame_pre_auth(_Transport,
                                   frame_max = NegotiatedFrameMax,
                                   heartbeat = Heartbeat,
                                   heartbeater = Heartbeater},
-     State#stream_connection_state{data = CoreState}};
+     State};
 handle_frame_pre_auth(Transport,
                       #stream_connection{user = User = #user{username = Username},
                                          socket = S,
                                          ranch_ref = RanchRef,
                                          transport = TransportLayer} =
                           Connection,
-                      State,
+                      #stream_connection_state{data = CoreState0} = State,
                       {request, CorrelationId, {open, VirtualHost}}) ->
     ?LOG_DEBUG("Open frame received for ~ts", [VirtualHost]),
-    Connection1 =
+    {Connection1, State1} =
         maybe
             ok ?= check_node_connection_limit(RanchRef),
             ok ?= check_vhost_alive(VirtualHost),
@@ -1621,7 +1626,11 @@ handle_frame_pre_auth(Transport,
             {_, Conn} = ensure_token_expiry_timer(User,
                                                   Connection#stream_connection{connection_step = opened,
                                                                                virtual_host = VirtualHost}),
-            Conn
+            %% Authenticated and authorized: switch the parser from the
+            %% pre-auth ceiling to the value negotiated at `tune`.
+            CoreState = rabbit_stream_core:set_frame_max(Conn#stream_connection.frame_max,
+                                                         CoreState0),
+            {Conn, State#stream_connection_state{data = CoreState}}
         else
             {error, Explanation} ->
                   ?LOG_WARNING("Opening connection failed: ~ts", [Explanation]),
@@ -1630,9 +1639,9 @@ handle_frame_pre_auth(Transport,
                                                  ?RESPONSE_VHOST_ACCESS_FAILURE,
                                                  #{}}}),
                   maybe_send_or_delay_frame(Transport, S, F, silent_close),
-                  Connection#stream_connection{connection_step = silent_close}
+                  {Connection#stream_connection{connection_step = silent_close}, State}
         end,
-    {Connection1, State};
+    {Connection1, State1};
 handle_frame_pre_auth(_Transport, Connection, State, heartbeat) ->
     ?LOG_DEBUG("Received heartbeat frame pre auth"),
     {Connection, State};

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -85,11 +85,6 @@
 -define(SILENT_CLOSE_DELAY, 3_000).
 -define(METADATA_TIMEOUT, 10_000).
 -define(SAC_MOD, rabbit_stream_sac_coordinator).
-%% Ceiling for the wire parser before authentication and authorization
-%% (i.e. before a successful `open`) complete, regardless of the
-%% configured frame_max, so an unauthenticated peer can't make the
-%% server commit to a large per-connection buffer.
--define(PRE_AUTH_FRAME_MAX, 8192).
 
 -import(rabbit_stream_utils, [check_write_permitted/2,
                               check_read_permitted/3,
@@ -150,6 +145,7 @@ init([KeepaliveSup,
       #{initial_credits := InitialCredits,
         credits_required_for_unblocking := CreditsRequiredBeforeUnblocking,
         frame_max := FrameMax,
+        initial_frame_max := InitialFrameMax,
         heartbeat := Heartbeat,
         transport := ConnTransport}]) ->
     process_flag(trap_exit, true),
@@ -200,12 +196,15 @@ init([KeepaliveSup,
                                    outstanding_requests = #{},
                                    request_timeout = RequestTimeout,
                                    deliver_version = DeliverVersion},
+            %% Until `open` succeeds, an unauthenticated peer must not be
+            %% able to negotiate a large per-connection buffer.
+            PreAuthFrameMax = negotiate_frame_max(InitialFrameMax, FrameMax),
             State =
                 #stream_connection_state{consumers = #{},
                                          blocked = false,
                                          data =
                                              rabbit_stream_core:init(#{frame_max =>
-                                                                           negotiate_frame_max(?PRE_AUTH_FRAME_MAX, FrameMax)})},
+                                                                           PreAuthFrameMax})},
             Transport:setopts(RealSocket, [{active, once}]),
             _ = rabbit_alarm:register(self(), {?MODULE, resource_alarm, []}),
             ConnectionNegotiationStepTimeout =
@@ -1560,7 +1559,7 @@ handle_frame_pre_auth(_Transport,
     ?LOG_DEBUG("Tuning response ~tp ~tp ",
                                 [FrameMax, Heartbeat]),
     %% 0 on either side means "no limit" and must not be clamped to 0.
-    %% The parser stays clamped to ?PRE_AUTH_FRAME_MAX until `open`
+    %% The parser stays clamped to the pre-auth ceiling until `open`
     %% succeeds; only Connection.frame_max is updated here.
     NegotiatedFrameMax = negotiate_frame_max(FrameMax, ConfiguredFrameMax),
     Parent = self(),

--- a/deps/rabbitmq_stream/src/rabbit_stream_sup.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_sup.erl
@@ -58,6 +58,9 @@ init([]) ->
           frame_max =>
               application:get_env(rabbitmq_stream, frame_max,
                                   ?DEFAULT_FRAME_MAX),
+          initial_frame_max =>
+              application:get_env(rabbitmq_stream, initial_frame_max,
+                                  ?DEFAULT_INITIAL_FRAME_MAX),
           heartbeat =>
               application:get_env(rabbitmq_stream, heartbeat,
                                   ?DEFAULT_HEARTBEAT)},

--- a/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
+++ b/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
@@ -85,5 +85,9 @@
   {max_super_stream_partitions_infinity,
       "stream.max_super_stream_partitions = infinity",
       [{rabbitmq_stream,[{max_super_stream_partitions, infinity}]}],
+      [rabbitmq_stream]},
+  {initial_frame_max,
+      "stream.initial_frame_max = 4096",
+      [{rabbitmq_stream,[{initial_frame_max, 4096}]}],
       [rabbitmq_stream]}
 ].

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -34,9 +34,13 @@
 -import(rabbit_ct_helpers, [await_condition/1]).
 
 -define(WAIT, 5000).
+%% Below ?DEFAULT_INITIAL_FRAME_MAX, so a frame the default ceiling
+%% would accept is rejected once this setting is applied.
+-define(CUSTOM_INITIAL_FRAME_MAX, 4096).
 
 all() ->
-    [{group, single_node}, {group, single_node_1}, {group, cluster}].
+    [{group, single_node}, {group, single_node_1},
+     {group, single_node_initial_frame_max}, {group, cluster}].
 
 groups() ->
     [{single_node, [],
@@ -93,6 +97,8 @@ groups() ->
      %% Run `test_global_counters` on its own so the global metrics are
      %% initialised to 0 for each testcase
      {single_node_1, [], [test_global_counters]},
+     {single_node_initial_frame_max, [],
+      [oversized_frame_rejected_pre_auth_custom_initial_frame_max]},
      {cluster, [], [test_stream, test_stream_tls, test_metadata, java,
                     test_resolve_offset_spec]}].
 
@@ -146,6 +152,21 @@ init_per_group(Group, Config)
                                                   500}]})
        end]
       ++ ExtraSetupSteps
+      ++ rabbit_ct_broker_helpers:setup_steps());
+init_per_group(single_node_initial_frame_max, Config) ->
+    Config1 = rabbit_ct_helpers:set_config(
+                Config, [{rmq_nodes_clustered, false},
+                         {rabbitmq_ct_tls_verify, verify_none},
+                         {rabbitmq_stream, verify_none}
+                        ]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      [fun(StepConfig) ->
+               rabbit_ct_helpers:merge_app_env(StepConfig,
+                                               {rabbitmq_stream,
+                                                [{initial_frame_max,
+                                                  ?CUSTOM_INITIAL_FRAME_MAX}]})
+       end]
       ++ rabbit_ct_broker_helpers:setup_steps());
 init_per_group(cluster = Group, Config) ->
     Config1 = rabbit_ct_helpers:set_config(
@@ -635,20 +656,39 @@ oversized_frame_rejected_pre_auth(Config) ->
     ?assertEqual(ok, gen_tcp:send(S, Header)),
     ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
 
-%% Before a successful `open`, the parser is clamped to a small
-%% constant (8192, see ?PRE_AUTH_FRAME_MAX in rabbit_stream_reader),
-%% not the full configured frame_max, so an unauthenticated peer
-%% can't make the server commit to a large per-connection buffer.
-%% This size sits between the two, so only the tighter ceiling
-%% catches it.
+%% Before a successful `open`, the pre-auth ceiling governs frames, not
+%% the configured frame_max. This size sits between the two, so only the
+%% tighter ceiling rejects it.
 oversized_frame_rejected_pre_auth_below_configured_ceiling(Config) ->
     Port = get_stream_port(Config),
     {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
     FrameMax = rpc(Config, 0, application, get_env,
                    [rabbitmq_stream, frame_max, ?DEFAULT_FRAME_MAX]),
-    PreAuthFrameMax = 8192,
+    PreAuthFrameMax = rpc(Config, 0, application, get_env,
+                          [rabbitmq_stream, initial_frame_max,
+                           ?DEFAULT_INITIAL_FRAME_MAX]),
     ?assert(PreAuthFrameMax < FrameMax),
     OversizedSize = PreAuthFrameMax + 1000,
+    ?assert(OversizedSize < FrameMax),
+    Header = <<OversizedSize:32>>,
+    ?assertEqual(ok, gen_tcp:send(S, Header)),
+    ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
+
+%% A frame under the default ceiling but over the configured, lower
+%% `initial_frame_max` is rejected, so the setting is honoured.
+oversized_frame_rejected_pre_auth_custom_initial_frame_max(Config) ->
+    Port = get_stream_port(Config),
+    {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
+    FrameMax = rpc(Config, 0, application, get_env,
+                   [rabbitmq_stream, frame_max, ?DEFAULT_FRAME_MAX]),
+    PreAuthFrameMax = rpc(Config, 0, application, get_env,
+                          [rabbitmq_stream, initial_frame_max,
+                           ?DEFAULT_INITIAL_FRAME_MAX]),
+    ?assertEqual(?CUSTOM_INITIAL_FRAME_MAX, PreAuthFrameMax),
+    OversizedSize = PreAuthFrameMax + 1000,
+    %% The default ceiling would accept this size; only the configured,
+    %% lower value rejects it.
+    ?assert(OversizedSize < ?DEFAULT_INITIAL_FRAME_MAX),
     ?assert(OversizedSize < FrameMax),
     Header = <<OversizedSize:32>>,
     ?assertEqual(ok, gen_tcp:send(S, Header)),

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -79,6 +79,7 @@ groups() ->
        test_consumer_with_too_long_reference_errors,
        subscribe_unsubscribe_should_create_events,
        oversized_frame_rejected_pre_auth,
+       oversized_frame_rejected_pre_auth_below_configured_ceiling,
        oversized_frame_rejected_post_auth,
        oversized_frame_rejected_after_tune_negotiation,
        frame_max_clamped_when_client_negotiates_higher,
@@ -630,6 +631,25 @@ oversized_frame_rejected_pre_auth(Config) ->
     FrameMax = rpc(Config, 0, application, get_env,
                    [rabbitmq_stream, frame_max, ?DEFAULT_FRAME_MAX]),
     OversizedSize = FrameMax + 1000,
+    Header = <<OversizedSize:32>>,
+    ?assertEqual(ok, gen_tcp:send(S, Header)),
+    ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
+
+%% Before a successful `open`, the parser is clamped to a small
+%% constant (8192, see ?PRE_AUTH_FRAME_MAX in rabbit_stream_reader),
+%% not the full configured frame_max, so an unauthenticated peer
+%% can't make the server commit to a large per-connection buffer.
+%% This size sits between the two, so only the tighter ceiling
+%% catches it.
+oversized_frame_rejected_pre_auth_below_configured_ceiling(Config) ->
+    Port = get_stream_port(Config),
+    {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
+    FrameMax = rpc(Config, 0, application, get_env,
+                   [rabbitmq_stream, frame_max, ?DEFAULT_FRAME_MAX]),
+    PreAuthFrameMax = 8192,
+    ?assert(PreAuthFrameMax < FrameMax),
+    OversizedSize = PreAuthFrameMax + 1000,
+    ?assert(OversizedSize < FrameMax),
     Header = <<OversizedSize:32>>,
     ?assertEqual(ok, gen_tcp:send(S, Header)),
     ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).

--- a/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
+++ b/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
@@ -84,6 +84,10 @@
 -define(DEFAULT_INITIAL_CREDITS, 50000).
 -define(DEFAULT_CREDITS_REQUIRED_FOR_UNBLOCKING, 12500).
 -define(DEFAULT_FRAME_MAX, 1048576). %% 1 MiB
+%% Frame size ceiling until a connection is authenticated and
+%% authorized (a successful `open`), bounding the buffer an
+%% unauthenticated peer can negotiate.
+-define(DEFAULT_INITIAL_FRAME_MAX, 8192). %% 8 KiB
 -define(DEFAULT_HEARTBEAT, 60). %% 60 seconds
 
 -define(STREAM_QUEUE_TYPE, rabbit_stream_queue).

--- a/deps/rabbitmq_stream_common/src/rabbit_stream_core.erl
+++ b/deps/rabbitmq_stream_common/src/rabbit_stream_core.erl
@@ -189,9 +189,9 @@ init(Opts) when is_map(Opts) ->
 init(_) ->
     #?MODULE{cfg = #cfg{frame_max = unlimited}}.
 
-%% Updates the frame_max enforced by the parser. Called by the
-%% reader after TUNE so the negotiated value is enforced instead of
-%% the initial ceiling.
+%% Updates the frame_max enforced by the parser. Called by the reader
+%% after a successful `open` (authenticated and authorized) so the
+%% negotiated value is enforced instead of the pre-auth ceiling.
 -spec set_frame_max(non_neg_integer() | unlimited, state()) -> state().
 set_frame_max(FrameMax, #?MODULE{cfg = Cfg} = State) ->
     State#?MODULE{cfg = Cfg#cfg{frame_max = normalise_frame_max(FrameMax)}}.

--- a/release-notes/4.3.5.md
+++ b/release-notes/4.3.5.md
@@ -8,10 +8,11 @@ RabbitMQ `4.3.5` is a maintenance release in the `4.3.x` [release series](https:
 #### Enhancements
 
  * Before a stream client connection completes authentication and authorization (that is, before
-   a successful `open`), the server now enforces a low `frame_max` ceiling of 8192 bytes instead of
-   the full configured value. This is high enough to accommodate realistic
+   a successful `open`), the server now enforces a low `frame_max` ceiling instead of
+   the full configured value. The default, 8192 bytes, is high enough to accommodate realistic
    [JWT tokens](https://www.rabbitmq.com/docs/oauth2) used with SASL PLAIN authentication,
-   and mirrors a mechanism already in place for AMQP 0-9-1 connections.
+   and mirrors a mechanism already in place for AMQP 0-9-1 connections. It can be adjusted
+   with the new `stream.initial_frame_max` setting.
 
    GitHub issue: [#17053](https://github.com/rabbitmq/rabbitmq-server/pull/17053)
 

--- a/release-notes/4.3.5.md
+++ b/release-notes/4.3.5.md
@@ -3,6 +3,19 @@
 RabbitMQ `4.3.5` is a maintenance release in the `4.3.x` [release series](https://www.rabbitmq.com/release-information).
 
 
+### Stream Plugin
+
+#### Enhancements
+
+ * Before a stream client connection completes authentication and authorization (that is, before
+   a successful `open`), the server now enforces a low `frame_max` ceiling of 8192 bytes instead of
+   the full configured value. This is high enough to accommodate realistic
+   [JWT tokens](https://www.rabbitmq.com/docs/oauth2) used with SASL PLAIN authentication,
+   and mirrors a mechanism already in place for AMQP 0-9-1 connections.
+
+   GitHub issue: [#17053](https://github.com/rabbitmq/rabbitmq-server/pull/17053)
+
+
 ### Dependency Changes
 
  * `ra` was upgraded to [`3.1.10`](https://github.com/rabbitmq/ra/releases/tag/v3.1.10)


### PR DESCRIPTION
rabbit_stream_reader seeded the wire parser with the configured frame_max (default 1 MiB, operators can set it higher) from the first byte on the socket. That ceiling governed parsing of peer_properties, sasl_handshake and every sasl_authenticate round-trip, well before the connection was authenticated and authorized.

Authentication actually completes before frame-size tuning: sasl_authenticate succeeds, the server sends tune, the client responds tune, then sends open. open is where vhost-alive, vhost/user/node connection limits and vhost access are checked, so a connection should only be trusted with the full negotiated frame size once open succeeds, not merely after sasl_authenticate.

Clamp the parser to 8192 bytes (or the configured frame_max, if stricter) until open succeeds, then switch to the value negotiated at tune. 8192 comfortably covers realistic SASL PLAIN payloads carrying OAuth 2.0 JWTs with several vhost-scoped claims, while keeping the pre-open buffer well below the default frame_max.