### PR TITLE
Stream: add max_uncompressed_sub_entry_batch_size setting

### DIFF
--- a/deps/rabbitmq_stream/Makefile
+++ b/deps/rabbitmq_stream/Makefile
@@ -14,6 +14,7 @@ define PROJECT_ENV
 	{initial_credits, 50000},
 	{credits_required_for_unblocking, 12500},
 	{frame_max, 1048576},
+	{max_uncompressed_sub_entry_batch_size, 67108864},
 	{heartbeat, 60},
 	{advertised_host, undefined},
 	{advertised_port, undefined}

--- a/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
+++ b/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
@@ -166,3 +166,15 @@ fun(Conf) ->
         _         -> cuttlefish:invalid("should be a non-negative integer")
     end
 end}.
+
+%% Maximum uncompressed size, in bytes, of a single sub-entry batch accepted
+%% at publish time. A publish carrying a compressed sub-entry batch that
+%% declares a larger uncompressed size is rejected.
+%%
+%% Defaults to 67108864 (64 MiB). Clients should be configured with the same
+%% value, since the broker's limit governs what can be written and the
+%% client's limit governs what can be read.
+
+{mapping, "stream.max_uncompressed_sub_entry_batch_size", "rabbitmq_stream.max_uncompressed_sub_entry_batch_size", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1992,7 +1992,7 @@ handle_frame_post_auth(Transport,
                        message_counters = Counters} =
                 Publisher,
                 increase_messages_received(Counters, MessageCount),
-                RejectedPublishingIds =
+                {N, RejectedPublishingIds} =
                     rabbit_stream_utils:write_messages(Version, Leader,
                                                        Reference,
                                                        PublisherId,
@@ -2000,25 +2000,20 @@ handle_frame_post_auth(Transport,
                                                        Messages,
                                                        MaxUncompressedSubEntryBatchSize,
                                                        Stream),
-                RejectedCount =
-                    case RejectedPublishingIds of
-                        [] ->
-                            0;
-                        _ ->
-                            Command =
-                                {publish_error,
-                                 PublisherId,
-                                 ?RESPONSE_CODE_PRECONDITION_FAILED,
-                                 RejectedPublishingIds},
-                            Frame = rabbit_stream_core:frame(Command),
-                            send(Transport, S, Frame),
-                            increase_protocol_counter(?PRECONDITION_FAILED),
-                            length(RejectedPublishingIds)
-                    end,
-                %% credits are returned to the connection only when osiris
-                %% confirms a write, so only debit the entries that were
-                %% actually written, not the rejected ones
-                sub_credits(Credits, MessageCount - RejectedCount),
+                case RejectedPublishingIds of
+                    [] ->
+                        ok;
+                    _ ->
+                        Command =
+                            {publish_error,
+                             PublisherId,
+                             ?RESPONSE_CODE_PRECONDITION_FAILED,
+                             RejectedPublishingIds},
+                        Frame = rabbit_stream_core:frame(Command),
+                        send(Transport, S, Frame),
+                        increase_protocol_counter(?PRECONDITION_FAILED)
+                end,
+                sub_credits(Credits, N),
                 {Connection, State};
         _ ->
             PublishingIds = publishing_ids_from_messages(Version, Messages),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1992,7 +1992,7 @@ handle_frame_post_auth(Transport,
                        message_counters = Counters} =
                 Publisher,
                 increase_messages_received(Counters, MessageCount),
-                {N, RejectedPublishingIds} =
+                RejectedPublishingIds =
                     rabbit_stream_utils:write_messages(Version, Leader,
                                                        Reference,
                                                        PublisherId,
@@ -2000,20 +2000,25 @@ handle_frame_post_auth(Transport,
                                                        Messages,
                                                        MaxUncompressedSubEntryBatchSize,
                                                        Stream),
-                case RejectedPublishingIds of
-                    [] ->
-                        ok;
-                    _ ->
-                        Command =
-                            {publish_error,
-                             PublisherId,
-                             ?RESPONSE_CODE_PRECONDITION_FAILED,
-                             RejectedPublishingIds},
-                        Frame = rabbit_stream_core:frame(Command),
-                        send(Transport, S, Frame),
-                        increase_protocol_counter(?PRECONDITION_FAILED)
-                end,
-                sub_credits(Credits, N),
+                RejectedCount =
+                    case RejectedPublishingIds of
+                        [] ->
+                            0;
+                        _ ->
+                            Command =
+                                {publish_error,
+                                 PublisherId,
+                                 ?RESPONSE_CODE_PRECONDITION_FAILED,
+                                 RejectedPublishingIds},
+                            Frame = rabbit_stream_core:frame(Command),
+                            send(Transport, S, Frame),
+                            increase_protocol_counter(?PRECONDITION_FAILED),
+                            length(RejectedPublishingIds)
+                    end,
+                %% credits are returned to the connection only when osiris
+                %% confirms a write, so only debit the entries that were
+                %% actually written, not the rejected ones
+                sub_credits(Credits, MessageCount - RejectedCount),
                 {Connection, State};
         _ ->
             PublishingIds = publishing_ids_from_messages(Version, Messages),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -114,7 +114,8 @@
 -export([ensure_token_expiry_timer/2,
          evaluate_state_after_secret_update/4,
          clean_subscriptions/4,
-         negotiate_frame_max/2]).
+         negotiate_frame_max/2,
+         publishing_ids_from_messages/2]).
 -endif.
 
 callback_mode() ->
@@ -167,6 +168,11 @@ init([KeepaliveSup,
             DeliverVersion = ?VERSION_1,
             RequestTimeout = application:get_env(rabbitmq_stream,
                                                  request_timeout, 60_000),
+            MaxUncompressedSubEntryBatchSize =
+              application:get_env(rabbitmq_stream,
+                                  max_uncompressed_sub_entry_batch_size,
+                                  ?DEFAULT_MAX_UNCOMPRESSED_SUB_ENTRY_BATCH_SIZE),
+
             Connection =
                 #stream_connection{name =
                                        rabbit_data_coercion:to_binary(ConnStr),
@@ -186,6 +192,8 @@ init([KeepaliveSup,
                                    authentication_state = none,
                                    connection_step = tcp_connected,
                                    frame_max = FrameMax,
+                                   max_uncompressed_sub_entry_batch_size =
+                                       MaxUncompressedSubEntryBatchSize,
                                    resource_alarm = false,
                                    send_file_oct = SendFileOct,
                                    transport = ConnTransport,
@@ -1412,6 +1420,13 @@ publishing_ids_from_messages(?VERSION_1 = V, <<PublishingId:64,
                                Rest/binary>>) ->
     [PublishingId | publishing_ids_from_messages(V, Rest)];
 publishing_ids_from_messages(?VERSION_2 = V, <<PublishingId:64,
+                               -1:16/signed,
+                               0:1,
+                               MessageSize:31,
+                               _Message:MessageSize/binary,
+                               Rest/binary>>) ->
+    [PublishingId | publishing_ids_from_messages(V, Rest)];
+publishing_ids_from_messages(?VERSION_2 = V, <<PublishingId:64,
                                FilterValueLength:16, _FilterValue:FilterValueLength/binary,
                                0:1,
                                MessageSize:31,
@@ -1962,7 +1977,9 @@ handle_frame_post_auth(Transport,
 handle_frame_post_auth(Transport,
                        #stream_connection{socket = S,
                                           credits = Credits,
-                                          publishers = Publishers} =
+                                          publishers = Publishers,
+                                          max_uncompressed_sub_entry_batch_size =
+                                              MaxUncompressedSubEntryBatchSize} =
                            Connection,
                        State,
                        {publish, Version, PublisherId, MessageCount, Messages}) ->
@@ -1971,15 +1988,37 @@ handle_frame_post_auth(Transport,
             #publisher{reference = Reference,
                        internal_id = InternalId,
                        leader = Leader,
+                       stream = Stream,
                        message_counters = Counters} =
                 Publisher,
                 increase_messages_received(Counters, MessageCount),
-                rabbit_stream_utils:write_messages(Version, Leader,
-                                                   Reference,
-                                                   PublisherId,
-                                                   InternalId,
-                                                   Messages),
-                sub_credits(Credits, MessageCount),
+                RejectedPublishingIds =
+                    rabbit_stream_utils:write_messages(Version, Leader,
+                                                       Reference,
+                                                       PublisherId,
+                                                       InternalId,
+                                                       Messages,
+                                                       MaxUncompressedSubEntryBatchSize,
+                                                       Stream),
+                RejectedCount =
+                    case RejectedPublishingIds of
+                        [] ->
+                            0;
+                        _ ->
+                            Command =
+                                {publish_error,
+                                 PublisherId,
+                                 ?RESPONSE_CODE_PRECONDITION_FAILED,
+                                 RejectedPublishingIds},
+                            Frame = rabbit_stream_core:frame(Command),
+                            send(Transport, S, Frame),
+                            increase_protocol_counter(?PRECONDITION_FAILED),
+                            length(RejectedPublishingIds)
+                    end,
+                %% credits are returned to the connection only when osiris
+                %% confirms a write, so only debit the entries that were
+                %% actually written, not the rejected ones
+                sub_credits(Credits, MessageCount - RejectedCount),
                 {Connection, State};
         _ ->
             PublishingIds = publishing_ids_from_messages(Version, Messages),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.hrl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.hrl
@@ -82,6 +82,7 @@
          virtual_host :: undefined | binary(),
          connection_step :: connection_step(),
          frame_max :: integer(),
+         max_uncompressed_sub_entry_batch_size :: integer(),
          heartbeat :: undefined | integer(),
          heartbeater :: any(),
          client_properties = #{} :: #{binary() => binary()},

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -80,10 +80,10 @@ check_name(_Name) ->
 -spec write_messages(rabbit_stream_core:command_version(), pid(),
                      undefined | binary(), byte(),
                      integer(), binary(), non_neg_integer(), binary()) ->
-    {non_neg_integer(), [integer()]}.
+    [integer()].
 write_messages(_Version, _ClusterLeader, _PublisherRef, _PublisherId, _InternalId, <<>>,
                _MaxUncompressedSize, _Stream) ->
-    {0, []};
+    [];
 write_messages(?VERSION_1 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -123,7 +123,7 @@ write_messages(?VERSION_1 = V, ClusterLeader,
                          "frame is rejected as well to avoid a gap in the "
                          "publishing ID sequence.",
                          [Stream, PublisherId, Reason]),
-            {0, [PublishingId | reject_remaining(V, Rest)]}
+            [PublishingId | reject_remaining(V, Rest)]
     end;
 write_messages(?VERSION_2 = V, ClusterLeader,
                PublisherRef,
@@ -164,10 +164,8 @@ write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Publi
                    PublishingId
            end,
     ok = osiris:write(ClusterLeader, PublisherRef, Corr, Data),
-    {Written, Rejected} =
-        write_messages(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Rest,
-                       MaxUncompressedSize, Stream),
-    {Written + 1, Rejected}.
+    write_messages(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Rest,
+                   MaxUncompressedSize, Stream).
 
 %% Only the ?VERSION_1 compressed sub-batch shape is validated, so only that shape
 %% (and the plain ?VERSION_1 entry it can be interleaved with) can appear here.

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -18,9 +18,13 @@
 
 -define(MAX_SUPER_STREAM_PARTITIONS, 1000).
 
+%% Sub-entry compression types 0-4 are assigned (none, gzip, snappy, lz4, zstd);
+%% 5-7 are not, and a batch declaring one of them can never be decoded by a consumer.
+-define(MAX_KNOWN_COMPRESSION_TYPE, 4).
+
 %% API
 -export([enforce_correct_name/1,
-         write_messages/6,
+         write_messages/8,
          parse_map/2,
          auth_mechanisms/1,
          auth_mechanism_to_module/2,
@@ -73,8 +77,13 @@ check_name(<<"">>) ->
 check_name(_Name) ->
     ok.
 
-write_messages(_Version, _ClusterLeader, _PublisherRef, _PublisherId, _InternalId, <<>>) ->
-    ok;
+-spec write_messages(rabbit_stream_core:command_version(), pid(),
+                     undefined | binary(), byte(),
+                     integer(), binary(), non_neg_integer(), binary()) ->
+    [integer()].
+write_messages(_Version, _ClusterLeader, _PublisherRef, _PublisherId, _InternalId, <<>>,
+               _MaxUncompressedSize, _Stream) ->
+    [];
 write_messages(?VERSION_1 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -83,9 +92,10 @@ write_messages(?VERSION_1 = V, ClusterLeader,
                  0:1,
                  MessageSize:31,
                  Message:MessageSize/binary,
-                 Rest/binary>>) ->
+                 Rest/binary>>,
+               MaxUncompressedSize, Stream) ->
     write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, Message, Rest);
+                    PublishingId, Message, Rest, MaxUncompressedSize, Stream);
 write_messages(?VERSION_1 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -98,10 +108,23 @@ write_messages(?VERSION_1 = V, ClusterLeader,
                  UncompressedSize:32,
                  BatchSize:32,
                  Batch:BatchSize/binary,
-                 Rest/binary>>) ->
-    Data = {batch, MessageCount, CompressionType, UncompressedSize, Batch},
-    write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, Data, Rest);
+                 Rest/binary>>,
+               MaxUncompressedSize, Stream) ->
+    case validate_compressed_sub_batch(CompressionType, MessageCount,
+                                       UncompressedSize, BatchSize,
+                                       MaxUncompressedSize) of
+        ok ->
+            Data = {batch, MessageCount, CompressionType, UncompressedSize, Batch},
+            write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
+                            PublishingId, Data, Rest, MaxUncompressedSize, Stream);
+        {error, Reason} ->
+            ?LOG_WARNING("Rejecting sub-entry batch published to stream '~ts' "
+                         "by publisher ~tp: ~tp. The rest of the publish "
+                         "frame is rejected as well to avoid a gap in the "
+                         "publishing ID sequence.",
+                         [Stream, PublisherId, Reason]),
+            [PublishingId | reject_remaining(V, Rest)]
+    end;
 write_messages(?VERSION_2 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -111,9 +134,10 @@ write_messages(?VERSION_2 = V, ClusterLeader,
                  0:1,
                  MessageSize:31,
                  Message:MessageSize/binary,
-                 Rest/binary>>) ->
+                 Rest/binary>>,
+               MaxUncompressedSize, Stream) ->
     write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, Message, Rest);
+                    PublishingId, Message, Rest, MaxUncompressedSize, Stream);
 write_messages(?VERSION_2 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -123,11 +147,13 @@ write_messages(?VERSION_2 = V, ClusterLeader,
                  0:1,
                  MessageSize:31,
                  Message:MessageSize/binary,
-                 Rest/binary>>) ->
+                 Rest/binary>>,
+               MaxUncompressedSize, Stream) ->
     write_messages0(V, ClusterLeader, PublisherRef, PublisherId, InternalId,
-                    PublishingId, {FilterValue, Message}, Rest).
+                    PublishingId, {FilterValue, Message}, Rest, MaxUncompressedSize, Stream).
 
-write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, PublishingId, Data, Rest) ->
+write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, PublishingId, Data,
+                Rest, MaxUncompressedSize, Stream) ->
     Corr = case PublisherRef of
                undefined ->
                    %% we add the internal ID to detect late confirms from a stale publisher
