### PR TITLE
Management UI history + connection link

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -18,7 +18,16 @@ const CONSUMER_OWNER_FORMATTERS = [
         }
     }},
     {order: 100, formatter: function(consumer) {
-        return link_channel(consumer.channel_details.name);
+        var cd = consumer.channel_details;
+        if (cd.name) {
+            return link_channel(cd.name);
+        }
+        // Consumers of channel-less protocols (e.g. MQTT) belong
+        // directly to a connection.
+        if (cd.connection_name) {
+            return link_conn(cd.connection_name);
+        }
+        return UNKNOWN_REPR;
     }}
 ];
 

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -387,6 +387,11 @@ var HELP = {
     'message-publish-headers':
       'Headers can have any name. Only long string headers can be set here.',
 
+    'message-publish-history':
+      'The last 50 string-encoded payloads published from this browser are remembered \
+      in its local storage. Picking one fills in the payload below. The history is \
+      never sent to the server and is shared across all queues and exchanges.',
+
     'message-publish-properties':
       '<p>You can set other message properties here (delivery mode and headers \
       are pulled out as the most common cases).</p>\

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -523,7 +523,8 @@ var HELP = {
 
     'consumer-owner' :
     '<a href="https://www.rabbitmq.com/consumers.html">AMQP 0-9-1 consumers</a> belong to a channel, \
-    and <a href="https://www.rabbitmq.com/stream.html">stream consumers</a> belong to a stream connection.',
+    <a href="https://www.rabbitmq.com/stream.html">stream consumers</a> belong to a stream connection, \
+    and consumers of channel-less protocols (e.g. MQTT) belong to a connection.',
 
     'plugins' :
     'Note that only plugins which are both explicitly enabled and running are shown here.',

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -964,6 +964,15 @@ function postprocess() {
         select_queue_type(this);
     });
 
+    $(document).on('change', 'select.publish-history', function() {
+        var payload = get_publish_history()[parseInt($(this).val(), 10)];
+        if (payload == undefined) return;
+        var form = $(this).closest('form');
+        form.find('textarea[name="payload"]').val(payload);
+        // History only holds string-encoded payloads.
+        form.find('select[name="payload_encoding"]').val('string');
+    });
+
     $('[name="upload-definitions"]').on('click', function(e) {
         e.preventDefault();
         submit_import($(this).closest('form')[0]);
@@ -1376,6 +1385,64 @@ function toggle_visibility(item) {
     }
 }
 
+var PUBLISH_MSG_HISTORY_KEY = 'publish-msg-history';
+var PUBLISH_MSG_HISTORY_MAX = 50;
+
+// The history is a plain array of payload strings, most recent first.
+function get_publish_history() {
+    var stored = get_local_pref(PUBLISH_MSG_HISTORY_KEY);
+    if (stored == undefined) return [];
+    try {
+        var history = JSON.parse(stored);
+        if (!Array.isArray(history)) return [];
+        return history.filter(function(e) { return typeof e == 'string'; });
+    } catch (e) {
+        return [];
+    }
+}
+
+function add_to_publish_history(params) {
+    // Only string-encoded payloads are remembered;
+    if (params.payload_encoding != 'string') return;
+    // Republishing an identical payload moves it to the top
+    // rather than duplicating it.
+    var history = get_publish_history().filter(function(e) {
+        return e != params.payload;
+    });
+    history.unshift(params.payload);
+    history = history.slice(0, PUBLISH_MSG_HISTORY_MAX);
+    try {
+        store_local_pref(PUBLISH_MSG_HISTORY_KEY, JSON.stringify(history));
+    } catch (e) {
+        // localStorage quota exceeded; drop the history rather than
+        // interfere with publishing.
+        clear_local_pref(PUBLISH_MSG_HISTORY_KEY);
+    }
+}
+
+function publish_history_options() {
+    var history = get_publish_history();
+    var res = '<option value="" selected>' +
+        (history.length == 0 ? '(no previously published messages)'
+                             : '(pick a previously published message)') +
+        '</option>';
+    for (var i = 0; i < history.length; i++) {
+        // Collapse newlines and indentation for the one-line preview;
+        // the stored payload keeps its original formatting.
+        var preview = history[i].replace(/\s+/g, ' ');
+        if (preview.length > 80) {
+            preview = preview.substring(0, 80) + '…';
+        }
+        res += '<option value="' + i + '">' +
+            fmt_escape_html(preview) + '</option>';
+    }
+    return res;
+}
+
+function refresh_publish_history_selects() {
+    $('select.publish-history').html(publish_history_options());
+}
+
 function publish_msg(params0) {
     try {
         var params = params_magic(params0);
@@ -1415,6 +1482,8 @@ function publish_msg0(params) {
     }
     with_req('POST', path, JSON.stringify(params), function(resp) {
             var result = JSON.parse(resp.responseText);
+            add_to_publish_history(params);
+            refresh_publish_history_selects();
             if (result.routed) {
                 show_popup('info', 'Message published.');
             } else {

--- a/deps/rabbitmq_management/priv/www/js/tmpl/consumers.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/consumers.ejs
@@ -3,7 +3,7 @@
       <thead>
         <tr>
 <% if (mode == 'queue') { %>
-          <th>Channel <span class="help" id="consumer-owner"></th>
+          <th>Owner <span class="help" id="consumer-owner"></th>
           <th>Consumer tag</th>
 <% } else { %>
           <th>Consumer tag</th>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/publish.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/publish.ejs
@@ -57,6 +57,19 @@
           </td>
         </tr>
         <tr>
+          <th>
+            <label>
+              History:
+              <span class="help" id="message-publish-history"></span>
+            </label>
+          </th>
+          <td>
+            <select class="publish-history">
+              <%= publish_history_options() %>
+            </select>
+          </td>
+        </tr>
+        <tr>
           <th><label>Payload:</label></th>
           <td><textarea name="payload"></textarea></td>
         </tr>

--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
@@ -23,7 +23,7 @@
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <groovy.version>3.0.25</groovy.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-    <spotless.version>3.8.0</spotless.version>
+    <spotless.version>3.9.0</spotless.version>
     <google-java-format.version>1.17.0</google-java-format.version>
     <test-keystore.ca>${project.build.directory}/ca.keystore</test-keystore.ca>
     <test-keystore.password>bunnychow</test-keystore.password>

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
@@ -33,7 +33,7 @@
         <logback.version>1.5.18</logback.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-        <spotless.version>3.8.0</spotless.version>
+        <spotless.version>3.9.0</spotless.version>
         <google-java-format.version>1.35.0</google-java-format.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
@@ -33,7 +33,7 @@
         <logback.version>1.5.18</logback.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-        <spotless.version>3.8.0</spotless.version>
+        <spotless.version>3.9.0</spotless.version>
         <google-java-format.version>1.35.0</google-java-format.version>
         <okhttp.version>5.4.0</okhttp.version>
         <gson.version>2.14.0</gson.version>

--- a/selenium/test/pageobjects/ExchangesPage.js
+++ b/selenium/test/pageobjects/ExchangesPage.js
@@ -30,7 +30,7 @@ module.exports = class ExchangesPage extends BasePage {
       "div#exchanges-table-section table tbody tr td a[href='#/exchanges/" + vhost + "/" + name + "']"))
   }
   async ensureAddExchangeSectionIsVisible() {
-    const button = await this.driver.findElement(ADD_BUTTON)
+    const button = await this.waitForLocated(ADD_BUTTON)
     if (!(await button.isDisplayed())) {
       await this.click(ADD_NEW_EXCHANGE_SECTION)
     }

--- a/selenium/test/pageobjects/QueuesAndStreamsPage.js
+++ b/selenium/test/pageobjects/QueuesAndStreamsPage.js
@@ -44,7 +44,7 @@ module.exports = class QueuesAndStreamsPage extends BasePage {
     })
   }
   async ensureAddQueueSectionIsVisible() {
-    const button = await this.driver.findElement(ADD_BUTTON)
+    const button = await this.waitForLocated(ADD_BUTTON)
     if (!(await button.isDisplayed())) {
       await this.click(ADD_NEW_QUEUE_SECTION)
     }


### PR DESCRIPTION
## Proposed Changes

Our team is using the management UI daily now for light management and we think more users could benefit from those improvements. We need to go quickly from the queue to the consumer connection to check the `client_properties`.

Hope you like it.

Thank you!
R

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [X] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
