### PR TITLE
Revert "Merge pull request #17083 from rabbitmq/stream-frame-size-on-delivery

### DIFF
--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -886,11 +886,3 @@ Until `Open` completes successfully, the server enforces a low `frame_max` ceili
 regardless of the value negotiated (or yet to be negotiated) with `Tune`. This ceiling is
 high enough to accommodate realistic
 https://www.rabbitmq.com/docs/oauth2[JWT tokens] carried as the SASL PLAIN password.
-
-The negotiated `frame_max` also bounds `Deliver` frames sent to a subscribing client.
-A `Deliver` frame carries one whole chunk (a batch of published messages) and the
-protocol has no fragmentation for it, so the server cannot shrink an oversized chunk to
-fit. If a chunk to be delivered to a given connection would exceed that connection's
-`frame_max`, the server closes the connection instead of sending an over-limit frame,
-sending a `close` request with the `Frame too large` code, the same way it does for an
-oversized incoming frame.

--- a/deps/rabbitmq_stream/include/rabbit_stream_metrics.hrl
+++ b/deps/rabbitmq_stream/include/rabbit_stream_metrics.hrl
@@ -36,7 +36,6 @@
 -define(ACCESS_REFUSED, ?NUM_PROTOCOL_COUNTERS + 15).
 -define(PRECONDITION_FAILED, ?NUM_PROTOCOL_COUNTERS + 16).
 -define(PUBLISHER_DOES_NOT_EXIST, ?NUM_PROTOCOL_COUNTERS + 17).
--define(DELIVER_FRAME_TOO_LARGE, ?NUM_PROTOCOL_COUNTERS + 18).
 
 -define(PROTOCOL_COUNTERS,
         [
@@ -107,9 +106,5 @@
          {
           stream_error_publisher_does_not_exist_total, ?PUBLISHER_DOES_NOT_EXIST, counter,
           "Total number of commands failed with publisher does not exist"
-         },
-         {
-          stream_error_deliver_frame_too_large_total, ?DELIVER_FRAME_TOO_LARGE, counter,
-          "Total number of Deliver frames rejected for exceeding the negotiated frame_max"
          }
         ]).

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1154,7 +1154,6 @@ open(cast,
                       #stream_connection{stream_subscriptions =
                                              StreamSubscriptions,
                                          send_file_oct = SendFileOct,
-                                         frame_max = FrameMax,
                                          deliver_version = DeliverVersion} =
                           Connection,
                   connection_state =
@@ -1178,72 +1177,44 @@ open(cast,
                                                               StreamSubscriptions)},
                  State};
             SubscriptionIds when is_list(SubscriptionIds) ->
-                {Consumers1, Connection2} =
-                    lists:foldl(fun(_SubscriptionId,
-                                    {_ConsumersAcc,
-                                     #stream_connection{connection_step = close_sent}} =
-                                        Acc) ->
-                                   %% already closing: don't bother dispatching
-                                   %% to (or possibly closing again) other
-                                   %% subscriptions on this connection
-                                   Acc;
-                                (SubscriptionId, {ConsumersAcc, ConnAcc}) ->
+                Consumers1 =
+                    lists:foldl(fun(SubscriptionId, ConsumersAcc) ->
                                    #{SubscriptionId := Consumer} = ConsumersAcc,
                                    #consumer{credit = Credit, log = Log} =
                                        Consumer,
-                                   case {Credit, Log} of
-                                       {_, undefined} ->
-                                           {ConsumersAcc, ConnAcc}; %% SAC not active
-                                       {0, _} ->
-                                           {ConsumersAcc, ConnAcc};
-                                       {_, _} ->
-                                           case send_chunks(DeliverVersion,
-                                                            Transport,
-                                                            Consumer,
-                                                            FrameMax,
-                                                            SendFileOct)
-                                           of
-                                               {error, closed} ->
-                                                   ?LOG_INFO("Stream protocol connection has been closed by "
-                                                                              "peer",
-                                                                              []),
-                                                   throw({stop, normal});
-                                               {error, {deliver_frame_too_large, Size, Max}} ->
-                                                   ConnAcc1 =
-                                                       handle_deliver_frame_too_large(Transport,
-                                                                                      ConnAcc,
-                                                                                      StreamName,
-                                                                                      SubscriptionId,
-                                                                                      Size,
-                                                                                      Max),
-                                                   {ConsumersAcc#{SubscriptionId => Consumer},
-                                                    ConnAcc1};
-                                               {error, Reason} ->
-                                                   ?LOG_INFO("Error while sending chunks: ~tp",
-                                                                              [Reason]),
-                                                   %% likely a connection problem
-                                                   {ConsumersAcc#{SubscriptionId => Consumer},
-                                                    ConnAcc};
-                                               {ok, Csmr} ->
-                                                   {ConsumersAcc#{SubscriptionId => Csmr},
-                                                    ConnAcc}
-                                           end
-                                   end
+                                   Consumer1 =
+                                       case {Credit, Log} of
+                                           {_, undefined} ->
+                                               Consumer; %% SAC not active
+                                           {0, _} -> Consumer;
+                                           {_, _} ->
+                                               case send_chunks(DeliverVersion,
+                                                                Transport,
+                                                                Consumer,
+                                                                SendFileOct)
+                                               of
+                                                   {error, closed} ->
+                                                       ?LOG_INFO("Stream protocol connection has been closed by "
+                                                                                  "peer",
+                                                                                  []),
+                                                       throw({stop, normal});
+                                                   {error, Reason} ->
+                                                       ?LOG_INFO("Error while sending chunks: ~tp",
+                                                                                  [Reason]),
+                                                       %% likely a connection problem
+                                                       Consumer;
+                                                   {ok, Csmr} -> Csmr
+                                               end
+                                       end,
+                                   ConsumersAcc#{SubscriptionId => Consumer1}
                                 end,
-                                {Consumers, Connection}, SubscriptionIds),
-                {Connection2,
+                                Consumers, SubscriptionIds),
+                {Connection,
                  State#stream_connection_state{consumers = Consumers1}}
         end,
-    case Connection1 of
-        #stream_connection{connection_step = close_sent} ->
-            {next_state, close_sent,
-             StatemData#statem_data{connection = Connection1,
-                                    connection_state = State1}};
-        _ ->
-            {keep_state,
-             StatemData#statem_data{connection = Connection1,
-                                    connection_state = State1}}
-    end;
+    {keep_state,
+     StatemData#statem_data{connection = Connection1,
+                            connection_state = State1}};
 open(cast, {force_event_refresh, Ref},
      #statem_data{connection = Connection, connection_state = State} =
          StatemData) ->
