### PR TITLE
Let a deprecated feature be denied while in use

### DIFF
--- a/.github/workflows/test-upgrades.sh
+++ b/.github/workflows/test-upgrades.sh
@@ -67,6 +67,79 @@ case "$scenario" in
 		wait
 		;;
 
+	transient_nonexclusive_queue)
+		# Declare a transient non-exclusive classic queue. The property
+		# combination is denied by default as of 4.3.0, so it is
+		# declared on the old node where it is still permitted.
+		cat > transient-nonexclusive-definitions.json <<-'EOF'
+		{
+		  "queues": [
+		    {
+		      "arguments": {"x-queue-type": "classic"},
+		      "auto_delete": false,
+		      "durable": false,
+		      "name": "transient-nonexclusive",
+		      "vhost": "/"
+		    }
+		  ]
+		}
+		EOF
+
+		if [ "$node_count" -eq 3 ]; then
+			queue_node=rabbit-3
+		else
+			queue_node=rabbit-1
+		fi
+
+		echo "=== Declare a transient non-exclusive classic queue on $queue_node"
+		$old_rabbitmqctl -n "$queue_node" import_definitions \
+			transient-nonexclusive-definitions.json
+		$old_rabbitmqctl -n "$queue_node" list_queues name durable | \
+			grep -qE '^transient-nonexclusive\s+false$'
+
+		if [ "$node_count" -eq 3 ]; then
+			# Upgrade two nodes and leave the queue and its owning node
+			# on the old version. The upgraded nodes must start even
+			# though the queue is still there and in use.
+			echo "=== Upgrade cluster to new RabbitMQ version (2 out of 3 nodes only)"
+			$make -C "$new_dist" restart-cluster NODES=2
+
+			$new_rabbitmqctl -n rabbit-1 list_queues name durable | \
+				grep -qE '^transient-nonexclusive\s+false$'
+
+			# The deprecated feature must be denied on both the
+			# upgraded and the old nodes.
+			$new_rabbitmqctl -n rabbit-1 eval \
+				'rabbit_deprecated_features:is_permitted(transient_nonexcl_queues).' \
+				| tail -n 1 | grep -qx false
+			$old_rabbitmqctl -n rabbit-3 eval \
+				'rabbit_deprecated_features:is_permitted(transient_nonexcl_queues).' \
+				| tail -n 1 | grep -qx false
+		fi
+
+		echo "=== Complete the upgrade"
+		$make -C "$new_dist" restart-cluster
+
+		# The queue is gone: a transient queue is deleted when the node
+		# hosting it restarts.
+		if $new_rabbitmqctl -n rabbit-1 list_queues name | \
+			grep -qE '^transient-nonexclusive$'; then
+			echo "ERROR: transient non-exclusive queue survived its node restart" >&2
+			exit 1
+		fi
+
+		# New declarations are still rejected.
+		echo "=== Ensure a new transient non-exclusive queue is rejected"
+		$new_rabbitmqctl -n rabbit-1 eval \
+			'rabbit_amqqueue:declare(rabbit_misc:r(<<"/">>, queue, <<"transient-nonexclusive-after-upgrade">>), false, false, [], none, <<"upgrade-test">>).' \
+			| grep -q 'transient_nonexcl_queues'
+		if $new_rabbitmqctl -n rabbit-1 list_queues name | \
+			grep -qE '^transient-nonexclusive-after-upgrade$'; then
+			echo "ERROR: rejected transient non-exclusive queue exists" >&2
+			exit 1
+		fi
+		;;
+
 	10k_queues_import)
 		# Import 10k classic queues
 		echo "=== Import 10k classic queues"

--- a/.github/workflows/test-upgrades.yaml
+++ b/.github/workflows/test-upgrades.yaml
@@ -11,6 +11,7 @@ on:
     - plugins.mk
     - rabbitmq-components.mk
     - .github/workflows/test-upgrades.yaml
+    - .github/workflows/test-upgrades.sh
   pull_request:
 
 concurrency:
@@ -95,6 +96,7 @@ jobs:
         scenario:
           - durable_queue
           - transient_queue
