### PR TITLE
MQTT: parse fragmented packets without quadratic copying

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_packet.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_packet.erl
@@ -189,9 +189,27 @@ parse_packet(Bin, #mqtt_packet_fixed{type = Type,
         {_, TooShortBin}
           when byte_size(TooShortBin) < Length ->
             {more, fun(BinMore) ->
-                           parse_packet(<<TooShortBin/binary, BinMore/binary>>,
-                                        Fixed, Length, ProtoVer)
+                           more_packet([BinMore, TooShortBin],
+                                       byte_size(TooShortBin) + byte_size(BinMore),
+                                       Fixed, Length, ProtoVer)
                    end}
+    end.
+
+%% A packet whose body is split across several TCP segments (or WebSocket
+%% messages) must not be re-concatenated on every fragment: that turns
+%% trickled packets into an O(n^2) copy.  Instead, accumulate the fragments
+%% in a list and join them once when the packet is complete.
+more_packet(Acc, Size, Fixed, Length, ProtoVer) ->
+    if
+        Size < Length ->
+            {more, fun(BinMore) ->
+                           more_packet([BinMore | Acc],
+                                       Size + byte_size(BinMore),
+                                       Fixed, Length, ProtoVer)
+                   end};
+        true ->
+            parse_packet(iolist_to_binary(lists:reverse(Acc)),
+                         Fixed, Length, ProtoVer)
     end.
 
 parse_connect(Bin, Fixed, Length) ->
@@ -202,9 +220,23 @@ parse_connect(Bin, Fixed, Length) ->
         TooShortBin
           when byte_size(TooShortBin) < Length ->
             {more, fun(BinMore) ->
-                           parse_connect(<<TooShortBin/binary, BinMore/binary>>,
-                                         Fixed, Length)
+                           more_connect([BinMore, TooShortBin],
+                                        byte_size(TooShortBin) + byte_size(BinMore),
+                                        Fixed, Length)
                    end}
+    end.
+
+more_connect(Acc, Size, Fixed, Length) ->
+    if
+        Size < Length ->
+            {more, fun(BinMore) ->
+                           more_connect([BinMore | Acc],
+                                        Size + byte_size(BinMore),
+                                        Fixed, Length)
+                   end};
+        true ->
+            parse_connect(iolist_to_binary(lists:reverse(Acc)),
+                          Fixed, Length)
     end.
 
 -spec parse_connect(binary()) ->

--- a/deps/rabbitmq_mqtt/test/rabbit_mqtt_packet_tests.erl
+++ b/deps/rabbitmq_mqtt/test/rabbit_mqtt_packet_tests.erl
@@ -1,0 +1,80 @@
+-module(rabbit_mqtt_packet_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(CONNECT, 1).
+-define(PUBLISH, 3).
+
+setup() ->
+    persistent_term:put(mqtt_max_packet_size_unauthenticated, 65536),
+    persistent_term:put(mqtt_max_packet_size_authenticated, 536870912),
+    ok.
+
+%% A CONNECT packet parsed in one shot must parse identically when the
+%% same bytes arrive one TCP fragment at a time.
+fragmented_connect_parses_test() ->
+    setup(),
+    Packet = connect_packet(64),
+    {ok, Whole, <<>>, _} = rabbit_mqtt_packet:parse(Packet, unauthenticated),
+    {ok, Frag, <<>>, _} = feed(Packet, unauthenticated),
+    ?assertEqual(Whole, Frag).
+
+%% Same for a PUBLISH body split across continuation calls.
+fragmented_publish_parses_test() ->
+    setup(),
+    Packet = publish_packet(),
+    {ok, Whole, <<>>, _} = rabbit_mqtt_packet:parse(Packet, 4),
+    {ok, Frag, <<>>, _} = feed(Packet, 4),
+    ?assertEqual(Whole, Frag).
+
+%% When the final fragment also carries the next packet, the leftover bytes
+%% must be returned as the Rest binary.
+fragment_overshoot_returns_rest_test() ->
+    setup(),
+    Packet = connect_packet(64),
+    PingReq = <<16#c0, 0>>,
+    Stream = <<Packet/binary, PingReq/binary>>,
+    {ok, _Whole, Rest0, _} = rabbit_mqtt_packet:parse(Stream, unauthenticated),
+    ?assertEqual(PingReq, Rest0),
+    {ok, _Frag, <<>>, S1} = feed(Stream, unauthenticated),
+    %% the leftover bytes still parse as the next packet on the same connection
+    {ok, _Ping, <<>>, _} = feed(PingReq, S1).
+
+feed(Bin, State) -> feed(Bin, State, 0).
+feed(<<>>, State, _) -> {ok, State};
+feed(Bin, _State, N) when N > 100000 ->
+    error({too_many_iterations, byte_size(Bin)});
+feed(<<B, Rest/binary>>, State, N) ->
+    case rabbit_mqtt_packet:parse(<<B>>, State) of
+        {more, S1} -> feed(Rest, S1, N + 1);
+        {ok, Packet, Rest1, S1} -> {ok, Packet, Rest1, S1};
+        {error, E} -> error({parse_error, E})
+    end.
+
+connect_packet(PasswordSize) ->
+    ProtocolName = <<0, 4, "MQTT">>,
+    Version = 4,
+    Flags = 2#11000010,
+    KeepAlive = <<0, 60>>,
+    ClientId = <<0, 1, "a">>,
+    Username = <<0, 4, "user">>,
+    Password = <<PasswordSize:16, 0:(PasswordSize*8)>>,
+    VarHdr = <<ProtocolName/binary, Version, Flags, KeepAlive/binary>>,
+    Payload = <<ClientId/binary, Username/binary, Password/binary>>,
+    Body = <<VarHdr/binary, Payload/binary>>,
+    RemLen = encode_remlen(byte_size(Body)),
+    <<16#10, RemLen/binary, Body/binary>>.
+
+publish_packet() ->
+    Topic = <<"a/b/c">>,
+    TopicLen = byte_size(Topic),
+    Payload = binary:copy(<<"x">>, 300),
+    Body = <<TopicLen:16, Topic/binary, Payload/binary>>,
+    RemLen = encode_remlen(byte_size(Body)),
+    <<16#30, RemLen/binary, Body/binary>>.
+
+encode_remlen(N) when N < 128 -> <<N>>;
+encode_remlen(N) ->
+    Low = N rem 128 + 128,
+    High = encode_remlen(N div 128),
+    <<Low, High/binary>>.

--- a/release-notes/4.3.5.md
+++ b/release-notes/4.3.5.md
@@ -22,6 +22,19 @@ RabbitMQ `4.3.5` is a maintenance release in the `4.3.x` [release series](https:
    GitHub issue: [#17083](https://github.com/rabbitmq/rabbitmq-server/pull/17083)
 
 
+### MQTT Plugin
+
+#### Bug Fixes
+
+ * Fragmented MQTT packets are no longer re-concatenated on every received
+   fragment.  A client trickling a packet in small chunks could previously
+   make the server copy O(n^2) bytes for an n-byte packet, consuming
+   excessive CPU time on the connection before authentication completes.
+   Fragments are now accumulated and joined once when the packet is complete.
+
+   GitHub issue: [#17091](https://github.com/rabbitmq/rabbitmq-server/pull/17091)
+
+
 ### Dependency Changes
 
  * `ra` was upgraded to [`3.1.10`](https://github.com/rabbitmq/ra/releases/tag/v3.1.10)


### PR DESCRIPTION
## Proposed Changes

MQTT packets whose bodies arrive split across many TCP segments (or WebSocket messages) were re-concatenated on every fragment: the parser kept the partial packet in a binary and copied it again each time a new fragment arrived. A client trickling a packet in small chunks could make the server copy O(n^2) bytes for an n-byte packet, burning CPU on the connection process before authentication completes (the CONNECT packet itself is subject to this, bounded by mqtt.max_packet_size_unauthenticated).

The parser now accumulates fragments in a list with a running byte count and joins them once when the packet is complete, the same approach the STOMP frame parser already uses for bodies. Parsing results are unchanged.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it