### PR TITLE
Shovel: report the specific reason a topology setup failure stops the worker

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -213,6 +213,15 @@ terminate({shutdown, restart}, State = #state{name = Name}) ->
     ?LOG_WARNING("Shovel ~ts is stopping to restart", [human_readable_name(Name)]),
     close_connections(State),
     ok;
+terminate({shutdown, Reason}, State = #state{name = Name}) ->
+    %% An expected failure with a specific reason, e.g. a topology setup
+    %% failure such as 'missing_source_queue'.
+    %% The `{shutdown, _}` wrapper is only needed to reduce Erlang/OTP supervisor
+    %% logging, in our own logging we should use the underlying reason directly.
+    ?LOG_WARNING("Shovel ~ts is stopping: ~tp", [human_readable_name(Name), Reason]),
+    report_terminated(State, Reason),
+    close_connections(State),
+    ok;
 terminate({{shutdown, {server_initiated_close, Code, Reason}}, _}, State = #state{name = Name}) ->
     ?LOG_WARNING("Shovel ~ts is stopping: one of its connections closed "
                             "with code ~b, reason: ~ts",

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -104,13 +104,9 @@ handle_cast(init_shovel, State = #state{config = Config}) ->
         ok = report_running(State1),
         {noreply, State1}
     catch
-        exit:{shutdown, autodelete} ->
-            %% `init_source/1` exits with this reason when a 'delete-after'
-            %% shovel has nothing left to transfer; see `terminate/2`.
-            {stop, {shutdown, autodelete}, State};
+        exit:{shutdown, _} = Reason ->
+            {stop, Reason, State};
         E:R ->
-            %% Topology setup failed, e.g. a predeclared queue is missing.
-            %% Same handling as the connect phases above.
             ?LOG_WARNING("Shovel ~ts could not set up its topology: ~p ~p",
                          [human_readable_name(maps:get(name, Config)), E, R]),
             report_terminated(State, "failed to set up topology"),


### PR DESCRIPTION
`init_dest/1` and `init_source/1` can exit with a `{shutdown, _}` reason to signal an expected condition, e.g. a predeclared queue is missing or (for 'delete-after' Shovels) that there is nothing left to transfer.

The catch-all clause in `handle_cast(init_shovel, ...)` caught every exception raised during topology setup, including these `{shutdown, _}` exits, and replaced them with a generic "failed to set up topology" status. This discarded the specific reason before `terminate/2` had a chance to report it.

Generalize the existing special case for `{shutdown, autodelete}` to any `{shutdown, _}` reason, so `terminate/2` reports the actual reason. Reasons that are not already wrapped in `{shutdown, _}` still fall through to the generic clause, so unexpected errors are not logged with a full stack trace.

This makes the following tanzu-rabbitmq suite green:
```
make -C deps/rabbitmq_shovel ct-stream_dynamic FULL=1
```