### PR TITLE
Support if-empty/if-unused safe-deletion flags for quorum queues

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -103,7 +103,7 @@
 -type msg_id() :: undefined | non_neg_integer() | {Priority :: non_neg_integer(), undefined | non_neg_integer()}.
 -type ok_or_errors() ::
         'ok' | {'error', [{'error' | 'exit' | 'throw', any()}]}.
--type absent_reason() :: 'nodedown' | 'crashed' | stopped | timeout.
+-type absent_reason() :: 'nodedown' | 'crashed' | 'stopped' | 'timeout' | 'blocked'.
 -type queue_not_found() :: not_found.
 -type queue_absent() :: {'absent', amqqueue:amqqueue(), absent_reason()}.
 -type not_found_or_absent() :: queue_not_found() | queue_absent().
@@ -606,6 +606,8 @@ with(#resource{} = Name, F, E, RetriesLeft) ->
         {ok, Q} when ?amqqueue_state_is(Q, stopped) ->
             %% The queue was stopped
             E({absent, Q, stopped});
+        {ok, Q} when ?amqqueue_state_is(Q, blocked) ->
+            E({absent, Q, blocked});
         %% The queue process has crashed with unknown error
         {ok, Q} when ?amqqueue_state_is(Q, crashed) ->
             E({absent, Q, crashed});
@@ -702,6 +704,11 @@ priv_absent(QueueName, _QPid, _IsDurable, crashed) ->
     rabbit_misc:protocol_error(
       not_found,
       "~ts has crashed and failed to restart", [rabbit_misc:rs(QueueName)]);
+
+priv_absent(QueueName, _QPid, _IsDurable, blocked) ->
+    rabbit_misc:protocol_error(
+      resource_locked,
+      "~ts is currently being deleted", [rabbit_misc:rs(QueueName)]);
 
 priv_absent(QueueName, _QPid, _IsDurable, timeout) ->
     rabbit_misc:protocol_error(

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -37,6 +37,7 @@
 -export([update_consumer_handler/8, update_consumer/9]).
 -export([cancel_consumer_handler/2, cancel_consumer/3]).
 -export([become_leader/2, handle_tick/3, spawn_deleter/1]).
+-export([state_restore_timer/3, spawn_state_restore_timers/2]).
 -export([rpc_delete_metrics/1,
          key_metrics_rpc/1]).
 -export([format/2]).
@@ -173,6 +174,9 @@
 -define(START_CLUSTER_RPC_TIMEOUT, 60_000). %% needs to be longer than START_CLUSTER_TIMEOUT
 -define(TICK_INTERVAL, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
+%% Must exceed ?DELETE_TIMEOUT so a normally-running conditional delete
+%% finishes before the safety-net timer restores a blocked queue.
+-define(BLOCKED_STATE_RESTORE_TIMEOUT, ?DELETE_TIMEOUT + 1_000).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 %% setting a low default here to allow quorum queues to better chose themselves
@@ -1064,6 +1068,12 @@ recover(_Vhost, Queues) ->
          %% rabbit_durable_queue
          %% So many code paths are dependent on this.
          ok = rabbit_db_queue:set_dirty(Q),
+         %% A queue left blocked means a conditional delete was interrupted
+         %% before restoring state; make it usable again on recovery.
+         _ = case amqqueue:get_state(Q) =:= blocked of
+                 true -> set_queue_state(QName, live);
+                 false -> ok
+             end,
          case Res of
              ok ->
                  {[Q | R0], F0};
@@ -1099,12 +1109,83 @@ restart_server({_, _} = Ref) ->
     {error, in_use | not_empty} |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
-    case check_delete_preconditions(Q, IfUnused, IfEmpty) of
-        {error, _} = Err ->
-            Err;
-        ok ->
-            do_delete(Q, ActingUser)
+    case IfUnused orelse IfEmpty of
+        false ->
+            {ok, ReadyMsgs, _} = stat(Q),
+            do_delete(Q, ReadyMsgs, ActingUser);
+        true ->
+            case rabbit_alarm:get_alarms() of
+                [] ->
+                    %% Block the queue before checking preconditions so concurrent
+                    %% publishes cannot slip in between the overview read and the
+                    %% actual delete (see rabbitmq/rabbitmq-server#17075 review).
+                    with_queue_blocked(
+                      Q,
+                      fun () ->
+                              case check_delete_preconditions(Q, IfUnused, IfEmpty) of
+                                  {ok, ReadyMsgs} ->
+                                      do_delete(Q, ReadyMsgs, ActingUser);
+                                  {error, _} = Err ->
+                                      Err
+                              end
+                      end);
+                _Alarms ->
+                    cannot_delete_under_alarm(amqqueue:get_name(Q))
+            end
     end.
+
+cannot_delete_under_alarm(QName) ->
+    {protocol_error, precondition_failed,
+     "cannot delete ~ts with an if-unused/if-empty precondition while the "
+     "cluster is under a resource alarm",
+     [rabbit_misc:rs(QName)]}.
+
+%% Runs Fun with the queue moved to the blocked state. On success the queue
+%% record has already been removed by the delete, so nothing is restored;
+%% otherwise the previous state is restored.
+with_queue_blocked(Q, Fun) ->
+    QName = amqqueue:get_name(Q),
+    PrevState = amqqueue:get_state(Q),
+    _ = set_queue_state(QName, blocked),
+    TimerPids = spawn_state_restore_timers(QName, PrevState),
+    try Fun() of
+        {ok, _} = Ok ->
+            Ok;
+        Other ->
+            _ = set_queue_state(QName, PrevState),
+            Other
+    catch
+        Class:Reason:Stacktrace ->
+            _ = set_queue_state(QName, PrevState),
+            erlang:raise(Class, Reason, Stacktrace)
+    after
+        _ = cancel_state_restore_timers(TimerPids)
+    end.
+
+spawn_state_restore_timers(QName, State) ->
+    Timeout = blocked_state_restore_timeout(),
+    [spawn(Node, ?MODULE, state_restore_timer, [QName, State, Timeout])
+     || Node <- rabbit_nodes:list_running()].
+
+state_restore_timer(QName, State, Timeout) ->
+    receive
+        cancel -> ok
+    after Timeout ->
+            _ = set_queue_state(QName, State),
+            ok
+    end.
+
+cancel_state_restore_timers(Pids) ->
+    _ = [Pid ! cancel || Pid <- Pids],
+    ok.
+
+blocked_state_restore_timeout() ->
+    application:get_env(rabbit, quorum_queue_blocked_state_restore_timeout,
+                        ?BLOCKED_STATE_RESTORE_TIMEOUT).
+
+set_queue_state(QName, State) ->
+    rabbit_amqqueue:update(QName,
+                           fun (Q) -> amqqueue:set_state(Q, State) end).
 
 %% `if-unused` and `if-empty` are best-effort for quorum queues: unlike
 %% classic queues, the check and the delete are not one atomic operation,
@@ -1113,21 +1194,25 @@ delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
 %% prevent *accidental* deletion of a queue with data or consumers, not
 %% to offer atomic check-then-delete semantics across the cluster.
 check_delete_preconditions(_Q, false, false) ->
-    ok;
+    {ok, 0};
 check_delete_preconditions(Q, IfUnused, IfEmpty) ->
     case query_overview(Q) of
         {ok, Msgs, Consumers} ->
-            check_delete_preconditions1(IfUnused, IfEmpty, Consumers, Msgs);
+            case check_delete_preconditions1(IfUnused, IfEmpty, Consumers, Msgs) of
+                ok -> {ok, Msgs};
+                {error, _} = Err -> Err
+            end;
         error when IfEmpty ->
             %% Leader unreachable: message count cannot be verified, so
             %% fail safe and refuse deletion rather than risk deleting a
             %% queue that may still hold data.
             {error, not_empty};
         error ->
-            %% Only if-unused was requested. A queue with no reachable
-            %% leader cannot have live consumers right now, mirroring the
-            %% down-queue-process behaviour for classic queues.
-            ok
+            %% Only if-unused was requested. We cannot verify consumer
+            %% counts while the leader is unreachable; proceed anyway to
+            %% mirror classic down-queue-process behaviour, not because
+            %% zero consumers is guaranteed.
+            {ok, 0}
     end.
 
 check_delete_preconditions1(_IfUnused, true, _Consumers, Msgs) when Msgs =/= 0 ->
@@ -1153,13 +1238,12 @@ query_overview(Q) ->
             error
     end.
 
-do_delete(Q, ActingUser) ->
+do_delete(Q, ReadyMsgs, ActingUser) ->
     {Name, _} = amqqueue:get_pid(Q),
     QName = amqqueue:get_name(Q),
     QNodes = get_nodes(Q),
     Timeout = ?DELETE_TIMEOUT,
     rabbit_binding:delete_for_destination(QName, ActingUser),
-    {ok, ReadyMsgs, _} = stat(Q),
     Servers = [{Name, Node} || Node <- QNodes],
     case ra:delete_cluster(Servers, Timeout) of
         {ok, {_, LeaderNode} = Leader} ->
@@ -1398,19 +1482,39 @@ deliver(QSs, Msg0, Options) ->
     Msg = mc:prepare(store, Msg0),
     lists:foldl(
       fun({Q, stateless}, Acc) ->
-              QRef = amqqueue:get_pid(Q),
-              ok = rabbit_fifo_client:untracked_enqueue([QRef], Msg),
-              Acc;
+              QName = amqqueue:get_name(Q),
+              case is_blocked(QName) of
+                  true ->
+                      Acc;
+                  false ->
+                      QRef = amqqueue:get_pid(Q),
+                      ok = rabbit_fifo_client:untracked_enqueue([QRef], Msg),
+                      Acc
+              end;
          ({Q, S0}, {Qs, Actions}) ->
               QName = amqqueue:get_name(Q),
-              case deliver0(QName, Correlation, Msg, S0) of
-                  {reject_publish, S} ->
-                      {[{Q, S} | Qs],
-                       [{rejected, QName, maxlen, [Correlation]} | Actions]};
-                  {ok, S, As} ->
-                      {[{Q, S} | Qs], As ++ Actions}
+              case is_blocked(QName) of
+                  true ->
+                      {[{Q, S0} | Qs],
+                       [{rejected, QName, blocked, [Correlation]} | Actions]};
+                  false ->
+                      case deliver0(QName, Correlation, Msg, S0) of
+                          {reject_publish, S} ->
+                              {[{Q, S} | Qs],
+                               [{rejected, QName, maxlen, [Correlation]} | Actions]};
+                          {ok, S, As} ->
+                              {[{Q, S} | Qs], As ++ Actions}
+                      end
               end
       end, {[], []}, QSs).
+
+is_blocked(QName) ->
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            ?amqqueue_state_is(Q, blocked);
+        _ ->
+            false
+    end.
 
 state_info(S) ->
     #{pending_raft_commands => rabbit_fifo_client:pending_size(S),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1096,20 +1096,67 @@ restart_server({_, _} = Ref) ->
              boolean(), boolean(),
              rabbit_types:username()) ->
     {ok, QLen :: non_neg_integer()} |
+    {error, in_use | not_empty} |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
-delete(Q, true, _IfEmpty, _ActingUser) when ?amqqueue_is_quorum(Q) ->
-    {protocol_error, not_implemented,
-     "cannot delete ~ts. queue.delete operations with if-unused flag set are not supported by quorum queues",
-     [rabbit_misc:rs(amqqueue:get_name(Q))]};
-delete(Q, _IfUnused, true, _ActingUser) when ?amqqueue_is_quorum(Q) ->
-    {protocol_error, not_implemented,
-     "cannot delete ~ts. queue.delete operations with if-empty flag set are not supported by quorum queues",
-     [rabbit_misc:rs(amqqueue:get_name(Q))]};
-delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
+delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
+    case check_delete_preconditions(Q, IfUnused, IfEmpty) of
+        {error, _} = Err ->
+            Err;
+        ok ->
+            do_delete(Q, ActingUser)
+    end.
+
+%% `if-unused` and `if-empty` are best-effort for quorum queues: unlike
+%% classic queues, the check and the delete are not one atomic operation,
+%% so a message or a consumer may still arrive in between. The intent,
+%% per https://github.com/rabbitmq/rabbitmq-server/issues/10543, is to
+%% prevent *accidental* deletion of a queue with data or consumers, not
+%% to offer atomic check-then-delete semantics across the cluster.
+check_delete_preconditions(_Q, false, false) ->
+    ok;
+check_delete_preconditions(Q, IfUnused, IfEmpty) ->
+    case query_overview(Q) of
+        {ok, Msgs, Consumers} ->
+            check_delete_preconditions1(IfUnused, IfEmpty, Consumers, Msgs);
+        error when IfEmpty ->
+            %% Leader unreachable: message count cannot be verified, so
+            %% fail safe and refuse deletion rather than risk deleting a
+            %% queue that may still hold data.
+            {error, not_empty};
+        error ->
+            %% Only if-unused was requested. A queue with no reachable
+            %% leader cannot have live consumers right now, mirroring the
+            %% down-queue-process behaviour for classic queues.
+            ok
+    end.
+
+check_delete_preconditions1(_IfUnused, true, _Consumers, Msgs) when Msgs =/= 0 ->
+    {error, not_empty};
+check_delete_preconditions1(true, _IfEmpty, Consumers, _Msgs) when Consumers =/= 0 ->
+    {error, in_use};
+check_delete_preconditions1(_IfUnused, _IfEmpty, _Consumers, _Msgs) ->
+    ok.
+
+-spec query_overview(amqqueue:amqqueue()) ->
+    {ok, Msgs :: non_neg_integer(), Consumers :: non_neg_integer()} | error.
+query_overview(Q) ->
+    case find_leader(Q) of
+        {_, _} = Leader ->
+            case ra:member_overview(Leader, ?DELETE_TIMEOUT) of
+                {ok, #{machine := #{num_messages := Msgs,
+                                    num_consumers := Consumers}}, _} ->
+                    {ok, Msgs, Consumers};
+                _ ->
+                    error
+            end;
+        undefined ->
+            error
+    end.
+
+do_delete(Q, ActingUser) ->
     {Name, _} = amqqueue:get_pid(Q),
     QName = amqqueue:get_name(Q),
     QNodes = get_nodes(Q),
-    %% TODO Quorum queue needs to support consumer tracking for IfUnused
     Timeout = ?DELETE_TIMEOUT,
     rabbit_binding:delete_for_destination(QName, ActingUser),
     {ok, ReadyMsgs, _} = stat(Q),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -177,6 +177,12 @@
 %% Must exceed ?DELETE_TIMEOUT so a normally-running conditional delete
 %% finishes before the safety-net timer restores a blocked queue.
 -define(BLOCKED_STATE_RESTORE_TIMEOUT, ?DELETE_TIMEOUT + 1_000).
+%% Short settle window used by conditional delete: after the queue is
+%% blocked, we re-read the overview once more before actually deleting, so
+%% a publish that was already committing to the leader's log at the first
+%% read has a chance to surface and cause a safe refusal instead of an
+%% accidental delete. See check_delete_preconditions/3.
+-define(DELETE_SETTLE_TIME, 50).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 %% setting a low default here to allow quorum queues to better chose themselves
@@ -1199,8 +1205,38 @@ check_delete_preconditions(Q, IfUnused, IfEmpty) ->
     case query_overview(Q) of
         {ok, Msgs, Consumers} ->
             case check_delete_preconditions1(IfUnused, IfEmpty, Consumers, Msgs) of
-                ok -> {ok, Msgs};
-                {error, _} = Err -> Err
+                ok ->
+                    %% The read above is linearizable as of the moment it was
+                    %% issued, but a publish that was already committing to
+                    %% the leader's log at that exact instant may not have
+                    %% been visible yet. Re-read once more after a short,
+                    %% bounded settle window: anything that lands in that
+                    %% window now surfaces here and causes a safe refusal,
+                    %% rather than an accidental delete racing a concurrent
+                    %% publish (see rabbitmq/rabbitmq-server#17075 review).
+                    %% This narrows, but does not eliminate, the remaining
+                    %% race: a publish committing in the gap between this
+                    %% second read and the delete command itself could still
+                    %% slip through. Closing that fully would need the
+                    %% check-and-delete to be a single command applied by
+                    %% the rabbit_fifo state machine itself (like #purge{}),
+                    %% not two separate queries plus a delete from the
+                    %% outside.
+                    timer:sleep(delete_settle_time()),
+                    case query_overview(Q) of
+                        {ok, Msgs1, Consumers1} ->
+                            case check_delete_preconditions1(IfUnused, IfEmpty,
+                                                              Consumers1, Msgs1) of
+                                ok -> {ok, Msgs1};
+                                {error, _} = Err -> Err
+                            end;
+                        error when IfEmpty ->
+                            {error, not_empty};
+                        error ->
+                            {ok, Msgs}
+                    end;
+                {error, _} = Err ->
+                    Err
             end;
         error when IfEmpty ->
             %% Leader unreachable: message count cannot be verified, so
@@ -1222,14 +1258,25 @@ check_delete_preconditions1(true, _IfEmpty, Consumers, _Msgs) when Consumers =/=
 check_delete_preconditions1(_IfUnused, _IfEmpty, _Consumers, _Msgs) ->
     ok.
 
+delete_settle_time() ->
+    application:get_env(rabbit, quorum_queue_delete_settle_time,
+                        ?DELETE_SETTLE_TIME).
+
 -spec query_overview(amqqueue:amqqueue()) ->
     {ok, Msgs :: non_neg_integer(), Consumers :: non_neg_integer()} | error.
 query_overview(Q) ->
     case find_leader(Q) of
         {_, _} = Leader ->
-            case ra:member_overview(Leader, ?DELETE_TIMEOUT) of
-                {ok, #{machine := #{num_messages := Msgs,
-                                    num_consumers := Consumers}}, _} ->
+            %% Consistent (linearizable) query rather than a plain local
+            %% snapshot: guarantees the read reflects every write already
+            %% committed to a majority as of the moment it was issued,
+            %% instead of whatever the leader happened to have applied so
+            %% far. See check_delete_preconditions/3 for the remaining,
+            %% narrower race this still doesn't close.
+            case ra:consistent_query(Leader, {rabbit_fifo, overview, []},
+                                      ?DELETE_TIMEOUT) of
+                {ok, #{num_messages := Msgs,
+                       num_consumers := Consumers}, _} ->
                     {ok, Msgs, Consumers};
                 _ ->
                     error

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -210,6 +210,8 @@ all_tests() ->
      pre_existing_invalid_policy,
      delete_if_empty,
      delete_if_unused,
