### PR TITLE
rabbit_stream_reader: Ignore queue events in close_sent state

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1314,6 +1314,13 @@ close_sent(info, Msg, _StatemData) ->
     ?LOG_WARNING("Ignored unknown message ~tp in state ~ts",
                                   [Msg, ?FUNCTION_NAME]),
     keep_state_and_data;
+close_sent(cast, {queue_event, _, _}, _StatemData) ->
+    %% Ignore confirmations and offset notifications while closing.
+    keep_state_and_data;
+close_sent(cast, Msg, _StatemData) ->
+    ?LOG_WARNING("Ignored unknown cast ~tp in state ~ts",
+                                  [Msg, ?FUNCTION_NAME]),
+    keep_state_and_data;
 close_sent({call, From}, {info, _Items}, _StateData) ->
     %% must be a CLI call, returning no information
     {keep_state_and_data, {reply, From, []}}.


### PR DESCRIPTION
A stream reader can receive publisher confirm notifications from the stream after it closes the connection to the producer. Currently this causes a crash - we can ignore the notification instead.

I can reproduce a crash for this queue event notification with a stream-perf-test command which exceeds the frame size (1 MiB at time of writing):

```shell
stream-perf-test --producers 6 --consumers 0 --streams my-stream \
                 --size 65536 --sub-entry-size 64 --compression none
```

    supervisor: {<0.1964.0>,rabbit_stream_connection_sup}
    errorContext: child_terminated
    reason: {function_clause,
             [{rabbit_stream_reader,close_sent,
               [cast,
                {queue_event,
                 {resource,<<"/">>,queue,<<"my-stream">>},
                 {osiris_written,
                  {resource,<<"/">>,queue,<<"my-stream">>},
                  undefined,
                  [{0,0,0}]}},

(Note: oddly I can only reproduce it when using 6 or more producers.)

It should also be possible for consumers to get osiris_offset notifications in close_sent, so this change ignores all queue events, plus we add a catch-all like we have for `info`s in this state.