### PR TITLE
QQ: fall back to prior machine version for local queries in mixed clusters

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1619,19 +1619,9 @@ consumers(Q) when ?amqqueue_is_classic(Q) ->
     end;
 consumers(Q) when ?amqqueue_is_quorum(Q) ->
     QPid = amqqueue:get_pid(Q),
-    case ra:local_query(QPid, fun rabbit_fifo:query_consumers/1) of
+    case rabbit_fifo_client:local_query(QPid, query_consumers) of
         {ok, {_, Result}, _} ->
             maps:values(Result);
-        {error, _} ->
-            %% try a prior module in case we're in mixed versions
-            %% TODO: hack, replace this with something that can actually
-            %% resolve the correct module to use
-            case ra:local_query(QPid, fun rabbit_fifo_v7:query_consumers/1) of
-                {ok, {_, Result}, _} ->
-                    maps:values(Result);
-                _  ->
-                    []
-            end;
         _ ->
             []
     end;

--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -39,6 +39,8 @@
          stat/1,
          stat/2,
          query_single_active_consumer/1,
+         local_query/2,
+         local_query/3,
          cluster_name/1
          ]).
 
@@ -432,12 +434,36 @@ checkout(ConsumerTag, CreditMode, #{} = Meta,
 query_single_active_consumer(#state{leader = undefined}) ->
     {error, leader_not_known};
 query_single_active_consumer(#state{leader = Leader}) ->
-    case ra:local_query(Leader, fun rabbit_fifo:query_single_active_consumer/1,
-                        ?COMMAND_TIMEOUT) of
+    case local_query(Leader, query_single_active_consumer, ?COMMAND_TIMEOUT) of
         {ok, {_, Reply}, _} ->
             {ok, Reply};
         Err ->
             Err
+    end.
+
+%% @doc Runs a read-only query function against the state machine.
+%%
+%% Queries the queue's own (latest) machine module first. In a
+%% mixed-version cluster the queue may still be running on an older
+%% machine version whose state shape doesn't match the latest module,
+%% in which case the query crashes with a (caught) `function_clause'
+%% and we retry against `rabbit_fifo_v7', the last frozen snapshot of
+%% the state shape prior to the current one.
+-spec local_query(ra:server_id(), atom()) ->
+    {ok, {ra:idxterm(), term()}, ra:server_id()} |
+    {error, term()} | {timeout, ra:server_id()}.
+local_query(Server, QueryFun) ->
+    local_query(Server, QueryFun, 5000).
+
+-spec local_query(ra:server_id(), atom(), timeout()) ->
+    {ok, {ra:idxterm(), term()}, ra:server_id()} |
+    {error, term()} | {timeout, ra:server_id()}.
+local_query(Server, QueryFun, Timeout) when is_atom(QueryFun) ->
+    case ra:local_query(Server, fun rabbit_fifo:QueryFun/1, Timeout) of
+        {error, function_clause} ->
+            ra:local_query(Server, fun rabbit_fifo_v7:QueryFun/1, Timeout);
+        Other ->
+            Other
     end.
 
 %% @doc Provide credit to the queue
@@ -575,15 +601,12 @@ stat(Leader) ->
 stat(Leader, Timeout) ->
     %% short timeout as we don't want to spend too long if it is going to
     %% fail anyway
-    %% TODO: the overview is too large to be super efficient
-    %% but we use it for backwards compatibilty
-    case ra:member_overview(Leader, Timeout) of
-      {ok, #{machine := #{num_ready_messages := R,
-                          num_consumers := C}}, _} ->
+    case local_query(Leader, query_stat, Timeout) of
+        {ok, {_, {R, C}}, _} ->
             {ok, R, C};
-      {error, _} = Error ->
+        {error, _} = Error ->
             Error;
-      {timeout, _} = Error ->
+        {timeout, _} = Error ->
             Error
     end.
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -2196,7 +2196,7 @@ i(open_files, Q) when ?is_amqqueue(Q) ->
                             [Name], ?RPC_TIMEOUT)];
 i(single_active_consumer_pid, Q) when ?is_amqqueue(Q) ->
     QPid = amqqueue:get_pid(Q),
-    case ra:local_query(QPid, fun rabbit_fifo:query_single_active_consumer/1) of
+    case rabbit_fifo_client:local_query(QPid, query_single_active_consumer) of
         {ok, {_, {value, {_ConsumerTag, ChPid}}}, _} ->
             ChPid;
         {ok, _, _} ->
@@ -2208,8 +2208,7 @@ i(single_active_consumer_pid, Q) when ?is_amqqueue(Q) ->
     end;
 i(single_active_consumer_tag, Q) when ?is_amqqueue(Q) ->
     QPid = amqqueue:get_pid(Q),
-    case ra:local_query(QPid,
-                        fun rabbit_fifo:query_single_active_consumer/1) of
+    case rabbit_fifo_client:local_query(QPid, query_single_active_consumer) of
         {ok, {_, {value, {ConsumerTag, _ChPid}}}, _} ->
             ConsumerTag;
         {ok, _, _} ->