@@ -138,7 +164,71 @@ write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Publi
                    PublishingId
            end,
     ok = osiris:write(ClusterLeader, PublisherRef, Corr, Data),
-    write_messages(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Rest).
+    write_messages(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Rest,
+                   MaxUncompressedSize, Stream).
+
+%% Only the ?VERSION_1 compressed sub-batch shape is validated, so only that shape
+%% (and the plain ?VERSION_1 entry it can be interleaved with) can appear here.
+reject_remaining(_V, <<>>) ->
+    [];
+reject_remaining(?VERSION_1 = V, <<PublishingId:64,
+                                    0:1,
+                                    MessageSize:31,
+                                    _Message:MessageSize/binary,
+                                    Rest/binary>>) ->
+    [PublishingId | reject_remaining(V, Rest)];
+reject_remaining(?VERSION_1 = V, <<PublishingId:64,
+                                    1:1,
+                                    _CompressionType:3,
+                                    _Unused:4,
+                                    _MessageCount:16,
+                                    _UncompressedSize:32,
+                                    BatchSize:32,
+                                    _Batch:BatchSize/binary,
+                                    Rest/binary>>) ->
+    [PublishingId | reject_remaining(V, Rest)].
+
+-spec validate_compressed_sub_batch(non_neg_integer(), non_neg_integer(),
+                                    non_neg_integer(), non_neg_integer(),
+                                    non_neg_integer()) -> ok | {error, term()}.
+validate_compressed_sub_batch(CompressionType, MessageCount, UncompressedSize,
+                              BatchSize, MaxUncompressedSize) ->
+    maybe
+        ok ?= check_uncompressed_size(UncompressedSize, MaxUncompressedSize),
+        ok ?= check_message_count(MessageCount),
+        ok ?= check_message_count_fits_uncompressed_size(MessageCount, UncompressedSize),
+        ok ?= check_compression_type(CompressionType),
+        check_batch_size(BatchSize, CompressionType)
+    end.
+
+check_uncompressed_size(UncompressedSize, MaxUncompressedSize)
+  when UncompressedSize > MaxUncompressedSize ->
+    {error, {uncompressed_size_exceeds_limit, UncompressedSize, MaxUncompressedSize}};
+check_uncompressed_size(_UncompressedSize, _MaxUncompressedSize) ->
+    ok.
+
+check_message_count(0) ->
+    {error, zero_message_count};
+check_message_count(_MessageCount) ->
+    ok.
+
+%% every sub-entry carries at least its own 4-byte length prefix
+check_message_count_fits_uncompressed_size(MessageCount, UncompressedSize)
+  when MessageCount * 4 > UncompressedSize ->
+    {error, {message_count_exceeds_uncompressed_size, MessageCount, UncompressedSize}};
+check_message_count_fits_uncompressed_size(_MessageCount, _UncompressedSize) ->
+    ok.
+
+check_compression_type(CompressionType)
+  when CompressionType > ?MAX_KNOWN_COMPRESSION_TYPE ->
+    {error, {unknown_compression_type, CompressionType}};
+check_compression_type(_CompressionType) ->
+    ok.
+
+check_batch_size(0, CompressionType) when CompressionType =/= 0 ->
+    {error, empty_batch_with_compression};
+check_batch_size(_BatchSize, _CompressionType) ->
+    ok.
 
 parse_map(<<>>, _Count) ->
     {#{}, <<>>};

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -80,10 +80,10 @@ check_name(_Name) ->
 -spec write_messages(rabbit_stream_core:command_version(), pid(),
                      undefined | binary(), byte(),
                      integer(), binary(), non_neg_integer(), binary()) ->
-    [integer()].
+    {non_neg_integer(), [integer()]}.
 write_messages(_Version, _ClusterLeader, _PublisherRef, _PublisherId, _InternalId, <<>>,
                _MaxUncompressedSize, _Stream) ->
-    [];
+    {0, []};
 write_messages(?VERSION_1 = V, ClusterLeader,
                PublisherRef,
                PublisherId,
@@ -123,7 +123,7 @@ write_messages(?VERSION_1 = V, ClusterLeader,
                          "frame is rejected as well to avoid a gap in the "
                          "publishing ID sequence.",
                          [Stream, PublisherId, Reason]),
-            [PublishingId | reject_remaining(V, Rest)]
+            {0, [PublishingId | reject_remaining(V, Rest)]}
     end;
 write_messages(?VERSION_2 = V, ClusterLeader,
                PublisherRef,
@@ -164,8 +164,10 @@ write_messages0(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Publi
                    PublishingId
            end,
     ok = osiris:write(ClusterLeader, PublisherRef, Corr, Data),
-    write_messages(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Rest,
-                   MaxUncompressedSize, Stream).
+    {Written, Rejected} =
+        write_messages(Vsn, ClusterLeader, PublisherRef, PublisherId, InternalId, Rest,
+                       MaxUncompressedSize, Stream),
+    {Written + 1, Rejected}.
 
 %% Only the ?VERSION_1 compressed sub-batch shape is validated, so only that shape
 %% (and the plain ?VERSION_1 entry it can be interleaved with) can appear here.

--- a/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
+++ b/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
@@ -89,5 +89,9 @@
   {initial_frame_max,
       "stream.initial_frame_max = 4096",
       [{rabbitmq_stream,[{initial_frame_max, 4096}]}],
+      [rabbitmq_stream]},
+  {max_uncompressed_sub_entry_batch_size,
+      "stream.max_uncompressed_sub_entry_batch_size = 33554432",
+      [{rabbitmq_stream,[{max_uncompressed_sub_entry_batch_size, 33554432}]}],
       [rabbitmq_stream]}
 ].

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -34,6 +34,7 @@
 -import(rabbit_ct_helpers, [await_condition/1]).
 
 -define(WAIT, 5000).
+-define(SUB_ENTRY_BATCH_VALIDATION_MAX, 200).
 %% Below ?DEFAULT_INITIAL_FRAME_MAX, so a frame the default ceiling
 %% would accept is rejected once this setting is applied.
 -define(CUSTOM_INITIAL_FRAME_MAX, 4096).
@@ -47,6 +48,10 @@ groups() ->
       [test_stream,
        test_stream_tls,
        test_publish_v2,
+       sub_entry_batch_validation,
+       sub_entry_batch_validation_fail_fast_partial_write,
+       credit_accounting_after_sub_entry_batch_rejection,
+       publish_v2_no_filter_value_to_unknown_publisher,
        test_super_stream_creation_deletion,
        test_gc_consumers,
        test_gc_publishers,
@@ -256,6 +261,16 @@ init_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, 
   ok = rabbit_ct_broker_helpers:add_user(Config, <<"other">>),
   rabbit_ct_helpers:testcase_started(Config, TestCase);
 
+init_per_testcase(sub_entry_batch_validation = TestCase, Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config,
+                                      0,
+                                      application,
+                                      set_env,
+                                      [rabbitmq_stream,
+                                       max_uncompressed_sub_entry_batch_size,
+                                       ?SUB_ENTRY_BATCH_VALIDATION_MAX]),
+    rabbit_ct_helpers:testcase_started(Config, TestCase);
+
 init_per_testcase(TestCase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, TestCase).
 
@@ -319,6 +334,16 @@ end_per_testcase(TestCase, Config)
                   end, [?K_AD_HOST, ?K_AD_PORT,
                         ?K_AD_TLS_HOST, ?K_AD_TLS_PORT]),
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
+end_per_testcase(sub_entry_batch_validation = TestCase, Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config,
+                                      0,
+                                      application,
+                                      set_env,
+                                      [rabbitmq_stream,
+                                       max_uncompressed_sub_entry_batch_size,
+                                       67_108_864]),
+    rabbit_ct_helpers:testcase_finished(Config, TestCase);
+
 end_per_testcase(TestCase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, TestCase).
 
@@ -460,6 +485,208 @@ test_publish_v2(Config) ->
     closed = wait_for_socket_close(Transport, S, 10),
     ok.
 
+%% Covers the checks in rabbit_stream_utils:write_messages/8 for compressed
+%% sub-entry batches, and that the configured limit takes effect.
+sub_entry_batch_validation(Config) ->
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    Transport = gen_tcp,
+    Port = get_stream_port(Config),
+    Opts = [{active, false}, {mode, binary}],
+    {ok, S} = Transport:connect("localhost", Port, Opts),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(Transport, S, C0),
+    C2 = test_authenticate(Transport, S, C1),
+    C3 = test_create_stream(Transport, S, Stream, C2),
+    PublisherId = 1,
+    C4 = test_declare_publisher(Transport, S, PublisherId, Stream, C3),
+
+    Max = ?SUB_ENTRY_BATCH_VALIDATION_MAX,
+    #{stream_error_precondition_failed_total := PreconditionFailedBefore} =
+        get_global_counters(Config),
+
+    %% declared size at the limit: accepted
+    C5 = publish_sub_batch_expect(Transport, S, PublisherId, 1,
+                                  sub_batch(1, 1, 1, Max, <<"compressed">>),
+                                  publish_confirm, C4),
+    %% declared size just above the limit: rejected
+    C6 = publish_sub_batch_expect(Transport, S, PublisherId, 2,
+                                  sub_batch(2, 1, 1, Max + 1, <<"compressed">>),
+                                  publish_error, C5),
+    %% no records declared: rejected
+    C7 = publish_sub_batch_expect(Transport, S, PublisherId, 3,
+                                  sub_batch(3, 1, 0, 40, <<"compressed">>),
+                                  publish_error, C6),
+    %% more records than the uncompressed size can hold: rejected
+    C8 = publish_sub_batch_expect(Transport, S, PublisherId, 4,
+                                  sub_batch(4, 1, 100, 10, <<"compressed">>),
+                                  publish_error, C7),
+    %% unknown compression type: rejected
+    C9 = publish_sub_batch_expect(Transport, S, PublisherId, 5,
+                                  sub_batch(5, 5, 1, 40, <<"compressed">>),
+                                  publish_error, C8),
+    %% empty payload declaring uncompressed bytes: rejected
+    C10 = publish_sub_batch_expect(Transport, S, PublisherId, 6,
+                                   sub_batch(6, 1, 1, 40, <<>>),
+                                   publish_error, C9),
+    %% no ratio limit: a high compression ratio within the size limit is accepted
+    C11 = publish_sub_batch_expect(Transport, S, PublisherId, 7,
+                                   sub_batch(7, 4, Max div 4, Max, <<"tiny">>),
+                                   publish_confirm, C10),
+
+    ExpectedPreconditionFailed = PreconditionFailedBefore + 5,
+    ?awaitMatch(#{stream_error_precondition_failed_total := ExpectedPreconditionFailed},
+               get_global_counters(Config), ?WAIT),
+
+    C12 = test_delete_stream(Transport, S, Stream, C11),
+    _C13 = test_close(Transport, S, C12),
+    closed = wait_for_socket_close(Transport, S, 10),
+    ok.
+
+%% once a sub-entry batch fails validation, the rest of the publish frame
+%% is rejected as well, instead of validating and writing the remaining
+%% entries independently. This avoids a gap in the publishing ID sequence.
+sub_entry_batch_validation_fail_fast_partial_write(Config) ->
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    Transport = gen_tcp,
+    Port = get_stream_port(Config),
+    Opts = [{active, false}, {mode, binary}],
+    {ok, S} = Transport:connect("localhost", Port, Opts),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(Transport, S, C0),
+    C2 = test_authenticate(Transport, S, C1),
+    C3 = test_create_stream(Transport, S, Stream, C2),
+    PublisherId = 1,
+    C4 = test_declare_publisher(Transport, S, PublisherId, Stream, C3),
+
+    Body = <<"hello">>,
+    BodySize = byte_size(Body),
+    Valid1 = <<1:64, 0:1, BodySize:31, Body:BodySize/binary>>,
+    Invalid = sub_batch(2, 1, 1, 67_108_865, <<"compressed">>),
+    Valid2 = <<3:64, 0:1, BodySize:31, Body:BodySize/binary>>,
+
+    PublishFrame = frame({publish, PublisherId, 3, [Valid1, Invalid, Valid2]}),
+    ok = Transport:send(S, PublishFrame),
+
+    {Cmd1, C5} = receive_commands(Transport, S, C4),
+    ?assertMatch({publish_error, PublisherId,
+                 ?RESPONSE_CODE_PRECONDITION_FAILED, [2, 3]}, Cmd1),
+
+    {Cmd2, C6} = receive_commands(Transport, S, C5),
+    ?assertMatch({publish_confirm, PublisherId, [1]}, Cmd2),
+
+    C7 = test_delete_stream(Transport, S, Stream, C6),
+    _C8 = test_close(Transport, S, C7),
+    closed = wait_for_socket_close(Transport, S, 10),
+    ok.
+
+%% Credits must be debited only for entries that are
+%% actually written, not for the whole frame's declared MessageCount.
+%% Credits are returned by osiris_written events, one per entry actually
+%% written; a rejected entry never generates one, so debiting for it too
+%% would permanently leak credit and eventually block the connection.
+%%
+%% A single oversized frame, entirely rejected (the first invalid entry
+%% rejects the rest too), exceeds the default initial_credits (50000) if
+%% every entry were wrongly debited -- that would block the connection and
+%% the follow-up request below would time out.
+credit_accounting_after_sub_entry_batch_rejection(Config) ->
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    Transport = gen_tcp,
+    Port = get_stream_port(Config),
+    Opts = [{active, false}, {mode, binary}],
+    {ok, S} = Transport:connect("localhost", Port, Opts),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(Transport, S, C0),
+    C2 = test_authenticate(Transport, S, C1),
+    C3 = test_create_stream(Transport, S, Stream, C2),
+    PublisherId = 1,
+    C4 = test_declare_publisher(Transport, S, PublisherId, Stream, C3),
+
+    Invalid = sub_batch(0, 0, 0, 0, <<>>),
+    FillerCount = 50_000,
+    Filler = binary:copy(<<0:64, 0:1, 0:31>>, FillerCount),
+    MessageCount = 1 + FillerCount,
+    PublishFrame = frame({publish, PublisherId, MessageCount, [Invalid, Filler]}),
+    ok = Transport:send(S, PublishFrame),
+
+    %% the response itself is a large frame (one 8-byte ID per rejected
+    %% entry): the shared receive_commands/3 helper only retries 10 times
+    %% waiting for a full frame, which is not always enough here
+    {Cmd, C5} = receive_large_command(Transport, S, C4),
+    {publish_error, PublisherId, RespCode, RejectedIds} = Cmd,
+    ?assertEqual(?RESPONSE_CODE_PRECONDITION_FAILED, RespCode),
+    ?assertEqual(MessageCount, length(RejectedIds)),
+
+    C6 = test_declare_publisher(Transport, S, 2, Stream, C5),
+
+    C7 = test_delete_stream(Transport, S, Stream, C6),
+    _C8 = test_close(Transport, S, C7),
+    closed = wait_for_socket_close(Transport, S, 10),
+    ok.
+
+%% A publish_v2 frame with no filter value, addressed to an
+%% unknown publisher ID, used to crash the reader (function_clause) instead
+%% of returning a publish_error.
+publish_v2_no_filter_value_to_unknown_publisher(Config) ->
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    Transport = gen_tcp,
+    Port = get_stream_port(Config),
+    Opts = [{active, false}, {mode, binary}],
+    {ok, S} = Transport:connect("localhost", Port, Opts),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(Transport, S, C0),
+    C2 = test_authenticate(Transport, S, C1),
+
+    UnknownPublisherId = 99,
+    Body = <<"hello">>,
+    BodySize = byte_size(Body),
+    Messages = [<<1:64, -1:16/signed, 0:1, BodySize:31, Body:BodySize/binary>>],
+    PublishFrame = frame({publish_v2, UnknownPublisherId, 1, Messages}),
+    ok = Transport:send(S, PublishFrame),
+
+    {Cmd, C3} = receive_commands(Transport, S, C2),
+    ?assertMatch({publish_error, UnknownPublisherId,
+                 ?RESPONSE_CODE_PUBLISHER_DOES_NOT_EXIST, [1]}, Cmd),
+
+    %% the connection is still alive: a subsequent request gets a normal response
+    C4 = test_create_stream(Transport, S, Stream, C3),
+    C5 = test_delete_stream(Transport, S, Stream, C4, false),
+    _C6 = test_close(Transport, S, C5),
+    closed = wait_for_socket_close(Transport, S, 10),
+    ok.
+
+publish_sub_batch_expect(Transport, S, PublisherId, Sequence, Entry, ExpectedCommand, C0) ->
+    PublishFrame = frame({publish, PublisherId, 1, [Entry]}),
+    ok = Transport:send(S, PublishFrame),
+    {Cmd, C} = receive_commands(Transport, S, C0),
+    case ExpectedCommand of
+        publish_confirm ->
+            ?assertMatch({publish_confirm, PublisherId, [Sequence]}, Cmd);
+        publish_error ->
+            ?assertMatch({publish_error, PublisherId,
+                         ?RESPONSE_CODE_PRECONDITION_FAILED, [Sequence]}, Cmd)
+    end,
+    C.
+
+sub_batch(PublishingId, CompressionType, MessageCount, UncompressedSize, Batch) ->
+    BatchSize = byte_size(Batch),
+    <<PublishingId:64, 1:1, CompressionType:3, 0:4, MessageCount:16,
+      UncompressedSize:32, BatchSize:32, Batch:BatchSize/binary>>.
+
+receive_large_command(Transport, S, C0) ->
+    receive_large_command(Transport, S, C0, 1000).
+
+receive_large_command(_Transport, _S, C0, 0) ->
+    rabbit_stream_core:next_command(C0);
+receive_large_command(Transport, S, C0, N) ->
+    case rabbit_stream_core:next_command(C0) of
+        empty ->
+            {ok, Data} = Transport:recv(S, 0, 5000),
+            C1 = rabbit_stream_core:incoming_data(Data, C0),
+            receive_large_command(Transport, S, C1, N - 1);
+        Res ->
+            Res
+    end.
 
 test_super_stream_creation_deletion(Config) ->
     T = gen_tcp,

--- a/deps/rabbitmq_stream/test/rabbit_stream_reader_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_reader_SUITE.erl
@@ -22,7 +22,8 @@
 -include_lib("rabbitmq_stream_common/include/rabbit_stream.hrl").
 
 -import(rabbit_stream_reader, [ensure_token_expiry_timer/2,
-                               negotiate_frame_max/2]).
+                               negotiate_frame_max/2,
+                               publishing_ids_from_messages/2]).
 
 %%%===================================================================
 %%% Common Test callbacks
@@ -242,6 +243,40 @@ negotiate_frame_max_test(_) ->
     ?assertEqual(1024, negotiate_frame_max(1024, 0)),
     %% Both unlimited: stays unlimited (0 on the wire).
     ?assertEqual(0, negotiate_frame_max(0, 0)),
+    ok.
+
+%% A V2 entry with no filter value is sent by the client as
+%% FilterValueLength = -1 (0xFFFF on the wire). Before the fix, the clause
+%% matching FilterValueLength as an unsigned int read that as 65535 and then
+%% demanded 65535 bytes of filter value that are not there, crashing the
+%% reader with a function_clause instead of returning the publishing ID.
+publishing_ids_from_messages_v2_no_filter_value_test(_) ->
+    Body = <<"hello">>,
+    BodySize = byte_size(Body),
+    Messages = <<42:64, -1:16/signed, 0:1, BodySize:31, Body:BodySize/binary>>,
+    ?assertEqual([42], publishing_ids_from_messages(?VERSION_2, Messages)),
+    ok.
+
+publishing_ids_from_messages_v2_with_filter_value_test(_) ->
+    FilterValue = <<"foo">>,
+    FilterValueSize = byte_size(FilterValue),
+    Body = <<"hello">>,
+    BodySize = byte_size(Body),
+    Messages = <<42:64, FilterValueSize:16, FilterValue:FilterValueSize/binary,
+                0:1, BodySize:31, Body:BodySize/binary>>,
+    ?assertEqual([42], publishing_ids_from_messages(?VERSION_2, Messages)),
+    ok.
+
+publishing_ids_from_messages_v1_test(_) ->
+    Body = <<"hello">>,
+    BodySize = byte_size(Body),
+    SimpleEntry = <<1:64, 0:1, BodySize:31, Body:BodySize/binary>>,
+    Batch = <<"compressed-bytes">>,
+    BatchSize = byte_size(Batch),
+    BatchEntry = <<2:64, 1:1, 1:3, 0:4, 10:16, 1000:32, BatchSize:32,
+                  Batch:BatchSize/binary>>,
+    ?assertEqual([1, 2],
+                 publishing_ids_from_messages(?VERSION_1, <<SimpleEntry/binary, BatchEntry/binary>>)),
     ok.
 
 consumer(S, Pid) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
@@ -36,8 +36,7 @@ groups() ->
        write_messages_sub_batch_unknown_compression_type_rejected,
        write_messages_sub_batch_empty_batch_with_compression_rejected,
        write_messages_sub_batch_high_compression_ratio_accepted,
-       write_messages_fail_fast_after_first_invalid_sub_batch,
-       write_messages_returns_written_count]}].
+       write_messages_fail_fast_after_first_invalid_sub_batch]}].
 
 init_per_suite(Config) ->
     Config.