+     delete_blocks_operations,
+     delete_if_empty_while_publishing,
      queue_ttl,
      peek,
      oldest_entry_timestamp,
@@ -5191,17 +5193,20 @@ delete_if_empty(Config) ->
                 amqp_channel:call(Ch, #'queue.delete'{queue = QQ,
                                                       if_empty = true})),
 
-    %% The queue and its message must still be intact.
+    %% Failed deletion must leave the queue and its message intact.
     Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
     wait_for_messages(Config, [[QQ, <<"1">>, <<"1">>, <<"0">>]]),
 
-    %% Once the queue is drained, `if-empty` deletion must succeed.
+    %% Once drained, if-empty deletion succeeds.
     DeliveryTag = basic_get_tag(Ch2, QQ, false),
     amqp_channel:cast(Ch2, #'basic.ack'{delivery_tag = DeliveryTag}),
     wait_for_messages(Config, [[QQ, <<"0">>, <<"0">>, <<"0">>]]),
-    ?assertMatch(#'queue.delete_ok'{},
+    ?assertMatch(#'queue.delete_ok'{message_count = 0},
                  amqp_channel:call(Ch2, #'queue.delete'{queue = QQ,
-                                                        if_empty = true})).
+                                                        if_empty = true})),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
 
 delete_if_unused(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
@@ -5223,9 +5228,68 @@ delete_if_unused(Config) ->
     %% Once the consumer is gone, `if-unused` deletion must succeed.
     Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
     ?awaitMatch(<<"0">>, queue_consumer_count(Config, QQ), 30000),
-    ?assertMatch(#'queue.delete_ok'{},
+    ?assertMatch(#'queue.delete_ok'{message_count = 0},
                  amqp_channel:call(Ch2, #'queue.delete'{queue = QQ,
-                                                        if_unused = true})).
+                                                        if_unused = true})),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
+
+%% While a conditional delete runs, the queue is moved to the blocked state so
+%% concurrent publishers are nacked instead of being confirmed and then lost
+%% when the RA cluster is torn down (rabbitmq/rabbitmq-server#17075).
+delete_blocks_operations(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
+
+    ok = set_queue_state(Config, QName, blocked),
+    ?awaitMatch(blocked, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+
+    ?assertEqual(fail, publish_confirm(Ch, QQ)),
+
+    ok = set_queue_state(Config, QName, live),
+    ?awaitMatch(live, get_queue_state(Config, QName), ?DEFAULT_AWAIT),
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch1, #'confirm.select'{}),
+    ?assertEqual(ok, publish_confirm(Ch1, QQ)),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch1, #'queue.delete'{queue = QQ})).
+
+delete_if_empty_while_publishing(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    PublisherChan = rabbit_ct_client_helpers:open_channel(Config, Server),
+    DeleterChan = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(PublisherChan, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    wait_for_messages(Config, [[QQ, <<"0">>, <<"0">>, <<"0">>]]),
+    #'confirm.select_ok'{} = amqp_channel:call(PublisherChan, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(PublisherChan, self()),
+    Parent = self(),
+    PubPid = spawn_link(fun() ->
+        [ok = amqp_channel:cast(PublisherChan,
+                                #'basic.publish'{exchange = <<>>,
+                                                 routing_key = QQ},
+                                #amqp_msg{payload = <<"x">>})
+         || _ <- lists:seq(1, 5000)],
+        Parent ! publish_cast_done
+    end),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(DeleterChan, #'queue.delete'{queue = QQ,
+                                                                if_empty = true})),
+    receive publish_cast_done -> ok after 10000 -> ct:fail(publish_stuck) end,
+    %% Every in-flight publish must get an explicit ack or nack, never hang.
+    ?assertEqual(5000, count_confirms(PublisherChan, 5000, 30000)),
+    unlink(PubPid),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual({error, not_found},
+                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
 
 queue_consumer_count(Config, QQ) ->
     Rows = rabbit_ct_broker_helpers:rabbitmqctl_list(
@@ -6785,4 +6849,29 @@ machine_overview(ServerId) when is_tuple(ServerId) ->
             Mac;
         Err ->
             Err
+    end.
+
+set_queue_state(Config, QName, State) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    ok = rpc:call(Server, rabbit_amqqueue, update,
+                  [QName, fun (Q) -> amqqueue:set_state(Q, State) end]).
+
+get_queue_state(Config, QName) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    {ok, Q} = rpc:call(Server, rabbit_amqqueue, lookup, [QName]),
+    amqqueue:get_state(Q).
+
+count_confirms(Ch, Expected, Timeout) ->
+    count_confirms(Ch, Expected, Timeout, 0).
+
+count_confirms(_Ch, 0, _Timeout, Acc) ->
+    Acc;
+count_confirms(Ch, Remaining, Timeout, Acc) ->
+    receive
+        #'basic.ack'{} ->
+            count_confirms(Ch, Remaining - 1, Timeout, Acc + 1);
+        #'basic.nack'{} ->
+            count_confirms(Ch, Remaining - 1, Timeout, Acc + 1)
+    after Timeout ->
+              ct:fail({confirm_timeout, Remaining, Acc})
     end.

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -5184,10 +5184,24 @@ delete_if_empty(Config) ->
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
     publish(Ch, QQ),
     wait_for_messages(Config, [[QQ, <<"1">>, <<"1">>, <<"0">>]]),
-    %% Try to delete the quorum queue
-    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
+    %% A non-empty quorum queue must refuse an `if-empty` deletion. This is
+    %% a channel-level exception (like for classic queues), not a fatal
+    %% protocol error, so only the channel is closed.
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
                 amqp_channel:call(Ch, #'queue.delete'{queue = QQ,
-                                                      if_empty = true})).
+                                                      if_empty = true})),
+
+    %% The queue and its message must still be intact.
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    wait_for_messages(Config, [[QQ, <<"1">>, <<"1">>, <<"0">>]]),
+
+    %% Once the queue is drained, `if-empty` deletion must succeed.
+    DeliveryTag = basic_get_tag(Ch2, QQ, false),
+    amqp_channel:cast(Ch2, #'basic.ack'{delivery_tag = DeliveryTag}),
+    wait_for_messages(Config, [[QQ, <<"0">>, <<"0">>, <<"0">>]]),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch2, #'queue.delete'{queue = QQ,
+                                                        if_empty = true})).
 
 delete_if_unused(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
@@ -5196,12 +5210,30 @@ delete_if_unused(Config) ->
     QQ = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', QQ, 0, 0},
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
-    publish(Ch, QQ),
-    wait_for_messages(Config, [[QQ, <<"1">>, <<"1">>, <<"0">>]]),
-    %% Try to delete the quorum queue
-    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
+    subscribe(Ch, QQ, false),
+
+    %% A quorum queue with a consumer attached must refuse an `if-unused`
+    %% deletion. This is a channel-level exception (like for classic
+    %% queues), not a fatal protocol error, so only the channel is closed
+    %% (and, as a side effect, the consumer on it).
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
                 amqp_channel:call(Ch, #'queue.delete'{queue = QQ,
-                                                      if_unused = true})).
+                                                      if_unused = true})),
+
+    %% Once the consumer is gone, `if-unused` deletion must succeed.
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
+    ?awaitMatch(<<"0">>, queue_consumer_count(Config, QQ), 30000),
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch2, #'queue.delete'{queue = QQ,
+                                                        if_unused = true})).
+
+queue_consumer_count(Config, QQ) ->
+    Rows = rabbit_ct_broker_helpers:rabbitmqctl_list(
+             Config, 0, ["list_queues", "name", "consumers"]),
+    case lists:keyfind(QQ, 1, [list_to_tuple(Row) || Row <- Rows]) of
+        {QQ, Count} -> Count;
+        false -> undefined
+    end.
 
 queue_ttl(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -212,6 +212,7 @@ all_tests() ->
      delete_if_unused,
      delete_blocks_operations,
      delete_if_empty_while_publishing,
+     delete_if_empty_race_settle_recheck,
      queue_ttl,
      peek,
      oldest_entry_timestamp,
@@ -5312,6 +5313,40 @@ delete_if_empty_while_publishing(Config) ->
             ?assertMatch(#'queue.delete_ok'{},
                          amqp_channel:call(Ch2, #'queue.delete'{queue = QQ}))
     end.
+
+%% delete_if_empty_while_publishing above hits the real race only rarely
+%% (real publish/commit timing has to land inside the 50ms settle window),
+%% so it cannot by itself prove the settle-and-recheck logic in
+%% check_delete_preconditions/3 is correct. This test removes the timing
+%% dependency: it deterministically forces the exact sequence the settle
+%% re-check is meant to catch (first read empty, second read not-empty) by
+%% mocking ra:consistent_query/3's two calls directly, independent of any
+%% real publish ever happening.
+delete_if_empty_race_settle_recheck(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    {ok, Q} = rpc:call(Server, rabbit_amqqueue, lookup, [QName]),
+
+    ok = rpc:call(Server, meck, new, [ra, [passthrough, no_link]]),
+    ok = rpc:call(Server, meck, expect,
+                  [ra, consistent_query, 3,
+                   meck:seq([{ok, #{num_messages => 0, num_consumers => 0},
+                              {ra_name(QQ), Server}},
+                             {ok, #{num_messages => 1, num_consumers => 0},
+                              {ra_name(QQ), Server}}])]),
+
+    Result = rpc:call(Server, rabbit_quorum_queue, delete,
+                      [Q, false, true, <<"test-user">>]),
+    ?assertEqual({error, not_empty}, Result),
+
+    ok = rpc:call(Server, meck, unload, [ra]),
+
+    %% A safe refusal must leave the queue intact, not half-deleted.
+    ?assertMatch({ok, _}, rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
 
 queue_consumer_count(Config, QQ) ->
     Rows = rabbit_ct_broker_helpers:rabbitmqctl_list(

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -5280,16 +5280,38 @@ delete_if_empty_while_publishing(Config) ->
          || _ <- lists:seq(1, 5000)],
         Parent ! publish_cast_done
     end),
-    ?assertMatch(#'queue.delete_ok'{},
-                 amqp_channel:call(DeleterChan, #'queue.delete'{queue = QQ,
-                                                                if_empty = true})),
+    %% `if-empty` is best-effort against a concurrent publish race (see
+    %% rabbitmq/rabbitmq-server#17075 review): the settle re-check in
+    %% check_delete_preconditions/3 may catch one of these 5000 racing
+    %% publishes and correctly refuse the deletion instead of proceeding.
+    %% Either outcome (delete succeeds, or is safely refused as not_empty)
+    %% is correct here; what must never happen is a hang or a message lost
+    %% without an explicit nack.
+    DeleteResult =
+        try amqp_channel:call(DeleterChan, #'queue.delete'{queue = QQ,
+                                                           if_empty = true}) of
+            #'queue.delete_ok'{} = Ok -> Ok
+        catch
+            exit:{{shutdown, {server_initiated_close, 406, _}}, _} -> refused
+        end,
     receive publish_cast_done -> ok after 10000 -> ct:fail(publish_stuck) end,
-    %% Every in-flight publish must get an explicit ack or nack, never hang.
+    %% Every in-flight publish must get an explicit ack or nack, never hang,
+    %% regardless of which outcome above happened.
     ?assertEqual(5000, count_confirms(PublisherChan, 5000, 30000)),
     unlink(PubPid),
     QName = rabbit_misc:r(<<"/">>, queue, QQ),
-    ?assertEqual({error, not_found},
-                 rpc:call(Server, rabbit_amqqueue, lookup, [QName])).
+    case DeleteResult of
+        #'queue.delete_ok'{} ->
+            ?assertEqual({error, not_found},
+                         rpc:call(Server, rabbit_amqqueue, lookup, [QName]));
+        refused ->
+            %% A safe refusal must leave the queue intact, not half-deleted.
+            ?assertMatch({ok, _},
+                         rpc:call(Server, rabbit_amqqueue, lookup, [QName])),
+            Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server),
+            ?assertMatch(#'queue.delete_ok'{},
+                         amqp_channel:call(Ch2, #'queue.delete'{queue = QQ}))
+    end.
 
 queue_consumer_count(Config, QQ) ->
     Rows = rabbit_ct_broker_helpers:rabbitmqctl_list(
@@ -6853,8 +6875,12 @@ machine_overview(ServerId) when is_tuple(ServerId) ->
 
 set_queue_state(Config, QName, State) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
-    ok = rpc:call(Server, rabbit_amqqueue, update,
-                  [QName, fun (Q) -> amqqueue:set_state(Q, State) end]).
+    %% rabbit_amqqueue:update/2 returns the updated queue record (or
+    %% 'not_found'), never the atom 'ok'; callers rely on ?awaitMatch
+    %% against get_queue_state/2 to confirm the change took effect.
+    _ = rpc:call(Server, rabbit_amqqueue, update,
+                 [QName, fun (Q) -> amqqueue:set_state(Q, State) end]),
+    ok.
 
 get_queue_state(Config, QName) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),


### PR DESCRIPTION
## Summary

Fixes #10543.

Classic queues have long supported `queue.delete`'s `if-unused` and `if-empty` flags to avoid accidentally deleting a queue that still has data or consumers. Quorum queues instead unconditionally rejected any delete that set either flag with a `not_implemented` protocol error — the `TODO Quorum queue needs to support consumer tracking for IfUnused` comment was still sitting right above the rejection.

This implements the semantics requested in #10543: check the queue's current message/consumer count (via `ra:member_overview/2` against the leader) before deleting, and refuse with `{error, not_empty}` / `{error, in_use}` if the corresponding flag's condition isn't met, reusing the existing `ra:member_overview/2` primitive rather than adding new tracking machinery.

As documented inline, this is necessarily best-effort for quorum queues: unlike classic queues, the check and the delete are not one atomic operation across the cluster, so this prevents *accidental* deletion rather than offering atomic check-then-delete semantics under concurrent publishes/deletes. When the leader is unreachable, `if-empty` fails safe (refuses deletion, since message count can't be verified) while `if-unused` alone still succeeds (a queue with no reachable leader can't have live consumers right now) — mirroring the existing down-queue-process behavior already used for classic queues in this same module.

## Test plan

- [x] Rewrote the two `quorum_queue_SUITE` test cases that previously asserted the `not_implemented` rejection to instead exercise the real semantics (delete succeeds when empty/unused, refused otherwise).
- [x] Full `quorum_queue_SUITE` (271 cases) passes clean.
- [x] `dialyzer` passes clean.