+          - transient_nonexclusive_queue
           - 10k_queues_import
           - topic_bindings_import
         node_count:

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -111,10 +111,14 @@
 
 %%----------------------------------------------------------------------------
 
+%% Denying this deprecated feature rejects new declarations and leaves
+%% existing transient queues alone, as they are deleted when the node hosting
+%% them restarts. Therefore existing queues must not prevent the denial.
 -rabbit_deprecated_feature(
    {transient_nonexcl_queues,
     #{deprecation_phase => denied_by_default,
       doc_url => "https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#removal-of-transient-non-exclusive-queues",
+      usage_prevents_denial => false,
       callbacks => #{is_feature_used => {?MODULE, are_transient_nonexcl_used}}
      }}).
 

--- a/deps/rabbit/src/rabbit_deprecated_features.erl
+++ b/deps/rabbit/src/rabbit_deprecated_features.erl
@@ -96,6 +96,13 @@
 %% a cluster-wide sync of the feature flags states. Again, the underlying
 %% feature flag won't be enabled if the feature is used.
 %%
+%% A deprecated feature can set the `usage_prevents_denial' property to
+%% `false' to opt out of that behavior. The callback still runs and its result
+%% is still reported by the CLI, but the feature being in use no longer
+%% prevents the underlying feature flag from being enabled. This is meant for
+%% deprecated features that need no migration because denying them only
+%% rejects new uses.
+%%
 %% Note that this callback is only used when in `permitted_by_default' or
 %% `denied_by_default': remember that `disconnected' and `removed' are the
 %% same as a required feature flag.
@@ -116,6 +123,7 @@
 
 -export([is_permitted/1,
          get_phase/1,
+         usage_prevents_denial/1,
          get_warning/1]).
 -export([extend_properties/2,
          should_be_permitted/2,
@@ -165,6 +173,7 @@
                            messages => #{when_permitted => string(),
                                          when_denied => string(),
                                          when_removed => string()},
+                           usage_prevents_denial => boolean(),
                            callbacks =>
                            #{callback_name() =>
                              rabbit_feature_flags:callback_fun_name()}}.
@@ -183,6 +192,14 @@
 %% use a denied deprecated feature is being made. It is logged as an error or
 %% displayed to the user by the CLI or in the management UI for instance.</li>
 %% </ul></li>
+%% <li>`usage_prevents_denial': whether the deprecated feature being in use
+%% prevents it from being denied. It defaults to `true' and is only consulted
+%% when an {@type is_feature_used_callback()} callback is declared.
+%%
+%% Set it to `false' when denying the deprecated feature needs no migration
+%% because the denial only applies to new uses. The `is_feature_used' callback
+%% is still called and its result is still reported by the CLI, but a
+%% deprecated feature in use no longer prevents RabbitMQ from starting.</li>
 %% </ul>
 %%
 %% Other properties are the same as {@link
@@ -198,6 +215,7 @@
         messages := #{when_permitted => string(),
                       when_denied => string(),
                       when_removed => string()},
+        usage_prevents_denial => boolean(),
         provided_by := atom()}.
 %% The deprecated feature properties, once expanded by this module when
 %% feature flags are discovered.
@@ -622,16 +640,48 @@ enable_underlying_feature_flag_cb(
     IsUsed = is_deprecated_feature_in_use(Args),
     case IsUsed of
         true ->
-            ?LOG_ERROR(
-               "Deprecated features: `~ts`: can't deny deprecated "
-               "feature because it is actively used",
-               [FeatureName],
-               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-            {error,
-             {failed_to_deny_deprecated_features, [FeatureName]}};
+            case usage_prevents_denial(FeatureName) of
+                true ->
+                    ?LOG_ERROR(
+                       "Deprecated features: `~ts`: can't deny deprecated "
+                       "feature because it is actively used",
+                       [FeatureName],
+                       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+                    {error,
+                     {failed_to_deny_deprecated_features, [FeatureName]}};
+                false ->
+                    ?LOG_WARNING(
+                       "Deprecated features: `~ts`: the deprecated feature is "
+                       "in use; it is denied anyway because the denial only "
+                       "applies to new uses",
+                       [FeatureName],
+                       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+                    ok
+            end;
         _ ->
             ok
     end.
+
+-spec usage_prevents_denial(FeatureName | FeatureProps) -> Prevents when
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      FeatureProps :: feature_props_extended(),
+      Prevents :: boolean().
+%% @doc Indicates if the deprecated feature being in use prevents it from
+%% being denied.
+%%
+%% @param FeatureName The name of the deprecated feature.
+%% @param FeatureProps The properties of the deprecated feature.
+%% @returns true if the deprecated feature can only be denied while it is
+%% unused, false if the denial applies to new uses only.
+
+usage_prevents_denial(FeatureName) when is_atom(FeatureName) ->
+    case rabbit_ff_registry_wrapper:get(FeatureName) of
+        undefined    -> true;
+        FeatureProps -> usage_prevents_denial(FeatureProps)
+    end;
+usage_prevents_denial(FeatureProps) when is_map(FeatureProps) ->
+    ?assert(?IS_DEPRECATION(FeatureProps)),
+    maps:get(usage_prevents_denial, FeatureProps, true).
 
 is_deprecated_feature_in_use(
   #{feature_props := #{callbacks := Callbacks}} = Args1) ->

--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1080,8 +1080,11 @@ assert_feature_flag_is_valid(FeatureName, FeatureProps) ->
                               doc_url,
                               deprecation_phase,
                               messages,
+                              usage_prevents_denial,
                               callbacks],
                 ?assertEqual([], maps:keys(FeatureProps) -- ValidProps),
+                ?assert(is_boolean(
+                          maps:get(usage_prevents_denial, FeatureProps, true))),
                 Phase = maps:get(deprecation_phase, FeatureProps),
                 ?assert(Phase =:= permitted_by_default orelse
                         Phase =:= denied_by_default orelse

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -1145,6 +1145,8 @@ check_required_and_enable(
                               [FeatureName],
                               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
                            true;
+                       _ when ?IS_DEPRECATION(FeatureProps) ->
+                           denial_needs_no_migration(FeatureName);
                        _ ->
                            false
                    end,
@@ -1165,13 +1167,30 @@ check_required_and_enable(
             update_feature_state_and_enable(Inventory, FeatureName);
         true ->
             ?LOG_DEBUG(
-               "Feature flags: `~s`: all nodes where the feature flag is "
-               "disabled are virgin, we can directly mark it as enabled "
-               "there",
+               "Feature flags: `~s`: it can be marked as enabled directly on "
+               "the nodes where it is disabled",
                [FeatureName],
                #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
             mark_as_enabled_on_nodes(
               NodesWhereDisabled, Inventory, FeatureName, true)
+    end.
+
+%% A deprecated feature that needs no migration before it is denied can be
+%% marked as enabled without running the `enable' callback. The local
+%% definition decides: the local node drives this sync and therefore runs the
+%% most recent version of that definition, while a node that has not been
+%% upgraded yet would refuse the denial.
+denial_needs_no_migration(FeatureName) ->
+    case rabbit_deprecated_features:usage_prevents_denial(FeatureName) of
+        true ->
+            false;
+        false ->
+            ?LOG_DEBUG(
+               "Feature flags: `~ts`: denying the deprecated feature needs no "
+               "migration; it does not have to be denied on other nodes first",
+               [FeatureName],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            true
     end.
 
 -spec update_feature_state_and_enable(Inventory, FeatureName) -> Ret when
@@ -1585,14 +1604,28 @@ list_deprecated_features_that_cant_be_denied(
                                                 is_feature_used, #{},
                                                 infinity),
                       case IsUsed of
-                          true   -> [FeatureName | Acc];
-                          false  -> Acc;
-                          _Error -> [FeatureName | Acc]
+                          false ->
+                              Acc;
+                          _ ->
+                              add_if_denial_is_prevented(FeatureName, Acc)
                       end
               end;
           (_FeatureName, false, Acc) ->
               Acc
       end, [], States).