@@ -186,8 +185,8 @@ write_messages_sub_batch_within_limit_accepted(_Config) ->
     Max = 1000,
     Batch = <<"compressed-bytes">>,
     Entry = sub_batch(1, 1, 2, 100, Batch),
-    ?assertEqual({1, []}, write_messages(?VERSION_1, self(), undefined, 7, 3,
-                                         Entry, Max, <<"s1">>)),
+    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 3,
+                                    Entry, Max, <<"s1">>)),
     ?assertMatch({'$gen_cast', {write, _, undefined, {7, 3, 1},
                                 {batch, 2, 1, 100, Batch}}},
                  flush_one()),
@@ -196,24 +195,24 @@ write_messages_sub_batch_within_limit_accepted(_Config) ->
 write_messages_sub_batch_at_limit_accepted(_Config) ->
     Max = 100,
     Entry = sub_batch(1, 1, 1, Max, <<"x">>),
-    ?assertEqual({1, []}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                         Entry, Max, <<"s1">>)),
+    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                    Entry, Max, <<"s1">>)),
     ?assertMatch({'$gen_cast', _}, flush_one()),
     ok.
 
 write_messages_sub_batch_over_limit_rejected(_Config) ->
     Max = 100,
     Entry = sub_batch(42, 1, 1, Max + 1, <<"x">>),
