### PR TITLE
Disallow MQTT 5.0 Receive Maximum to be 0

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_packet.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_packet.erl
@@ -348,7 +348,14 @@ parse_prop(<<16#1F, Len:16, Val:Len/binary, Rest/binary>>, Type, Props)
   when Type =:= ?PUBACK orelse Type =:= ?DISCONNECT ->
     parse_prop(Rest, Type, Props#{'Reason-String' => Val});
 parse_prop(<<16#21, Val:16, Bin/binary>>, ?CONNECT = Type, Props) ->
-    parse_prop(Bin, Type, Props#{'Receive-Maximum' => Val});
+    case Val of
+        0 ->
+            %% "It is a Protocol Error [...] for it to have the value 0."
+            %% [MQTT 5.0 3.1.2.11.3]
+            throw({invalid_receive_maximum, Val});
+        _ ->
+            parse_prop(Bin, Type, Props#{'Receive-Maximum' => Val})
+    end;
 parse_prop(<<16#22, Val:16, Bin/binary>>, ?CONNECT = Type, Props) ->
     parse_prop(Bin, Type, Props#{'Topic-Alias-Maximum' => Val});
 parse_prop(<<16#23, Val:16, Bin/binary>>, ?PUBLISH = Type, Props) ->

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -76,6 +76,7 @@ cluster_size_1_tests() ->
      client_rejects_publish,
      client_receive_maximum_min,
      client_receive_maximum_large,
+     client_receive_maximum_invalid,
      unsubscribe_success,
      unsubscribe_topic_not_found,
      subscription_option_no_local,
@@ -278,8 +279,8 @@ client_set_max_packet_size_connack(Config) ->
     %% We expect the server to drop the CONNACK packet because it's larger than 2 bytes.
     ?assertEqual({error, connack_timeout}, Connect(C)).
 
-%% "It is a Protocol Error to include the Receive Maximum
-%% value more than once or for it to have the value 0."
+%% "It is a Protocol Error to include the Maximum Packet Size
+%% more than once, or for the value to be set to zero." [MQTT 5.0 3.1.2.11.4]
 client_set_max_packet_size_invalid(Config) ->
     {C, Connect} = start_client(?FUNCTION_NAME, Config, 0,
                                 [{properties, #{'Maximum-Packet-Size' => 0}}]),
@@ -624,6 +625,14 @@ client_receive_maximum_large(Config) ->
     %% Receive Maximum value.
     assert_nothing_received(),
     ok = emqtt:disconnect(C).
+
+%% "It is a Protocol Error to include the Receive Maximum
+%% value more than once or for it to have the value 0." [MQTT 5.0 3.1.2.11.3]
+client_receive_maximum_invalid(Config) ->
+    {C, Connect} = start_client(?FUNCTION_NAME, Config, 0,
+                                [{properties, #{'Receive-Maximum' => 0}}]),
+    unlink(C),
+    ?assertMatch({error, _}, Connect(C)).
 
 unsubscribe_success(Config) ->
     C = connect(?FUNCTION_NAME, Config),

--- a/deps/rabbitmq_web_mqtt/test/web_mqtt_v5_SUITE.erl
+++ b/deps/rabbitmq_web_mqtt/test/web_mqtt_v5_SUITE.erl
@@ -61,6 +61,7 @@ client_publish_qos2(Config) -> v5_SUITE:?FUNCTION_NAME(Config).
 client_rejects_publish(Config) -> v5_SUITE:?FUNCTION_NAME(Config).
 client_receive_maximum_min(Config) -> v5_SUITE:?FUNCTION_NAME(Config).
 client_receive_maximum_large(Config) -> v5_SUITE:?FUNCTION_NAME(Config).
+client_receive_maximum_invalid(Config) -> v5_SUITE:?FUNCTION_NAME(Config).
 unsubscribe_success(Config) -> v5_SUITE:?FUNCTION_NAME(Config).
 unsubscribe_topic_not_found(Config) -> v5_SUITE:?FUNCTION_NAME(Config).
 subscription_option_no_local(Config) -> v5_SUITE:?FUNCTION_NAME(Config).


### PR DESCRIPTION
> It is a Protocol Error to include the Receive Maximum value more than once or for it to have the value 0.