### PR TITLE
Revert "stream: bump max frame size from 1 MiB to 20 MiB (backport #17126)"

### DIFF
--- a/deps/rabbitmq_stream/Makefile
+++ b/deps/rabbitmq_stream/Makefile
@@ -13,7 +13,7 @@ define PROJECT_ENV
 	{ssl_listen_options, []},
 	{initial_credits, 50000},
 	{credits_required_for_unblocking, 12500},
-	{frame_max, 20971520},
+	{frame_max, 1048576},
 	{max_uncompressed_sub_entry_batch_size, 67108864},
 	{heartbeat, 60},
 	{advertised_host, undefined},

--- a/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
+++ b/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
@@ -83,7 +83,7 @@
 
 -define(DEFAULT_INITIAL_CREDITS, 50000).
 -define(DEFAULT_CREDITS_REQUIRED_FOR_UNBLOCKING, 12500).
--define(DEFAULT_FRAME_MAX, 20971520). %% 20 MiB
+-define(DEFAULT_FRAME_MAX, 1048576). %% 1 MiB
 %% Frame size ceiling until a connection is authenticated and
 %% authorized (a successful `open`), bounding the buffer an
 %% unauthenticated peer can negotiate.

--- a/release-notes/4.3.5.md
+++ b/release-notes/4.3.5.md
@@ -60,13 +60,6 @@ Release notes can be found on GitHub at [rabbitmq-server/release-notes](https://
 
    GitHub issue: [#17103](https://github.com/rabbitmq/rabbitmq-server/pull/17103)
 
- * The max frame size has been bumped from 1048576 (1 MiB) to 20971520 (20 MiB).
-   This is a follow-up of the enforcement of `frame_max` for `Deliver` frames,
-   to avoid breaking existing installations while keeping a reasonable default.
-   It is possible to change the value with the `stream.frame_max` setting to adapt
-   it to the size of stream chunks (if known).
-
-   GitHub issue: [#17126](https://github.com/rabbitmq/rabbitmq-server/pull/17126)
 
 ### Management Plugin
 


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-server#17139