-    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                           Entry, Max, <<"s1">>)),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
 write_messages_sub_batch_zero_message_count_rejected(_Config) ->
     Max = 1000,
     Entry = sub_batch(42, 1, 0, 40, <<"x">>),
-    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                           Entry, Max, <<"s1">>)),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
@@ -221,8 +220,8 @@ write_messages_sub_batch_message_count_exceeds_uncompressed_size_rejected(_Confi
     Max = 1000,
     %% 100 sub-entries, each at least 4 bytes, cannot fit in 10 uncompressed bytes
     Entry = sub_batch(42, 1, 100, 10, <<"x">>),
-    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                           Entry, Max, <<"s1">>)),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
@@ -230,8 +229,8 @@ write_messages_sub_batch_unknown_compression_type_rejected(_Config) ->
     Max = 1000,
     [begin
          Entry = sub_batch(42, CompressionType, 1, 40, <<"0123456789">>),
-         ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                                Entry, Max, <<"s1">>)),
+         ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                           Entry, Max, <<"s1">>)),
          ?assertEqual(no_message, flush_one())
      end || CompressionType <- [5, 6, 7]],
     ok.
@@ -239,16 +238,16 @@ write_messages_sub_batch_unknown_compression_type_rejected(_Config) ->
 write_messages_sub_batch_empty_batch_with_compression_rejected(_Config) ->
     Max = 1000,
     Entry = sub_batch(42, 1, 1, 40, <<>>),
