### PR TITLE
Fix event handler that caused a double alert message

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -54,14 +54,14 @@ function removeDuplicates(array){
 
 function startWithOAuthLogin (oauth) {
   if (!oauth.logged_in) {
-    hasAnyResourceServerReady(oauth, (oauth, warnings) => {  render_login_oauth(oauth, warnings); start_app_login(); })
+    hasAnyResourceServerReady(oauth, (oauth, escaped_warnings) => {  render_login_oauth(oauth, escaped_warnings); start_app_login(); })
   } else {
     start_app_login()
   }
 }
-function render_login_oauth(oauth, messages) {
+function render_login_oauth(oauth, escaped_messages) {
   let formatData = {};
-  formatData.warnings = [];
+  formatData.escaped_warnings = [];
   formatData.notAuthorized = false;
   formatData.resource_servers = oauth.resource_servers;
   formatData.declared_resource_servers_count = oauth.declared_resource_servers_count;
@@ -69,11 +69,11 @@ function render_login_oauth(oauth, messages) {
   formatData.strict_auth_mechanism = oauth.strict_auth_mechanism || null;
   formatData.preferred_auth_mechanism = oauth.preferred_auth_mechanism || null;
 
-  if (Array.isArray(messages)) {
-    formatData.warnings = messages
-  } else if (typeof messages == "string") {
-    formatData.warnings = [messages]
-    formatData.notAuthorized = messages == "Not authorized"
+  if (Array.isArray(escaped_messages)) {
+    formatData.escaped_warnings = escaped_messages
+  } else if (typeof escaped_messages == "string") {
+    formatData.escaped_warnings = [escaped_messages]
+    formatData.notAuthorized = escaped_messages == "Not authorized"
   }
   replace_content('outer', format('login_oauth', formatData))
 
@@ -964,9 +964,9 @@ function postprocess() {
         select_queue_type(this);
     });
 
-    $('[name="upload-definitions"]').on('click', function(e) {
+    $('form[name="upload-definitions"]').on('submit', function(e) {
         e.preventDefault();
-        submit_import($(this).closest('form')[0]);
+        submit_import(this);
     });
 
     $(document).on('click', '.help', function() {

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -374,9 +374,9 @@ function warningMessageOAuthResource(oauthResource, reason) {
  * @returns 
  */
 function warningMessageOAuthResources(commonProviderURL, oauthResources, reason) {
-  return "OAuth resources [ <b>" 
-    + fmt_escape_html(oauthResources.map(resource => resource["label"] != null ? resource.label : resource.id)).join("</b>,<b>")
-    + "</b>] not available. OpenId Discovery endpoint " 
+  return "OAuth resources [ <b>"
+    + oauthResources.map(resource => fmt_escape_html(resource["label"] != null ? resource.label : resource.id)).join("</b>,<b>")
+    + "</b>] not available. OpenId Discovery endpoint "
     + fmt_escape_html(commonProviderURL) + fmt_escape_html(reason)
 }
 

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -351,13 +351,33 @@ function validate_openid_configuration(payload) {
 
 }
 
+/**
+ * Return a warning message for a single OAuth resource already escaped, i.e
+ * safe to append to the DOM.
+ * @param {*} oauthResource 
+ * @param {*} reason 
+ * @returns 
+ */
 function warningMessageOAuthResource(oauthResource, reason) {
-  return "OAuth resource [<b>" + (oauthResource["label"] != null ? oauthResource.label : oauthResource.id) +
-    "</b>] not available. OpenId Discovery endpoint " + readiness_url(oauthResource) + reason
+  return "OAuth resource [<b>" 
+    + fmt_escape_html(oauthResource["label"] != null ? oauthResource.label : oauthResource.id) 
+    + "</b>] not available. OpenId Discovery endpoint " 
+    + fmt_escape_html(readiness_url(oauthResource)) 
+    + fmt_escape_html(reason)
 }
+/**
+ * Return a warning message for multiple OAuth resources already escaped, i.e
+ * safe to append to the DOM.
+ * @param {*} commonProviderURL 
+ * @param {*} oauthResources 
+ * @param {*} reason 
+ * @returns 
+ */
 function warningMessageOAuthResources(commonProviderURL, oauthResources, reason) {
-  return "OAuth resources [ <b>" + oauthResources.map(resource => resource["label"] != null ? resource.label : resource.id).join("</b>,<b>")
-    + "</b>] not available. OpenId Discovery endpoint " + commonProviderURL + reason
+  return "OAuth resources [ <b>" 
+    + fmt_escape_html(oauthResources.map(resource => resource["label"] != null ? resource.label : resource.id)).join("</b>,<b>")
+    + "</b>] not available. OpenId Discovery endpoint " 
+    + fmt_escape_html(commonProviderURL) + fmt_escape_html(reason)
 }
 
 export function hasAnyResourceServerReady(oauth, onReadyCallback) {

--- a/deps/rabbitmq_management/priv/www/js/tmpl/login_oauth.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/login_oauth.ejs
@@ -2,9 +2,9 @@
   <p><img src="img/rabbitmqlogo.svg" alt="RabbitMQ logo" width="204" height="37"/></p>
   <!-- begin login status -->
   <div id="login-status">
-    <% if (Array.isArray(warnings)) { %>
-        <% for (var i = 0; i < warnings.length; i++) { %>
-        <p class="warning"><%=fmt_escape_html(warnings[i])%> </p>
+    <% if (Array.isArray(escaped_warnings)) { %>
+        <% for (var i = 0; i < escaped_warnings.length; i++) { %>
+        <p class="warning"><%=escaped_warnings[i]%> </p>
         <% } %>
     <% } %>
     <% if (notAuthorized) { %>


### PR DESCRIPTION
## Proposed Changes

Fix issues reported via selenium test failures. The first issue is related to how javascript form events were subscribed which caused a double alert message.  
Fix another issue: when rendering oauth2 warning messages, those messages should arrive to the template already escaped this way the warning messages can contain safe (i.e. escaped) html strings produced by the js/oidc-oauth/helper.js. 


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x]  Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
