### PR TITLE
GH Discussion template: list 4.3 in the version dropdown

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -18,6 +18,7 @@ body:
       options:
         - 4.1.x
         - 4.2.x
+        - 4.3.x
     validations:
       required: true
   - type: input

--- a/.github/DISCUSSION_TEMPLATE/other.yml
+++ b/.github/DISCUSSION_TEMPLATE/other.yml
@@ -23,6 +23,7 @@ body:
     attributes:
       label: RabbitMQ version used
       options:
+        - 4.3.x
         - 4.2.x
         - 4.1.x
         - 4.0.x


### PR DESCRIPTION
Tiny PR here to add 4.3.x to ideas/other discussion templates. I didn't touch the questions discussion (https://github.com/rabbitmq/rabbitmq-server/blob/main/.github/DISCUSSION_TEMPLATE/questions.yml) as I see that the template has a template. I think for that discussion kind it might be better to have a freeform version field which is required anyway.