-    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                           Entry, Max, <<"s1">>)),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
 write_messages_sub_batch_high_compression_ratio_accepted(_Config) ->
     Max = 67108864,
     Entry = sub_batch(1, 4, 65535, Max, <<"tiny-compressed-payload">>),
-    ?assertEqual({1, []}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                         Entry, Max, <<"s1">>)),
+    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                    Entry, Max, <<"s1">>)),
     ?assertMatch({'$gen_cast', _}, flush_one()),
     ok.
 
@@ -261,24 +260,10 @@ write_messages_fail_fast_after_first_invalid_sub_batch(_Config) ->
     Invalid = sub_batch(2, 1, 1, Max + 1, <<"x">>),
     Valid2 = simple_entry(3, <<"world">>),
     Messages = <<Valid1/binary, Invalid/binary, Valid2/binary>>,
-    ?assertEqual({1, [2, 3]}, write_messages(?VERSION_1, self(), undefined, 9, 1,
-                                             Messages, Max, <<"s1">>)),
+    ?assertEqual([2, 3], write_messages(?VERSION_1, self(), undefined, 9, 1,
+                                        Messages, Max, <<"s1">>)),
     %% only the entry preceding the failure was written
     ?assertMatch({'$gen_cast', {write, _, undefined, {9, 1, 1}, <<"hello">>}},
-                 flush_one()),
-    ?assertEqual(no_message, flush_one()),
-    ok.
-
-write_messages_returns_written_count(_Config) ->
-    Max = 1000,
-    Entry1 = simple_entry(1, <<"hello">>),
-    Entry2 = simple_entry(2, <<"world">>),
-    Messages = <<Entry1/binary, Entry2/binary>>,
-    ?assertEqual({2, []}, write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                         Messages, Max, <<"s1">>)),
-    ?assertMatch({'$gen_cast', {write, _, undefined, {7, 1, 1}, <<"hello">>}},
-                 flush_one()),
-    ?assertMatch({'$gen_cast', {write, _, undefined, {7, 1, 2}, <<"world">>}},
                  flush_one()),
     ?assertEqual(no_message, flush_one()),
     ok.