@@ -2226,8 +2225,7 @@ i(message_bytes_ram, Q) when ?is_amqqueue(Q) ->
     0;
 i(messages_dlx, Q) when ?is_amqqueue(Q) ->
     QPid = amqqueue:get_pid(Q),
-    case ra:local_query(QPid,
-                        fun rabbit_fifo:query_stat_dlx/1) of
+    case rabbit_fifo_client:local_query(QPid, query_stat_dlx) of
         {ok, {_, {Num, _}}, _} ->
             Num;
         {error, _} ->
@@ -2237,8 +2235,7 @@ i(messages_dlx, Q) when ?is_amqqueue(Q) ->
     end;
 i(message_bytes_dlx, Q) when ?is_amqqueue(Q) ->
     QPid = amqqueue:get_pid(Q),
-    case ra:local_query(QPid,
-                        fun rabbit_fifo:query_stat_dlx/1) of
+    case rabbit_fifo_client:local_query(QPid, query_stat_dlx) of
         {ok, {_, {_, Bytes}}, _} ->
             Bytes;
         {error, _} ->
@@ -2491,7 +2488,7 @@ overflow(<<"reject-publish-dlx">> = V, Def, QName) ->
 notify_decorators(Q) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
     QPid = amqqueue:get_pid(Q),
-    case ra:local_query(QPid, fun rabbit_fifo:query_notify_decorators_info/1) of
+    case rabbit_fifo_client:local_query(QPid, query_notify_decorators_info) of
         {ok, {_, {MaxActivePriority, IsEmpty}}, _} ->
             notify_decorators(QName, consumer_state_changed,
                               [MaxActivePriority, IsEmpty]);

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -124,7 +124,8 @@ groups() ->
                                             replica_states,
                                             restart_after_queue_reincarnation,
                                             no_messages_after_queue_reincarnation,
-                                            consumer_message_is_delevered_after_snapshot
+                                            consumer_message_is_delevered_after_snapshot,
+                                            mixed_version_local_queries
                                            ]
                        ++ all_tests()},
                       {cluster_size_5, [], [start_queue,
@@ -4857,6 +4858,47 @@ status(Config) ->
                         rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_queue_type_ra,
                                                      status, [<<"/">>, QQ])),
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
+    ok.
+
+%% Only meaningful in a mixed-version cluster test. Since the queue's
+%% group spans all three nodes, its machine version stays pinned to
+%% whatever the oldest member supports, so local queries from the first
+%% node must still succeed instead of crashing with function_clause
+%% against that older state shape.
+mixed_version_local_queries(Config) ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        false ->
+            {skip, "mixed_version_local_queries only relevant in mixed version mode"};
+        true ->
+            mixed_version_local_queries0(Config)
+    end.
+
+mixed_version_local_queries0(Config) ->
+    [Server0 | _] = Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    RaName = ra_name(QQ),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                  {<<"x-quorum-initial-group-size">>, long, 3}])),
+    ?awaitMatch({ok, Members, _} when length(Members) == 3,
+                ra:members({RaName, Server0}),
+                ?DEFAULT_AWAIT),
+
+    publish(Ch, QQ),
+    wait_for_messages_ready(Nodes, RaName, 1),
+
+    [begin
+         ServerId = {RaName, Node},
+         [?assertMatch({ok, _, _},
+                       rabbit_ct_broker_helpers:rpc(
+                         Config, 0, rabbit_fifo_client, local_query,
+                         [ServerId, QueryFun, 5000]))
+          || QueryFun <- [query_notify_decorators_info,
+                          query_consumers,
+                          query_stat]]
+     end || Node <- Nodes],
     ok.
 
 status_noproc(Config) ->

--- a/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
@@ -44,7 +44,9 @@ all_tests() ->
      untracked_enqueue,
      flow,
      test_queries,
-     duplicate_delivery
+     duplicate_delivery,
+     local_query_resolves_pinned_v7_machine_version,
+     local_query_does_not_retry_on_unrelated_error
     ].
 
 groups() ->
@@ -814,6 +816,43 @@ test_queries(Config) ->
     rabbit_quorum_queue:stop_server(ServerId),
     ok.
 
