### PR TITLE
Add connection link for queue consummers without channel

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -18,7 +18,16 @@ const CONSUMER_OWNER_FORMATTERS = [
         }
     }},
     {order: 100, formatter: function(consumer) {
-        return link_channel(consumer.channel_details.name);
+        var cd = consumer.channel_details;
+        if (cd.name) {
+            return link_channel(cd.name);
+        }
+        // Consumers of channel-less protocols (e.g. MQTT) belong
+        // directly to a connection.
+        if (cd.connection_name) {
+            return link_conn(cd.connection_name);
+        }
+        return UNKNOWN_REPR;
     }}
 ];
 

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -523,7 +523,8 @@ var HELP = {
 
     'consumer-owner' :
     '<a href="https://www.rabbitmq.com/consumers.html">AMQP 0-9-1 consumers</a> belong to a channel, \
-    and <a href="https://www.rabbitmq.com/stream.html">stream consumers</a> belong to a stream connection.',
+    <a href="https://www.rabbitmq.com/stream.html">stream consumers</a> belong to a stream connection, \
+    and consumers of channel-less protocols (e.g. MQTT) belong to a connection.',
 
     'plugins' :
     'Note that only plugins which are both explicitly enabled and running are shown here.',

--- a/deps/rabbitmq_management/priv/www/js/tmpl/consumers.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/consumers.ejs
@@ -3,7 +3,7 @@
       <thead>
         <tr>
 <% if (mode == 'queue') { %>
-          <th>Channel <span class="help" id="consumer-owner"></th>
+          <th>Owner <span class="help" id="consumer-owner"></th>
           <th>Consumer tag</th>
 <% } else { %>
           <th>Consumer tag</th>


### PR DESCRIPTION
## Proposed Changes

Our team is using the management UI daily now for light management and we think more users could benefit from those improvements. We need to go quickly from the queue to the consumer connection to check the client_properties and this is currently working only for AMQP.

API was already prepared for this, the column was just rendering empty until now in the UI.

Hope you like it.

Thank you!
R

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [X] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

-