--- a/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
@@ -36,7 +36,8 @@ groups() ->
        write_messages_sub_batch_unknown_compression_type_rejected,
        write_messages_sub_batch_empty_batch_with_compression_rejected,
        write_messages_sub_batch_high_compression_ratio_accepted,
-       write_messages_fail_fast_after_first_invalid_sub_batch]}].
+       write_messages_fail_fast_after_first_invalid_sub_batch,
+       write_messages_returns_written_count]}].
 
 init_per_suite(Config) ->
     Config.
@@ -185,8 +186,8 @@ write_messages_sub_batch_within_limit_accepted(_Config) ->
     Max = 1000,
     Batch = <<"compressed-bytes">>,
     Entry = sub_batch(1, 1, 2, 100, Batch),
-    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 3,
-                                    Entry, Max, <<"s1">>)),
+    ?assertEqual({1, []}, write_messages(?VERSION_1, self(), undefined, 7, 3,
+                                         Entry, Max, <<"s1">>)),
     ?assertMatch({'$gen_cast', {write, _, undefined, {7, 3, 1},
                                 {batch, 2, 1, 100, Batch}}},
                  flush_one()),
@@ -195,24 +196,24 @@ write_messages_sub_batch_within_limit_accepted(_Config) ->
 write_messages_sub_batch_at_limit_accepted(_Config) ->
     Max = 100,
     Entry = sub_batch(1, 1, 1, Max, <<"x">>),