+
+add_if_denial_is_prevented(FeatureName, Acc) ->
+    case rabbit_deprecated_features:usage_prevents_denial(FeatureName) of
+        true ->
+            [FeatureName | Acc];
+        false ->
+            ?LOG_WARNING(
+               "Feature flags: `~ts`: the deprecated feature is in use; it is "
+               "denied anyway because the denial only applies to new uses",
+               [FeatureName],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            Acc
+    end.
 
 -spec disable_permitted_deprecated_features(Inventory) -> ok when
       Inventory :: rabbit_feature_flags:cluster_inventory().

--- a/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
+++ b/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
@@ -30,6 +30,7 @@
 
          when_transient_nonexcl_is_not_permitted/1,
          when_transient_nonexcl_is_permitted_from_conf/1,
+         existing_transient_nonexcl_does_not_block_restart/1,
 
          when_queue_master_locator_is_permitted_from_conf/1,
          when_queue_master_locator_is_not_permitted_by_default/1
@@ -56,7 +57,8 @@ groups() ->
        set_policy_when_cmq_is_not_permitted_from_conf]},
      {transient_nonexcl_queues, [],
       [when_transient_nonexcl_is_not_permitted,
-       when_transient_nonexcl_is_permitted_from_conf]},
+       when_transient_nonexcl_is_permitted_from_conf,
+       existing_transient_nonexcl_does_not_block_restart]},
      {queue_master_locator, [],
       [when_queue_master_locator_is_permitted_from_conf,
        when_queue_master_locator_is_not_permitted_by_default]}
