### PR TITLE
Add queue published payload history to local-storage

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -387,6 +387,11 @@ var HELP = {
     'message-publish-headers':
       'Headers can have any name. Only long string headers can be set here.',
 
+    'message-publish-history':
+      'The last 50 string-encoded payloads published from this browser are remembered \
+      in its local storage. Picking one fills in the payload below. The history is \
+      never sent to the server and is shared across all queues and exchanges.',
+
     'message-publish-properties':
       '<p>You can set other message properties here (delivery mode and headers \
       are pulled out as the most common cases).</p>\

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -964,7 +964,16 @@ function postprocess() {
         select_queue_type(this);
     });
 
-    $('form[name="upload-definitions"]').on('submit', function(e) {
+    $(document).on('change', 'select.publish-history', function() {
+        var payload = get_publish_history()[parseInt($(this).val(), 10)];
+        if (payload == undefined) return;
+        var form = $(this).closest('form');
+        form.find('textarea[name="payload"]').val(payload);
+        // History only holds string-encoded payloads.
+        form.find('select[name="payload_encoding"]').val('string');
+    });
+
+    $('[name="upload-definitions"]').on('click', function(e) {
         e.preventDefault();
         submit_import(this);
     });
@@ -1376,6 +1385,64 @@ function toggle_visibility(item) {
     }
 }
 
+var PUBLISH_MSG_HISTORY_KEY = 'publish-msg-history';
+var PUBLISH_MSG_HISTORY_MAX = 50;
+
+// The history is a plain array of payload strings, most recent first.
+function get_publish_history() {
+    var stored = get_local_pref(PUBLISH_MSG_HISTORY_KEY);
+    if (stored == undefined) return [];
+    try {
+        var history = JSON.parse(stored);
+        if (!Array.isArray(history)) return [];
+        return history.filter(function(e) { return typeof e == 'string'; });
+    } catch (e) {
+        return [];
+    }
+}
+
+function add_to_publish_history(params) {
+    // Only string-encoded payloads are remembered;
+    if (params.payload_encoding != 'string') return;
+    // Republishing an identical payload moves it to the top
+    // rather than duplicating it.
+    var history = get_publish_history().filter(function(e) {
+        return e != params.payload;
+    });
+    history.unshift(params.payload);
+    history = history.slice(0, PUBLISH_MSG_HISTORY_MAX);
+    try {
+        store_local_pref(PUBLISH_MSG_HISTORY_KEY, JSON.stringify(history));
+    } catch (e) {
+        // localStorage quota exceeded; drop the history rather than
+        // interfere with publishing.
+        clear_local_pref(PUBLISH_MSG_HISTORY_KEY);
+    }
+}
+
+function publish_history_options() {
+    var history = get_publish_history();
+    var res = '<option value="" selected>' +
+        (history.length == 0 ? '(no previously published messages)'
+                             : '(pick a previously published message)') +
+        '</option>';
+    for (var i = 0; i < history.length; i++) {
+        // Collapse newlines and indentation for the one-line preview;
+        // the stored payload keeps its original formatting.
+        var preview = history[i].replace(/\s+/g, ' ');
+        if (preview.length > 80) {
+            preview = preview.substring(0, 80) + '…';
+        }
+        res += '<option value="' + i + '">' +
+            fmt_escape_html(preview) + '</option>';
+    }
+    return res;
+}
+
+function refresh_publish_history_selects() {
+    $('select.publish-history').html(publish_history_options());
+}
+
 function publish_msg(params0) {
     try {
         var params = params_magic(params0);
@@ -1415,6 +1482,8 @@ function publish_msg0(params) {
     }
     with_req('POST', path, JSON.stringify(params), function(resp) {
             var result = JSON.parse(resp.responseText);
+            add_to_publish_history(params);
+            refresh_publish_history_selects();
             if (result.routed) {
                 show_popup('info', 'Message published.');
             } else {

--- a/deps/rabbitmq_management/priv/www/js/tmpl/publish.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/publish.ejs
@@ -57,6 +57,19 @@
           </td>
         </tr>
         <tr>
+          <th>
+            <label>
+              History:
+              <span class="help" id="message-publish-history"></span>
+            </label>
+          </th>
+          <td>
+            <select class="publish-history">
+              <%= publish_history_options() %>
+            </select>
+          </td>
+        </tr>
+        <tr>
           <th><label>Payload:</label></th>
           <td><textarea name="payload"></textarea></td>
         </tr>


### PR DESCRIPTION
## Proposed Changes

Our team is using the management UI daily now for light management and we think more users could benefit from those improvements. We need to constantly send some debug JSON messages to different queues / consumers and previously we were using Postman for this, which had history, slowing us down significantly now.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [X] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Since this is a rather lengthy JS code, I'm open for suggestions on how to make it lighter, the important thing for us is the functionality, which we can't build in our own plugin for this use-case.

Thank you!
R