-    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                    Entry, Max, <<"s1">>)),
+    ?assertEqual({1, []}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                         Entry, Max, <<"s1">>)),
     ?assertMatch({'$gen_cast', _}, flush_one()),
     ok.
 
 write_messages_sub_batch_over_limit_rejected(_Config) ->
     Max = 100,
     Entry = sub_batch(42, 1, 1, Max + 1, <<"x">>),
-    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                      Entry, Max, <<"s1">>)),
+    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                           Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
 write_messages_sub_batch_zero_message_count_rejected(_Config) ->
     Max = 1000,
     Entry = sub_batch(42, 1, 0, 40, <<"x">>),
-    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                      Entry, Max, <<"s1">>)),
+    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                           Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
@@ -220,8 +221,8 @@ write_messages_sub_batch_message_count_exceeds_uncompressed_size_rejected(_Confi
     Max = 1000,
     %% 100 sub-entries, each at least 4 bytes, cannot fit in 10 uncompressed bytes
     Entry = sub_batch(42, 1, 100, 10, <<"x">>),
-    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                      Entry, Max, <<"s1">>)),
+    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                           Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
@@ -229,8 +230,8 @@ write_messages_sub_batch_unknown_compression_type_rejected(_Config) ->
     Max = 1000,
     [begin
          Entry = sub_batch(42, CompressionType, 1, 40, <<"0123456789">>),
-         ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                           Entry, Max, <<"s1">>)),
+         ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                                Entry, Max, <<"s1">>)),
          ?assertEqual(no_message, flush_one())
      end || CompressionType <- [5, 6, 7]],
     ok.
@@ -238,16 +239,16 @@ write_messages_sub_batch_unknown_compression_type_rejected(_Config) ->
 write_messages_sub_batch_empty_batch_with_compression_rejected(_Config) ->
     Max = 1000,
     Entry = sub_batch(42, 1, 1, 40, <<>>),
-    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                      Entry, Max, <<"s1">>)),
+    ?assertEqual({0, [42]}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                           Entry, Max, <<"s1">>)),
     ?assertEqual(no_message, flush_one()),
     ok.
 
 write_messages_sub_batch_high_compression_ratio_accepted(_Config) ->
     Max = 67108864,
     Entry = sub_batch(1, 4, 65535, Max, <<"tiny-compressed-payload">>),
-    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 1,
-                                    Entry, Max, <<"s1">>)),
+    ?assertEqual({1, []}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                         Entry, Max, <<"s1">>)),
     ?assertMatch({'$gen_cast', _}, flush_one()),
     ok.
 
@@ -260,10 +261,24 @@ write_messages_fail_fast_after_first_invalid_sub_batch(_Config) ->
     Invalid = sub_batch(2, 1, 1, Max + 1, <<"x">>),
     Valid2 = simple_entry(3, <<"world">>),
     Messages = <<Valid1/binary, Invalid/binary, Valid2/binary>>,
-    ?assertEqual([2, 3], write_messages(?VERSION_1, self(), undefined, 9, 1,
-                                        Messages, Max, <<"s1">>)),
+    ?assertEqual({1, [2, 3]}, write_messages(?VERSION_1, self(), undefined, 9, 1,
+                                             Messages, Max, <<"s1">>)),
     %% only the entry preceding the failure was written
     ?assertMatch({'$gen_cast', {write, _, undefined, {9, 1, 1}, <<"hello">>}},
+                 flush_one()),
+    ?assertEqual(no_message, flush_one()),
+    ok.
+
+write_messages_returns_written_count(_Config) ->
+    Max = 1000,
+    Entry1 = simple_entry(1, <<"hello">>),
+    Entry2 = simple_entry(2, <<"world">>),
+    Messages = <<Entry1/binary, Entry2/binary>>,
+    ?assertEqual({2, []}, write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                         Messages, Max, <<"s1">>)),
+    ?assertMatch({'$gen_cast', {write, _, undefined, {7, 1, 1}, <<"hello">>}},
+                 flush_one()),
+    ?assertMatch({'$gen_cast', {write, _, undefined, {7, 1, 2}, <<"world">>}},
                  flush_one()),
     ?assertEqual(no_message, flush_one()),
     ok.

--- a/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
@@ -5,9 +5,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbitmq_stream_common/include/rabbit_stream.hrl").
 
 -import(rabbit_stream_utils,
-        [validate_super_stream_max_partitions/2]).
+        [validate_super_stream_max_partitions/2,
+         write_messages/8]).
 
 %%%===================================================================
 %%% Common Test callbacks
@@ -25,7 +27,16 @@ groups() ->
        filter_spec,
        filter_defined,
        test_validate_max_super_stream_partitions,
-       super_stream_partition_helpers]}].
+       super_stream_partition_helpers,
+       write_messages_sub_batch_within_limit_accepted,
+       write_messages_sub_batch_at_limit_accepted,
+       write_messages_sub_batch_over_limit_rejected,
+       write_messages_sub_batch_zero_message_count_rejected,
+       write_messages_sub_batch_message_count_exceeds_uncompressed_size_rejected,
+       write_messages_sub_batch_unknown_compression_type_rejected,
+       write_messages_sub_batch_empty_batch_with_compression_rejected,
+       write_messages_sub_batch_high_compression_ratio_accepted,
+       write_messages_fail_fast_after_first_invalid_sub_batch]}].
 
 init_per_suite(Config) ->
     Config.
@@ -161,6 +172,117 @@ super_stream_partition_helpers(_) ->
                  rabbit_stream_utils:binding_keys(<<"  ">>)),
 
     ok.
