### PR TITLE
Rename prop test fun for keep-while conds in db_bindings suite

### DIFF
--- a/deps/rabbit/test/rabbit_db_binding_prop_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_binding_prop_SUITE.erl
@@ -69,7 +69,7 @@ tie_binding_to_dest_with_keep_while_cond(Config) ->
 
 tie_binding_to_dest_with_keep_while_cond1(_Config) ->
     proper:quickcheck(
-      prop_tie_binding_to_dest_with_keep_while_cond(),
+      tie_binding_to_dest_with_keep_while_cond_prop(),
       [{numtests, ?NUM_TESTS}]).
 
 %% Each exchange is described by whether it is auto-delete and whether it has a
@@ -83,7 +83,7 @@ topology() ->
 %% For any topology, the migration must succeed, keep every exchange, and add a
 %% `keep_while' condition to exactly those auto-delete exchanges that have a
 %% source binding.
-prop_tie_binding_to_dest_with_keep_while_cond() ->
+tie_binding_to_dest_with_keep_while_cond_prop() ->
     ?FORALL(
        Specs, topology(),
        begin


### PR DESCRIPTION
PropEr automatically runs functions of arity zero with the prop_ prefix. This test depends on a broker running so it won't succeed when run by proper instead of CommonTest. We can rename the prop part to the end to avoid PropEr running it automatically. `proper` is a subtarget of `tests`, so this fixes `make tests`.

This is the same as https://github.com/rabbitmq/rabbitmq-server/pull/16534. I'm not sure if we can make some kind of lint or heuristic we can introduce to avoid falling into this pitfall with future tests too.