@@ -2245,7 +2216,6 @@ handle_frame_post_auth(Transport,
 handle_frame_post_auth(Transport,
                        #stream_connection{socket = S,
                                           send_file_oct = SendFileOct,
-                                          frame_max = FrameMax,
                                           deliver_version = DeliverVersion} =
                            Connection,
                        #stream_connection_state{consumers = Consumers} = State,
@@ -2270,15 +2240,13 @@ handle_frame_post_auth(Transport,
              State#stream_connection_state{consumers =
                                            Consumers#{SubscriptionId => Consumer1}}};
         #{SubscriptionId := Consumer} ->
-            #consumer{credit = AvailableCredit, last_listener_offset = LLO,
-                      configuration = #consumer_configuration{stream = Stream}} =
+            #consumer{credit = AvailableCredit, last_listener_offset = LLO} =
                 Consumer,
             case send_chunks(DeliverVersion,
                              Transport,
                              Consumer,
                              AvailableCredit + Credit,
                              LLO,
-                             FrameMax,
                              SendFileOct)
             of
                 {error, closed} ->
@@ -2286,14 +2254,6 @@ handle_frame_post_auth(Transport,
                                                "peer",
                                                []),
                     throw({stop, normal});
-                {error, {deliver_frame_too_large, Size, Max}} ->
-                    Connection1 =
-                        handle_deliver_frame_too_large(Transport, Connection,
-                                                       Stream, SubscriptionId,
-                                                       Size, Max),
-                    Consumers1 = Consumers#{SubscriptionId => Consumer},
-                    {Connection1,
-                     State#stream_connection_state{consumers = Consumers1}};
                 {error, Reason} ->
                     ?LOG_INFO("Error while sending chunks: ~tp",
                                                [Reason]),
@@ -2778,7 +2738,6 @@ handle_frame_post_auth(Transport,
                        #stream_connection{transport = ConnTransport,
                                           outstanding_requests = Requests0,
                                           send_file_oct = SendFileOct,
-                                          frame_max = FrameMax,
                                           virtual_host = VirtualHost,
                                           deliver_version = DeliverVersion} =
                            Connection,
@@ -2798,7 +2757,7 @@ handle_frame_post_auth(Transport,
             ?LOG_DEBUG("Received consumer update response for subscription "
                              "~tp on stream ~tp, correlation ID ~tp",
                              [SubscriptionId, Stream, CorrelationId]),
-            {Consumers1, Connection1} =
+            Consumers1 =
                 case Consumers of
                     #{SubscriptionId :=
                           #consumer{configuration =
@@ -2853,47 +2812,37 @@ handle_frame_post_auth(Transport,
 
                         ConsumedMessagesBefore = messages_consumed(ConsumerCounters),
 
-                        case send_chunks(DeliverVersion,
-                                        Transport,
-                                        Consumer1,
-                                        FrameMax,
-                                        SendFileOct)
-                        of
-                            {error, closed} ->
-                                ?LOG_INFO("Stream protocol connection has been closed by "
-                                          "peer", []),
-                                throw({stop, normal});
-                            {error, {deliver_frame_too_large, Size, Max}} ->
-                                %% `Consumer1` holds the reader opened above.
-                                %% It will be closed during the teardown.
-                                ClosedConnection =
-                                    handle_deliver_frame_too_large(Transport,
-                                                                   Connection,
-                                                                   Stream,
-                                                                   SubscriptionId,
-                                                                   Size, Max),
-                                {Consumers#{SubscriptionId => Consumer1},
-                                 ClosedConnection};
-                            {error, Reason} ->
-                                ?LOG_INFO("Error while sending chunks: ~tp",
-                                                           [Reason]),
-                                %% likely a connection problem
-                                {Consumers#{SubscriptionId => Consumer},
-                                 Connection};
-                            {ok, Csmr} ->
-                                #consumer{log = Log2} = Csmr,
-                                ConsumerOffset = osiris_log:next_offset(Log2),
+                        Consumer2 =
+                            case send_chunks(DeliverVersion,
+                                             Transport,
+                                             Consumer1,
+                                             SendFileOct)
+                            of
+                                {error, closed} ->
+                                    ?LOG_INFO("Stream protocol connection has been closed by "
+                                                               "peer",
+                                                               []),
+                                    throw({stop, normal});
+                                {error, Reason} ->
+                                    ?LOG_INFO("Error while sending chunks: ~tp",
+                                                               [Reason]),
+                                    %% likely a connection problem
+                                    Consumer;
+                                {ok, Csmr} ->
+                                    Csmr
+                            end,
+                        #consumer{log = Log2} = Consumer2,
+                        ConsumerOffset = osiris_log:next_offset(Log2),
 
-                                ConsumedMessagesAfter = messages_consumed(ConsumerCounters),
-                                ?LOG_DEBUG("Subscription ~tp (stream ~tp) is now at offset ~tp with ~tp "
-                                           "message(s) distributed after subscription",
-                                           [SubscriptionId,
-                                            Stream,
-                                            ConsumerOffset,
-                                            ConsumedMessagesAfter - ConsumedMessagesBefore]),
-                                {Consumers#{SubscriptionId => Csmr},
-                                 Connection}
-                        end;
+                        ConsumedMessagesAfter = messages_consumed(ConsumerCounters),
+                        ?LOG_DEBUG("Subscription ~tp (stream ~tp) is now at offset ~tp with ~tp "
+                                         "message(s) distributed after subscription",
+                                         [SubscriptionId,
+                                          Stream,
+                                          ConsumerOffset,
+                                          ConsumedMessagesAfter - ConsumedMessagesBefore]),
+
+                        Consumers#{SubscriptionId => Consumer2};
                     #{SubscriptionId :=
                           #consumer{configuration =
                                         #consumer_configuration{active = false,
@@ -2915,14 +2864,14 @@ handle_frame_post_auth(Transport,
                                 ok
                         end,
 
-                        {Consumers, Connection};
+                        Consumers;
                     _ ->
                         ?LOG_DEBUG("No consumer found for subscription ~tp",
                                          [SubscriptionId]),
-                        {Consumers, Connection}
+                        Consumers
                 end,
 
-            {Connection1#stream_connection{outstanding_requests = Rs},
+            {Connection#stream_connection{outstanding_requests = Rs},
              State#stream_connection_state{consumers = Consumers1}};
         {V, _Rs} ->
             ?LOG_WARNING("Unexpected outstanding requests for correlation "
@@ -3239,7 +3188,6 @@ maybe_dispatch_on_subscription(Transport,
                                State,
                                ConsumerState,
                                #stream_connection{deliver_version = DeliverVersion,
-                                                  frame_max = FrameMax,
                                                   user = #user{username = Username}} = Connection,
                                Consumers,
                                Stream,
@@ -3248,12 +3196,11 @@ maybe_dispatch_on_subscription(Transport,
                                SendFileOct,
                                false = _Sac) ->
     ?LOG_DEBUG("Distributing existing messages to subscription "
-               "~tp on ~tp",
-               [SubscriptionId, Stream]),
+                     "~tp on ~tp",
+                     [SubscriptionId, Stream]),
     case send_chunks(DeliverVersion,
                      Transport,
                      ConsumerState,
-                     FrameMax,
                      SendFileOct)
     of
         {error, closed} ->
@@ -3261,17 +3208,11 @@ maybe_dispatch_on_subscription(Transport,
                                        "peer",
                                        []),
             throw({stop, normal});
-        {error, {deliver_frame_too_large, Size, Max}} ->
-            Connection1 =
-                handle_deliver_frame_too_large(Transport, Connection, Stream,
-                                               SubscriptionId, Size, Max),
-            Consumers1 = Consumers#{SubscriptionId => ConsumerState},
-            {Connection1, State#stream_connection_state{consumers = Consumers1}};
         {error, Reason} ->
             ?LOG_INFO("Error while sending chunks: ~tp",
                                        [Reason]),
             Consumers1 = Consumers#{SubscriptionId => ConsumerState},
-            {Connection, State#stream_connection_state{consumers = Consumers1}};
+            State#stream_connection_state{consumers = Consumers1};
         {ok, #consumer{log = Log1, credit = Credit1} = ConsumerState1} ->
             Consumers1 = Consumers#{SubscriptionId => ConsumerState1},
 
@@ -3298,7 +3239,7 @@ maybe_dispatch_on_subscription(Transport,
                                                    true,
                                                    SubscriptionProperties,
                                                    Username),
-            {Connection, State#stream_connection_state{consumers = Consumers1}}
+            State#stream_connection_state{consumers = Consumers1}
     end;
 maybe_dispatch_on_subscription(_Transport,
                                State,
@@ -3330,7 +3271,7 @@ maybe_dispatch_on_subscription(_Transport,
                                            SubscriptionProperties,
                                            Username),
     Consumers1 = Consumers#{SubscriptionId => ConsumerState},
-    {Connection, State#stream_connection_state{consumers = Consumers1}}.
+    State#stream_connection_state{consumers = Consumers1}.
 
 handle_subscription(Transport,#stream_connection{
                                  name = ConnName,
@@ -3394,16 +3335,16 @@ handle_subscription(Transport,#stream_connection{
                                                Stream,
                                                Connection),
 
-            {Connection2, State1} = maybe_dispatch_on_subscription(Transport,
-                                                                   State,
-                                                                   ConsumerState,
-                                                                   Connection1,
-                                                                   Consumers,
-                                                                   Stream,
-                                                                   SubscriptionId,
-                                                                   Properties,
-                                                                   SendFileOct,
-                                                                   Sac),
+            State1 = maybe_dispatch_on_subscription(Transport,
+                                                    State,
+                                                    ConsumerState,
+                                                    Connection1,
+                                                    Consumers,
+                                                    Stream,
+                                                    SubscriptionId,
+                                                    Properties,
+                                                    SendFileOct,
+                                                    Sac),
             StreamSubscriptions1 =
             case StreamSubscriptions of
                 #{Stream := SubscriptionIds} ->
@@ -3413,7 +3354,7 @@ handle_subscription(Transport,#stream_connection{
                     StreamSubscriptions#{Stream =>
                                          [SubscriptionId]}
             end,
-            {Connection2#stream_connection{stream_subscriptions
+            {Connection1#stream_connection{stream_subscriptions
                                            =
                                            StreamSubscriptions1},
              State1};
@@ -3977,12 +3918,10 @@ send_file_callback(?VERSION_1,
                    #consumer{configuration =
                                  #consumer_configuration{subscription_id = SubId,
                                                          counters = Counters}},
-                   Counter,
-                   FrameMax) ->
+                   Counter) ->
     fun(#{chunk_id := FirstOffsetInChunk, num_entries := NumEntries},
         Size) ->
        FrameSize = 2 + 2 + 1 + Size,
-       assert_frame_max(FrameSize, FrameMax),
        FrameBeginning =
            <<FrameSize:32,
              ?REQUEST:1,
@@ -3999,12 +3938,10 @@ send_file_callback(?VERSION_2,
                    #consumer{configuration =
                                  #consumer_configuration{subscription_id = SubId,
                                                          counters = Counters}},
-                   Counter,
-                   FrameMax) ->
+                   Counter) ->
     fun(#{chunk_id := FirstOffsetInChunk, num_entries := NumEntries},
         Size) ->
        FrameSize = 2 + 2 + 1 + 8 + Size,
-       assert_frame_max(FrameSize, FrameMax),
        CommittedChunkId = osiris_log:committed_chunk_id(Log),
        FrameBeginning =
            <<FrameSize:32,
@@ -4019,32 +3956,21 @@ send_file_callback(?VERSION_2,
        FrameBeginning
     end.
 
-%% 0 means "no limit", mirroring negotiate_frame_max/2.
-assert_frame_max(_FrameSize, 0) ->
-    ok;
-assert_frame_max(FrameSize, FrameMax) when FrameSize > FrameMax ->
-    throw({deliver_frame_too_large, FrameSize, FrameMax});
-assert_frame_max(_FrameSize, _FrameMax) ->
-    ok.
-
 -spec send_chunks(rabbit_stream_core:command_version(),
                   module(),
                   #consumer{},
-                  non_neg_integer(),
                   atomics:atomics_ref()) ->
     {ok, #consumer{}} | {error, term()}.
 send_chunks(DeliverVersion,
             Transport,
             #consumer{credit = Credit, last_listener_offset = LastLstOffset} =
                 Consumer,
-            FrameMax,
             Counter) ->
     send_chunks(DeliverVersion,
                 Transport,
                 Consumer,
                 Credit,
                 LastLstOffset,
-                FrameMax,
                 Counter).
 
 -spec send_chunks(rabbit_stream_core:command_version(),
@@ -4052,7 +3978,6 @@ send_chunks(DeliverVersion,
                   #consumer{},
                   non_neg_integer(),
                   undefined | osiris:offset(),
-                  non_neg_integer(),
                   atomics:atomics_ref()) ->
     {ok, #consumer{}} | {error, term()}.
 send_chunks(_DeliverVersion,
@@ -4060,7 +3985,6 @@ send_chunks(_DeliverVersion,
             #consumer{send_limit = SendLimit} = Consumer,
             Credit,
             LastLstOffset,
-            _FrameMax,
             _Counter) when Credit =< SendLimit ->
     %% there are fewer credits than the credit limit so we won't enter
     %% the send_chunks loop until we have more than the limit available.
@@ -4074,7 +3998,6 @@ send_chunks(DeliverVersion,
                       log = Log} = Consumer,
             Credit,
             LastLstOffset,
-            FrameMax,
             Counter) ->
     setopts(Transport, Socket, [{nopush, true}]),
     send_chunks(DeliverVersion,
@@ -4084,7 +4007,6 @@ send_chunks(DeliverVersion,
                 Credit,
                 LastLstOffset,
                 true,
-                FrameMax,
                 Counter).
 
 -spec send_chunks(rabbit_stream_core:command_version(),
@@ -4094,7 +4016,6 @@ send_chunks(DeliverVersion,
                   non_neg_integer(),
                   undefined | osiris:offset(),
                   boolean(),
-                  non_neg_integer(),
                   atomics:atomics_ref()) ->
     {ok, #consumer{}} | {error, term()}.
 send_chunks(_DeliverVersion,
@@ -4106,7 +4027,6 @@ send_chunks(_DeliverVersion,
             0,
             LastLstOffset,
             _Retry,
-            _FrameMax,
             _Counter) ->
     %% we have finished sending so need to uncork
     setopts(Transport, Socket, [{nopush, false}]),
@@ -4122,18 +4042,11 @@ send_chunks(DeliverVersion,
             Credit,
             LastLstOffset,
             Retry,
-            FrameMax,
             Counter) ->
-    case try
-             osiris_log:send_file(Socket, Log,
-                                  send_file_callback(DeliverVersion, Log,
-                                                     Consumer,
-                                                     Counter,
-                                                     FrameMax))
-         catch
-             throw:{deliver_frame_too_large, Size, Max} ->
-                 {error, {deliver_frame_too_large, Size, Max}}
-         end
+    case osiris_log:send_file(Socket, Log,
+                              send_file_callback(DeliverVersion, Log,
+                                                 Consumer,
+                                                 Counter))
     of
         {ok, Log1} ->
             send_chunks(DeliverVersion,
@@ -4143,7 +4056,6 @@ send_chunks(DeliverVersion,
                         Credit - 1,
                         LastLstOffset,
                         true,
-                        FrameMax,
                         Counter);
         {error, closed} ->
             {error, closed};
@@ -4162,7 +4074,6 @@ send_chunks(DeliverVersion,
                                 Credit,
                                 LastLstOffset,
                                 false,
-                                FrameMax,
                                 Counter);
                 false ->
                     #consumer{configuration =
@@ -4188,29 +4099,6 @@ send_chunks(DeliverVersion,
                                        last_listener_offset = LLO}}
             end
     end.
-
-%% The chunk is fixed size once committed by osiris and cannot be re-encoded
-%% smaller for this one connection, so the only option is to refuse it and
-%% close the whole connection, reusing the same wire pattern as an oversized
-%% inbound frame.
--spec handle_deliver_frame_too_large(module(), #stream_connection{},
-                                     binary(), integer(),
-                                     non_neg_integer(), non_neg_integer()) ->
-    #stream_connection{}.
-handle_deliver_frame_too_large(Transport,
-                               #stream_connection{socket = S} = Connection,
-                               Stream, SubscriptionId, Size, Max) ->
-    ?LOG_WARNING("Closing connection because a chunk to deliver for "
-                 "subscription ~tp on stream ~tp (~b bytes) exceeds "
-                 "the connection's negotiated frame_max (~b bytes)",
-                 [SubscriptionId, Stream, Size, Max]),
-    increase_protocol_counter(?DELIVER_FRAME_TOO_LARGE),
-    Frame =
-        rabbit_stream_core:frame({request, 1,
-                                  {close, ?RESPONSE_CODE_FRAME_TOO_LARGE,
-                                   <<"frame too large">>}}),
-    send(Transport, S, Frame),
-    Connection#stream_connection{connection_step = close_sent}.
 
 emit_stats(#stream_connection{publishers = Publishers} = Connection,
            #stream_connection_state{consumers = Consumers} = ConnectionState) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -95,10 +95,6 @@ groups() ->
        oversized_frame_rejected_after_tune_negotiation,
        frame_max_clamped_when_client_negotiates_higher,
        client_tune_response_with_zero_frame_max_is_unlimited,
-       deliver_frame_too_large_closes_connection_on_new_chunk,
-       deliver_frame_too_large_closes_connection_on_subscribe,
-       deliver_frame_too_large_closes_connection_on_consumer_update,
-       deliver_under_frame_max_delivers_normally,
        test_stream_test_utils,
        sac_subscription_with_partition_index_conflict_should_return_error,
        test_metadata_with_advertised_hints,
@@ -362,7 +358,6 @@ test_global_counters(Config) ->
                    messages_unroutable_returned_total => 0,
                    stream_error_access_refused_total => 0,
                    stream_error_authentication_failure_total => 0,
-                   stream_error_deliver_frame_too_large_total => 0,
                    stream_error_frame_too_large_total => 0,
                    stream_error_internal_error_total => 0,
                    stream_error_precondition_failed_total => 0,
@@ -1034,168 +1029,6 @@ client_tune_response_with_zero_frame_max_is_unlimited(Config) ->
     {Cmd, _C5} = receive_commands(Transport, S, C4),
     ?assertMatch({response, 3, {open, ?RESPONSE_CODE_OK, _}}, Cmd),
     gen_tcp:close(S).
-
-%% A subscriber that negotiates a small frame_max must not receive a
-%% Deliver frame bigger than what it agreed to. Here the subscriber has an
-%% empty stream open when a publisher, on another, normally-tuned
-%% connection, writes a chunk larger than the subscriber's frame_max; the
-%% subscribing connection is closed instead of receiving the oversized
-%% frame. This exercises the reactive (queue offset event) delivery path.
-deliver_frame_too_large_closes_connection_on_new_chunk(Config) ->
-    Transport = gen_tcp,
-    Port = get_stream_port(Config),
-    Opts = [{active, false}, {mode, binary}],
-    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
-
-    {ok, SubS} = Transport:connect("localhost", Port, Opts),
-    SubC0 = rabbit_stream_core:init(0),
-    SubC1 = test_peer_properties(Transport, SubS, SubC0),
-    SubC2 = sasl_handshake(Transport, SubS, SubC1),
-    SubC3 = test_plain_sasl_authenticate(Transport, SubS, SubC2, <<"guest">>),
-    {{tune, ServerFrameMax, _}, SubC4} = receive_commands(Transport, SubS, SubC3),
-    SmallFrameMax = 1024,
-    ?assert(SmallFrameMax < ServerFrameMax),
-    ok = Transport:send(SubS, frame({response, 0, {tune, SmallFrameMax, 0}})),
-    ok = Transport:send(SubS, request(3, {open, <<"/">>})),
-    {{response, 3, {open, ?RESPONSE_CODE_OK, _}}, SubC5} =
-        receive_commands(Transport, SubS, SubC4),
-    SubC6 = test_create_stream(Transport, SubS, Stream, SubC5),
-    SubscriptionId = 1,
-    SubC7 = test_subscribe(Transport, SubS, SubscriptionId, Stream, SubC6),
-
-    {ok, PubS} = Transport:connect("localhost", Port, Opts),
-    PubC0 = rabbit_stream_core:init(0),
-    PubC1 = test_peer_properties(Transport, PubS, PubC0),
-    PubC2 = test_authenticate(Transport, PubS, PubC1),
-    PublisherId = 1,
-    PubC3 = test_declare_publisher(Transport, PubS, PublisherId, Stream, PubC2),
-    Body = binary:copy(<<"a">>, SmallFrameMax + 1000),
-    _PubC4 = test_publish_confirm(Transport, PubS, PublisherId, Body, PubC3),
-
-    {Cmd, _SubC8} = receive_commands(Transport, SubS, SubC7),
-    ?assertMatch({request, _, {close, ?RESPONSE_CODE_FRAME_TOO_LARGE, _}}, Cmd),
-    ?assertEqual(closed, wait_for_socket_close(Transport, SubS, 10)),
-    Transport:close(PubS).
-
-%% Same failure as above, but triggered by the immediate dispatch that
-%% happens when a client subscribes to a stream that already holds a chunk
-%% bigger than the frame_max it just negotiated.
-deliver_frame_too_large_closes_connection_on_subscribe(Config) ->
-    Transport = gen_tcp,
-    Port = get_stream_port(Config),
-    Opts = [{active, false}, {mode, binary}],
-    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
-
-    {ok, PubS} = Transport:connect("localhost", Port, Opts),
-    PubC0 = rabbit_stream_core:init(0),
-    PubC1 = test_peer_properties(Transport, PubS, PubC0),
-    PubC2 = test_authenticate(Transport, PubS, PubC1),
-    PubC3 = test_create_stream(Transport, PubS, Stream, PubC2),
-    PublisherId = 1,
-    PubC4 = test_declare_publisher(Transport, PubS, PublisherId, Stream, PubC3),
-    SmallFrameMax = 1024,
-    Body = binary:copy(<<"a">>, SmallFrameMax + 1000),
-    _PubC5 = test_publish_confirm(Transport, PubS, PublisherId, Body, PubC4),
-
-    {ok, SubS} = Transport:connect("localhost", Port, Opts),
-    SubC0 = rabbit_stream_core:init(0),
-    SubC1 = test_peer_properties(Transport, SubS, SubC0),
-    SubC2 = sasl_handshake(Transport, SubS, SubC1),
-    SubC3 = test_plain_sasl_authenticate(Transport, SubS, SubC2, <<"guest">>),
-    {{tune, ServerFrameMax, _}, SubC4} = receive_commands(Transport, SubS, SubC3),
-    ?assert(SmallFrameMax < ServerFrameMax),
-    ok = Transport:send(SubS, frame({response, 0, {tune, SmallFrameMax, 0}})),
-    ok = Transport:send(SubS, request(3, {open, <<"/">>})),
-    {{response, 3, {open, ?RESPONSE_CODE_OK, _}}, SubC5} =
-        receive_commands(Transport, SubS, SubC4),
-    SubscriptionId = 1,
-    SubC6 = test_subscribe(Transport, SubS, SubscriptionId, Stream, SubC5),
-
-    {Cmd, _SubC7} = receive_commands(Transport, SubS, SubC6),
-    ?assertMatch({request, _, {close, ?RESPONSE_CODE_FRAME_TOO_LARGE, _}}, Cmd),
-    ?assertEqual(closed, wait_for_socket_close(Transport, SubS, 10)),
-    Transport:close(PubS).
-
-%% A chunk that fits comfortably within the negotiated frame_max is
-%% delivered as normal, even when that frame_max is deliberately small
-%% rather than the default multi-megabyte ceiling.
-deliver_under_frame_max_delivers_normally(Config) ->
-    Transport = gen_tcp,
-    Port = get_stream_port(Config),
-    Opts = [{active, false}, {mode, binary}],
-    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
-
-    {ok, S} = Transport:connect("localhost", Port, Opts),
-    C0 = rabbit_stream_core:init(0),
-    C1 = test_peer_properties(Transport, S, C0),
-    C2 = sasl_handshake(Transport, S, C1),
-    C3 = test_plain_sasl_authenticate(Transport, S, C2, <<"guest">>),
-    {{tune, ServerFrameMax, _}, C4} = receive_commands(Transport, S, C3),
-    SmallFrameMax = 1024,
-    ?assert(SmallFrameMax < ServerFrameMax),
-    ok = Transport:send(S, frame({response, 0, {tune, SmallFrameMax, 0}})),
-    ok = Transport:send(S, request(3, {open, <<"/">>})),
-    {{response, 3, {open, ?RESPONSE_CODE_OK, _}}, C5} =
-        receive_commands(Transport, S, C4),
-    C6 = test_create_stream(Transport, S, Stream, C5),
-    PublisherId = 1,
-    C7 = test_declare_publisher(Transport, S, PublisherId, Stream, C6),
-    Body = <<"a small message">>,
-    C8 = test_publish_confirm(Transport, S, PublisherId, Body, C7),
-    SubscriptionId = 1,
-    C9 = test_subscribe(Transport, S, SubscriptionId, Stream, C8),
-    _C10 = test_deliver(Transport, S, SubscriptionId, 0, Body, C9),
-    Transport:close(S).
-
-%% Same failure again, but triggered by the consumer_update response path:
-%% a single-active-consumer subscriber is asked by the server to confirm
-%% activation and, once it does, the server's dispatch of the pre-existing
-%% oversized chunk must close the connection.
-deliver_frame_too_large_closes_connection_on_consumer_update(Config) ->
-    Transport = gen_tcp,
-    Port = get_stream_port(Config),
-    Opts = [{active, false}, {mode, binary}],
-    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
-
-    {ok, PubS} = Transport:connect("localhost", Port, Opts),
-    PubC0 = rabbit_stream_core:init(0),
-    PubC1 = test_peer_properties(Transport, PubS, PubC0),
-    PubC2 = test_authenticate(Transport, PubS, PubC1),
-    PubC3 = test_create_stream(Transport, PubS, Stream, PubC2),
-    PublisherId = 1,
-    PubC4 = test_declare_publisher(Transport, PubS, PublisherId, Stream, PubC3),
-    SmallFrameMax = 1024,
-    Body = binary:copy(<<"a">>, SmallFrameMax + 1000),
-    _PubC5 = test_publish_confirm(Transport, PubS, PublisherId, Body, PubC4),
-
-    {ok, SubS} = Transport:connect("localhost", Port, Opts),
-    SubC0 = rabbit_stream_core:init(0),
-    SubC1 = test_peer_properties(Transport, SubS, SubC0),
-    SubC2 = sasl_handshake(Transport, SubS, SubC1),
-    SubC3 = test_plain_sasl_authenticate(Transport, SubS, SubC2, <<"guest">>),
-    {{tune, ServerFrameMax, _}, SubC4} = receive_commands(Transport, SubS, SubC3),
-    ?assert(SmallFrameMax < ServerFrameMax),
-    ok = Transport:send(SubS, frame({response, 0, {tune, SmallFrameMax, 0}})),
-    ok = Transport:send(SubS, request(3, {open, <<"/">>})),
-    {{response, 3, {open, ?RESPONSE_CODE_OK, _}}, SubC5} =
-        receive_commands(Transport, SubS, SubC4),
-    SubscriptionId = 1,
-    SacProps = #{<<"single-active-consumer">> => <<"true">>,
-                 <<"name">> => <<"sac-1">>},
-    SubC6 = test_subscribe(Transport, SubS, SubscriptionId, Stream,
-                           SacProps, ?RESPONSE_CODE_OK, SubC5),
-
-    {ConsumerUpdateRequest, SubC7} = receive_commands(Transport, SubS, SubC6),
-    {request, CorrelationId, {consumer_update, SubscriptionId, true}} =
-        ConsumerUpdateRequest,
-    ok = Transport:send(SubS,
-                        frame({response, CorrelationId,
-                              {consumer_update, ?RESPONSE_CODE_OK, none}})),
-
-    {Cmd, _SubC8} = receive_commands(Transport, SubS, SubC7),
-    ?assertMatch({request, _, {close, ?RESPONSE_CODE_FRAME_TOO_LARGE, _}}, Cmd),
-    ?assertEqual(closed, wait_for_socket_close(Transport, SubS, 10)),
-    Transport:close(PubS).
 
 timeout_tcp_connected(Config) ->
     Port = get_stream_port(Config),

--- a/release-notes/4.3.5.md
+++ b/release-notes/4.3.5.md
@@ -48,11 +48,6 @@ Release notes can be found on GitHub at [rabbitmq-server/release-notes](https://
 
    GitHub issue: [#17053](https://github.com/rabbitmq/rabbitmq-server/pull/17053)
 
- * `Deliver` frames sent to stream consumers are now checked against the connection's
-   negotiated `frame_max`.
-
-   GitHub issue: [#17083](https://github.com/rabbitmq/rabbitmq-server/pull/17083)
-
  * New setting: `stream.max_uncompressed_sub_entry_batch_size`. It bounds the declared
    uncompressed size of a published sub-entry batch, and defaults to 67108864 (64 MiB),
    the same default already used by the Java client's `maxUncompressedSubEntryBatchSize`.
@@ -155,7 +150,6 @@ Release notes can be found on GitHub at [rabbitmq-server/release-notes](https://
    has authenticated, matching the behavior of "regular" STOMP connections.
 
    GitHub issue: [#17065](https://github.com/rabbitmq/rabbitmq-server/pull/17065)
-
 
 ### Dependency Changes
 


### PR DESCRIPTION
This reverts commit 1af4a74824b3bad5286c87bc4d1d810c2d126d0c, reversing changes made to 47ce9262a76923aa2d5d98ced03630db2cbcde6c.

Conflicts:
        release-notes/4.3.5.md