+local_query_resolves_pinned_v7_machine_version(Config) ->
+    ClusterName = ?config(cluster_name, Config),
+    ServerId = ?config(node_id, Config),
+    %% pin this cluster's machine at version 7: it never upgrades to the
+    %% latest (rabbit_fifo/v8) state shape
+    ok = start_cluster(ClusterName, [ServerId],
+                       #{name => some_name, queue_resource => ClusterName},
+                       7),
+
+    F0 = rabbit_fifo_client:init([ServerId]),
+    {ok, F1, []} = rabbit_fifo_client:enqueue(ClusterName, msg1, F0),
+    _ = process_ra_events(receive_ra_events(1, 0), ClusterName, F1),
+
+    %% querying with the latest module hardcoded still crashes against
+    %% this v7-shaped state, confirming the fallback below is load-bearing
+    ?assertEqual({error, function_clause},
+                 ra:local_query(ServerId,
+                                fun rabbit_fifo:query_notify_decorators_info/1)),
+    %% local_query retries against rabbit_fifo_v7 instead of assuming the
+    %% latest module
+    ?assertMatch({ok, {_, {empty, false}}, _},
+                 rabbit_fifo_client:local_query(
+                   ServerId, query_notify_decorators_info, 5000)),
+
+    rabbit_quorum_queue:stop_server(ServerId),
+    ok.
+
+local_query_does_not_retry_on_unrelated_error(_Config) ->
+    ok = meck:new(ra, [passthrough]),
+    meck:expect(ra, local_query, fun (_Server, _Fun, _Timeout) -> {error, noproc} end),
+    ?assertEqual({error, noproc},
+                 rabbit_fifo_client:local_query(
+                   some_server, query_notify_decorators_info, 1000)),
+    ?assertEqual(1, meck:num_calls(ra, local_query, '_')),
+    meck:unload(ra),
+    ok.
+
 dead_letter_handler(Pid, Reason, Msgs) ->
     Pid ! {dead_letter, Reason, Msgs}.
 
@@ -954,6 +993,12 @@ discard_next_delivery(ClusterName, State0, Wait) ->
     end.
 
 start_cluster(ClusterName, ServerIds, RaFifoConfig) ->
+    start_cluster(ClusterName, ServerIds, RaFifoConfig, rabbit_fifo:version()).
+
+%% pins the cluster's machine at MachineVersion instead of the latest,
+%% e.g. to test how the latest code behaves against an older state shape
+start_cluster(ClusterName, ServerIds, RaFifoConfig, MachineVersion) ->
+    Module = rabbit_fifo:which_module(MachineVersion),
     NameBin = ra_lib:to_binary(ClusterName#resource.name),
     Confs = [begin
                  UId = ra:new_uid(NameBin),
@@ -962,8 +1007,8 @@ start_cluster(ClusterName, ServerIds, RaFifoConfig) ->
                    cluster_name => ClusterName#resource.name,
                    log_init_args => #{uid => UId},
                    initial_members => ServerIds,
-                   initial_machine_version => rabbit_fifo:version(),
-                   machine => {module, rabbit_fifo, RaFifoConfig}}
+                   initial_machine_version => MachineVersion,
+                   machine => {module, Module, RaFifoConfig}}
              end
              || Id <- ServerIds],
     {ok, Started, _} = ra:start_cluster(?RA_SYSTEM, Confs),

--- a/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
@@ -845,12 +845,15 @@ local_query_resolves_pinned_v7_machine_version(Config) ->
 
 local_query_does_not_retry_on_unrelated_error(_Config) ->
     ok = meck:new(ra, [passthrough]),
-    meck:expect(ra, local_query, fun (_Server, _Fun, _Timeout) -> {error, noproc} end),
-    ?assertEqual({error, noproc},
-                 rabbit_fifo_client:local_query(
-                   some_server, query_notify_decorators_info, 1000)),
-    ?assertEqual(1, meck:num_calls(ra, local_query, '_')),
-    meck:unload(ra),
+    try
+        meck:expect(ra, local_query, fun (_Server, _Fun, _Timeout) -> {error, noproc} end),
+        ?assertEqual({error, noproc},
+                     rabbit_fifo_client:local_query(
+                       some_server, query_notify_decorators_info, 1000)),
+        ?assertEqual(1, meck:num_calls(ra, local_query, '_'))
+    after
+        meck:unload(ra)
+    end,
     ok.
 
 dead_letter_handler(Pid, Reason, Msgs) ->


### PR DESCRIPTION
## Proposed Changes

Same underlying bug pattern as a mixed-cluster test failure seen between 4.0.x and 3.13.7 (`amqp_client_SUITE > cluster_size_3 > last_queue_confirms`): a local query hardcodes the latest `rabbit_fifo` module and crashes against an older state shape still held by a old cluster member. Confirmed this pattern concretely at the 4.2.x/4.3.x boundary instead (`rabbit_fifo` machine version 8 shipped in 4.3.0): during a rolling upgrade, a queue whose Ra group still includes a pre-4.3 member stays capped at the v7 state shape, and `query_notify_decorators_info` / `query_consumers` crash with `function_clause` against it, silently turning into skipped consumer notifications or an empty consumer list

Generalizes the fallback `query_single_active_consumer/1` already had into a shared `rabbit_fifo_client:local_query/2,3`, routes the other affected call sites through it, and removes `rabbit_amqqueue: consumers/1`'s own ad hoc version of the same fix. `stat/2` also drops `ra:member_overview` in favor of the same lightweight helper.

Added `quorum_queue_SUITE:mixed_version_local_queries` (skips outside mixed-version runs) plus `rabbit_fifo_int_SUITE` unit tests.