### PR TITLE
Return framing error for malformed AMQP frames

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -348,10 +348,15 @@ error_frame(Condition, Fmt, Args) ->
     #'v1_0.error'{condition = Condition,
                   description = {utf8, Description}}.
 
+%% "A valid frame header cannot be formed from the incoming byte stream." [2.8.16]
+framing_error(State, Channel, Fmt, Args) ->
+    Error = error_frame(?V_1_0_CONNECTION_ERROR_FRAMING_ERROR, Fmt, Args),
+    handle_exception(State, Channel, Error).
+
 handle_exception(State = #v1{connection_state = CS}, _Channel,
                  Error = #'v1_0.error'{description =
                                        {utf8, <<"Connection forced: ", Explanation/binary>>}})
-  when ?IS_RUNNING(State) orelse CS =:= closing ->
+  when (?IS_RUNNING(State)) orelse CS =:= closing ->
     %% Only ever raised by terminate/2 when the connection is deliberately
     %% closed by an operator or by the broker itself (e.g. rabbitmqctl
     %% close_connection, the management UI, maintenance mode draining, or
@@ -368,7 +373,7 @@ handle_exception(State = #v1{connection_state = closed}, Channel,
     State;
 handle_exception(State = #v1{connection_state = CS}, Channel,
                  Error = #'v1_0.error'{description = {utf8, Desc}})
-  when ?IS_RUNNING(State) orelse CS =:= closing ->
+  when (?IS_RUNNING(State)) orelse CS =:= closing ->
     ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~tp",
                [self(), CS, Channel, Desc]),
     close(Error, State);
@@ -380,6 +385,8 @@ is_connection_frame(#'v1_0.open'{})  -> true;
 is_connection_frame(#'v1_0.close'{}) -> true;
 is_connection_frame(_)               -> false.
 
+handle_frame(_Mode, _Channel, <<>>, State) ->
+    State;
 handle_frame(Mode, Channel, Body, State) ->
     try
         handle_frame0(Mode, Channel, Body, State)
@@ -677,24 +684,40 @@ handle_input(Handshake = <<"AMQP",0,1,0,0>>,
               %% sending any other frames." [2.4.1]
               connection_state = waiting_open},
     switch_callback(State, {frame_header, amqp}, 8);
-handle_input(Header = <<Size:32, DOff:8, Type:8, Channel:16>>,
-             State0 = #v1{callback = {frame_header, Mode}})
-  when DOff >= 2 ->
-    case {Mode, Type} of
-        {amqp, 0} -> ok;
-        {sasl, 1} -> ok;
-        _ -> throw({bad_1_0_header_type, Header, Mode})
-    end,
+handle_input(<<Size:32, DOff:8, Type:8, Channel:16>>,
+             #v1{callback = {frame_header, Mode}} = State0) ->
     MaxFrameSize = State0#v1.connection#v1_connection.incoming_max_frame_size,
-    State = if Size =:= 8 ->
+    ExpectedType = case Mode of
+                       amqp -> 0;
+                       sasl -> 1
+                   end,
+    State = if Size < 8 ->
+                   %% "The frame is malformed if the size is less than the size
+                   %% of the frame header (8 bytes)." [2.3.1]
+                   framing_error(State0, Channel,
+                                 "frame size (~b bytes) < minimum frame size (8 bytes)",
+                                 [Size]);
+               Size > MaxFrameSize ->
+                   framing_error(State0, Channel,
+                                 "frame size (~b bytes) > maximum frame size (~b bytes)",
+                                 [Size, MaxFrameSize]);
+               DOff < 2 ->
+                   %% "Due to the mandatory 8-byte frame header, the frame is
+                   %% malformed if the value is less than 2." [2.3.1]
+                   framing_error(State0, Channel,
+                                 "data offset (~b) < minimum data offset (2)",
+                                 [DOff]);
+               DOff * 4 > Size ->
+                   framing_error(State0, Channel,
+                                 "data offset (~b bytes) > frame size (~b bytes)",
+                                 [DOff * 4, Size]);
+               Type =/= ExpectedType ->
+                   framing_error(State0, Channel,
+                                 "unexpected frame type ~b in ~s mode (expected ~b)",
+                                 [Type, Mode, ExpectedType]);
+               Size =:= 8 ->
                    %% heartbeat
                    State0;
-               Size > MaxFrameSize ->
-                   Err = error_frame(
-                           ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR,
-                           "frame size (~b bytes) > maximum frame size (~b bytes)",
-                           [Size, MaxFrameSize]),
-                   handle_exception(State0, Channel, Err);
                true ->
                    switch_callback(State0, {frame_body, Mode, DOff, Channel}, Size - 8)
             end,

--- a/deps/rabbit/test/unit_amqp_reader_SUITE.erl
+++ b/deps/rabbit/test/unit_amqp_reader_SUITE.erl
@@ -9,20 +9,31 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbit/include/rabbit_amqp_reader.hrl").
+-include_lib("amqp10_common/include/amqp10_framing.hrl").
 
 -compile(export_all).
 
 all() ->
     [
-      {group, parallel_tests}
+     {group, tests}
     ].
 
 groups() ->
     [
-      {parallel_tests, [parallel], [
-          socket_stat_on_live_socket,
-          socket_stat_on_closed_socket
-        ]}
+     {tests, [parallel],
+      [
+       socket_stat_on_live_socket,
+       socket_stat_on_closed_socket,
+       undersized_frame,
+       oversized_frame,
+       undersized_data_offset,
+       data_offset_past_end_of_frame,
+       unexpected_frame_type,
+       empty_frame,
+       empty_frame_with_extended_header,
+       valid_frame_header,
+       close_frame_on_framing_error
+      ]}
     ].
 
 %% -------------------------------------------------------------------
@@ -45,4 +56,107 @@ socket_stat_on_closed_socket(_Config) ->
     0 = rabbit_amqp_reader:i(send_oct, #v1{sock = LSock}),
     0 = rabbit_amqp_reader:i(send_cnt, #v1{sock = LSock}),
     0 = rabbit_amqp_reader:i(send_pend, #v1{sock = LSock}),
+    passed.
+
+undersized_frame(_Config) ->
+    assert_framing_error(<<0:32, 2, 1, 0:16>>).
+
+oversized_frame(_Config) ->
+    assert_framing_error(<<9000:32, 2, 1, 0:16>>).
+
+undersized_data_offset(_Config) ->
+    assert_framing_error(<<9:32, 1, 1, 0:16>>).
+
+data_offset_past_end_of_frame(_Config) ->
+    assert_framing_error(<<9:32, 3, 1, 0:16>>).
+
+%% An AMQP frame while a SASL frame is expected.
+unexpected_frame_type(_Config) ->
+    assert_framing_error(<<9:32, 2, 0, 0:16>>).
+
+%% An empty frame carries no frame body and is ignored.
+empty_frame(_Config) ->
+    State = test_state(),
+    ?assertEqual(State,
+                 rabbit_amqp_reader:handle_input(<<8:32, 2, 1, 0:16>>, State)),
+    passed.
+
+%% DOff * 4 =:= Size means that the frame consists of the frame header and a
+%% 4-byte extended header, but no frame body. The extended header must be read
+%% off the socket, otherwise the reader would parse it as the next frame
+%% header.
+empty_frame_with_extended_header(_Config) ->
+    State0 = test_state(),
+    State1 = rabbit_amqp_reader:handle_input(<<12:32, 3, 1, 0:16>>, State0),
+    ?assertMatch(#v1{callback = {frame_body, sasl, 3, 0},
+                     recv_len = 4},
+                 State1),
+    ?assertMatch(#v1{callback = {frame_header, sasl},
+                     recv_len = 8},
+                 rabbit_amqp_reader:handle_input(<<0:32>>, State1)),
+    passed.
+
+valid_frame_header(_Config) ->
+    State = test_state(),
+    %% SASL frame with a 4-byte extended header and a 4-byte frame body.
+    ?assertMatch(#v1{callback = {frame_body, sasl, 3, 0},
+                     recv_len = 8},
+                 rabbit_amqp_reader:handle_input(<<16:32, 3, 1, 0:16>>, State)),
+    %% AMQP frame on channel 7 without an extended header.
+    ?assertMatch(#v1{callback = {frame_body, amqp, 2, 7},
+                     recv_len = 12},
+                 rabbit_amqp_reader:handle_input(
+                   <<20:32, 2, 0, 7:16>>,
+                   State#v1{connection_state = waiting_open,
+                            callback = {frame_header, amqp}})),
+    passed.
+
+%% "Prior to closing a connection, each peer MUST write a close frame with a
+%% code indicating the reason for closing." [2.4.6] Therefore, a malformed
+%% frame header on a running connection should result in a close frame instead
+%% of a crashing connection process.
+close_frame_on_framing_error(_Config) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listener),
+    State = (test_state())#v1{connection_state = running,
+                              callback = {frame_header, amqp},
+                              sock = Server},
+
+    ?assertMatch(#v1{connection_state = closed},
+                 rabbit_amqp_reader:handle_input(<<0:32, 2, 0, 0:16>>, State)),
+
+    {ok, <<Size:32, 2, 0, 0:16>>} = gen_tcp:recv(Client, 8, 5000),
+    {ok, Body} = gen_tcp:recv(Client, Size - 8, 5000),
+    {Described, _BytesParsed} = amqp10_binary_parser:parse(Body),
+    ?assertMatch(
+       #'v1_0.close'{
+          error = #'v1_0.error'{
+                     condition = ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR}},
+       amqp10_framing:decode(Described)),
+
+    ok = gen_tcp:close(Client),
+    ok = gen_tcp:close(Server),
+    ok = gen_tcp:close(Listener),
+    passed.
+
+%% -------------------------------------------------------------------
+%% Helpers
+%% -------------------------------------------------------------------
+
+test_state() ->
+    #v1{connection = #v1_connection{incoming_max_frame_size = 8192},
+        connection_state = waiting_sasl_init,
+        callback = {frame_header, sasl},
+        sock = none,
+        websocket = false}.
+
+%% The connection is not running yet, therefore `handle_exception/3` throws
+%% instead of writing a close frame.
+assert_framing_error(FrameHeader) ->
+    ?assertThrow(
+       {handshake_error, waiting_sasl_init,
+        #'v1_0.error'{condition = ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR}},
+       rabbit_amqp_reader:handle_input(FrameHeader, test_state())),
     passed.


### PR DESCRIPTION
Instead of crashing the AMQP connection, return framing errors for malformed AMQP frames.

Supersedes #17092