### PR TITLE
AMQP 1.0: reject undersized frame headers with a framing error

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -689,6 +689,15 @@ handle_input(Header = <<Size:32, DOff:8, Type:8, Channel:16>>,
     State = if Size =:= 8 ->
                    %% heartbeat
                    State0;
+               Size < 8 ->
+                   %% the size field covers the 8-byte frame header; anything
+                   %% smaller is malformed and would otherwise make recv_len
+                   %% negative and crash the connection process
+                   Err = error_frame(
+                           ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR,
+                           "frame size (~b bytes) < minimum frame size (8 bytes)",
+                           [Size]),
+                   handle_exception(State0, Channel, Err);
                Size > MaxFrameSize ->
                    Err = error_frame(
                            ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR,
@@ -705,9 +714,20 @@ handle_input(FrameBin, State0 = #v1{callback = {frame_body, Mode, DOff, Channel}
     %% Figure 2.16
     %% DOff = 4-byte words minus 8 bytes we've already read
     ExtendedHeaderSize = (DOff * 32 - 64),
-    <<_IgnoreExtendedHeader:ExtendedHeaderSize, FrameBody/binary>> = FrameBin,
-    State = switch_callback(State0, {frame_header, Mode}, 8),
-    handle_frame(Mode, Channel, FrameBody, State);
+    case FrameBin of
+        <<_IgnoreExtendedHeader:ExtendedHeaderSize, FrameBody/binary>> ->
+            State = switch_callback(State0, {frame_header, Mode}, 8),
+            handle_frame(Mode, Channel, FrameBody, State);
+        _ ->
+            %% DOff claims more extended header bytes than the frame
+            %% contains; report it as a framing error instead of crashing
+            %% on the binary match
+            Err = error_frame(
+                    ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR,
+                    "extended header size (~b bytes) exceeds frame size (~b bytes)",
+                    [ExtendedHeaderSize, byte_size(FrameBin)]),
+            handle_exception(State0, Channel, Err)
+    end;
 handle_input(Data, #v1{callback = Callback}) ->
     throw({bad_input, Callback, Data}).
 

--- a/deps/rabbit/test/rabbit_amqp_reader_tests.erl
+++ b/deps/rabbit/test/rabbit_amqp_reader_tests.erl
@@ -1,0 +1,47 @@
+-module(rabbit_amqp_reader_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit/include/rabbit_amqp_reader.hrl").
+-include_lib("amqp10_common/include/amqp10_framing.hrl").
+
+%% Regression tests for the frame-header validation added in
+%% "AMQP 1.0: reject undersized frame headers with a framing error".
+%%
+%% Before the fix, an 8-byte frame header with Size < 8 made recv_len
+%% negative and the connection process crashed on split_binary in
+%% recvloop; a DOff claiming more extended header bytes than the frame
+%% contained crashed on the binary match in the frame-body clause.
+%% Both must now be reported as a framing error: handle_exception
+%% throws {handshake_error, State, #'v1_0.error'{condition = amqp:connection:framing-error}}.
+
+test_state() ->
+    #v1{connection = #v1_connection{incoming_max_frame_size = 8192},
+        connection_state = waiting_sasl_init,
+        callback = {frame_header, sasl},
+        sock = undefined,
+        websocket = false}.
+
+undersized_size_is_a_framing_error_test() ->
+    S = test_state(),
+    ?assertThrow(
+       {handshake_error, waiting_sasl_init,
+        #'v1_0.error'{condition = {symbol, <<"amqp:connection:framing-error">>}}},
+       rabbit_amqp_reader:handle_input(<<0:32, 2, 1, 0:16>>, S)).
+
+doff_exceeding_frame_is_a_framing_error_test() ->
+    S = test_state(),
+    ?assertThrow(
+       {handshake_error, waiting_sasl_init,
+        #'v1_0.error'{condition = {symbol, <<"amqp:connection:framing-error">>}}},
+       rabbit_amqp_reader:handle_input(<<1>>, S#v1{callback = {frame_body, sasl, 255, 0}})).
+
+oversized_frame_is_still_rejected_test() ->
+    S = test_state(),
+    ?assertThrow(
+       {handshake_error, waiting_sasl_init,
+        #'v1_0.error'{condition = {symbol, <<"amqp:connection:framing-error">>}}},
+       rabbit_amqp_reader:handle_input(<<9000:32, 2, 1, 0:16>>, S)).
+
+heartbeat_frame_unchanged_test() ->
+    S = test_state(),
+    ?assertEqual(S, rabbit_amqp_reader:handle_input(<<8:32, 2, 1, 0:16>>, S)).


### PR DESCRIPTION
## Proposed Changes

Two malformed 8-byte frame headers crashed the AMQP 1.0 connection
process instead of producing a framing error:

* a frame header whose Size field is smaller than 8 (the size field
  covers the header itself) made the next recv_len negative, and
  split_binary in recvloop then raised badarg;
* a DOff claiming more extended header bytes than the frame actually
  contains made the binary match in the frame-body clause fail.

Both cases are now reported as `amqp:connection:framing-error` and the
connection is closed the normal way, matching the handling that already
existed for oversized frames.  Heartbeat frames (Size=8) and legitimate
frames are unaffected.

Verified against a running broker: before the change the log shows the
connection process crashing with `{badarg,[{erlang,split_binary,[<<>>,-8],...}]}`
(Size < 8) and `{{badmatch,<<1>>},...}` (oversized DOff); after the
change the broker replies with a `framing-error` frame instead.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it