### PR TITLE
fix(stream): enforce max number of publishers and subscriptions per connection

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -85,6 +85,9 @@
 -define(SILENT_CLOSE_DELAY, 3_000).
 -define(METADATA_TIMEOUT, 10_000).
 -define(SAC_MOD, rabbit_stream_sac_coordinator).
+%% publisher_id and subscription_id are encoded as a single byte on the wire.
+-define(MAX_PUBLISHERS_PER_CONNECTION, 256).
+-define(MAX_SUBSCRIPTIONS_PER_CONNECTION, 256).
 
 -import(rabbit_stream_utils, [check_write_permitted/2,
                               check_read_permitted/3,
@@ -1846,6 +1849,20 @@ handle_frame_post_auth(Transport,
       end,
     {Connection1, State1};
 handle_frame_post_auth(Transport,
+                       #stream_connection{publishers = Publishers0,
+                                          resource_alarm = false} = Connection0,
+                       State,
+                       {request, CorrelationId,
+                        {declare_publisher, _PublisherId, _WriterRef, _Stream}})
+                      when map_size(Publishers0) >= ?MAX_PUBLISHERS_PER_CONNECTION ->
+    response(Transport,
+             Connection0,
+             declare_publisher,
+             CorrelationId,
+             ?RESPONSE_CODE_PRECONDITION_FAILED),
+    increase_protocol_counter(?PRECONDITION_FAILED),
+    {Connection0, State};
+handle_frame_post_auth(Transport,
                        #stream_connection{user = User,
                                           resource_alarm = false} = C,
                        State,
@@ -2113,6 +2130,19 @@ handle_frame_post_auth(Transport, #stream_connection{} = Connection, State,
                         {subscribe,
                          _, _, _, _, _}} = Request) ->
     handle_frame_post_auth(Transport, {ok, Connection}, State, Request);
+handle_frame_post_auth(Transport,
+                       {ok, Connection},
+                       #stream_connection_state{consumers = Consumers} = State,
+                       {request, CorrelationId,
+                        {subscribe, _, _, _, _, _}})
+                      when map_size(Consumers) >= ?MAX_SUBSCRIPTIONS_PER_CONNECTION ->
+    response(Transport,
+             Connection,
+             subscribe,
+             CorrelationId,
+             ?RESPONSE_CODE_PRECONDITION_FAILED),
+    increase_protocol_counter(?PRECONDITION_FAILED),
+    {Connection, State};
 handle_frame_post_auth(Transport, {ok, #stream_connection{user = User} = C}, State,
                        {request, CorrelationId,
                         {subscribe, _, S, _, _, #{ <<"name">> := N}}})
@@ -2141,7 +2171,6 @@ handle_frame_post_auth(Transport,
         #resource{name = Stream,
                   kind = queue,
                   virtual_host = VirtualHost},
-    %% FIXME check the max number of subs is not reached already
     case rabbit_stream_utils:check_read_permitted(QueueResource, User,
                                                   #{})
     of

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -86,6 +86,8 @@ groups() ->
        sasl_anonymous,
        test_publisher_with_too_long_reference_errors,
        test_consumer_with_too_long_reference_errors,
+       declare_publisher_max_reached,
+       subscribe_max_reached,
        subscribe_unsubscribe_should_create_events,
        oversized_frame_rejected_pre_auth,
        oversized_frame_rejected_pre_auth_below_configured_ceiling,
@@ -1936,6 +1938,64 @@ test_consumer_with_too_long_reference_errors(Config) ->
 
   C4 = lists:foldl(fun({SubId, Ref, ExpectedResponseCode}, CAcc) ->
      F = request({subscribe, SubId, Stream, first, 1, #{<<"name">> => Ref}}),
+     ok = T:send(S, F),
+     {Cmd, CNext} = receive_commands(T, S, CAcc),
+     ?assertMatch({response, 1, {subscribe, ExpectedResponseCode}}, Cmd),
+     CNext
+   end, C3, Tests),
+
+  C5 = test_delete_stream(T, S, Stream, C4),
+  test_close(T, S, C5),
+  ok.
+
+declare_publisher_max_reached(Config) ->
+  FunctionName = atom_to_binary(?FUNCTION_NAME, utf8),
+  T = gen_tcp,
+  Port = get_port(T, Config),
+  Opts = get_opts(T),
+  {ok, S} = T:connect("localhost", Port, Opts),
+  C0 = rabbit_stream_core:init(0),
+  ConnectionName = FunctionName,
+  C1 = test_peer_properties(T, S, #{<<"connection_name">> => ConnectionName}, C0),
+  C2 = test_authenticate(T, S, C1),
+
+  Stream = FunctionName,
+  C3 = test_create_stream(T, S, Stream, C2),
+
+  Tests = [{Id, ?RESPONSE_CODE_OK} || Id <- lists:seq(0, 255)] ++
+          [{0, ?RESPONSE_CODE_PRECONDITION_FAILED}],
+
+  C4 = lists:foldl(fun({PubId, ExpectedResponseCode}, CAcc) ->
+     F = request({declare_publisher, PubId, <<>>, Stream}),
+     ok = T:send(S, F),
+     {Cmd, CNext} = receive_commands(T, S, CAcc),
+     ?assertMatch({response, 1, {declare_publisher, ExpectedResponseCode}}, Cmd),
+     CNext
+   end, C3, Tests),
+
+  C5 = test_delete_stream(T, S, Stream, C4),
+  test_close(T, S, C5),
+  ok.
+
+subscribe_max_reached(Config) ->
+  FunctionName = atom_to_binary(?FUNCTION_NAME, utf8),
+  T = gen_tcp,
+  Port = get_port(T, Config),
+  Opts = get_opts(T),
+  {ok, S} = T:connect("localhost", Port, Opts),
+  C0 = rabbit_stream_core:init(0),
+  ConnectionName = FunctionName,
+  C1 = test_peer_properties(T, S, #{<<"connection_name">> => ConnectionName}, C0),
+  C2 = test_authenticate(T, S, C1),
+
+  Stream = FunctionName,
+  C3 = test_create_stream(T, S, Stream, C2),
+
+  Tests = [{Id, ?RESPONSE_CODE_OK} || Id <- lists:seq(0, 255)] ++
+          [{0, ?RESPONSE_CODE_PRECONDITION_FAILED}],
+
+  C4 = lists:foldl(fun({SubId, ExpectedResponseCode}, CAcc) ->
+     F = request({subscribe, SubId, Stream, first, 10, #{}}),
      ok = T:send(S, F),
      {Cmd, CNext} = receive_commands(T, S, CAcc),
      ?assertMatch({response, 1, {subscribe, ExpectedResponseCode}}, Cmd),


### PR DESCRIPTION
publisher_id and subscription_id are one byte on the wire, so a connection can have at most 256 of each. This was never checked explicitly; it only failed once the ID space was exhausted, via the unrelated "ID already exists" checks, after paying for permission checks and (for subscribe) a stream lookup RPC.

Add a guarded clause for each command that fast-rejects with precondition-failed once the connection is already at the limit, following the file's existing pattern of guard-based special-case clauses (resource_alarm, invalid reference).