+
+%%%===================================================================
+%%% write_messages/8 - sub-entry batch validation
+%%%===================================================================
+
+%% write_messages/8 casts to osiris via gen_batch_server:cast/2, which is a
+%% plain message send: using self() as the "cluster leader" lets these tests
+%% assert on writes without a real osiris process.
+
+write_messages_sub_batch_within_limit_accepted(_Config) ->
+    Max = 1000,
+    Batch = <<"compressed-bytes">>,
+    Entry = sub_batch(1, 1, 2, 100, Batch),
+    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 3,
+                                    Entry, Max, <<"s1">>)),
+    ?assertMatch({'$gen_cast', {write, _, undefined, {7, 3, 1},
+                                {batch, 2, 1, 100, Batch}}},
+                 flush_one()),
+    ok.
+
+write_messages_sub_batch_at_limit_accepted(_Config) ->
+    Max = 100,
+    Entry = sub_batch(1, 1, 1, Max, <<"x">>),
+    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                    Entry, Max, <<"s1">>)),
+    ?assertMatch({'$gen_cast', _}, flush_one()),
+    ok.
+
+write_messages_sub_batch_over_limit_rejected(_Config) ->
+    Max = 100,
+    Entry = sub_batch(42, 1, 1, Max + 1, <<"x">>),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
+    ?assertEqual(no_message, flush_one()),
+    ok.
+
+write_messages_sub_batch_zero_message_count_rejected(_Config) ->
+    Max = 1000,
+    Entry = sub_batch(42, 1, 0, 40, <<"x">>),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
+    ?assertEqual(no_message, flush_one()),
+    ok.
+
+write_messages_sub_batch_message_count_exceeds_uncompressed_size_rejected(_Config) ->
+    Max = 1000,
+    %% 100 sub-entries, each at least 4 bytes, cannot fit in 10 uncompressed bytes
+    Entry = sub_batch(42, 1, 100, 10, <<"x">>),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
+    ?assertEqual(no_message, flush_one()),
+    ok.
+
+write_messages_sub_batch_unknown_compression_type_rejected(_Config) ->
+    Max = 1000,
+    [begin
+         Entry = sub_batch(42, CompressionType, 1, 40, <<"0123456789">>),
+         ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                           Entry, Max, <<"s1">>)),
+         ?assertEqual(no_message, flush_one())
+     end || CompressionType <- [5, 6, 7]],
+    ok.
+
+write_messages_sub_batch_empty_batch_with_compression_rejected(_Config) ->
+    Max = 1000,
+    Entry = sub_batch(42, 1, 1, 40, <<>>),
+    ?assertEqual([42], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                      Entry, Max, <<"s1">>)),
+    ?assertEqual(no_message, flush_one()),
+    ok.
+
+write_messages_sub_batch_high_compression_ratio_accepted(_Config) ->
+    Max = 67108864,
+    Entry = sub_batch(1, 4, 65535, Max, <<"tiny-compressed-payload">>),
+    ?assertEqual([], write_messages(?VERSION_1, self(), undefined, 7, 1,
+                                    Entry, Max, <<"s1">>)),
+    ?assertMatch({'$gen_cast', _}, flush_one()),
+    ok.
+
+%% once an entry fails validation, the rest of the frame is rejected too,
+%% instead of being validated and written independently. This avoids leaving
+%% a gap in the publishing ID sequence for publishers that rely on order.
+write_messages_fail_fast_after_first_invalid_sub_batch(_Config) ->
+    Max = 1000,
+    Valid1 = simple_entry(1, <<"hello">>),
+    Invalid = sub_batch(2, 1, 1, Max + 1, <<"x">>),
+    Valid2 = simple_entry(3, <<"world">>),
+    Messages = <<Valid1/binary, Invalid/binary, Valid2/binary>>,
+    ?assertEqual([2, 3], write_messages(?VERSION_1, self(), undefined, 9, 1,
+                                        Messages, Max, <<"s1">>)),
+    %% only the entry preceding the failure was written
+    ?assertMatch({'$gen_cast', {write, _, undefined, {9, 1, 1}, <<"hello">>}},
+                 flush_one()),
+    ?assertEqual(no_message, flush_one()),
+    ok.
+
+simple_entry(PublishingId, Message) ->
+    MessageSize = byte_size(Message),
+    <<PublishingId:64, 0:1, MessageSize:31, Message:MessageSize/binary>>.
+
+sub_batch(PublishingId, CompressionType, MessageCount, UncompressedSize, Batch) ->
+    BatchSize = byte_size(Batch),
+    <<PublishingId:64, 1:1, CompressionType:3, 0:4, MessageCount:16,
+      UncompressedSize:32, BatchSize:32, Batch:BatchSize/binary>>.
+
+flush_one() ->
+    receive
+        Msg -> Msg
+    after 100 ->
+        no_message
+    end.
 
 binding(Destination, Order) ->
     #binding{destination = #resource{name = Destination},

--- a/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
+++ b/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
@@ -88,6 +88,7 @@
 %% authorized (a successful `open`), bounding the buffer an
 %% unauthenticated peer can negotiate.
 -define(DEFAULT_INITIAL_FRAME_MAX, 8192). %% 8 KiB
+-define(DEFAULT_MAX_UNCOMPRESSED_SUB_ENTRY_BATCH_SIZE, 67108864). %% 64 MiB
 -define(DEFAULT_HEARTBEAT, 60). %% 60 seconds
 
 -define(STREAM_QUEUE_TYPE, rabbit_stream_queue).

--- a/release-notes/4.3.5.md
+++ b/release-notes/4.3.5.md
@@ -21,6 +21,13 @@ RabbitMQ `4.3.5` is a maintenance release in the `4.3.x` [release series](https:
 
    GitHub issue: [#17083](https://github.com/rabbitmq/rabbitmq-server/pull/17083)
 
+ * New setting: `stream.max_uncompressed_sub_entry_batch_size`. It bounds the declared
+   uncompressed size of a published sub-entry batch, and defaults to 67108864 (64 MiB),
+   the same default already used by the Java client's `maxUncompressedSubEntryBatchSize`.
+   The broker and any client publishing to it should be configured with the same value.
+
+   GitHub issue: [#17103](https://github.com/rabbitmq/rabbitmq-server/pull/17103)
+
 
 ### Dependency Changes
 


### PR DESCRIPTION
The broker stores a published sub-entry batch as-is, including its declared uncompressed size, without decompressing or verifying it: doing so would defeat the point of end-to-end sub-entry compression.

Add a per-node setting, max_uncompressed_sub_entry_batch_size, that bounds this declared size at publish time. It defaults to 67108864 (64 MiB), matching the default of the same setting on the Java client (maxUncompressedSubEntryBatchSize). Configure it via stream.max_uncompressed_sub_entry_batch_size in rabbitmq.conf; the broker and the clients publishing to it should use the same value, since the broker's setting governs what can be written and a client's setting governs what it will read back.

A publish frame with a sub-entry batch over the limit gets a publish_error with the existing precondition_failed response code instead of being stored. If one sub-entry in a frame is rejected, the rest of that frame is rejected too, so a publisher never sees a gap in its publishing ID sequence.

Also fixes a bug found while making this change: a publish_v2 frame with no filter value, addressed to an unknown publisher ID, crashed the reader instead of returning a publish_error.