@@ -273,6 +275,33 @@ when_transient_nonexcl_is_permitted_from_conf(Config) ->
          Config, NodeA,
          ["Deprecated features: `transient_nonexcl_queues`: Feature `transient_nonexcl_queues` is deprecated",
           "Its use is permitted per the configuration"])).
+
+existing_transient_nonexcl_does_not_block_restart(Config) ->
+    [NodeA] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    QName = list_to_binary(atom_to_list(?FUNCTION_NAME)),
+    QResource = rabbit_misc:r(<<"/">>, queue, QName),
+    %% The queue type API is used directly to bypass the declaration check,
+    %% the way a node running an older version would have declared this queue
+    %% before the cluster was upgraded.
+    Q = amqqueue:new(
+          QResource, none, false, false, none, [], <<"/">>, #{},
+          rabbit_classic_queue),
+    ?assertMatch(
+       {new, _},
+       rabbit_ct_broker_helpers:rpc(
+         Config, NodeA, rabbit_queue_type, declare, [Q, NodeA])),
+
+    ok = rabbit_ct_broker_helpers:restart_broker(Config, NodeA),
+
+    ?assertEqual(
+       {error, not_found},
+       rabbit_ct_broker_helpers:rpc(
+         Config, NodeA, rabbit_amqqueue, lookup, [QResource])),
+    ?assertNot(
+       rabbit_ct_broker_helpers:rpc(
+         Config, NodeA, rabbit_deprecated_features, is_permitted,
+         [transient_nonexcl_queues])).
 
 %% -------------------------------------------------------------------
 %% (x-)queue-master-locator


### PR DESCRIPTION
The motivation for this is the deprecated `transient_nonexcl_queues` feature which moved to `denied_by_default` in 4.3.0. When denied by default, the `is_feature_used` callback is used for three purposes:

* To report deprecated features in use in the management UI and in `rabbitmqctl list_deprecated_features`, etc.
* As a gate for state transition to denied. When true, it prevents the underlying feature flag from being enabled.
* As a gate at boot, failing boot if the denied feature is in use.

The last (gate at boot) means that a single-node broker (or cluster during rolling upgrade) fails to boot if it has a transient non-exclusive queue in the metadata store. This is problematic for single-node since the cleanup of these queues happens in a later boot step, and it's a problem for clusters since an older member on 4.2 might have a transient non-exclusive queue in a mixed version cluster, preventing the 4.3 node(s)' boots.

This change allows marking a deprecated feature flag so that the underlying feature flag can be enabled even if the deprecated feature is still in use. This prevents further declarations and fixes the boot issue. This is appropriate for deprecated features which need no migration, especially if they are transient.