### PR TITLE
CQ shared store v2 file format implementation

### DIFF
--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -880,14 +880,8 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
     State2 = State1 #msstate { current_file         = CurFile,
                                current_file_handle  = CurHdl,
                                current_file_offset  = CurOffset },
-    %% CurFile0 was still current_file (and therefore exempt from
-    %% every delete_file_if_empty/2 check run so far, including the
-    %% one build_index/3 just did for dirty recovery) right up until
-    %% open_current_file/5 above decided to roll away from it because
-    %% it's v1. If it turned out to hold no valid messages, nothing
-    %% else will ever reconsider it once we return here with a
-    %% different file current: check it once, now, while we still
-    %% remember it was just abandoned.
+    %% After an upgrade the most recent v1 file may be empty,
+    %% we delete it now instead of leaving it forever.
     State3 = case CurFile of
         CurFile0 -> State2;
         _        -> delete_file_if_empty(CurFile0, State2)
@@ -896,14 +890,9 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
      hibernate,
      {backoff, ?HIBERNATE_AFTER_MIN, ?HIBERNATE_AFTER_MIN, ?DESIRED_HIBERNATE}}.
 
-%% The current write file must always be v2. build_index/3 may have left
-%% us pointing at a v1 file, either because the store predates v2 or
-%% because nothing has been written since upgrading: in that case we
-%% force a roll to a fresh v2 file (CurFile0 + 1) before accepting any
-%% writes. Separately, if the recovered v2 "current" file has nothing
-%% but (at most) a partial header in it, we (re)create it fresh via
-%% writer_open/2 rather than let writer_recover/3's truncate conjure up
-%% a correct 64-byte header out of implicit zero-fill.
+%% The current write file is always v2. If the current file is v1,
+%% we create a new v2 current file. We also do if the v2 file has
+%% nothing in it (we overwrite the header if any).
 open_current_file(Dir, CurFile, CurOffset, LastV1File, FileSummaryEts) ->
     case file_format(CurFile, LastV1File) of
         %% v1 files can't take v2 records, so roll over to a brand new file.
@@ -1654,10 +1643,6 @@ mark_handle_closed(FileHandlesEts, File, Ref) ->
 
 form_filename(Dir, Name) -> filename:join(Dir, Name).
 
-%% Format is determined solely by the file number relative to the
-%% store's last_v1_file boundary: writes always produce v2 from this
-%% release onward, so any file above the boundary (or every file, when
-%% the store has no v1 files at all) is v2.
 file_format(_File, none)                       -> v2;
 file_format(File,  LastV1) when File =< LastV1 -> v1;
 file_format(_,     _)                          -> v2.
@@ -1816,7 +1801,7 @@ scan_v1_next_byte(<<_, Rest/bits>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
 %% as in v1. We never fall back to scanning the next byte: that is
 %% exactly the kind of guess that could land on something that merely
 %% looks like a record.
-
+%%
 %% Any exception raised while scanning (whether one of the deliberate
 %% rabbit_msg_store_v2_scan corruption errors above, or anything else
 %% unexpected) is re-raised with Path attached, so whatever eventually
@@ -1826,12 +1811,6 @@ scan_v2_file_for_valid_messages(Path, Fun) ->
     try
         case file:open(Path, [read, binary, raw]) of
             {ok, Fd} ->
-                %% The fd must close on every exit from the scan below,
-                %% not just success: scan_file_recovering_corruption/2
-                %% retries a failed scan of this same file in a loop,
-                %% and each retry calls back in here, so a leaked fd
-                %% per failed attempt would accumulate for as long as
-                %% the process doing the scanning lives.
                 try
                     {ok, FileSize} = file:position(Fd, eof),
                     Messages = case FileSize < ?V2_HEADER_SIZE of
@@ -1964,11 +1943,7 @@ scan_v2_data(<<?REC_MESSAGE:8, Size:32, Rest0/bits>> = Data, Fd, Fun, Offset, Fi
             PayloadLen = Size - 21,
             case Rest0 of
                 <<MsgIdInt:128, Body:PayloadLen/binary, Rest/bits>> ->
-                    %% A torn write reproducing a syntactically valid
-                    %% Erlang external term by chance is astronomically
-                    %% unlikely, so this catches a Type/Size that happened
-                    %% to validate numerically but isn't really a message,
-                    %% regardless of what MsgId lookup would say below.
+                    %% We only need to know this is a valid Erlang term.
                     try binary_to_term(Body) of
                         _ -> ok
                     catch
@@ -2039,9 +2014,7 @@ index_recover(Dir) ->
     Path = filename:join(Dir, ?INDEX_FILE_NAME),
     %% {verify, true} rejects a truncated dump (e.g. left behind by a
     %% shutdown that was killed mid-write) instead of silently loading
-    %% however many objects made it to disk. The caller already falls
-    %% back to a full dirty-recovery rescan on any error here, which is
-    %% what must happen instead of trusting a partial index.
+    %% however many objects made it to disk.
     case ets:file2tab(Path, [{verify, true}]) of
         {ok, IndexEts}  -> _ = file:delete(Path),
                            {ok, IndexEts};
@@ -2081,16 +2054,8 @@ index_update(IndexEts, Obj) ->
 %% write racing this compaction can delete and reinsert the same msg_id
 %% under a different file (or a different offset in the same file) before
 %% this runs; if that happened, the entry no longer belongs to this
-%% compaction pass and must not be touched -- its own physical bytes were
-%% already copied into the new location regardless (write_compact_file_v2
-%% doesn't know or care whether the index update will succeed), so the
-%% only consequence of skipping is an orphaned, harmless duplicate copy
-%% that scan_and_vacuum_message_file/3's existing fan-out clause already
-%% recognises and discards on this file's next scan.
+%% compaction pass and must not be touched.
 index_update_offset_if_unchanged(IndexEts, MsgId, File, OldOffset, NewOffset) ->
-    %% The extra {...} around the replacement record is required by
-    %% ets:select_replace/2: without it, a literal tuple appearing in a
-    %% match spec's body is parsed as a function call instead.
     MatchSpec = [{#msg_location{msg_id = MsgId, ref_count = '$1', file = File,
                                 offset = OldOffset, total_size = '$2'},
                   [],
@@ -2173,8 +2138,6 @@ recover_index_and_client_refs(true, ClientRefs, Dir, Name) ->
             end
     end.
 
-%% Ground truth for the v1/v2 boundary when it cannot be trusted from
-%% persisted terms (dirty recovery).
 scan_for_last_v1_file(Dir) ->
     case filelib:wildcard("*" ++ ?FILE_EXTENSION_V1, Dir) of
         []    -> none;
@@ -2206,13 +2169,9 @@ recover_file_summary(false, _Dir) ->
                     [ordered_set, public, {keypos, #file_summary.file}])};
 recover_file_summary(true, Dir) ->
     Path = filename:join(Dir, ?FILE_SUMMARY_FILENAME),
-    %% {verify, true} rejects a truncated dump instead of silently
-    %% loading whatever entries made it to disk -- a partial table can
-    %% be missing exactly the highest-numbered (most recently added)
-    %% files, which would otherwise make a stale, lower file look like
-    %% the current one. Falling back to recover_file_summary(false, ...)
-    %% forces the full dirty-recovery rescan, which derives the true
-    %% current file from the real directory listing instead.
+    %% {verify, true} rejects a truncated dump (e.g. left behind by a
+    %% shutdown that was killed mid-write) instead of silently loading
+    %% however many objects made it to disk.
     case ets:file2tab(Path, [{verify, true}]) of
         {ok, Tid}       -> ok = file:delete(Path),
                            {true, Tid};
@@ -2374,13 +2333,8 @@ scan_file_recovering_corruption(Path, Fun) ->
             end
     end.
 
-%% Every rabbit_msg_store_v2_scan reason (wrapped by
-%% scan_v2_file_for_valid_messages/2 in rabbit_msg_store_v2_scan_error)
-%% reports the offset of the record it rejected as its second element.
-%% Only that specific, unambiguous shape is trusted: anything else,
-%% including a tuple that merely happens to also have an integer in
-%% the same position, is not our own error and must not be mistaken
-%% for one.
+%% Every rabbit_msg_store_v2_scan reason reports the offset of the
+%% record it rejected as its second element.
 corruption_offset({rabbit_msg_store_v2_scan_error, _Path, InnerReason})
         when is_tuple(InnerReason), tuple_size(InnerReason) >= 2,
              element(1, InnerReason) =:= rabbit_msg_store_v2_scan,
@@ -2388,8 +2342,6 @@ corruption_offset({rabbit_msg_store_v2_scan_error, _Path, InnerReason})
     {ok, element(2, InnerReason)};
 corruption_offset(_Reason) -> error.
 
-%% Runs in the same process as its caller, rebuild_index/3, rather than
-%% a separate spawned process -- see the comment there for why.
 enqueue_build_index_workers(_Gatherer, [], _State) ->
     ok;
 enqueue_build_index_workers(Gatherer, [File|Files], State) ->
@@ -2420,22 +2372,6 @@ reduce_index(Gatherer, LastFile,
             reduce_index(Gatherer, LastFile, State)
     end.
 
-%% Dispatching used to happen in a separate, unlinked, spawned process,
-%% concurrently with reduce_index/3 below draining the gatherer. If
-%% that process died before dispatching every file -- for any reason,
-%% since nothing linked or usefully monitored it -- the gatherer's
-%% per-file fork count (already bumped for every file up front, just
-%% below) would never reach zero, so gatherer:out/1 would never return
-%% empty and reduce_index/3 would block forever; rabbit_msg_store's own
-%% start_link/5 uses {timeout, infinity}, so nothing would ever time
-%% that out either -- the store just never came up, with no crash and
-%% no log. worker_pool:dispatch_sync/1 paces on free-worker availability
-%% either way, identically whether it's called from a separate process
-%% or inline, so doing it inline here doesn't change how long dispatching
-%% every file takes; it just means a failure part-way through (e.g. the
-%% shared worker_pool itself dying while a dispatch call is in flight)
-%% now propagates directly out of this function instead of vanishing
-%% silently.
 rebuild_index(Gatherer, Files, State) ->
     lists:foreach(fun (_File) ->
                           ok = gatherer:fork(Gatherer)
@@ -2683,27 +2619,10 @@ do_compact_file_v1(Fd, _, [#msg_location{ offset = StartMsgOffset, total_size = 
 do_compact_file_v1(_, Offset, _, [], IndexAcc) ->
     {ok, Offset, IndexAcc}.
 
-%% gap_size == 0  -> nothing
-%% gap_size <  5  -> 1..4 SMALL_HOLE bytes
-%% gap_size >= 5  -> one HOLE record, inner bytes zeroed
-%%
 %% The scanner only ever looks at the HOLE record's own 5-byte header
 %% to know how much to skip; it never reads the inner bytes. We zero
 %% them anyway so that a completed write leaves no message bytes
 %% behind for a raw scan (a salvage tool, for instance) to recover.
-%%
-%% This doesn't add crash resilience: the zeros are the last bytes in
-%% the pwrite, written after the message and the header, so a write
-%% torn partway through is, if anything, more likely to leave old
-%% bytes behind unzeroed than to leave zeros. What a scanner relies on
-%% after a crash is the header's own type and size landing intact,
-%% which zeroing the payload does nothing for.
-%%
-%% It does have one incidental benefit for a *different* failure mode,
-%% though: REC_RESERVED is 0 and has no matching scan clause, so if a
-%% scan ever gets misaligned (say, from a corrupted Size elsewhere) and
-%% lands inside a hole's zeroed payload, it hits the unrecognised-type
-%% crash instead of silently reading zeros as if they were meaningful.
 hole_bytes(0) ->
     <<>>;
 hole_bytes(Size) when Size < 5 ->
@@ -2714,15 +2633,7 @@ hole_bytes(Size) ->
 %% We decide the whole compaction plan first, as pure data,
 %% then write it. This way nothing is ever written based on
 %% information that a later part of the plan could still
-%% invalidate. write_compact_file_v2/2 writes a hole record for
-%% whatever's left of the space each run of moves lands in, so the
-%% file is always fully valid and scannable at every point during
-%% compaction and before the physical truncation that follows it has
-%% actually happened: a crash never leaves an unmarked, ambiguous gap
-%% for the next scan (this one, recovery, or the salvage tool) to
-%% trip over. Messages we leave in place are untouched, including
-%% whatever follows them: we haven't broken anything there, so there
-%% is nothing for us to mark.
+%% invalidate.
 do_compact_file_v2(Fd, StartOffset, Messages) ->
     {Plan, TruncateSize} = plan_compact_file_v2(StartOffset, Messages, lists:reverse(Messages), []),
     IndexUpdates = write_compact_file_v2(Fd, Plan),
@@ -2735,15 +2646,6 @@ do_compact_file_v2(Fd, StartOffset, Messages) ->
 %% this never touches the file: it only decides the final, static
 %% layout, so nothing here can be invalidated by a read or a write
 %% that a later decision hasn't been made yet when it happens.
-%%
-%% A move's own hole size isn't known until we see what ends up right
-%% after it in the finished plan: packing can stop either because this
-%% was the very last message that could possibly move (the terminal
-%% clause below), or because the next candidate from the end of the
-%% file simply doesn't fit and we fall through to leaving a message
-%% where it is instead. Either way leaves a leftover behind this move,
-%% so the hole size is filled in from the finished plan, in
-%% write_compact_file_v2/2, rather than decided here.
 plan_compact_file_v2(Offset, Start = [#msg_location{ offset = StartMsgOffset }|_],
         [#msg_location{ msg_id = EndMsgId, offset = EndMsgOffset, total_size = EndMsgSize }|EndTail],
         Acc)

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -40,7 +40,18 @@
 -define(CLEAN_FILENAME, "clean.dot").
 -define(FILE_SUMMARY_FILENAME, "file_summary.ets").
 
--define(FILE_EXTENSION,        ".rdq").
+-define(FILE_EXTENSION_V1, ".rdq").
+-define(FILE_EXTENSION_V2, ".sqs").
+
+-define(V2_MAGIC, 16#52535153). %% "RSQS"
+-define(V2_HEADER_SIZE, 64). %% bytes
+
+%% Record 0 is reserved forever so that zero-filled regions
+%% never look like valid records.
+-define(REC_RESERVED,   0).
+-define(REC_SMALL_HOLE, 1).
+-define(REC_HOLE,       2).
+-define(REC_MESSAGE,    3).
 
 %% We keep track of flying messages for writes and removes. The idea is that
 %% when a remove comes in before we could process the write, we skip the
@@ -109,7 +120,10 @@
           %% client ref to synced messages mapping
           cref_to_msg_ids,
           %% See CREDIT_DISC_BOUND in rabbit.hrl
-          credit_disc_bound
+          credit_disc_bound,
+          %% Highest-numbered v1 (.rdq) file, or 'none' if the store has
+          %% no v1 files at all.
+          last_v1_file
         }).
 
 -record(client_msstate,
@@ -121,7 +135,8 @@
           file_handles_ets,
           cur_file_cache_ets,
           flying_ets,
-          credit_disc_bound
+          credit_disc_bound,
+          last_v1_file
         }).
 
 -record(file_summary,
@@ -132,7 +147,8 @@
           index_ets,
           file_summary_ets,
           file_handles_ets,
-          msg_store
+          msg_store,
+          last_v1_file
         }).
 
 -record(dying_client,
@@ -149,23 +165,26 @@
                                 index_ets        :: ets:tid(),
                                 file_summary_ets :: ets:tid(),
                                 file_handles_ets :: ets:tid(),
-                                msg_store        :: server()
+                                msg_store        :: server(),
+                                last_v1_file     :: file_num() | 'none'
                               }.
 
 -type server() :: pid() | atom().
 -type client_ref() :: binary().
 -type file_num() :: non_neg_integer().
+-type file_format() :: 'v1' | 'v2'.
 -type client_msstate() :: #client_msstate {
                       server             :: server(),
                       client_ref         :: client_ref(),
-                      reader             :: undefined | {non_neg_integer(), file:fd()},
+                      reader             :: undefined | {file_num(), file:fd(), file_format()},
                       index_ets          :: any(),
                       %% Stored as binary() as opposed to file:filename() to save memory.
                       dir                :: binary(),
                       file_handles_ets   :: ets:tid(),
                       cur_file_cache_ets :: ets:tid(),
                       flying_ets         :: ets:tid(),
-                      credit_disc_bound  :: {pos_integer(), pos_integer()}}.
+                      credit_disc_bound  :: {pos_integer(), pos_integer()},
+                      last_v1_file       :: file_num() | 'none'}.
 -type msg_ref_delta_gen(A) ::
         fun ((A) -> 'finished' |
                     {rabbit_types:msg_id(), non_neg_integer(), A}).
@@ -408,7 +427,7 @@ gc_pid(Server) ->
 -spec client_init(server(), client_ref(), maybe_msg_id_fun()) -> client_msstate().
 
 client_init(Server, Ref, MsgOnDiskFun) when is_pid(Server); is_atom(Server) ->
-    {IndexEts, Dir, FileHandlesEts, CurFileCacheEts, FlyingEts} =
+    {IndexEts, Dir, FileHandlesEts, CurFileCacheEts, FlyingEts, LastV1File} =
         gen_server2:call(
           Server, {new_client_state, Ref, self(), MsgOnDiskFun},
           infinity),
@@ -422,7 +441,8 @@ client_init(Server, Ref, MsgOnDiskFun) when is_pid(Server); is_atom(Server) ->
                       file_handles_ets   = FileHandlesEts,
                       cur_file_cache_ets = CurFileCacheEts,
                       flying_ets         = FlyingEts,
-                      credit_disc_bound  = CreditDiscBound }.
+                      credit_disc_bound  = CreditDiscBound,
+                      last_v1_file       = LastV1File }.
 
 -spec client_terminate(client_msstate()) -> 'ok'.
 
@@ -518,7 +538,8 @@ read_many_file2(MsgIds0, CState = #client_msstate{ dir              = Dir,
                                                    index_ets        = IndexEts,
                                                    file_handles_ets = FileHandlesEts,
                                                    reader           = Reader0,
-                                                   client_ref       = Ref }, Acc0, File) ->
+                                                   client_ref       = Ref,
+                                                   last_v1_file     = LastV1File }, Acc0, File) ->
     %% Mark file handle open.
     mark_handle_open(FileHandlesEts, File, Ref),
     %% Get index for all Msgids in File.
@@ -539,7 +560,7 @@ read_many_file2(MsgIds0, CState = #client_msstate{ dir              = Dir,
             %% Then we can do the consolidation to get the pread LocNums.
             LocNums = consolidate_reads(MsgLocations, []),
             %% Read the data from the file.
-            Reader = reader_open(Reader0, Dir, File),
+            Reader = reader_open(Reader0, Dir, File, LastV1File),
             {ok, Msgs} = reader_pread(Reader, LocNums),
             %% Before we continue the read_many calls we must remove the
             %% MsgIds we have read from the list and add the messages to
@@ -642,8 +663,10 @@ client_read3(#msg_location { msg_id = MsgId, file = File },
     end.
 
 read_from_disk(#msg_location { msg_id = MsgId, file = File, offset = Offset,
-                               total_size = TotalSize }, State = #client_msstate{ reader = Reader0, dir = Dir }) ->
-    Reader = reader_open(Reader0, Dir, File),
+                               total_size = TotalSize },
+               State = #client_msstate{ reader = Reader0, dir = Dir,
+                                        last_v1_file = LastV1File }) ->
+    Reader = reader_open(Reader0, Dir, File, LastV1File),
     Msg = case reader_pread(Reader, [{Offset, TotalSize}]) of
         {ok, [Msg0]} ->
             Msg0;
@@ -659,7 +682,7 @@ read_from_disk(#msg_location { msg_id = MsgId, file = File, offset = Offset,
     {Msg, State#client_msstate{ reader = Reader }}.
 
 %%----------------------------------------------------------------------------
-%% Reader functions. A reader is a file num + fd tuple.
+%% Reader functions. A reader is a file num + fd + format tuple.
 %%----------------------------------------------------------------------------
 
 %% The reader tries to keep the FD open for subsequent reads.
@@ -668,43 +691,89 @@ read_from_disk(#msg_location { msg_id = MsgId, file = File, offset = Offset,
 %%
 %% The FD will be closed when the queue hibernates to save
 %% resources.
-reader_open(Reader, Dir, File) ->
+%%
+%% We compute and cache the file's format here so that reader_pread/2
+%% doesn't need LastV1File (or to recompute file_format/2) on every read:
+%% a reader is only ever used against the file it was just opened for.
+reader_open(Reader, Dir, File, LastV1File) ->
+    Format = file_format(File, LastV1File),
     {ok, Fd} = case Reader of
-        {File, Fd0} ->
+        {File, Fd0, _} ->
             {ok, Fd0};
-        {_AnotherFile, Fd0} ->
+        {_AnotherFile, Fd0, _} ->
             ok = file:close(Fd0),
-            file:open(form_filename(Dir, filenum_to_name(File)),
+            file:open(form_filename(Dir, filenum_to_name(File, Format)),
                       [binary, read, raw]);
         undefined ->
-            file:open(form_filename(Dir, filenum_to_name(File)),
+            file:open(form_filename(Dir, filenum_to_name(File, Format)),
                       [binary, read, raw])
     end,
-    {File, Fd}.
+    {File, Fd, Format}.
 
-reader_pread({_, Fd}, LocNums) ->
+reader_pread({File, Fd, Format}, LocNums) ->
     case file:pread(Fd, LocNums) of
-        {ok, DataL} -> {ok, reader_pread_parse(DataL)};
+        {ok, DataL} -> {ok, reader_pread_parse(DataL, Format, File)};
         KO -> KO
     end.
 
-reader_pread_parse([<<Size:64,
-                      _MsgId:16/binary,
-                      Rest0/bits>>|Tail]) ->
+reader_pread_parse(DataL, v1, File) -> reader_pread_parse_v1(DataL, File);
+reader_pread_parse(DataL, v2, File) -> reader_pread_parse_v2(DataL, File).
+
+%% A message record that fails to parse or decode raises with the file
+%% number attached, rather than crashing with a bare badmatch/badarg or
+%% (if nothing here even matches) a function_clause that says nothing
+%% about which file was being read. The msg_id is attached too when the
+%% record was recognised far enough to read one out, so the specific
+%% message can be located directly instead of having to scan the whole
+%% file to find whatever's at fault.
+reader_pread_parse_v1([<<Size:64,
+                         MsgId:16/binary,
+                         Rest0/bits>>|Tail], File) ->
     BodyBinSize = Size - 16, %% Remove size of MsgId.
-    <<MsgBodyBin:BodyBinSize/binary,
-      255, %% OK marker.
-      Rest/bits>> = Rest0,
-    [binary_to_term(MsgBodyBin)|reader_pread_parse([Rest|Tail])];
-reader_pread_parse([<<>>]) ->
+    case Rest0 of
+        <<MsgBodyBin:BodyBinSize/binary, 255, Rest/bits>> ->
+            try binary_to_term(MsgBodyBin) of
+                Term -> [Term|reader_pread_parse_v1([Rest|Tail], File)]
+            catch
+                error:badarg ->
+                    error({rabbit_msg_store_v1_read, invalid_message_body, File, MsgId})
+            end;
+        _ ->
+            error({rabbit_msg_store_v1_read, invalid_message_size, File, MsgId})
+    end;
+reader_pread_parse_v1([<<>>], _File) ->
     [];
-reader_pread_parse([<<>>|Tail]) ->
-    reader_pread_parse(Tail).
+reader_pread_parse_v1([<<>>|Tail], File) ->
+    reader_pread_parse_v1(Tail, File);
+reader_pread_parse_v1(_Data, File) ->
+    error({rabbit_msg_store_v1_read, unrecognised_data, File}).
+
+reader_pread_parse_v2([<<?REC_MESSAGE:8, Size:32,
+                         MsgId:16/binary,
+                         Rest0/bits>>|Tail], File) ->
+    BodyBinSize = Size - 21,
+    case Rest0 of
+        <<MsgBodyBin:BodyBinSize/binary, Rest/bits>> ->
+            try binary_to_term(MsgBodyBin) of
+                Term -> [Term|reader_pread_parse_v2([Rest|Tail], File)]
+            catch
+                error:badarg ->
+                    error({rabbit_msg_store_v2_read, invalid_message_body, File, MsgId})
+            end;
+        _ ->
+            error({rabbit_msg_store_v2_read, invalid_message_size, File, MsgId})
+    end;
+reader_pread_parse_v2([<<>>], _File) ->
+    [];
+reader_pread_parse_v2([<<>>|Tail], File) ->
+    reader_pread_parse_v2(Tail, File);
+reader_pread_parse_v2(_Data, File) ->
+    error({rabbit_msg_store_v2_read, unrecognised_data, File}).
 
 reader_close(Reader) ->
     case Reader of
         undefined -> ok;
-        {_File, Fd} -> ok = file:close(Fd)
+        {_File, Fd, _Format} -> ok = file:close(Fd)
     end.
 
 %%----------------------------------------------------------------------------
@@ -734,7 +803,7 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
     %% we start recovering messages from the files on disk.
     {FileSummaryRecovered, FileSummaryEts} =
         recover_file_summary(AttemptFileSummaryRecovery, Dir),
-    {CleanShutdown, IndexEts, ClientRefs1} =
+    {CleanShutdown, IndexEts, ClientRefs1, LastV1File} =
         recover_index_and_client_refs(FileSummaryRecovered,
                                       ClientRefs, Dir, Name),
     Clients = maps:from_list(
@@ -765,7 +834,8 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
                                 index_ets        = IndexEts,
                                 file_summary_ets = FileSummaryEts,
                                 file_handles_ets = FileHandlesEts,
-                                msg_store        = self()
+                                msg_store        = self(),
+                                last_v1_file     = LastV1File
                               }),
 
     CreditDiscBound = rabbit_misc:get_env(rabbit, msg_store_credit_disc_bound,
@@ -789,7 +859,8 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
                        successfully_recovered = CleanShutdown,
                        file_size_limit        = FileSizeLimit,
                        cref_to_msg_ids        = #{},
-                       credit_disc_bound      = CreditDiscBound
+                       credit_disc_bound      = CreditDiscBound,
+                       last_v1_file           = LastV1File
                      },
     %% If we didn't recover the msg location index then we need to
     %% rebuild it now.
@@ -799,15 +870,65 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
                   end,
     ?LOG_DEBUG("Rebuilding message location index after ~ts shutdown...",
                      [Cleanliness]),
-    {CurOffset, State1 = #msstate { current_file = CurFile }} =
+    {CurOffset0, State1 = #msstate { current_file = CurFile0 }} =
         build_index(CleanShutdown, StartupFunState, State),
     ?LOG_DEBUG("Finished rebuilding index", []),
     %% Open the most recent file.
-    {ok, CurHdl} = writer_recover(Dir, CurFile, CurOffset),
-    {ok, State1 #msstate { current_file_handle = CurHdl,
-                           current_file_offset = CurOffset },
+    {CurFile, CurOffset, CurHdl} =
+        open_current_file(Dir, CurFile0, CurOffset0, LastV1File,
+                          State1 #msstate.file_summary_ets),
+    State2 = State1 #msstate { current_file         = CurFile,
+                               current_file_handle  = CurHdl,
+                               current_file_offset  = CurOffset },
+    %% CurFile0 was still current_file (and therefore exempt from
+    %% every delete_file_if_empty/2 check run so far, including the
+    %% one build_index/3 just did for dirty recovery) right up until
+    %% open_current_file/5 above decided to roll away from it because
+    %% it's v1. If it turned out to hold no valid messages, nothing
+    %% else will ever reconsider it once we return here with a
+    %% different file current: check it once, now, while we still
+    %% remember it was just abandoned.
+    State3 = case CurFile of
+        CurFile0 -> State2;
+        _        -> delete_file_if_empty(CurFile0, State2)
+    end,
+    {ok, State3,
      hibernate,
      {backoff, ?HIBERNATE_AFTER_MIN, ?HIBERNATE_AFTER_MIN, ?DESIRED_HIBERNATE}}.
+
+%% The current write file must always be v2. build_index/3 may have left
+%% us pointing at a v1 file, either because the store predates v2 or
+%% because nothing has been written since upgrading: in that case we
+%% force a roll to a fresh v2 file (CurFile0 + 1) before accepting any
+%% writes. Separately, if the recovered v2 "current" file has nothing
+%% but (at most) a partial header in it, we (re)create it fresh via
+%% writer_open/2 rather than let writer_recover/3's truncate conjure up
+%% a correct 64-byte header out of implicit zero-fill.
+open_current_file(Dir, CurFile, CurOffset, LastV1File, FileSummaryEts) ->
+    case file_format(CurFile, LastV1File) of
+        %% v1 files can't take v2 records, so roll over to a brand new file.
+        v1 ->
+            open_new_current_file(Dir, CurFile + 1, FileSummaryEts);
+        %% The v2 file has no valid data yet (e.g. just recovered with
+        %% nothing in it): reopen it fresh rather than roll over.
+        v2 when CurOffset =< ?V2_HEADER_SIZE ->
+            open_new_current_file(Dir, CurFile, FileSummaryEts);
+        v2 ->
+            {ok, Hdl} = writer_recover(Dir, CurFile, CurOffset),
+            {CurFile, CurOffset, Hdl}
+    end.
+
+open_new_current_file(Dir, File, FileSummaryEts) ->
+    true = ets:insert(FileSummaryEts, #file_summary {
+                        file             = File,
+                        valid_total_size = 0,
+                        file_size        = ?V2_HEADER_SIZE,
+                        locked           = false }),
+    {ok, Hdl} = writer_open(Dir, File),
+    %% The file may have data that is stale and not valid
+    %% message data when recovering the current file.
+    ok = writer_truncate(Hdl),
+    {File, ?V2_HEADER_SIZE, Hdl}.
 
 prioritise_call(Msg, _From, _Len, _State) ->
     case Msg of
@@ -842,11 +963,12 @@ handle_call({new_client_state, CRef, CPid, MsgOnDiskFun}, _From,
                                file_handles_ets   = FileHandlesEts,
                                cur_file_cache_ets = CurFileCacheEts,
                                flying_ets         = FlyingEts,
-                               clients            = Clients }) ->
+                               clients            = Clients,
+                               last_v1_file       = LastV1File }) ->
     Clients1 = maps:put(CRef, {CPid, MsgOnDiskFun}, Clients),
     erlang:monitor(process, CPid),
     reply({IndexEts, Dir, FileHandlesEts,
-           CurFileCacheEts, FlyingEts},
+           CurFileCacheEts, FlyingEts, LastV1File},
           State #msstate { clients = Clients1 });
 
 handle_call({client_terminate, CRef}, _From, State) ->
@@ -1005,7 +1127,8 @@ terminate(Reason, State = #msstate { index_ets           = IndexEts,
     [true = ets:delete(T) || T <- [FileSummaryEts, FileHandlesEts,
                                    CurFileCacheEts, FlyingEts]],
     index_terminate(IndexEts, Dir),
-    case store_recovery_terms([{client_refs, maps:keys(Clients)}], Dir) of
+    case store_recovery_terms([{client_refs, maps:keys(Clients)},
+                               {last_v1_file, State #msstate.last_v1_file}], Dir) of
         ok           ->
             ?LOG_INFO("Message store for directory '~ts' is stopped", [Dir]),
             ok;
@@ -1290,13 +1413,13 @@ flush_or_roll_to_new_file(
     true = ets:insert_new(FileSummaryEts, #file_summary {
                             file             = NextFile,
                             valid_total_size = 0,
-                            file_size        = 0,
+                            file_size        = ?V2_HEADER_SIZE,
                             locked           = false }),
     %% Delete messages from the cache that were written to disk.
     true = ets:match_delete(CurFileCacheEts, {'_', '_', 0}),
     State1 #msstate { current_file_handle = NextHdl,
                       current_file        = NextFile,
-                      current_file_offset = 0 };
+                      current_file_offset = ?V2_HEADER_SIZE };
 %% If we need to flush, do so here.
 flush_or_roll_to_new_file(_, flush, State) ->
     internal_sync(State);
@@ -1312,8 +1435,8 @@ write_large_message(MsgId, MsgBodyBin,
                                   file_summary_ets    = FileSummaryEts,
                                   cur_file_cache_ets  = CurFileCacheEts }) ->
     {LargeMsgFile, LargeMsgHdl} = case CurOffset of
-        %% We haven't written in the file yet. Use it.
-        0 ->
+        %% We haven't written anything but the header in the file yet. Use it.
+        ?V2_HEADER_SIZE ->
             {CurFile, CurHdl};
         %% Flush the current file and close it. Open a new file.
         _ ->
@@ -1329,7 +1452,7 @@ write_large_message(MsgId, MsgBodyBin,
     %% Update ets with the new information.
     ok = index_insert(IndexEts,
            #msg_location { msg_id = MsgId, ref_count = 1, file = LargeMsgFile,
-                           offset = 0, total_size = TotalSize }),
+                           offset = ?V2_HEADER_SIZE, total_size = TotalSize }),
     State1 = case CurFile of
         %% We didn't open a new file. We must update the existing value.
         LargeMsgFile ->
@@ -1345,11 +1468,11 @@ write_large_message(MsgId, MsgBodyBin,
             true = ets:insert_new(FileSummaryEts, #file_summary {
                                     file             = LargeMsgFile,
                                     valid_total_size = TotalSize,
-                                    file_size        = TotalSize,
+                                    file_size        = ?V2_HEADER_SIZE + TotalSize,
                                     locked           = false }),
             delete_file_if_empty(CurFile, State0 #msstate { current_file_handle = LargeMsgHdl,
                                                             current_file        = LargeMsgFile,
-                                                            current_file_offset = TotalSize })
+                                                            current_file_offset = ?V2_HEADER_SIZE + TotalSize })
     end,
     %% Roll over to the next file.
     NextFile = LargeMsgFile + 1,
@@ -1357,7 +1480,7 @@ write_large_message(MsgId, MsgBodyBin,
     true = ets:insert_new(FileSummaryEts, #file_summary {
                             file             = NextFile,
                             valid_total_size = 0,
-                            file_size        = 0,
+                            file_size        = ?V2_HEADER_SIZE,
                             locked           = false }),
     %% Delete messages from the cache that were written to disk.
     true = ets:match_delete(CurFileCacheEts, {'_', '_', 0}),
@@ -1365,7 +1488,7 @@ write_large_message(MsgId, MsgBodyBin,
     State = internal_sync(State1),
     State #msstate { current_file_handle = NextHdl,
                      current_file        = NextFile,
-                     current_file_offset = 0 }.
+                     current_file_offset = ?V2_HEADER_SIZE }.
 
 contains_message(MsgId, From, State = #msstate{ index_ets = IndexEts }) ->
     MsgLocation = index_lookup_positive_ref_count(IndexEts, MsgId),
@@ -1452,27 +1575,39 @@ should_mask_action(CRef, MsgId, #msstate{
 
 -define(MAX_BUFFER_SIZE, 1048576). %% 1MB.
 
+%% Writes always produce v2 files.
 writer_open(Dir, Num) ->
-    {ok, Fd} = file:open(form_filename(Dir, filenum_to_name(Num)),
-                         [append, binary, raw]),
+    {ok, Fd} = file:open(form_filename(Dir, filenum_to_name(Num, v2)),
+                         [read, write, binary, raw]),
+    ok = file:write(Fd, v2_file_header()),
     {ok, #writer{fd = Fd, buffer = prim_buffer:new()}}.
 
+%% The magic and version bytes are reserved for future use: nothing
+%% currently reads or validates them (not the scanner, not
+%% writer_recover/3, not open_current_file/5). They exist so a future
+%% format change has somewhere to look without shifting every offset.
+v2_file_header() ->
+    <<?V2_MAGIC:32, 2:8, 0:(8 * (?V2_HEADER_SIZE - 5))>>.
+
 writer_recover(Dir, Num, Offset) ->
-    {ok, Fd} = file:open(form_filename(Dir, filenum_to_name(Num)),
+    {ok, Fd} = file:open(form_filename(Dir, filenum_to_name(Num, v2)),
                          [read, write, binary, raw]),
     {ok, Offset} = file:position(Fd, Offset),
     ok = file:truncate(Fd),
     {ok, #writer{fd = Fd, buffer = prim_buffer:new()}}.
 
+writer_truncate(#writer{fd = Fd}) ->
+    ok = file:truncate(Fd).
+
 writer_append(#writer{buffer = Buffer}, MsgId, MsgBodyBin) ->
     MsgBodyBinSize = byte_size(MsgBodyBin),
-    EntrySize = MsgBodyBinSize + 16, %% Size of MsgId + MsgBodyBin.
+    %% Type:8 + Size:32 + MsgId:128 + Body.
+    TotalSize = MsgBodyBinSize + 21,
     %% We send an iovec to the buffer instead of building a binary.
     prim_buffer:write(Buffer, [
-        <<EntrySize:64>>,
+        <<?REC_MESSAGE:8, TotalSize:32>>,
         MsgId,
-        MsgBodyBin,
-        <<255>> %% OK marker.
+        MsgBodyBin
     ]),
     Res = case prim_buffer:size(Buffer) of
         Size when Size >= ?MAX_BUFFER_SIZE ->
@@ -1480,7 +1615,7 @@ writer_append(#writer{buffer = Buffer}, MsgId, MsgBodyBin) ->
         _ ->
             ok
     end,
-    {Res, EntrySize + 9}. %% EntrySize + size field + OK marker.
+    {Res, TotalSize}.
 
 %% Note: the message store no longer fsyncs; it only flushes data
 %% to disk. This is in line with classic queues v2 behavior.
@@ -1498,14 +1633,13 @@ writer_flush(#writer{fd = Fd, buffer = Buffer}) ->
 %% This is basically the same as writer_append except no buffering.
 writer_direct_write(#writer{fd = Fd}, MsgId, MsgBodyBin) ->
     MsgBodyBinSize = byte_size(MsgBodyBin),
-    EntrySize = MsgBodyBinSize + 16, %% Size of MsgId + MsgBodyBin.
+    TotalSize = MsgBodyBinSize + 21,
     ok = file:write(Fd, [
-        <<EntrySize:64>>,
+        <<?REC_MESSAGE:8, TotalSize:32>>,
         MsgId,
-        MsgBodyBin,
-        <<255>> %% OK marker.
+        MsgBodyBin
     ]),
-    EntrySize + 9.
+    TotalSize.
 
 writer_close(#writer{fd = Fd}) ->
     file:close(Fd).
@@ -1520,13 +1654,28 @@ mark_handle_closed(FileHandlesEts, File, Ref) ->
 
 form_filename(Dir, Name) -> filename:join(Dir, Name).
 
-filenum_to_name(File) -> integer_to_list(File) ++ ?FILE_EXTENSION.
+%% Format is determined solely by the file number relative to the
+%% store's last_v1_file boundary: writes always produce v2 from this
+%% release onward, so any file above the boundary (or every file, when
+%% the store has no v1 files at all) is v2.
+file_format(_File, none)                       -> v2;
+file_format(File,  LastV1) when File =< LastV1 -> v1;
+file_format(_,     _)                          -> v2.
+
+filenum_to_name(File, v1) ->
+    integer_to_list(File) ++ ?FILE_EXTENSION_V1;
+filenum_to_name(File, v2) ->
+    integer_to_list(File) ++ ?FILE_EXTENSION_V2.
 
 filename_to_num(FileName) -> list_to_integer(filename:rootname(FileName)).
 
-list_sorted_filenames(Dir, Ext) ->
-    lists:sort(fun (A, B) -> filename_to_num(A) < filename_to_num(B) end,
-               filelib:wildcard("*" ++ Ext, Dir)).
+%% Combined, numerically sorted file numbers across both formats. A
+%% given file number is only ever one format, so a plain numeric sort
+%% of the union is enough; no need to sort per-extension first.
+list_sorted_file_numbers(Dir) ->
+    lists:sort([filename_to_num(FileName) ||
+                   FileName <- filelib:wildcard("*" ++ ?FILE_EXTENSION_V1, Dir) ++
+                               filelib:wildcard("*" ++ ?FILE_EXTENSION_V2, Dir)]).
 
 %%----------------------------------------------------------------------------
 %% file scanning
@@ -1535,16 +1684,32 @@ list_sorted_filenames(Dir, Ext) ->
 -define(SCAN_BLOCK_SIZE, 4194304). %% 4MB
 
 %% Exported as a salvage tool. Not as accurate as node recovery
-%% because it doesn't have the queue index.
+%% because it doesn't have the queue index. The format is inferred
+%% from the file extension since salvage callers do not have a
+%% last_v1_file boundary to consult.
 scan_file_for_valid_messages(Path) ->
     scan_file_for_valid_messages(Path, fun(Obj) -> {valid, Obj} end).
 
 scan_file_for_valid_messages(Path, Fun) ->
+    scan_file_for_valid_messages(format_from_extension(Path), Path, Fun).
+
+format_from_extension(Path) ->
+    case filename:extension(Path) of
+        ?FILE_EXTENSION_V2 -> v2;
+        _                  -> v1
+    end.
+
+scan_file_for_valid_messages(v1, Path, Fun) ->
+    scan_v1_file_for_valid_messages(Path, Fun);
+scan_file_for_valid_messages(v2, Path, Fun) ->
+    scan_v2_file_for_valid_messages(Path, Fun).
+
+scan_v1_file_for_valid_messages(Path, Fun) ->
     case file:open(Path, [read, binary, raw]) of
         {ok, Fd} ->
             {ok, FileSize} = file:position(Fd, eof),
             {ok, _} = file:position(Fd, bof),
-            Messages = scan(<<>>, Fd, Fun, 0, FileSize, #{}, []),
+            Messages = scan_v1(<<>>, Fd, Fun, 0, FileSize, #{}, []),
             ok = file:close(Fd),
             {ok, Messages};
         {error, enoent} ->
@@ -1555,7 +1720,7 @@ scan_file_for_valid_messages(Path, Fun) ->
                      Reason}}
     end.
 
-scan(Buffer, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+scan_v1(Buffer, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
     case file:read(Fd, ?SCAN_BLOCK_SIZE) of
         eof ->
             Acc;
@@ -1564,11 +1729,11 @@ scan(Buffer, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
                 <<>> -> Data0;
                 _ -> <<Buffer/binary, Data0/binary>>
             end,
-            scan_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+            scan_v1_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
     end.
 
 %% Message might have been found.
-scan_data(<<Size:64, MsgIdAndMsg:Size/binary, 255, Rest/bits>> = Data,
+scan_v1_data(<<Size:64, MsgIdAndMsg:Size/binary, 255, Rest/bits>> = Data,
           Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
           when Size >= 16 ->
     <<MsgIdInt:128, _/bits>> = MsgIdAndMsg,
@@ -1577,20 +1742,20 @@ scan_data(<<Size:64, MsgIdAndMsg:Size/binary, 255, Rest/bits>> = Data,
         %% a remnant from a previous compaction, but it might
         %% simply be a coincidence. Try the next byte.
         #{MsgIdInt := true} ->
-            scan_next_byte(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
+            scan_v1_next_byte(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
         %% Data looks to be a message.
         _ ->
             TotalSize = Size + 9,
             case check_msg(Fun, MsgIdInt, TotalSize, Offset, Acc) of
                 {continue, NewAcc} ->
-                    scan_data(Rest, Fd, Fun, Offset + TotalSize, FileSize,
+                    scan_v1_data(Rest, Fd, Fun, Offset + TotalSize, FileSize,
                               MsgIdsFound#{MsgIdInt => true}, NewAcc);
-                try_next_byte ->
-                    scan_next_byte(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+                try_next ->
+                    scan_v1_next_byte(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
             end
     end;
 %% Large message alone in its own file
-scan_data(<<Size:64, MsgIdInt:128, _Rest/bits>> = Data, Fd, Fun, Offset, FileSize, _MsgIdsFound, _Acc)
+scan_v1_data(<<Size:64, MsgIdInt:128, _Rest/bits>> = Data, Fd, Fun, Offset, FileSize, _MsgIdsFound, _Acc)
   when Offset == 0,
        FileSize == Size + 9 ->
     {ok, CurrentPos} = file:position(Fd, cur),
@@ -1600,28 +1765,249 @@ scan_data(<<Size:64, MsgIdInt:128, _Rest/bits>> = Data, Fd, Fun, Offset, FileSiz
             case check_msg(Fun, MsgIdInt, TotalSize, Offset, []) of
                 {continue, NewAcc} ->
                     NewAcc;
-                try_next_byte ->
+                try_next ->
                     {ok, _} = file:position(Fd, CurrentPos),
-                    scan_next_byte(Data, Fd, Fun, Offset, FileSize, #{}, [])
+                    scan_v1_next_byte(Data, Fd, Fun, Offset, FileSize, #{}, [])
             end;
         _ ->
             %% Wrong end marker
             {ok, _} = file:position(Fd, CurrentPos),
-            scan_next_byte(Data, Fd, Fun, Offset, FileSize, #{}, [])
+            scan_v1_next_byte(Data, Fd, Fun, Offset, FileSize, #{}, [])
     end;
 %% This might be the start of a message.
-scan_data(<<Size:64, Rest/bits>> = Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+scan_v1_data(<<Size:64, Rest/bits>> = Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
           when byte_size(Rest) < Size + 1, Size + 9 =< FileSize - Offset ->
-    scan(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
-scan_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+    scan_v1(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
+scan_v1_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
           when byte_size(Data) < 8 ->
-    scan(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
+    scan_v1(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
 %% This is definitely not a message. Try the next byte.
-scan_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
-    scan_next_byte(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc).
+scan_v1_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    scan_v1_next_byte(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc).
 
-scan_next_byte(<<_, Rest/bits>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
-    scan_data(Rest, Fd, Fun, Offset + 1, FileSize, MsgIdsFound, Acc).
+scan_v1_next_byte(<<_, Rest/bits>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    scan_v1_data(Rest, Fd, Fun, Offset + 1, FileSize, MsgIdsFound, Acc).
+
+%%----------------------------------------------------------------------------
+%% file scanning - v2
+%%----------------------------------------------------------------------------
+%%
+%% Unlike v1, records are typed and self-describing, so once Type/Size
+%% validate there is no ambiguity about whether we found real data: we
+%% always advance by the full record size, we never byte-shift. Holes
+%% (both HOLE and the bounded run of at most 4 SMALL_HOLEs that replace
+%% a HOLE below the 5-byte minimum) are skipped without interpreting
+%% their contents. A HOLE larger than what's currently buffered is
+%% skipped via file:position/2 rather than read, so scanning cost does
+%% not scale with the size of the hole.
+%%
+%% Type/Size validating is not, on its own, proof that a record is
+%% real: a torn write can produce a plausible-looking Type and Size by
+%% coincidence. We tighten this with two invariants compaction never
+%% violates, so any violation is treated as corruption rather than
+%% something to recover from: a hole (of either kind) is never
+%% immediately followed by another hole, and a SMALL_HOLE run is never
+%% 5 bytes or longer. A MESSAGE record's body must additionally decode
+%% via binary_to_term/1, which a torn write is astronomically unlikely
+%% to produce by chance.
+%%
+%% A record whose Size does not fit within the file is treated as a
+%% torn last write and the remainder of the file is discarded, exactly
+%% as in v1. We never fall back to scanning the next byte: that is
+%% exactly the kind of guess that could land on something that merely
+%% looks like a record.
+
+%% Any exception raised while scanning (whether one of the deliberate
+%% rabbit_msg_store_v2_scan corruption errors above, or anything else
+%% unexpected) is re-raised with Path attached, so whatever eventually
+%% reports the crash doesn't just say which offset failed but in which
+%% file.
+scan_v2_file_for_valid_messages(Path, Fun) ->
+    try
+        case file:open(Path, [read, binary, raw]) of
+            {ok, Fd} ->
+                %% The fd must close on every exit from the scan below,
+                %% not just success: scan_file_recovering_corruption/2
+                %% retries a failed scan of this same file in a loop,
+                %% and each retry calls back in here, so a leaked fd
+                %% per failed attempt would accumulate for as long as
+                %% the process doing the scanning lives.
+                try
+                    {ok, FileSize} = file:position(Fd, eof),
+                    Messages = case FileSize < ?V2_HEADER_SIZE of
+                        true ->
+                            %% Not even a complete header: nothing recoverable.
+                            [];
+                        false ->
+                            {ok, _} = file:position(Fd, ?V2_HEADER_SIZE),
+                            scan_v2(<<>>, Fd, Fun, ?V2_HEADER_SIZE, FileSize, #{}, [])
+                    end,
+                    {ok, Messages}
+                after
+                    ok = file:close(Fd)
+                end;
+            {error, enoent} ->
+                {ok, []};
+            {error, Reason} ->
+                {error, {unable_to_scan_file,
+                         filename:basename(Path),
+                         Reason}}
+        end
+    catch
+        error:CaughtReason:Stacktrace ->
+            erlang:raise(error, {rabbit_msg_store_v2_scan_error, Path, CaughtReason}, Stacktrace)
+    end.
+
+scan_v2(Buffer, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    case file:read(Fd, ?SCAN_BLOCK_SIZE) of
+        eof ->
+            Acc;
+        {ok, Data0} ->
+            Data = case Buffer of
+                <<>> -> Data0;
+                _ -> <<Buffer/binary, Data0/binary>>
+            end,
+            scan_v2_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+    end.
+
+%% Reads fresh data right after skipping a HOLE via file:position/2 (its
+%% payload was too large to have been buffered), and rejects outright if
+%% the very next record is also a hole: two holes never legitimately sit
+%% back to back (see the comment on the HOLE clauses below).
+scan_v2_after_hole(Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    case file:read(Fd, ?SCAN_BLOCK_SIZE) of
+        eof ->
+            Acc;
+        {ok, Data} ->
+            case Data of
+                <<?REC_HOLE:8, _/bits>> ->
+                    error({rabbit_msg_store_v2_scan, Offset, hole_after_hole});
+                <<?REC_SMALL_HOLE:8, _/bits>> ->
+                    error({rabbit_msg_store_v2_scan, Offset, hole_after_hole});
+                _ ->
+                    scan_v2_data(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+            end
+    end.
+
+%% Runs of SMALL_HOLE are bounded to at most 4 bytes by construction
+%% (see hole_bytes/1): a 5th in a row can only be corruption.
+scan_v2_data(<<?REC_SMALL_HOLE:8, ?REC_SMALL_HOLE:8, ?REC_SMALL_HOLE:8,
+               ?REC_SMALL_HOLE:8, ?REC_SMALL_HOLE:8, _/bits>>,
+        _Fd, _Fun, Offset, _FileSize, _MsgIdsFound, _Acc) ->
+    error({rabbit_msg_store_v2_scan, Offset, small_hole_run_too_long});
+%% A hole is never immediately followed by another hole: compaction only
+%% ever writes a hole as the trailing remainder of a move, immediately
+%% followed by real message data (either the next moved message, or a
+%% message left in place untouched); it never writes a hole immediately
+%% after another hole. Two adjacent holes can only mean corruption.
+scan_v2_data(<<?REC_SMALL_HOLE:8, ?REC_HOLE:8, _/bits>>,
+        _Fd, _Fun, Offset, _FileSize, _MsgIdsFound, _Acc) ->
+    error({rabbit_msg_store_v2_scan, Offset + 1, hole_after_hole});
+%% Fewer than 5 bytes buffered isn't enough to rule out either of the
+%% two clauses above: a run that is actually 5 or more SMALL_HOLEs
+%% long, or one immediately followed by a HOLE, can start with any
+%% number of SMALL_HOLE bytes up to 4 before the buffer happens to
+%% run out. Read more before consuming anything, the same way an
+%% incomplete HOLE/MESSAGE header below does, unless the file
+%% genuinely ends here (nothing more will ever be read).
+scan_v2_data(<<?REC_SMALL_HOLE:8, _/bits>> = Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+        when byte_size(Data) < 5, Offset + byte_size(Data) < FileSize ->
+    scan_v2(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
+scan_v2_data(<<?REC_SMALL_HOLE:8, Rest/bits>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    scan_v2_data(Rest, Fd, Fun, Offset + 1, FileSize, MsgIdsFound, Acc);
+
+%% A HOLE record with a size that does not fit the type's minimum is
+%% corruption, not a torn write (a torn write cannot fully flush a
+%% valid 5-byte HOLE header with a bogus size field).
+scan_v2_data(<<?REC_HOLE:8, Size:32, _/bits>>, _Fd, _Fun, Offset, _FileSize, _MsgIdsFound, _Acc)
+        when Size < 5 ->
+    error({rabbit_msg_store_v2_scan, Offset, invalid_hole_size, Size});
+scan_v2_data(<<?REC_HOLE:8, Size:32, Rest0/bits>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    case Offset + Size > FileSize of
+        true ->
+            Acc;
+        false ->
+            InnerSize = Size - 5,
+            case Rest0 of
+                <<_Inner:InnerSize/binary, Rest/bits>> when Rest =/= <<>> ->
+                    case Rest of
+                        <<NextType:8, _/bits>>
+                                when NextType =:= ?REC_HOLE; NextType =:= ?REC_SMALL_HOLE ->
+                            error({rabbit_msg_store_v2_scan, Offset + Size, hole_after_hole});
+                        _ ->
+                            scan_v2_data(Rest, Fd, Fun, Offset + Size, FileSize, MsgIdsFound, Acc)
+                    end;
+                <<_Inner:InnerSize/binary>> ->
+                    %% Fully buffered, but nothing left yet to check what
+                    %% immediately follows: read more before deciding.
+                    scan_v2_after_hole(Fd, Fun, Offset + Size, FileSize, MsgIdsFound, Acc);
+                _ ->
+                    %% Payload too large to have been buffered: skip over
+                    %% it without reading it, same as before.
+                    {ok, _} = file:position(Fd, Offset + Size),
+                    scan_v2_after_hole(Fd, Fun, Offset + Size, FileSize, MsgIdsFound, Acc)
+            end
+    end;
+scan_v2_data(<<?REC_HOLE:8, _/bits>> = Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    %% Type byte seen but the 4-byte size field isn't fully buffered yet.
+    scan_v2(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
+
+scan_v2_data(<<?REC_MESSAGE:8, Size:32, _/bits>>, _Fd, _Fun, Offset, _FileSize, _MsgIdsFound, _Acc)
+        when Size < 21 ->
+    error({rabbit_msg_store_v2_scan, Offset, invalid_message_size, Size});
+scan_v2_data(<<?REC_MESSAGE:8, Size:32, Rest0/bits>> = Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    case Offset + Size > FileSize of
+        true ->
+            Acc;
+        false ->
+            %% MsgId (16 bytes) is included below; this is the body only.
+            PayloadLen = Size - 21,
+            case Rest0 of
+                <<MsgIdInt:128, Body:PayloadLen/binary, Rest/bits>> ->
+                    %% A torn write reproducing a syntactically valid
+                    %% Erlang external term by chance is astronomically
+                    %% unlikely, so this catches a Type/Size that happened
+                    %% to validate numerically but isn't really a message,
+                    %% regardless of what MsgId lookup would say below.
+                    try binary_to_term(Body) of
+                        _ -> ok
+                    catch
+                        error:badarg ->
+                            error({rabbit_msg_store_v2_scan, Offset, invalid_message_body})
+                    end,
+                    case MsgIdsFound of
+                        %% Remnant of a crash mid-compaction: the same
+                        %% message exists at an earlier (and later, here)
+                        %% offset. Keep the earlier copy, matching v1.
+                        #{MsgIdInt := true} ->
+                            scan_v2_data(Rest, Fd, Fun, Offset + Size, FileSize, MsgIdsFound, Acc);
+                        _ ->
+                            case check_msg(Fun, MsgIdInt, Size, Offset, Acc) of
+                                {continue, NewAcc} ->
+                                    scan_v2_data(Rest, Fd, Fun, Offset + Size, FileSize,
+                                                 MsgIdsFound#{MsgIdInt => true}, NewAcc);
+                                %% Unlike v1, a record that Fun rejects (e.g.
+                                %% superseded elsewhere) is still known-good
+                                %% data once Type/Size validate, not
+                                %% suspected corruption.
+                                try_next ->
+                                    scan_v2_data(Rest, Fd, Fun, Offset + Size, FileSize,
+                                                 MsgIdsFound#{MsgIdInt => true}, Acc)
+                            end
+                    end;
+                _ ->
+                    %% Not enough buffered yet; read more.
+                    scan_v2(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
+            end
+    end;
+scan_v2_data(<<?REC_MESSAGE:8, _/bits>> = Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    scan_v2(Data, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
+
+scan_v2_data(<<>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc) ->
+    scan_v2(<<>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc);
+
+scan_v2_data(<<Type:8, _/bits>>, _Fd, _Fun, Offset, _FileSize, _MsgIdsFound, _Acc) ->
+    error({rabbit_msg_store_v2_scan, Offset, unrecognised_record_type, Type}).
 
 check_msg(Fun, MsgIdInt, TotalSize, Offset, Acc) ->
     %% Avoid sub-binary construction.
@@ -1635,7 +2021,7 @@ check_msg(Fun, MsgIdInt, TotalSize, Offset, Acc) ->
             {continue, Acc};
         %% Not a message, try the next byte.
         invalid ->
-            try_next_byte
+            try_next
     end.
 
 %%----------------------------------------------------------------------------
@@ -1726,31 +2112,49 @@ index_terminate(IndexEts, Dir) ->
 %%----------------------------------------------------------------------------
 
 recover_index_and_client_refs(_Recover, undefined, Dir, _Name) ->
-    {false, index_new(Dir), []};
+    %% Transient: the directory was just recursively deleted and recreated
+    %% empty, so there cannot be any v1 files.
+    {false, index_new(Dir), [], none};
 recover_index_and_client_refs(false, _ClientRefs, Dir, Name) ->
     ?LOG_WARNING("Message store ~tp: rebuilding indices from scratch", [Name]),
-    {false, index_new(Dir), []};
+    {false, index_new(Dir), [], scan_for_last_v1_file(Dir)};
 recover_index_and_client_refs(true, ClientRefs, Dir, Name) ->
     Fresh = fun (ErrorMsg, ErrorArgs) ->
                     ?LOG_WARNING("Message store ~tp : " ++ ErrorMsg ++ "~n"
                                        "rebuilding indices from scratch",
                                        [Name | ErrorArgs]),
-                    {false, index_new(Dir), []}
+                    {false, index_new(Dir), [], scan_for_last_v1_file(Dir)}
             end,
     case read_recovery_terms(Dir) of
         {false, Error} ->
             Fresh("failed to read recovery terms: ~tp", [Error]);
         {true, Terms} ->
+            %% A pre-v2 clean.dot has no last_v1_file term at all: that must
+            %% fall back to a disk scan, not silently default to 'none',
+            %% otherwise every pre-existing .rdq file would be misread as v2
+            %% immediately after an upgrade.
+            LastV1File = case proplists:lookup(last_v1_file, Terms) of
+                {last_v1_file, V} -> V;
+                none              -> scan_for_last_v1_file(Dir)
+            end,
             RecClientRefs = proplists:get_value(client_refs, Terms, []),
             case lists:sort(ClientRefs) =:= lists:sort(RecClientRefs) of
                 true  -> case index_recover(Dir) of
                              {ok, IndexEts} ->
-                                 {true, IndexEts, ClientRefs};
+                                 {true, IndexEts, ClientRefs, LastV1File};
                              {error, Error} ->
                                  Fresh("failed to recover index: ~tp", [Error])
                          end;
                 false -> Fresh("recovery terms differ from present", [])
             end
+    end.
+
+%% Ground truth for the v1/v2 boundary when it cannot be trusted from
+%% persisted terms (dirty recovery).
+scan_for_last_v1_file(Dir) ->
+    case filelib:wildcard("*" ++ ?FILE_EXTENSION_V1, Dir) of
+        []    -> none;
+        Files -> lists:max([filename_to_num(F) || F <- Files])
     end.
 
 store_recovery_terms(Terms, Dir) ->
@@ -1816,8 +2220,7 @@ build_index(false, {MsgRefDeltaGen, MsgRefDeltaGenInit},
     ok = count_msg_refs(MsgRefDeltaGen, MsgRefDeltaGenInit, State),
     ?LOG_DEBUG("Done rebuilding message refcount", []),
     {ok, Pid} = gatherer:start_link(),
-    case [filename_to_num(FileName) ||
-             FileName <- list_sorted_filenames(Dir, ?FILE_EXTENSION)] of
+    case list_sorted_file_numbers(Dir) of
         []     -> rebuild_index(Pid, [State #msstate.current_file],
                                 State);
         Files  -> {Offset, State1} = rebuild_index(Pid, Files, State),
@@ -1825,34 +2228,60 @@ build_index(false, {MsgRefDeltaGen, MsgRefDeltaGenInit},
                                        State1, Files)}
     end.
 
-build_index_worker(Gatherer, #msstate { index_ets = IndexEts, dir = Dir },
+build_index_worker(Gatherer, #msstate { index_ets = IndexEts, dir = Dir,
+                                        last_v1_file = LastV1File },
                    File, Files) ->
-    Path = form_filename(Dir, filenum_to_name(File)),
+    Format = file_format(File, LastV1File),
+    Path = form_filename(Dir, filenum_to_name(File, Format)),
     ?LOG_DEBUG("Rebuilding message location index from ~ts (~B file(s) remaining)",
                      [Path, length(Files)]),
     %% The scan function already dealt with duplicate messages
     %% within the file, and only returns valid messages (we do
     %% the index lookup in the fun). But we get messages in reverse order.
-    {ok, Messages} = scan_file_for_valid_messages(Path,
-        fun (Obj = {MsgId, TotalSize, Offset}) ->
-            %% Fan-out may result in the same message data in multiple
-            %% files so we have to guard against it.
-            case index_lookup(IndexEts, MsgId) of
-                #msg_location { file = undefined } = StoreEntry ->
-                    ok = index_update(IndexEts, StoreEntry #msg_location {
-                                        file = File, offset = Offset,
-                                        total_size = TotalSize }),
-                    {valid, Obj};
-                _ ->
-                    invalid
-            end
-        end),
+    ScanFun = fun (Obj = {MsgId, TotalSize, Offset}) ->
+        %% Fan-out may result in the same message data in multiple
+        %% files so we have to guard against it.
+        case index_lookup(IndexEts, MsgId) of
+            #msg_location { file = undefined } = StoreEntry ->
+                ok = index_update(IndexEts, StoreEntry #msg_location {
+                                    file = File, offset = Offset,
+                                    total_size = TotalSize }),
+                {valid, Obj};
+            %% Already resolved to this exact file/offset/size: not a
+            %% fan-out duplicate, just scan_file_recovering_corruption
+            %% rescanning this same file from the start after
+            %% truncating a corrupted tail found later in an earlier
+            %% attempt. Confirm it again rather than rejecting it.
+            #msg_location { file = File, offset = Offset,
+                            total_size = TotalSize } ->
+                {valid, Obj};
+            _ ->
+                invalid
+        end
+    end,
+    %% v1 has no corruption-recovery path to speak of (see the comment
+    %% above scan_file_recovering_corruption/2), so it is scanned
+    %% directly, unwrapped: a scan failure there is always unexpected
+    %% and should surface as one, not be quietly turned into data loss.
+    {ok, Messages} = case Format of
+        v1 -> scan_file_for_valid_messages(v1, Path, ScanFun);
+        v2 -> scan_file_recovering_corruption(Path, ScanFun)
+    end,
     ValidTotalSize = lists:foldl(fun({_, TotalSize, _}, Acc) -> Acc + TotalSize end, 0, Messages),
     %% Any file may have rubbish at the end of it that we will want truncated.
     %% Note that the last message in the file is the first in the list.
     FileSize = case Messages of
+        %% A v1 file with no messages genuinely has nothing on disk.
+        %%
+        %% A v2 file always has at least its header even when it holds no
+        %% valid messages. This holds even for a missing/partial header:
+        %% it's either the current file (header will get rewritten and the
+        %% file truncated) or the file gets deleted.
         [] ->
-            0;
+            case Format of
+                v1 -> 0;
+                v2 -> ?V2_HEADER_SIZE
+            end;
         [{_, TotalSize, Offset}|_] ->
             Offset + TotalSize
     end,
@@ -1862,6 +2291,71 @@ build_index_worker(Gatherer, #msstate { index_ets = IndexEts, dir = Dir },
                                   file_size        = FileSize,
                                   locked           = false }),
     ok = gatherer:finish(Gatherer).
+
+%% Dirty recovery cannot let one corrupted v2 file take the whole
+%% store down, and cannot safely resync past a corrupted record
+%% either -- that is exactly the byte-guessing v2 was designed to
+%% avoid. So on a scan failure that is unambiguously one of our own
+%% tagged corruption errors (and only here; compaction and the
+%% salvage tool still crash outright, since they operate on files
+%% that may still be actively referenced, unlike a queue's own dirty
+%% recovery which simply drops a message it can no longer find) we
+%% truncate the file at the offset the error reports and retry.
+%% Scanning proceeds strictly in increasing offset order and stops at
+%% the first bad spot it finds, so the bytes up to the truncation
+%% point already scanned cleanly once: the retry over that same,
+%% now-final, prefix is guaranteed to succeed, and this never needs
+%% more than one retry.
+%%
+%% Anything else -- an error we didn't specifically anticipate, most
+%% plausibly an I/O failure from file:read/2 (scan_v2_file_for_valid_messages/2
+%% wraps *any* error raised while scanning, not just its own) -- is
+%% deliberately let through uncaught instead of being guessed at. The
+%% guess used to be "truncate to the header", but Fun has already
+%% updated the index for every message reached before the error, so
+%% guessing wrong here doesn't just lose the file's own data: it
+%% leaves those index entries pointing at a file this then discards,
+%% turning a later, unrelated read of one of those messages into a
+%% crash instead of a clean "not found". v1 has the exact same
+%% principle already: corruption there is handled entirely by
+%% scan_v1_next_byte/7 silently shifting forward a byte at a time,
+%% never raising, so nothing ever reaches build_index_worker for a v1
+%% file except an equally unanticipated error, and it is scanned
+%% directly, unwrapped, for the same reason.
+scan_file_recovering_corruption(Path, Fun) ->
+    try
+        scan_file_for_valid_messages(v2, Path, Fun)
+    catch
+        error:Reason:Stacktrace ->
+            case corruption_offset(Reason) of
+                {ok, TruncateAt0} ->
+                    TruncateAt = min(TruncateAt0, filelib:file_size(Path)),
+                    ?LOG_ERROR("Message store file ~ts is corrupted (~tp); "
+                               "discarding everything from byte ~b onwards",
+                               [Path, Reason, TruncateAt]),
+                    {ok, Fd} = file:open(Path, [read, write, binary, raw]),
+                    {ok, TruncateAt} = file:position(Fd, TruncateAt),
+                    ok = file:truncate(Fd),
+                    ok = file:close(Fd),
+                    scan_file_recovering_corruption(Path, Fun);
+                error ->
+                    erlang:raise(error, Reason, Stacktrace)
+            end
+    end.
+
+%% Every rabbit_msg_store_v2_scan reason (wrapped by
+%% scan_v2_file_for_valid_messages/2 in rabbit_msg_store_v2_scan_error)
+%% reports the offset of the record it rejected as its second element.
+%% Only that specific, unambiguous shape is trusted: anything else,
+%% including a tuple that merely happens to also have an integer in
+%% the same position, is not our own error and must not be mistaken
+%% for one.
+corruption_offset({rabbit_msg_store_v2_scan_error, _Path, InnerReason})
+        when is_tuple(InnerReason), tuple_size(InnerReason) >= 2,
+             element(1, InnerReason) =:= rabbit_msg_store_v2_scan,
+             is_integer(element(2, InnerReason)) ->
+    {ok, element(2, InnerReason)};
+corruption_offset(_Reason) -> error.
 
 enqueue_build_index_workers(_Gatherer, [], _State) ->
     exit(normal);
@@ -2011,24 +2505,33 @@ compact_file(File, FileSize,
              State = #gc_state { index_ets        = IndexEts,
                                  file_summary_ets = FileSummaryEts,
                                  dir              = Dir,
-                                 msg_store        = Server }) ->
+                                 msg_store        = Server,
+                                 last_v1_file     = LastV1File }) ->
+    Format = file_format(File, LastV1File),
     %% Get metadata about the file. Will be used to calculate
     %% how much data was reclaimed as a result of compaction.
     [#file_summary{file_size = FileSize}] = ets:lookup(FileSummaryEts, File),
     %% Open the file.
-    FileName = filenum_to_name(File),
+    FileName = filenum_to_name(File, Format),
     {ok, Fd} = file:open(form_filename(Dir, FileName), [read, write, binary, raw]),
     %% Load the messages. It's possible to get 0 messages here;
     %% that's OK. That means we have little to do as the file is
     %% about to be deleted.
-    Messages = scan_and_vacuum_message_file(File, State),
-    %% Blank holes. We must do this first otherwise the file is left
-    %% with data that may confuse the code (for example data that looks
-    %% like a message, isn't a message, but spans over a real message).
-    %% We blank more than is likely required but better safe than sorry.
-    blank_holes_in_file(Fd, Messages),
-    %% Compact the file.
-    {ok, TruncateSize, IndexUpdates} = do_compact_file(Fd, 0, Messages, lists:reverse(Messages), []),
+    Messages = scan_and_vacuum_message_file(Format, File, State),
+    StartOffset = case Format of
+        v1 -> 0;
+        v2 -> ?V2_HEADER_SIZE
+    end,
+    {ok, TruncateSize, IndexUpdates} = case Format of
+        v1 ->
+            %% v1 has no typed hole record to fall back on, so leftover
+            %% message bytes are zero-filled up front, before moving
+            %% anything: unchanged from before the v2 format existed.
+            blank_holes_in_file_v1(Fd, Messages),
+            do_compact_file_v1(Fd, StartOffset, Messages, lists:reverse(Messages), []);
+        v2 ->
+            do_compact_file_v2(Fd, StartOffset, Messages)
+    end,
     %% Sync and close the file.
     ok = file:sync(Fd),
     ok = file:close(Fd),
@@ -2056,12 +2559,13 @@ compact_file(File, FileSize,
     %% index data and so truncation is safe to do even if there are new
     %% readers. We do not need to lock the file for truncation.
     %%
-    %% It's possible that after we compact we end up with a TruncateSize of 0.
-    %% In that case we don't schedule a truncation and will let the message
-    %% store ask the GC process to delete the file.
-    case TruncateSize of
-        0 -> ok;
-        _ -> rabbit_msg_store_gc:truncate(self(), File, TruncateSize, ThresholdTimestamp)
+    %% It's possible that after we compact we end up with a TruncateSize that
+    %% still has no valid data (0 for v1, or just the header for v2). In that
+    %% case we don't schedule a truncation and will let the message store ask
+    %% the GC process to delete the file.
+    case TruncateSize =< StartOffset of
+        true  -> ok;
+        false -> rabbit_msg_store_gc:truncate(self(), File, TruncateSize, ThresholdTimestamp)
     end,
     %% Force a GC because we had to read data into memory to move it within
     %% the file and we don't want to keep it around. The GC process will also
@@ -2071,15 +2575,15 @@ compact_file(File, FileSize,
     ok.
 
 %% We must special case the blanking of the beginning of the file.
-blank_holes_in_file(Fd, [#msg_location{ offset = Offset }|Tail])
+blank_holes_in_file_v1(Fd, [#msg_location{ offset = Offset }|Tail])
         when Offset =/= 0 ->
     Bytes = <<0:Offset/unit:8>>,
     ok = file:pwrite(Fd, 0, Bytes),
-    blank_holes_in_file1(Fd, Tail);
-blank_holes_in_file(Fd, Messages) ->
-    blank_holes_in_file1(Fd, Messages).
+    blank_holes_in_file_v1_1(Fd, Tail);
+blank_holes_in_file_v1(Fd, Messages) ->
+    blank_holes_in_file_v1_1(Fd, Messages).
 
-blank_holes_in_file1(Fd, [
+blank_holes_in_file_v1_1(Fd, [
             #msg_location{ offset = OneOffset, total_size = OneSize },
             #msg_location{ offset = TwoOffset } = Two
         |Tail]) when OneOffset + OneSize < TwoOffset ->
@@ -2087,18 +2591,18 @@ blank_holes_in_file1(Fd, [
     Size = TwoOffset - Offset,
     Bytes = <<0:Size/unit:8>>,
     ok = file:pwrite(Fd, Offset, Bytes),
-    blank_holes_in_file1(Fd, [Two|Tail]);
+    blank_holes_in_file_v1_1(Fd, [Two|Tail]);
 %% We either have only one message left, or contiguous messages.
-blank_holes_in_file1(Fd, [_|Tail]) ->
-    blank_holes_in_file1(Fd, Tail);
+blank_holes_in_file_v1_1(Fd, [_|Tail]) ->
+    blank_holes_in_file_v1_1(Fd, Tail);
 %% No need to blank the hole past the last message as we will
 %% not write there (no confusion possible) and truncate afterwards.
-blank_holes_in_file1(_, []) ->
+blank_holes_in_file_v1_1(_, []) ->
     ok.
 
 %% If the message at the end fits into the hole we have found, we copy it there.
 %% We will do the ets:updates after the data is synced to disk.
-do_compact_file(Fd, Offset, Start = [#msg_location{ offset = StartMsgOffset }|_],
+do_compact_file_v1(Fd, Offset, Start = [#msg_location{ offset = StartMsgOffset }|_],
         [#msg_location{ msg_id = EndMsgId, offset = EndMsgOffset, total_size = EndMsgSize }|EndTail],
         IndexAcc)
         when EndMsgSize =< StartMsgOffset - Offset ->
@@ -2111,30 +2615,182 @@ do_compact_file(Fd, Offset, Start = [#msg_location{ offset = StartMsgOffset }|_]
             {ok, Offset + EndMsgSize, [{EndMsgId, Offset}|IndexAcc]};
         _ ->
             %% We may be able to fit another message in the same hole.
-            do_compact_file(Fd, Offset + EndMsgSize, Start, EndTail,
+            do_compact_file_v1(Fd, Offset + EndMsgSize, Start, EndTail,
                 [{EndMsgId, Offset}|IndexAcc])
     end;
 %% If the message didn't fit into the hole and this was the last message
 %% we could move (start and end have the same message), we stop there.
 %% The truncate size is right after this last message.
-do_compact_file(_, _, [#msg_location{ offset = MsgOffset, total_size = MsgSize }|_],
+do_compact_file_v1(_, _, [#msg_location{ offset = MsgOffset, total_size = MsgSize }|_],
         [#msg_location{ offset = MsgOffset }|_], IndexAcc) ->
     {ok, MsgOffset + MsgSize, IndexAcc};
 %% Regardless of where we are in the file, even if there is a small hole, if the last
 %% message can't fit it, we skip to after the hole + the next message to look for
 %% another hole.
-do_compact_file(Fd, _, [#msg_location{ offset = StartMsgOffset, total_size = StartMsgSize }|StartTail],
+do_compact_file_v1(Fd, _, [#msg_location{ offset = StartMsgOffset, total_size = StartMsgSize }|StartTail],
         End, IndexAcc) ->
-    do_compact_file(Fd, StartMsgOffset + StartMsgSize, StartTail, End, IndexAcc);
+    do_compact_file_v1(Fd, StartMsgOffset + StartMsgSize, StartTail, End, IndexAcc);
 %% We have moved all messages in the file. Stop.
 %% The offset is the truncate size of the file.
-do_compact_file(_, Offset, _, [], IndexAcc) ->
+do_compact_file_v1(_, Offset, _, [], IndexAcc) ->
     {ok, Offset, IndexAcc}.
+
+%% gap_size == 0  -> nothing
+%% gap_size <  5  -> 1..4 SMALL_HOLE bytes
+%% gap_size >= 5  -> one HOLE record, inner bytes zeroed
+%%
+%% The scanner only ever looks at the HOLE record's own 5-byte header
+%% to know how much to skip; it never reads the inner bytes. We zero
+%% them anyway so that a completed write leaves no message bytes
+%% behind for a raw scan (a salvage tool, for instance) to recover.
+%%
+%% This doesn't add crash resilience: the zeros are the last bytes in
+%% the pwrite, written after the message and the header, so a write
+%% torn partway through is, if anything, more likely to leave old
+%% bytes behind unzeroed than to leave zeros. What a scanner relies on
+%% after a crash is the header's own type and size landing intact,
+%% which zeroing the payload does nothing for.
+%%
+%% It does have one incidental benefit for a *different* failure mode,
+%% though: REC_RESERVED is 0 and has no matching scan clause, so if a
+%% scan ever gets misaligned (say, from a corrupted Size elsewhere) and
+%% lands inside a hole's zeroed payload, it hits the unrecognised-type
+%% crash instead of silently reading zeros as if they were meaningful.
+hole_bytes(0) ->
+    <<>>;
+hole_bytes(Size) when Size < 5 ->
+    binary:copy(<<?REC_SMALL_HOLE:8>>, Size);
+hole_bytes(Size) ->
+    <<?REC_HOLE:8, Size:32, 0:(Size - 5)/unit:8>>.
+
+%% We decide the whole compaction plan first, as pure data,
+%% then write it. This way nothing is ever written based on
+%% information that a later part of the plan could still
+%% invalidate. write_compact_file_v2/2 writes a hole record for
+%% whatever's left of the space each run of moves lands in, so the
+%% file is always fully valid and scannable at every point during
+%% compaction and before the physical truncation that follows it has
+%% actually happened: a crash never leaves an unmarked, ambiguous gap
+%% for the next scan (this one, recovery, or the salvage tool) to
+%% trip over. Messages we leave in place are untouched, including
+%% whatever follows them: we haven't broken anything there, so there
+%% is nothing for us to mark.
+do_compact_file_v2(Fd, StartOffset, Messages) ->
+    {Plan, TruncateSize} = plan_compact_file_v2(StartOffset, Messages, lists:reverse(Messages), []),
+    IndexUpdates = write_compact_file_v2(Fd, Plan),
+    {ok, TruncateSize, IndexUpdates}.
+
+%% Same decisions as do_compact_file_v1/5: fill the hole between the
+%% write cursor and the next not-yet-decided message with messages
+%% taken from the end of the file, packing as many as fit; a message
+%% that doesn't fit is left where it is. Unlike do_compact_file_v1/5,
+%% this never touches the file: it only decides the final, static
+%% layout, so nothing here can be invalidated by a read or a write
+%% that a later decision hasn't been made yet when it happens.
+%%
+%% A move's own hole size isn't known until we see what ends up right
+%% after it in the finished plan: packing can stop either because this
+%% was the very last message that could possibly move (the terminal
+%% clause below), or because the next candidate from the end of the
+%% file simply doesn't fit and we fall through to leaving a message
+%% where it is instead. Either way leaves a leftover behind this move,
+%% so the hole size is filled in from the finished plan, in
+%% write_compact_file_v2/2, rather than decided here.
+plan_compact_file_v2(Offset, Start = [#msg_location{ offset = StartMsgOffset }|_],
+        [#msg_location{ msg_id = EndMsgId, offset = EndMsgOffset, total_size = EndMsgSize }|EndTail],
+        Acc)
+        when EndMsgSize =< StartMsgOffset - Offset ->
+    NewOffset = Offset + EndMsgSize,
+    Entry = {moved, Offset, EndMsgId, EndMsgOffset, EndMsgSize},
+    case StartMsgOffset of
+        EndMsgOffset ->
+            %% We moved the last message we could.
+            {lists:reverse([Entry|Acc]), NewOffset};
+        _ ->
+            %% We may be able to fit another message in the same hole.
+            plan_compact_file_v2(NewOffset, Start, EndTail, [Entry|Acc])
+    end;
+%% If the message didn't fit into the hole and this was the last message
+%% we could move (start and end have the same message), we leave it where
+%% it is. The truncate size is right after this last message.
+plan_compact_file_v2(_, [#msg_location{ offset = MsgOffset, total_size = MsgSize }|_],
+        [#msg_location{ offset = MsgOffset }|_], Acc) ->
+    {lists:reverse([{kept, MsgOffset}|Acc]), MsgOffset + MsgSize};
+%% Regardless of where we are in the file, even if there is a small hole, if the last
+%% message can't fit it, we skip to after the hole + the next message to look for
+%% another hole, leaving this one where it is.
+plan_compact_file_v2(_, [#msg_location{ offset = StartMsgOffset, total_size = StartMsgSize }|StartTail],
+        End, Acc) ->
+    plan_compact_file_v2(StartMsgOffset + StartMsgSize, StartTail, End, [{kept, StartMsgOffset}|Acc]);
+%% We have moved or accounted for all messages in the file. Stop.
+%% The offset is the truncate size of the file.
+plan_compact_file_v2(Offset, _, [], Acc) ->
+    {lists:reverse(Acc), Offset}.
+
+%% Write out what the plan decided. A run of moved messages packed
+%% back to back, with no gap between them, is written in a single
+%% pwrite, so the whole run either lands or doesn't: until it does,
+%% the space it targets still holds whatever was there before, so a
+%% crash partway through the run must not be able to leave some of
+%% its messages written and others not. What follows the run (after
+%% its own trailing hole, for whatever's left of the space it moved
+%% into) is left unmarked only when it's already a valid record on
+%% disk on its own: a kept message, never touched, so still there and
+%% valid; or, at the end of the plan, the terminal moved message's own
+%% source copy, which the index still points to at the moment of this
+%% write (index_update_fields/3 in compact_file/3 only runs later,
+%% once every write in the plan has landed and the file has been
+%% synced) and so must not be overwritten. The final group's hole is
+%% therefore sized against that source offset, not against the next
+%% plan entry or the file's original size: everything from there to
+%% the true old end of file is left as whatever was physically there
+%% before this compaction, which for every message still holding a
+%% valid record (every source at or beyond the terminal move's own
+%% source offset belongs to a message this pass moved) is itself a
+%% real, if now-superseded, record; scan_v2_data's MsgIdsFound
+%% deduplication resolves the resulting duplicates by keeping the
+%% earlier (moved) copy, and physical truncation removes them for
+%% good once it eventually runs. A kept message is left untouched
+%% entirely: we never overwrote anything around it, so there is
+%% nothing there for us to mark. Both tuple shapes carry their offset
+%% in the same, second position, so the next entry's offset can be
+%% read with element/2 without matching out which shape it is.
+write_compact_file_v2(Fd, Plan) ->
+    write_compact_file_v2(Fd, Plan, []).
+
+write_compact_file_v2(Fd, [{moved, NewOffset, MsgId, OldOffset, Size}|Rest], Group) ->
+    {ok, Bytes} = file:pread(Fd, OldOffset, Size),
+    Group1 = [{MsgId, NewOffset, Bytes}|Group],
+    case Rest of
+        [{moved, NextOffset, _, _, _}|_] when NextOffset =:= NewOffset + Size ->
+            %% The next message packs right after this one with no
+            %% gap: it hasn't been written yet, so we can't treat the
+            %% boundary as safe. Fold it into the same write instead.
+            write_compact_file_v2(Fd, Rest, Group1);
+        [Next|_] ->
+            HoleSize = element(2, Next) - (NewOffset + Size),
+            write_compact_group_v2(Fd, Group1, HoleSize)
+                ++ write_compact_file_v2(Fd, Rest, []);
+        [] ->
+            write_compact_group_v2(Fd, Group1, OldOffset - (NewOffset + Size))
+    end;
+write_compact_file_v2(Fd, [{kept, _}|Rest], []) ->
+    write_compact_file_v2(Fd, Rest, []);
+write_compact_file_v2(_, [], []) ->
+    [].
+
+write_compact_group_v2(Fd, Group0, HoleSize) ->
+    Group = lists:reverse(Group0),
+    [{_, StartOffset, _}|_] = Group,
+    Data = [Bytes || {_, _, Bytes} <- Group],
+    ok = file:pwrite(Fd, StartOffset, [Data, hole_bytes(HoleSize)]),
+    [{MsgId, Offset} || {MsgId, Offset, _} <- Group].
 
 -spec truncate_file(non_neg_integer(), non_neg_integer(), integer(), gc_state()) -> ok | defer.
 
 truncate_file(File, Size, ThresholdTimestamp, #gc_state{ file_summary_ets = FileSummaryEts,
                                                          file_handles_ets = FileHandlesEts,
+                                                         last_v1_file     = LastV1File,
                                                          dir = Dir }) ->
     %% We must first check that the file still exists because the store GC process
     %% may have been asked to delete the file during compaction, before truncate
@@ -2150,7 +2806,8 @@ truncate_file(File, Size, ThresholdTimestamp, #gc_state{ file_summary_ets = File
                                      [File]),
                     defer;
                 _ ->
-                    FileName = filenum_to_name(File),
+                    Format = file_format(File, LastV1File),
+                    FileName = filenum_to_name(File, Format),
                     {ok, Fd} = file:open(form_filename(Dir, FileName), [read, write, binary, raw]),
                     {ok, _} = file:position(Fd, Size),
                     ok = file:truncate(Fd),
@@ -2166,6 +2823,7 @@ truncate_file(File, Size, ThresholdTimestamp, #gc_state{ file_summary_ets = File
 
 delete_file(File, State = #gc_state { file_summary_ets = FileSummaryEts,
                                       file_handles_ets = FileHandlesEts,
+                                      last_v1_file     = LastV1File,
                                       dir              = Dir }) ->
     case ets:match_object(FileHandlesEts, {{'_', File}, '_'}, 1) of
         {[_|_], _Cont} ->
@@ -2175,17 +2833,21 @@ delete_file(File, State = #gc_state { file_summary_ets = FileSummaryEts,
         _ ->
             [#file_summary{ valid_total_size = 0,
                             file_size = FileSize }] = ets:lookup(FileSummaryEts, File),
-            [] = scan_and_vacuum_message_file(File, State),
-            ok = file:delete(form_filename(Dir, filenum_to_name(File))),
+            Format = file_format(File, LastV1File),
+            [] = scan_and_vacuum_message_file(Format, File, State),
+            ok = file:delete(form_filename(Dir, filenum_to_name(File, Format))),
             true = ets:delete(FileSummaryEts, File),
             ?LOG_DEBUG("Deleted empty file number ~tp; reclaimed ~tp bytes", [File, FileSize]),
             ok
     end.
 
-scan_and_vacuum_message_file(File, #gc_state{ index_ets = IndexEts, dir = Dir }) ->
-    %% Messages here will be end-of-file at start-of-list
-    Path = form_filename(Dir, filenum_to_name(File)),
-    {ok, Messages} = scan_file_for_valid_messages(Path,
+scan_and_vacuum_message_file(Format, File, #gc_state{ index_ets = IndexEts,
+                                                       dir       = Dir }) ->
+    %% The scanner itself returns entries end-of-file-first (descending
+    %% offset); the reverse/1 below flips that, so what this function
+    %% returns is ascending offset order (start-of-file first).
+    Path = form_filename(Dir, filenum_to_name(File, Format)),
+    {ok, Messages} = scan_file_for_valid_messages(Format, Path,
         fun ({MsgId, TotalSize, Offset}) ->
             case index_lookup(IndexEts, MsgId) of
                 #msg_location { file = File, total_size = TotalSize,

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -2037,7 +2037,12 @@ index_new(Dir) ->
 
 index_recover(Dir) ->
     Path = filename:join(Dir, ?INDEX_FILE_NAME),
-    case ets:file2tab(Path) of
+    %% {verify, true} rejects a truncated dump (e.g. left behind by a
+    %% shutdown that was killed mid-write) instead of silently loading
+    %% however many objects made it to disk. The caller already falls
+    %% back to a full dirty-recovery rescan on any error here, which is
+    %% what must happen instead of trusting a partial index.
+    case ets:file2tab(Path, [{verify, true}]) of
         {ok, IndexEts}  -> _ = file:delete(Path),
                            {ok, IndexEts};
         Error           -> Error
@@ -2201,7 +2206,14 @@ recover_file_summary(false, _Dir) ->
                     [ordered_set, public, {keypos, #file_summary.file}])};
 recover_file_summary(true, Dir) ->
     Path = filename:join(Dir, ?FILE_SUMMARY_FILENAME),
-    case ets:file2tab(Path) of
+    %% {verify, true} rejects a truncated dump instead of silently
+    %% loading whatever entries made it to disk -- a partial table can
+    %% be missing exactly the highest-numbered (most recently added)
+    %% files, which would otherwise make a stale, lower file look like
+    %% the current one. Falling back to recover_file_summary(false, ...)
+    %% forces the full dirty-recovery rescan, which derives the true
+    %% current file from the real directory listing instead.
+    case ets:file2tab(Path, [{verify, true}]) of
         {ok, Tid}       -> ok = file:delete(Path),
                            {true, Tid};
         {error, _Error} -> recover_file_summary(false, Dir)

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -2388,8 +2388,10 @@ corruption_offset({rabbit_msg_store_v2_scan_error, _Path, InnerReason})
     {ok, element(2, InnerReason)};
 corruption_offset(_Reason) -> error.
 
+%% Runs in the same process as its caller, rebuild_index/3, rather than
+%% a separate spawned process -- see the comment there for why.
 enqueue_build_index_workers(_Gatherer, [], _State) ->
-    exit(normal);
+    ok;
 enqueue_build_index_workers(Gatherer, [File|Files], State) ->
     ok = worker_pool:dispatch_sync(
            fun () ->
@@ -2418,16 +2420,27 @@ reduce_index(Gatherer, LastFile,
             reduce_index(Gatherer, LastFile, State)
     end.
 
+%% Dispatching used to happen in a separate, unlinked, spawned process,
+%% concurrently with reduce_index/3 below draining the gatherer. If
+%% that process died before dispatching every file -- for any reason,
+%% since nothing linked or usefully monitored it -- the gatherer's
+%% per-file fork count (already bumped for every file up front, just
+%% below) would never reach zero, so gatherer:out/1 would never return
+%% empty and reduce_index/3 would block forever; rabbit_msg_store's own
+%% start_link/5 uses {timeout, infinity}, so nothing would ever time
+%% that out either -- the store just never came up, with no crash and
+%% no log. worker_pool:dispatch_sync/1 paces on free-worker availability
+%% either way, identically whether it's called from a separate process
+%% or inline, so doing it inline here doesn't change how long dispatching
+%% every file takes; it just means a failure part-way through (e.g. the
+%% shared worker_pool itself dying while a dispatch call is in flight)
+%% now propagates directly out of this function instead of vanishing
+%% silently.
 rebuild_index(Gatherer, Files, State) ->
     lists:foreach(fun (_File) ->
                           ok = gatherer:fork(Gatherer)
                   end, Files),
-    Pid = spawn(
-            fun () ->
-                    enqueue_build_index_workers(Gatherer,
-                                                Files, State)
-            end),
-    erlang:monitor(process, Pid),
+    ok = enqueue_build_index_workers(Gatherer, Files, State),
     reduce_index(Gatherer, lists:last(Files), State).
 
 %%----------------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -2071,8 +2071,27 @@ index_update(IndexEts, Obj) ->
     true = ets:insert(IndexEts, Obj),
     ok.
 
-index_update_fields(IndexEts, Key, Updates) ->
-    _ = ets:update_element(IndexEts, Key, Updates),
+%% Only updates the offset if the entry still matches File and OldOffset --
+%% i.e. it's still the exact copy this compaction pass moved. A fan-out
+%% write racing this compaction can delete and reinsert the same msg_id
+%% under a different file (or a different offset in the same file) before
+%% this runs; if that happened, the entry no longer belongs to this
+%% compaction pass and must not be touched -- its own physical bytes were
+%% already copied into the new location regardless (write_compact_file_v2
+%% doesn't know or care whether the index update will succeed), so the
+%% only consequence of skipping is an orphaned, harmless duplicate copy
+%% that scan_and_vacuum_message_file/3's existing fan-out clause already
+%% recognises and discards on this file's next scan.
+index_update_offset_if_unchanged(IndexEts, MsgId, File, OldOffset, NewOffset) ->
+    %% The extra {...} around the replacement record is required by
+    %% ets:select_replace/2: without it, a literal tuple appearing in a
+    %% match spec's body is parsed as a function call instead.
+    MatchSpec = [{#msg_location{msg_id = MsgId, ref_count = '$1', file = File,
+                                offset = OldOffset, total_size = '$2'},
+                  [],
+                  [{#msg_location{msg_id = MsgId, ref_count = '$1', file = File,
+                                 offset = NewOffset, total_size = '$2'}}]}],
+    _ = ets:select_replace(IndexEts, MatchSpec),
     ok.
 
 index_update_ref_counter(IndexEts, Key, RefCount) ->
@@ -2538,9 +2557,13 @@ compact_file(File, FileSize,
     %% Update the index. We synced and closed the file so we know the data will
     %% be there for readers. Note that it's OK if we crash at any point before we
     %% update the index because the old data is still there until we truncate.
-    lists:foreach(fun ({UpdateMsgId, UpdateOffset}) ->
-        ok = index_update_fields(IndexEts, UpdateMsgId,
-                                 [{#msg_location.offset, UpdateOffset}])
+    %%
+    %% The update only takes effect if the entry still matches File and its
+    %% original offset: a fan-out write can race this compaction and rewrite
+    %% the same msg_id under a different file (or offset) before we get here,
+    %% and blindly overwriting that live entry's offset would corrupt it.
+    lists:foreach(fun ({UpdateMsgId, OldOffset, NewOffset}) ->
+        ok = index_update_offset_if_unchanged(IndexEts, UpdateMsgId, File, OldOffset, NewOffset)
     end, IndexUpdates),
     %% We can truncate only if there are no files opened before this timestamp.
     ThresholdTimestamp = erlang:monotonic_time(),
@@ -2612,11 +2635,11 @@ do_compact_file_v1(Fd, Offset, Start = [#msg_location{ offset = StartMsgOffset }
     case StartMsgOffset of
         EndMsgOffset ->
             %% We moved the last message we could.
-            {ok, Offset + EndMsgSize, [{EndMsgId, Offset}|IndexAcc]};
+            {ok, Offset + EndMsgSize, [{EndMsgId, EndMsgOffset, Offset}|IndexAcc]};
         _ ->
             %% We may be able to fit another message in the same hole.
             do_compact_file_v1(Fd, Offset + EndMsgSize, Start, EndTail,
-                [{EndMsgId, Offset}|IndexAcc])
+                [{EndMsgId, EndMsgOffset, Offset}|IndexAcc])
     end;
 %% If the message didn't fit into the hole and this was the last message
 %% we could move (start and end have the same message), we stop there.
@@ -2738,7 +2761,7 @@ plan_compact_file_v2(Offset, _, [], Acc) ->
 %% disk on its own: a kept message, never touched, so still there and
 %% valid; or, at the end of the plan, the terminal moved message's own
 %% source copy, which the index still points to at the moment of this
-%% write (index_update_fields/3 in compact_file/3 only runs later,
+%% write (index_update_offset_if_unchanged/5 in compact_file/3 only runs later,
 %% once every write in the plan has landed and the file has been
 %% synced) and so must not be overwritten. The final group's hole is
 %% therefore sized against that source offset, not against the next
@@ -2760,7 +2783,7 @@ write_compact_file_v2(Fd, Plan) ->
 
 write_compact_file_v2(Fd, [{moved, NewOffset, MsgId, OldOffset, Size}|Rest], Group) ->
     {ok, Bytes} = file:pread(Fd, OldOffset, Size),
-    Group1 = [{MsgId, NewOffset, Bytes}|Group],
+    Group1 = [{MsgId, OldOffset, NewOffset, Bytes}|Group],
     case Rest of
         [{moved, NextOffset, _, _, _}|_] when NextOffset =:= NewOffset + Size ->
             %% The next message packs right after this one with no
@@ -2781,10 +2804,10 @@ write_compact_file_v2(_, [], []) ->
 
 write_compact_group_v2(Fd, Group0, HoleSize) ->
     Group = lists:reverse(Group0),
-    [{_, StartOffset, _}|_] = Group,
-    Data = [Bytes || {_, _, Bytes} <- Group],
+    [{_, _, StartOffset, _}|_] = Group,
+    Data = [Bytes || {_, _, _, Bytes} <- Group],
     ok = file:pwrite(Fd, StartOffset, [Data, hole_bytes(HoleSize)]),
-    [{MsgId, Offset} || {MsgId, Offset, _} <- Group].
+    [{MsgId, OldOffset, NewOffset} || {MsgId, OldOffset, NewOffset, _} <- Group].
 
 -spec truncate_file(non_neg_integer(), non_neg_integer(), integer(), gc_state()) -> ok | defer.
 

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -1797,8 +1797,8 @@ scan_v1_next_byte(<<_, Rest/bits>>, Fd, Fun, Offset, FileSize, MsgIdsFound, Acc)
 %% to produce by chance.
 %%
 %% A record whose Size does not fit within the file is treated as a
-%% torn last write and the remainder of the file is discarded, exactly
-%% as in v1. We never fall back to scanning the next byte: that is
+%% torn last write and the remainder of the file is discarded.
+%% We never fall back to scanning the next byte: that is
 %% exactly the kind of guess that could land on something that merely
 %% looks like a record.
 %%

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -67,6 +67,7 @@ groups() ->
           msg_store_compaction_v2,
           msg_store_compaction_v2_exact_fit,
           msg_store_compaction_v2_scannable_before_truncate,
+          msg_store_compaction_v2_index_update_survives_fanout_rewrite,
           msg_store_compaction_v2_packed_run_atomic,
           msg_store_compaction_v2_packed_run_with_trailing_hole,
           msg_store_v1_compat,
@@ -664,6 +665,124 @@ msg_store_compaction_v2_scannable_before_truncate1(_Config) ->
     ok = file:close(ReadFd),
 
     ok = rabbit_msg_store:client_terminate(MSCState),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% compact_file/3 applies its planned offset updates keyed only on
+%% msg_id (index_update_offset_if_unchanged/5). If a message's ref_count
+%% reaches 0 and it gets rewritten under the same msg_id into a
+%% different file while a compaction pass on its original file is still
+%% in flight -- after that pass's own scan snapshot but before it
+%% applies its index updates -- a blind update would stamp the *new*
+%% entry (now pointing at the other file) with an offset that only
+%% makes sense in the *old* file, corrupting it. This constructs exactly
+%% that race by injecting the rewrite from inside a mocked file:sync/1,
+%% the single call compact_file/3 makes between finishing its writes
+%% and applying its index updates.
+msg_store_compaction_v2_index_update_survives_fanout_rewrite(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_compaction_v2_index_update_survives_fanout_rewrite1, [Config]).
+
+msg_store_compaction_v2_index_update_survives_fanout_rewrite1(_Config) ->
+    {ok, DefaultFileSizeLimit} = application:get_env(rabbit, msg_store_file_size_limit),
+    %% Small enough that the second message's own write rolls file 0
+    %% over to file 1 immediately (64 + 39 + 29 = 132 > 120), so file 0
+    %% is no longer current by the time we compact it below. Restored in
+    %% the `after` clause regardless of outcome, so a failure here can't
+    %% leak this override into every later test in the group.
+    ok = application:set_env(rabbit, msg_store_file_size_limit, 120),
+    try
+        msg_store_compaction_v2_index_update_survives_fanout_rewrite2()
+    after
+        ok = application:set_env(rabbit, msg_store_file_size_limit, DefaultFileSizeLimit)
+    end.
+
+msg_store_compaction_v2_index_update_survives_fanout_rewrite2() ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgIdDead = msg_id_bin(fanout_rewrite_dead),
+    MsgIdFanout = msg_id_bin(fanout_rewrite_live),
+    %% 21 bytes of v2 framing plus the term_to_binary/1 envelope (6
+    %% bytes): MsgIdDead is 27 + 12 = 39 bytes (offset 64-103),
+    %% MsgIdFanout is 27 + 2 = 29 bytes (offset 103-132), pushing file 0
+    %% past the 120-byte limit and rolling to file 1 as part of its own
+    %% write.
+    ok = rabbit_msg_store:write(1, MsgIdDead, crypto:strong_rand_bytes(12), MSCState),
+    ok = rabbit_msg_store:write(2, MsgIdFanout, <<"lo">>, MSCState),
+    ok = on_disk_await(Cap, [{1, MsgIdDead}, {2, MsgIdFanout}]),
+
+    StorePid = rabbit_vhost_msg_store:vhost_store_pid(?VHOST, ?PERSISTENT_MSG_STORE),
+    GCPid = rabbit_msg_store:gc_pid(StorePid),
+    Path0 = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    132 = filelib:file_size(Path0),
+
+    %% A filler message written into file 1 (now current) before the
+    %% race below, so the fresh copy of MsgIdFanout that the race writes
+    %% lands at an offset other than 64. Without this, file 0's planned
+    %% offset for MsgIdFanout (also 64, both files' headers being the
+    %% same size and this being the first write into either) would
+    %% coincidentally match the fresh copy's real offset in file 1,
+    %% masking the corruption instead of exposing it.
+    MsgIdFiller = msg_id_bin(fanout_rewrite_filler),
+    ok = rabbit_msg_store:write(4, MsgIdFiller, crypto:strong_rand_bytes(20), MSCState),
+    ok = on_disk_await(Cap, [{4, MsgIdFiller}]),
+
+    %% Removing MsgIdDead leaves a hole compaction will move MsgIdFanout
+    %% into; MsgIdFanout itself stays live (ref_count=1) so compaction's
+    %% scan includes it in the plan.
+    {ok, _} = rabbit_msg_store:remove([{1, MsgIdDead}], MSCState),
+    timer:sleep(200),
+
+    %% Inject the race at the one point compact_file/3 calls
+    %% file:sync/1: after its writes have landed, but before it applies
+    %% its planned index updates. Removing MsgIdFanout's only remaining
+    %% reference here drops file 0's valid_total_size to exactly 0 (file
+    %% 0 is no longer current, so write_action/3's "never increase the
+    %% ref_count for a file about to be deleted" clause fires), and the
+    %% immediately following write of the same msg_id deletes that stale
+    %% entry and inserts a fresh one in file 1 -- exactly the fan-out
+    %% shape from OTHER_ISSUES.md issue #22, without needing a second
+    %% real client.
+    %% Same length as the original body: scan_and_vacuum_message_file/3's
+    %% fan-out clause matches the orphaned copy left in file 0 on
+    %% total_size, so a same-length replacement is what makes that copy
+    %% recognisable as a duplicate to discard rather than corruption
+    %% (always true in production, since a msg_id is never rewritten
+    %% with a different-length body).
+    NewBody = <<"hi">>,
+    ok = meck:new(file, [unstick, passthrough, no_link]),
+    ok = meck:expect(file, sync, fun(Fd) ->
+        Result = meck:passthrough([Fd]),
+        case self() of
+            GCPid ->
+                {ok, _} = rabbit_msg_store:remove([{2, MsgIdFanout}], MSCState),
+                ok = rabbit_msg_store:write(3, MsgIdFanout, NewBody, MSCState),
+                ok = on_disk_await(Cap, [{3, MsgIdFanout}]);
+            _ ->
+                ok
+        end,
+        Result
+    end),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    %% Let the compaction cast (and the delete cast it triggers once
+    %% file 0's valid_total_size reaches 0 from the injected remove
+    %% above) run to completion before we unload the mock.
+    timer:sleep(500),
+    ok = meck:unload(file),
+
+    %% The index must point at the fresh copy in file 1, not at whatever
+    %% offset compaction planned for the stale copy in file 0.
+    {{ok, NewBody}, MSCState1} = rabbit_msg_store:read(MsgIdFanout, MSCState),
+
+    %% File 0 has nothing left referencing it (the stale copy compaction
+    %% moved there is orphaned, unindexed) and must be cleanly deleted by
+    %% the automatic delete the injected remove triggered -- proving the
+    %% GC process never crashed scanning it.
+    false = filelib:is_file(Path0),
+
+    ok = rabbit_msg_store:client_terminate(MSCState1),
     ok = on_disk_stop(Cap),
     restart_msg_store_empty(),
     passed.

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -72,6 +72,8 @@ groups() ->
           msg_store_compaction_v2_packed_run_with_trailing_hole,
           msg_store_v1_compat,
           msg_store_v1_current_file_emptied_before_crash,
+          msg_store_recovers_from_truncated_file_summary_dump,
+          msg_store_recovers_from_truncated_index_dump,
           msg_store_recovers_torn_current_file,
           msg_store_recovers_from_corrupted_file,
           msg_store_recovers_from_corrupted_file_no_fd_leak,
@@ -987,6 +989,42 @@ assert_compacted_file_intact(Path, KeepMsgIds, MSCState) ->
 msg_store_file_path(VHost, MsgStore, FileName) ->
     filename:join([rabbit_vhost:msg_store_dir_path(VHost), atom_to_list(MsgStore), FileName]).
 
+%% Finds a byte length that, when Dump (a dump of a table that holds
+%% ExpectedCount objects) is truncated to it, still round-trips through
+%% ets:file2tab/1 (without {verify, true}) as *fewer* objects than
+%% ExpectedCount -- a real, silent loss of entries, not merely the
+%% trailing checksum/metadata footer with every object still intact.
+%% Scanning downward from just under the full size finds a cut past the
+%% footer first (which drops no objects) before reaching one that drops
+%% real content, exactly what a shutdown-timeout kill landing partway
+%% through the write would leave behind, and exactly the shape
+%% {verify, true} is meant to catch. Also confirms {verify, true}
+%% genuinely rejects the chosen cut, so the two tests using this can't
+%% pass by accident regardless of which code path is under test.
+find_silently_truncatable_cut(Dump, ScratchPath, ExpectedCount) ->
+    Size = byte_size(Dump),
+    Cuts = [round(Size * P / 100) || P <- lists:seq(95, 50, -1)],
+    find_silently_truncatable_cut(Dump, ScratchPath, ExpectedCount, Cuts).
+
+find_silently_truncatable_cut(_Dump, _ScratchPath, _ExpectedCount, []) ->
+    error(no_silently_truncatable_cut_found);
+find_silently_truncatable_cut(Dump, ScratchPath, ExpectedCount, [Cut|Rest]) ->
+    ok = file:write_file(ScratchPath, binary:part(Dump, 0, Cut)),
+    case ets:file2tab(ScratchPath) of
+        {ok, Tab} ->
+            Size1 = ets:info(Tab, size),
+            true = ets:delete(Tab),
+            case Size1 < ExpectedCount of
+                true ->
+                    {error, _} = ets:file2tab(ScratchPath, [{verify, true}]),
+                    Cut;
+                false ->
+                    find_silently_truncatable_cut(Dump, ScratchPath, ExpectedCount, Rest)
+            end;
+        {error, _} ->
+            find_silently_truncatable_cut(Dump, ScratchPath, ExpectedCount, Rest)
+    end.
+
 %% None of the other msg_store_* tests ever produce or touch a v1 (.rdq)
 %% file: restart_msg_store_empty/0 always boots a store with no files at
 %% all, and a store with no v1 files writes v2 from the very first byte.
@@ -1152,6 +1190,151 @@ msg_store_v1_current_file_emptied_before_crash1(_Config) ->
     NewMsg = {payload, <<"written after the empty v1 file was reclaimed">>},
     ok = rabbit_msg_store:write(make_ref(), NewMsgId, NewMsg, MSCState0),
     {{ok, NewMsg}, MSCState1} = rabbit_msg_store:read(NewMsgId, MSCState0),
+
+    ok = rabbit_msg_store:client_terminate(MSCState1),
+    restart_msg_store_empty(),
+    passed.
+
+%% recover_file_summary/2 used to accept a truncated file_summary.ets
+%% dump (e.g. left behind by a shutdown killed mid-write) as if it had
+%% loaded successfully, silently trusting whatever entries survived --
+%% which can be missing exactly the highest-numbered (most recently
+%% added) files, making a stale, lower file look like the current one.
+%% This corrupts only file_summary.ets (clean.dot and the index dump
+%% are untouched and still agree with the client refs below), so its
+%% own truncation is the only thing that can force this boot onto the
+%% dirty path.
+msg_store_recovers_from_truncated_file_summary_dump(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_recovers_from_truncated_file_summary_dump1, [Config]).
+
+msg_store_recovers_from_truncated_file_summary_dump1(_Config) ->
+    {ok, DefaultFileSizeLimit} = application:get_env(rabbit, msg_store_file_size_limit),
+    %% file_summary.ets holds one entry per segment file, so a truncation
+    %% that drops some entries but not others needs several files. A tiny
+    %% limit forces a rollover after every message. Restored in the
+    %% `after` clause regardless of outcome, so a failure here can't leak
+    %% this override into every later test in the group.
+    ok = application:set_env(rabbit, msg_store_file_size_limit, 100),
+    try
+        msg_store_recovers_from_truncated_file_summary_dump2()
+    after
+        ok = application:set_env(rabbit, msg_store_file_size_limit, DefaultFileSizeLimit)
+    end.
+
+msg_store_recovers_from_truncated_file_summary_dump2() ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    %% Each of these is 27 + 12 = 39 bytes: 64 + 39 = 103 > 100 rolls the
+    %% file over on every single write, so five messages land in five
+    %% separate segment files (0.sqs-4.sqs), giving file_summary.ets five
+    %% entries -- enough for a truncation to genuinely drop some.
+    MsgIds = [msg_id_bin({truncated_file_summary_dump, N}) || N <- lists:seq(1, 5)],
+    Msg = {payload, <<"still readable after the dump is rejected">>},
+    Writes = lists:zip(lists:seq(1, 5), MsgIds),
+    ok = lists:foreach(fun({N, MsgId}) ->
+        ok = rabbit_msg_store:write(N, MsgId, Msg, MSCState0)
+    end, Writes),
+    ok = on_disk_await(Cap, Writes),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap),
+
+    %% A clean shutdown: file_summary.ets, msg_store_index.ets, and
+    %% clean.dot are all written correctly.
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "file_summary.ets"),
+    {ok, Dump} = file:read_file(Path),
+    true = byte_size(Dump) > 10,
+    %% Simulates a shutdown-timeout kill landing mid-write: syntactically
+    %% still a well-formed (but incomplete) ets dump, genuinely missing
+    %% some of the five file entries -- the same shape a real partial
+    %% write would leave behind, and specifically the shape that can make
+    %% a stale, lower-numbered file look like the current one (issue #25).
+    ScratchPath = Path ++ ".scratch",
+    %% +1 for the current file (6.sqs, still empty, never gets its own
+    %% write above but does get a file_summary entry once it's rolled
+    %% into).
+    Cut = find_silently_truncatable_cut(Dump, ScratchPath, length(MsgIds) + 1),
+    ok = file:delete(ScratchPath),
+    ok = file:write_file(Path, binary:part(Dump, 0, Cut)),
+
+    %% Dirty recovery only keeps a message that count_msg_refs/3
+    %% registers as still needed -- report every MsgId, mirroring a real
+    %% queue's own index still referencing all of them.
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, MsgIds}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    %% Dirty recovery's full rescan still finds every message correctly,
+    %% including whichever files the truncated dump would have silently
+    %% dropped.
+    MSCState1 = lists:foldl(fun(MsgId, MSCStateM) ->
+        {{ok, Msg}, MSCStateN} = rabbit_msg_store:read(MsgId, MSCStateM),
+        MSCStateN
+    end, msg_store_client_init(?PERSISTENT_MSG_STORE, Ref), MsgIds),
+
+    ok = rabbit_msg_store:client_terminate(MSCState1),
+    restart_msg_store_empty(),
+    passed.
+
+%% Same as msg_store_recovers_from_truncated_file_summary_dump but for
+%% the index dump instead: index_recover/1 used to accept a truncated
+%% msg_store_index.ets the same way. This also exercises a different
+%% branch of init/1 than the file_summary case does: file_summary.ets
+%% loads successfully here (FileSummaryRecovered = true), so it's the
+%% "recovered file_summary but not the index" path that must clear it
+%% back out (init/1's `{true, false} -> ets:delete_all_objects(...)`)
+%% rather than the path that never trusted it in the first place.
+msg_store_recovers_from_truncated_index_dump(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_recovers_from_truncated_index_dump1, [Config]).
+
+msg_store_recovers_from_truncated_index_dump1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    %% Several entries, so a truncation can genuinely drop some while
+    %% leaving others intact -- not just lose the dump's trailing
+    %% checksum/metadata with every entry still there.
+    MsgIds = [msg_id_bin({truncated_index_dump, N}) || N <- lists:seq(1, 5)],
+    Msg = {payload, <<"still readable after the index dump is rejected">>},
+    Writes = lists:zip(lists:seq(1, 5), MsgIds),
+    ok = lists:foreach(fun({N, MsgId}) ->
+        ok = rabbit_msg_store:write(N, MsgId, Msg, MSCState0)
+    end, Writes),
+    ok = on_disk_await(Cap, Writes),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap),
+
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "msg_store_index.ets"),
+    {ok, Dump} = file:read_file(Path),
+    true = byte_size(Dump) > 10,
+    ScratchPath = Path ++ ".scratch",
+    Cut = find_silently_truncatable_cut(Dump, ScratchPath, length(MsgIds)),
+    ok = file:delete(ScratchPath),
+    ok = file:write_file(Path, binary:part(Dump, 0, Cut)),
+
+    %% Dirty recovery only keeps a message that count_msg_refs/3
+    %% registers as still needed -- report every MsgId, mirroring a
+    %% real queue's own index still referencing all of them.
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, MsgIds}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    %% Every message is found, including whichever ones the truncated
+    %% dump would have silently dropped.
+    MSCState1 = lists:foldl(fun(MsgId, MSCStateM) ->
+        {{ok, Msg}, MSCStateN} = rabbit_msg_store:read(MsgId, MSCStateM),
+        MSCStateN
+    end, msg_store_client_init(?PERSISTENT_MSG_STORE, Ref), MsgIds),
 
     ok = rabbit_msg_store:client_terminate(MSCState1),
     restart_msg_store_empty(),

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -74,6 +74,7 @@ groups() ->
           msg_store_v1_current_file_emptied_before_crash,
           msg_store_recovers_from_truncated_file_summary_dump,
           msg_store_recovers_from_truncated_index_dump,
+          msg_store_dirty_recovery_dispatch_failure_does_not_hang,
           msg_store_recovers_torn_current_file,
           msg_store_recovers_from_corrupted_file,
           msg_store_recovers_from_corrupted_file_no_fd_leak,
@@ -1338,6 +1339,114 @@ msg_store_recovers_from_truncated_index_dump1(_Config) ->
 
     ok = rabbit_msg_store:client_terminate(MSCState1),
     restart_msg_store_empty(),
+    passed.
+
+%% rebuild_index/3 used to spawn a separate, unlinked process just to
+%% dispatch each segment file's scan job to the worker pool, while its
+%% own caller concurrently blocked waiting for gathered results from a
+%% gatherer that process neither owned nor was linked to. If that
+%% dispatcher process died partway through dispatching -- e.g. because
+%% the shared worker_pool itself died while a dispatch call was in
+%% flight -- nothing else ever noticed: the gatherer's per-file fork
+%% count could never reach zero, so the consumer blocked forever, and
+%% since the store's own start_link/5 uses an infinite timeout, nothing
+%% ever timed that out either. This simulates exactly that failure (a
+%% dispatch call raising partway through a dirty recovery forced across
+%% several segment files, so there's a "partway" to speak of) and
+%% asserts that boot fails loudly, well within a bounded wait, instead
+%% of hanging.
+msg_store_dirty_recovery_dispatch_failure_does_not_hang(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_dirty_recovery_dispatch_failure_does_not_hang1, [Config]).
+
+msg_store_dirty_recovery_dispatch_failure_does_not_hang1(_Config) ->
+    {ok, DefaultFileSizeLimit} = application:get_env(rabbit, msg_store_file_size_limit),
+    %% Force several segment files, so the dispatch loop genuinely still
+    %% has files left after the one call we make fail.
+    ok = application:set_env(rabbit, msg_store_file_size_limit, 100),
+    try
+        msg_store_dirty_recovery_dispatch_failure_does_not_hang2()
+    after
+        ok = application:set_env(rabbit, msg_store_file_size_limit, DefaultFileSizeLimit)
+    end.
+
+msg_store_dirty_recovery_dispatch_failure_does_not_hang2() ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    %% Each of these is 27 + 12 = 39 bytes: 64 + 39 = 103 > 100 rolls the
+    %% file over on every single write, so five messages land in five
+    %% separate segment files.
+    MsgIds = [msg_id_bin({dispatch_failure, N}) || N <- lists:seq(1, 5)],
+    Msg = {payload, <<"irrelevant to this test">>},
+    Writes = lists:zip(lists:seq(1, 5), MsgIds),
+    ok = lists:foreach(fun({N, MsgId}) ->
+        ok = rabbit_msg_store:write(N, MsgId, Msg, MSCState0)
+    end, Writes),
+    ok = on_disk_await(Cap, Writes),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap),
+
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    %% No clean.dot => dirty recovery => rebuild_index/3 dispatches one
+    %% job per segment file.
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    ok = file:delete(filename:join(Dir, "clean.dot")),
+
+    %% Fail the second dispatch_sync call outright, simulating the
+    %% shared worker_pool dying while that call is in flight, with
+    %% files still left to dispatch afterwards. The transient store
+    %% (started first, always empty here) issues one phantom dispatch
+    %% of its own for its single, absent current file, so this is
+    %% actually the persistent store's first file dispatch -- but since
+    %% the persistent store has five segment files, that still leaves
+    %% four genuinely undispatched afterwards, which is the shape that
+    %% matters here.
+    Counter = counters:new(1, []),
+    ok = meck:new(worker_pool, [unstick, passthrough, no_link]),
+    ok = meck:expect(worker_pool, dispatch_sync, fun(Fun) ->
+        N = counters:get(Counter, 1) + 1,
+        counters:add(Counter, 1, 1),
+        case N of
+            2 -> error(simulated_worker_pool_death);
+            _ -> meck:passthrough([Fun])
+        end
+    end),
+
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    Parent = self(),
+    {Pid, MRef} = spawn_monitor(fun() ->
+        Result = (catch rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, MsgIds})),
+        Parent ! {self(), Result}
+    end),
+    %% Comfortably above how long even a slow, correct boot takes, but
+    %% far below how long a genuine hang would need to be mistaken for
+    %% one -- this is testing "does it come back at all", not timing.
+    Outcome = receive
+        {'DOWN', MRef, process, Pid, DownReason} -> {'DOWN', DownReason};
+        {Pid, Result} -> Result
+    after 10000 ->
+        timeout
+    end,
+    ok = meck:unload(worker_pool),
+
+    %% The one assertion that matters: boot does not hang forever. The
+    %% exact crash shape isn't the point -- not hanging is.
+    true = Outcome =/= timeout,
+
+    %% The failed start above means the persistent store's supervisor
+    %% child spec was never successfully registered (the transient
+    %% store, which needs no dirty recovery, did start) --
+    %% restart_msg_store_empty/0 would try to stop it again and badmatch
+    %% on {error, not_found}. Stop each independently, tolerating that,
+    %% before starting both fresh for real.
+    catch rabbit_vhost_msg_store:stop(?VHOST, ?TRANSIENT_MSG_STORE),
+    catch rabbit_vhost_msg_store:stop(?VHOST, ?PERSISTENT_MSG_STORE),
+    ok = rabbit_variable_queue:start_msg_store(?VHOST,
+           undefined, {fun (ok) -> finished end, ok}),
     passed.
 
 %% open_current_file/5 has three branches: roll a v1 current file to a

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -64,7 +64,22 @@ groups() ->
      {backing_queue_tests, [], [
           msg_store,
           msg_store_read_many_fanout,
+          msg_store_compaction_v2,
+          msg_store_compaction_v2_exact_fit,
+          msg_store_compaction_v2_scannable_before_truncate,
+          msg_store_compaction_v2_packed_run_atomic,
+          msg_store_compaction_v2_packed_run_with_trailing_hole,
+          msg_store_v1_compat,
+          msg_store_v1_current_file_emptied_before_crash,
+          msg_store_recovers_torn_current_file,
+          msg_store_recovers_from_corrupted_file,
+          msg_store_recovers_from_corrupted_file_no_fd_leak,
+          msg_store_read_error_includes_msg_id,
+          msg_store_recovers_from_corrupted_non_current_file,
+          msg_store_v2_scan_failure_crashes_recovery,
+          msg_store_v1_scan_failure_crashes_recovery,
           msg_store_file_scan,
+          msg_store_file_scan_v2,
           msg_store_gc_stuck_suspended,
           msg_store_gc_stuck_mid_callback,
           {backing_queue_v2, [], Common ++ V2Only}
@@ -94,9 +109,16 @@ init_per_group(Group, Config) ->
     case lists:member({group, Group}, all()) of
         true ->
             ClusterSize = 1,
+            %% msg_store_v1_scan_failure_crashes_recovery and
+            %% msg_store_v2_scan_failure_crashes_recovery each
+            %% deliberately crash message store startup once, to prove
+            %% a scan failure is not silently mistaken for corruption:
+            %% expect those gen_server terminations rather than failing
+            %% the whole group over them.
             Config1 = rabbit_ct_helpers:set_config(Config, [
                 {rmq_nodename_suffix, Group},
-                {rmq_nodes_count, ClusterSize}
+                {rmq_nodes_count, ClusterSize},
+                {ignored_crashes, ["eio"]}
               ]),
             rabbit_ct_helpers:run_steps(Config1,
               rabbit_ct_broker_helpers:setup_steps() ++
@@ -376,6 +398,1225 @@ msg_store_read_many_fanout1(_Config) ->
                                           QueueOnlyMsgIds, MSCStateM),
                    MSCStateN
            end),
+    passed.
+
+%% Compaction of a v2 (.sqs) segment file is the one path that isn't
+%% adequately covered by scanning hand-built files (msg_store_file_scan_v2):
+%% do_compact_file_v2/3 plans the whole move up front (plan_compact_file_v2/4)
+%% and then writes it (write_compact_file_v2/2), and when a moved message is
+%% smaller than the hole it lands in (the common case with mixed message
+%% sizes), whatever remains of that hole must be re-marked as a HOLE or
+%% SMALL_HOLE record rather than left as arbitrary leftover bytes. A
+%% structural scan of the compacted file, not just reads through the index,
+%% is what actually proves this: reads alone would succeed even if
+%% compaction never touched the surviving messages' bytes at all.
+msg_store_compaction_v2(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_compaction_v2_1, [Config]).
+
+%% A single hand-picked size/removal distribution wouldn't tell us much
+%% about shapes it doesn't happen to produce, so this runs several:
+%% many small messages packed several-to-a-hole, few survivors spread
+%% across large holes, most of the file left untouched with only
+%% scattered removals, and the original mixed-size scattered pattern.
+msg_store_compaction_v2_1(_Config) ->
+    lists:foreach(fun({NumMsgs, SizeFun, KeepFun1, KeepFun2}) ->
+        ok = msg_store_compaction_v2_scenario(NumMsgs, SizeFun, KeepFun1, KeepFun2)
+    end, [
+        {60, fun(N) -> 50 + (N * 37 rem 400) end,
+             fun(N) -> N rem 7 =:= 0 end, fun(N) -> N rem 3 =:= 0 end},
+        {80, fun(_) -> 20 end,
+             fun(N) -> N rem 5 =:= 0 end, fun(N) -> N rem 2 =:= 0 end},
+        {50, fun(N) -> 30 + (N * 91 rem 900) end,
+             fun(N) -> N rem 10 =/= 0 end, fun(N) -> N rem 6 =:= 0 end},
+        {50, fun(N) -> 40 + (N * 53 rem 300) end,
+             fun(N) -> N rem 11 =:= 0 end, fun(N) -> N rem 2 =:= 0 end}
+    ]),
+    passed.
+
+msg_store_compaction_v2_scenario(NumMsgs, SizeFun, KeepFun1, KeepFun2) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    %% Writes must be confirmed on disk before we measure file sizes below:
+    %% with no confirm callback the message store never arms its periodic
+    %% write-buffer flush (update_pending_confirms/3 short-circuits), so
+    %% small messages can sit unflushed in memory indefinitely.
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgIds = [{SeqId, msg_id_bin(N), SizeFun(N)} ||
+                 {SeqId, N} <- lists:enumerate(0, lists:seq(1, NumMsgs))],
+    MSCState = lists:foldl(fun({SeqId, MsgId, BodySize}, MSCStateM) ->
+        ok = rabbit_msg_store:write(SeqId, MsgId, crypto:strong_rand_bytes(BodySize), MSCStateM),
+        MSCStateM
+    end, MSCState0, MsgIds),
+    ok = on_disk_await(Cap, [{SeqId, MsgId} || {SeqId, MsgId, _} <- MsgIds]),
+
+    StorePid = rabbit_vhost_msg_store:vhost_store_pid(?VHOST, ?PERSISTENT_MSG_STORE),
+    GCPid = rabbit_msg_store:gc_pid(StorePid),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+
+    %% Keep a scattered subset and remove the rest. A single burst-remove
+    %% like this lands all of file 0's candidacy in one gc_candidate
+    %% timer window, which maybe_gc/2's anti-thrash check then
+    %% permanently defers (nothing removes from file 0 again to
+    %% re-trigger reconsideration), so drive compaction directly instead
+    %% of waiting on the timer, the same way msg_store_gc_stuck_mid_callback
+    %% does elsewhere in this suite.
+    {KeepMsgs, RemoveMsgs} = lists:partition(
+        fun({_, _, N}) -> KeepFun1(N) end,
+        [{SeqId, MsgId, N} || {N, {SeqId, MsgId, _BodySize}} <- lists:enumerate(MsgIds)]),
+    KeepMsgIds = [MsgId || {_, MsgId, _} <- KeepMsgs],
+    {ok, _} = rabbit_msg_store:remove([{SeqId, MsgId} || {SeqId, MsgId, _} <- RemoveMsgs], MSCState),
+    timer:sleep(200),
+    SizeBefore = filelib:file_size(Path),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    timer:sleep(500),
+    true = filelib:file_size(Path) < SizeBefore,
+    ok = assert_compacted_file_intact(Path, KeepMsgIds, MSCState),
+
+    %% Compact a second time after removing more of the survivors: this
+    %% exercises scan_and_vacuum_message_file re-scanning a file that
+    %% already contains HOLE/SMALL_HOLE records written by the *previous*
+    %% compaction, not just holes derived directly from the original
+    %% (pre-compaction) layout.
+    {KeepMsgs2, RemoveMsgs2} = lists:partition(
+        fun({_, _, N}) -> KeepFun2(N) end,
+        [{SeqId, MsgId, N} || {N, {SeqId, MsgId}} <- lists:enumerate(
+            [{SeqId, MsgId} || {SeqId, MsgId, _} <- KeepMsgs])]),
+    KeepMsgIds2 = [MsgId || {_, MsgId, _} <- KeepMsgs2],
+    {ok, _} = rabbit_msg_store:remove([{SeqId, MsgId} || {SeqId, MsgId, _} <- RemoveMsgs2], MSCState),
+    timer:sleep(200),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    timer:sleep(500),
+    ok = assert_compacted_file_intact(Path, KeepMsgIds2, MSCState),
+
+    %% Removing every remaining survivor empties the v2 file entirely,
+    %% which goes through delete_file's v2 dispatch (file_format/2,
+    %% filenum_to_name/2) and the file disappears, exactly as
+    %% msg_store_v1_compat exercises for the v1 dispatch. Drive it
+    %% directly via rabbit_msg_store_gc:delete/2, the same reason
+    %% compaction above is driven directly rather than via the timer:
+    %% this file's candidacy already went through several manually
+    %% triggered rounds, and maybe_gc/2's anti-thrash check defers
+    %% automatic reconsideration once that's happened.
+    {ok, _} = rabbit_msg_store:remove([{SeqId, MsgId} || {SeqId, MsgId, _} <- KeepMsgs2], MSCState),
+    timer:sleep(200),
+    ok = rabbit_msg_store_gc:delete(GCPid, 0),
+    timer:sleep(500),
+    {ok, Files} = file:list_dir(filename:dirname(Path)),
+    false = lists:member(filename:basename(Path), Files),
+
+    ok = rabbit_msg_store:client_terminate(MSCState),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    ok.
+
+%% do_compact_file_v2 calls hole_bytes(0) (an empty binary; no write at
+%% all beyond the moved message itself) whenever a moved message exactly
+%% fills the hole it lands in. The randomised scenarios above are likely
+%% to hit this by chance given enough different sizes, but nothing
+%% asserts it directly, so this constructs it deterministically instead:
+%% two equally-sized messages, one removed to open a hole, the other
+%% pulled from the end of the file to exactly fill it, with a third,
+%% untouched message positioned right after to prove there is no gap at
+%% all between the moved message and whatever follows it.
+msg_store_compaction_v2_exact_fit(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_compaction_v2_exact_fit1, [Config]).
+
+msg_store_compaction_v2_exact_fit1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgIdKeep1 = msg_id_bin(exact_fit_keep1),
+    MsgIdRemoved = msg_id_bin(exact_fit_removed),
+    MsgIdKeep2 = msg_id_bin(exact_fit_keep2),
+    MsgIdMoved = msg_id_bin(exact_fit_moved),
+    %% MsgIdRemoved and MsgIdMoved have identical body sizes, so their
+    %% on-disk record sizes match exactly: moving MsgIdMoved into the
+    %% hole left by removing MsgIdRemoved leaves nothing over.
+    SameSize = 50,
+    Writes = [
+        {1, MsgIdKeep1,   100},
+        {2, MsgIdRemoved, SameSize},
+        {3, MsgIdKeep2,   100},
+        {4, MsgIdMoved,   SameSize}
+    ],
+    MSCState = lists:foldl(fun({SeqId, MsgId, BodySize}, MSCStateM) ->
+        ok = rabbit_msg_store:write(SeqId, MsgId, crypto:strong_rand_bytes(BodySize), MSCStateM),
+        MSCStateM
+    end, MSCState0, Writes),
+    ok = on_disk_await(Cap, [{SeqId, MsgId} || {SeqId, MsgId, _} <- Writes]),
+
+    StorePid = rabbit_vhost_msg_store:vhost_store_pid(?VHOST, ?PERSISTENT_MSG_STORE),
+    GCPid = rabbit_msg_store:gc_pid(StorePid),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+
+    {ok, _} = rabbit_msg_store:remove([{2, MsgIdRemoved}], MSCState),
+    timer:sleep(200),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    timer:sleep(500),
+
+    lists:foreach(fun(MsgId) ->
+        {{ok, _}, _} = rabbit_msg_store:read(MsgId, MSCState)
+    end, [MsgIdKeep1, MsgIdKeep2, MsgIdMoved]),
+    {ok, ScannedEntries} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    Entries = maps:from_list([{MsgId, {TotalSize, Offset}} ||
+                                  {MsgId, TotalSize, Offset} <- ScannedEntries]),
+    3 = maps:size(Entries),
+    {MovedSize, MovedOffset} = maps:get(MsgIdMoved, Entries),
+    {_, Keep2Offset} = maps:get(MsgIdKeep2, Entries),
+    %% No gap at all between the moved message and the one right after
+    %% it: proof the leftover was genuinely zero bytes, not merely a
+    %% small hole that happened not to get noticed otherwise.
+    Keep2Offset = MovedOffset + MovedSize,
+
+    ok = rabbit_msg_store:client_terminate(MSCState),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% Physically truncating a compacted file down to its planned
+%% TruncateSize is a separate step, deferred by rabbit_msg_store_gc
+%% until there are no readers (and droppable entirely if a delete
+%% supersedes it). Until that truncation actually happens, the file
+%% is still physically at its old size, and a scan (from another
+%% compaction pass, a delete, or dirty recovery after a crash in that
+%% window) must not trip over whatever is physically sitting between
+%% TruncateSize and the old end of file. This constructs a plan whose
+%% last move leaves real leftover space behind it (as opposed to
+%% msg_store_compaction_v2_exact_fit, which deliberately leaves none),
+%% mocks the truncate away entirely, and scans the file while it is
+%% still at its original, untruncated size.
+%%
+%% The leftover space is deliberately *not* the last moved message's
+%% own source copy: at the point this write happens the index still
+%% points there (index_update_fields/3 only runs later, once every
+%% write has landed and the file has been synced), so overwriting it
+%% would make a concurrent read, or a crash before the index update
+%% lands, see a hole where it still expects that message. Only the
+%% torn remainder of whatever the move partially overwrote -- here,
+%% the tail of MsgIdDead's removed record -- gets marked; the last
+%% moved message's own now-redundant source copy is left as a plain,
+%% untouched, still-valid (if stale) record instead, exactly like
+%% every earlier moved message's source copy already is. This checks
+%% that too, directly.
+msg_store_compaction_v2_scannable_before_truncate(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_compaction_v2_scannable_before_truncate1, [Config]).
+
+msg_store_compaction_v2_scannable_before_truncate1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgIdDead = msg_id_bin(scannable_before_truncate_dead),
+    MsgIdLive = msg_id_bin(scannable_before_truncate_live),
+    %% Records are 21 bytes of v2 framing plus the term_to_binary/1
+    %% envelope (6 bytes) plus the body: MsgIdDead is 27 + 12 = 39
+    %% bytes (offset 64-103), MsgIdLive is 27 + 2 = 29 bytes (offset
+    %% 103-132). MsgIdLive is the only survivor and the only message
+    %% pulled from the end of the file, so it moves into the hole
+    %% MsgIdDead's removal leaves (39 bytes, starting at 64) but only
+    %% fills 29 of it: TruncateSize is 64 + 29 = 93. The 10-byte
+    %% remainder between TruncateSize and MsgIdLive's own original
+    %% offset (103) is the torn tail of MsgIdDead's old record; the
+    %% 29 bytes from 103 to the original 132-byte end of file are
+    %% MsgIdLive's own source copy, left alone.
+    Writes = [
+        {1, MsgIdDead, 12},
+        {2, MsgIdLive, 2}
+    ],
+    MSCState = lists:foldl(fun({SeqId, MsgId, BodySize}, MSCStateM) ->
+        ok = rabbit_msg_store:write(SeqId, MsgId, crypto:strong_rand_bytes(BodySize), MSCStateM),
+        MSCStateM
+    end, MSCState0, Writes),
+    ok = on_disk_await(Cap, [{SeqId, MsgId} || {SeqId, MsgId, _} <- Writes]),
+
+    StorePid = rabbit_vhost_msg_store:vhost_store_pid(?VHOST, ?PERSISTENT_MSG_STORE),
+    GCPid = rabbit_msg_store:gc_pid(StorePid),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    132 = filelib:file_size(Path),
+
+    {ok, _} = rabbit_msg_store:remove([{1, MsgIdDead}], MSCState),
+    timer:sleep(200),
+
+    %% Prevent the physical truncation entirely, so the scan below is
+    %% guaranteed to see the file exactly as compaction left it, not
+    %% whatever it happens to look like in a narrow timing window.
+    ok = meck:new(rabbit_msg_store_gc, [no_link, passthrough]),
+    ok = meck:expect(rabbit_msg_store_gc, truncate, fun(_, _, _, _) -> ok end),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    timer:sleep(500),
+    ok = meck:unload(rabbit_msg_store_gc),
+
+    %% Still at the original size: truncation genuinely never happened.
+    132 = filelib:file_size(Path),
+
+    {{ok, _}, _} = rabbit_msg_store:read(MsgIdLive, MSCState),
+    {ok, ScannedEntries} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    [{MsgIdLive, 29, 64}] = ScannedEntries,
+
+    %% MsgIdLive's own source copy, at its original offset (103), must
+    %% still be a real, untouched REC_MESSAGE record (type byte 3),
+    %% not zeroed out as part of the trailing hole: the index still
+    %% pointed there when this write happened.
+    {ok, ReadFd} = file:open(Path, [read, binary, raw]),
+    {ok, <<3:8, _/binary>>} = file:pread(ReadFd, 103, 1),
+    ok = file:close(ReadFd),
+
+    ok = rabbit_msg_store:client_terminate(MSCState),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% write_compact_file_v2 must not leave a moved message's trailing
+%% space unmarked when what immediately follows is *another* moved
+%% message that hasn't been written yet: until that write happens,
+%% the space is still whatever was there before compaction, so a
+%% crash between the two writes would leave the second message's
+%% target offset holding stale bytes, and the next scan wouldn't
+%% just lose the interrupted message: it would treat the stale bytes
+%% as corruption and discard everything after them too, including
+%% anything that compaction never touched. The fix packs a whole run
+%% of messages with no gaps between them into a single pwrite, so
+%% the run lands atomically. This constructs a hole exactly big
+%% enough for two messages pulled from the end of the file, with a
+%% third message positioned right after the hole, and checks that
+%% compaction issues exactly one pwrite for the pair rather than one
+%% per message.
+msg_store_compaction_v2_packed_run_atomic(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_compaction_v2_packed_run_atomic1, [Config]).
+
+msg_store_compaction_v2_packed_run_atomic1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgIdKeep1 = msg_id_bin(packed_run_keep1),
+    MsgIdRemoved = msg_id_bin(packed_run_removed),
+    MsgIdKeep2 = msg_id_bin(packed_run_keep2),
+    MsgIdMovedPenultimate = msg_id_bin(packed_run_moved_penultimate),
+    MsgIdMovedLast = msg_id_bin(packed_run_moved_last),
+    %% MsgIdRemoved's record is exactly as big as MsgIdMovedPenultimate's
+    %% and MsgIdMovedLast's combined, so both fit into the hole its
+    %% removal leaves with nothing left over between them. Record sizes
+    %% are 27 bytes plus the body size given here: 21 bytes of v2
+    %% REC_MESSAGE framing (type, size, msg id) plus the 6-byte
+    %% external term format header term_to_binary/1 adds to wrap the
+    %% body as a binary term.
+    Writes = [
+        {1, MsgIdKeep1,            100},
+        {2, MsgIdRemoved,          56},
+        {3, MsgIdKeep2,            100},
+        {4, MsgIdMovedPenultimate, 9},
+        {5, MsgIdMovedLast,        20}
+    ],
+    MSCState = lists:foldl(fun({SeqId, MsgId, BodySize}, MSCStateM) ->
+        ok = rabbit_msg_store:write(SeqId, MsgId, crypto:strong_rand_bytes(BodySize), MSCStateM),
+        MSCStateM
+    end, MSCState0, Writes),
+    ok = on_disk_await(Cap, [{SeqId, MsgId} || {SeqId, MsgId, _} <- Writes]),
+
+    StorePid = rabbit_vhost_msg_store:vhost_store_pid(?VHOST, ?PERSISTENT_MSG_STORE),
+    GCPid = rabbit_msg_store:gc_pid(StorePid),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+
+    {ok, _} = rabbit_msg_store:remove([{2, MsgIdRemoved}], MSCState),
+    timer:sleep(200),
+
+    %% Capture every file:pwrite/3 call made anywhere while compaction
+    %% runs: the GC process does the actual writing, not this one, so
+    %% this has to be a real (if narrowly scoped and brief) mock,
+    %% rather than something local to this process.
+    TestPid = self(),
+    ok = meck:new(file, [unstick, passthrough, no_link]),
+    ok = meck:expect(file, pwrite, fun(Fd, Offset, Data) ->
+        TestPid ! {pwrite, Offset, iolist_size(Data)},
+        meck:passthrough([Fd, Offset, Data])
+    end),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    timer:sleep(500),
+    ok = meck:unload(file),
+    PwriteCalls = flush_pwrite_calls(),
+
+    %% One pwrite for both moved messages together, at the offset the
+    %% first of them (the one pulled from furthest into the file)
+    %% lands at, sized for both records combined with no hole between
+    %% them: not one pwrite per message, which would also produce a
+    %% call at the second message's own offset and size (238, 36).
+    true = lists:member({191, 83}, PwriteCalls),
+    false = lists:member({238, 36}, PwriteCalls),
+
+    lists:foreach(fun(MsgId) ->
+        {{ok, _}, _} = rabbit_msg_store:read(MsgId, MSCState)
+    end, [MsgIdKeep1, MsgIdKeep2, MsgIdMovedPenultimate, MsgIdMovedLast]),
+    {ok, ScannedEntries} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    Entries = maps:from_list([{MsgId, {TotalSize, Offset}} ||
+                                  {MsgId, TotalSize, Offset} <- ScannedEntries]),
+    4 = maps:size(Entries),
+    {_, 64}  = maps:get(MsgIdKeep1, Entries),
+    {_, 191} = maps:get(MsgIdMovedLast, Entries),
+    {_, 238} = maps:get(MsgIdMovedPenultimate, Entries),
+    {_, 274} = maps:get(MsgIdKeep2, Entries),
+    401 = filelib:file_size(Path),
+
+    ok = rabbit_msg_store:client_terminate(MSCState),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% msg_store_compaction_v2_packed_run_atomic's packed run exactly
+%% fills the hole it lands in, so its group's trailing hole is always
+%% zero-sized (no bytes actually written for it). This constructs a
+%% packed run that only partially fills its hole, so the group's one
+%% pwrite must also carry a real, non-empty trailing hole record.
+msg_store_compaction_v2_packed_run_with_trailing_hole(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_compaction_v2_packed_run_with_trailing_hole1, [Config]).
+
+msg_store_compaction_v2_packed_run_with_trailing_hole1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgIdKeep1 = msg_id_bin(packed_hole_keep1),
+    MsgIdRemoved = msg_id_bin(packed_hole_removed),
+    MsgIdKeep2 = msg_id_bin(packed_hole_keep2),
+    MsgIdMovedPenultimate = msg_id_bin(packed_hole_moved_penultimate),
+    MsgIdMovedLast = msg_id_bin(packed_hole_moved_last),
+    %% MsgIdRemoved's record (27 + 73 = 100 bytes) is bigger than
+    %% MsgIdMovedPenultimate's and MsgIdMovedLast's combined (32 + 37 =
+    %% 69 bytes), so both fit into the hole its removal leaves with
+    %% 31 bytes still left over afterwards.
+    Writes = [
+        {1, MsgIdKeep1,            100},
+        {2, MsgIdRemoved,          73},
+        {3, MsgIdKeep2,            100},
+        {4, MsgIdMovedPenultimate, 5},
+        {5, MsgIdMovedLast,        10}
+    ],
+    MSCState = lists:foldl(fun({SeqId, MsgId, BodySize}, MSCStateM) ->
+        ok = rabbit_msg_store:write(SeqId, MsgId, crypto:strong_rand_bytes(BodySize), MSCStateM),
+        MSCStateM
+    end, MSCState0, Writes),
+    ok = on_disk_await(Cap, [{SeqId, MsgId} || {SeqId, MsgId, _} <- Writes]),
+
+    StorePid = rabbit_vhost_msg_store:vhost_store_pid(?VHOST, ?PERSISTENT_MSG_STORE),
+    GCPid = rabbit_msg_store:gc_pid(StorePid),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+
+    {ok, _} = rabbit_msg_store:remove([{2, MsgIdRemoved}], MSCState),
+    timer:sleep(200),
+
+    TestPid = self(),
+    ok = meck:new(file, [unstick, passthrough, no_link]),
+    ok = meck:expect(file, pwrite, fun(Fd, Offset, Data) ->
+        TestPid ! {pwrite, Offset, iolist_size(Data)},
+        meck:passthrough([Fd, Offset, Data])
+    end),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    timer:sleep(500),
+    ok = meck:unload(file),
+    PwriteCalls = flush_pwrite_calls(),
+
+    %% One pwrite covering both moved messages plus the 31-byte hole
+    %% left over after them (37 + 32 + 31 = 100, the exact size of the
+    %% hole MsgIdRemoved's removal left): not one pwrite per message,
+    %% each with its own trailing hole (the second of which, sized
+    %% against the 31-byte leftover alone, would be {228, 32 + 31}).
+    true = lists:member({191, 100}, PwriteCalls),
+    false = lists:member({228, 63}, PwriteCalls),
+
+    lists:foreach(fun(MsgId) ->
+        {{ok, _}, _} = rabbit_msg_store:read(MsgId, MSCState)
+    end, [MsgIdKeep1, MsgIdKeep2, MsgIdMovedPenultimate, MsgIdMovedLast]),
+    {ok, ScannedEntries} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    Entries = maps:from_list([{MsgId, {TotalSize, Offset}} ||
+                                  {MsgId, TotalSize, Offset} <- ScannedEntries]),
+    4 = maps:size(Entries),
+    {_, 64}  = maps:get(MsgIdKeep1, Entries),
+    {_, 191} = maps:get(MsgIdMovedLast, Entries),
+    {_, 228} = maps:get(MsgIdMovedPenultimate, Entries),
+    {_, 291} = maps:get(MsgIdKeep2, Entries),
+    418 = filelib:file_size(Path),
+
+    ok = rabbit_msg_store:client_terminate(MSCState),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+flush_pwrite_calls() ->
+    receive
+        {pwrite, Offset, Size} -> [{Offset, Size} | flush_pwrite_calls()]
+    after 0 ->
+        []
+    end.
+
+%% A raw scan may also find messages that compaction left in place
+%% without touching (complete, still-valid records that are simply no
+%% longer referenced by the index): that's expected, so we only check
+%% that every message we kept is among the ones found, not that
+%% nothing else is. A real message store scan reconciles against the
+%% index and would remove such stale entries.
+assert_compacted_file_intact(Path, KeepMsgIds, MSCState) ->
+    lists:foreach(fun(MsgId) ->
+        {{ok, _}, _} = rabbit_msg_store:read(MsgId, MSCState)
+    end, KeepMsgIds),
+    {ok, ScannedEntries} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    ScannedMsgIds = sets:from_list([MsgId || {MsgId, _TotalSize, _Offset} <- ScannedEntries], [{version, 2}]),
+    true = sets:is_subset(sets:from_list(KeepMsgIds, [{version, 2}]), ScannedMsgIds),
+    ok.
+
+msg_store_file_path(VHost, MsgStore, FileName) ->
+    filename:join([rabbit_vhost:msg_store_dir_path(VHost), atom_to_list(MsgStore), FileName]).
+
+%% None of the other msg_store_* tests ever produce or touch a v1 (.rdq)
+%% file: restart_msg_store_empty/0 always boots a store with no files at
+%% all, and a store with no v1 files writes v2 from the very first byte.
+%% msg_store_file_scan only covers the standalone scanner against
+%% hand-built files, never the live client read path, the v1-to-v2
+%% rollover on boot, or GC dispatching to the v1 code paths. This test
+%% hand-places a legacy v1 segment file to cover all of that.
+msg_store_v1_compat(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_v1_compat1, [Config]).
+
+msg_store_v1_compat1(_Config) ->
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    ok = rabbit_file:recursive_delete([Dir]),
+    ok = filelib:ensure_dir(filename:join(Dir, "nothing")),
+
+    %% Hand-write a legacy v1 segment file (0.rdq) with two messages of
+    %% deliberately different sizes (so that removing the larger one
+    %% leaves a hole the smaller one can be moved into during
+    %% compaction), with no clean.dot present, so the next boot must go
+    %% through dirty recovery and discover it purely from what's on disk
+    %% -- mirroring a store that predates the v2 format.
+    MsgId1 = msg_id_bin(v1_legacy_1),
+    LegacyMsg1 = {legacy, "first-v1-message", crypto:strong_rand_bytes(500)},
+    MsgId2 = msg_id_bin(v1_legacy_2),
+    LegacyMsg2 = {legacy, "second-v1-message"},
+    V1Record = fun(MsgId, Msg) ->
+        Bin = term_to_binary(Msg),
+        Size = byte_size(MsgId) + byte_size(Bin),
+        [<<Size:64>>, MsgId, Bin, <<255>>]
+    end,
+    ok = file:write_file(filename:join(Dir, "0.rdq"),
+        [V1Record(MsgId1, LegacyMsg1), V1Record(MsgId2, LegacyMsg2)]),
+
+    %% No matching client refs => dirty recovery. The ref-count generator
+    %% mimics the shape rabbit_classic_queue_index_v2:queue_index_walker/1
+    %% actually reports: a list of msg ids per batch.
+    Ref = rabbit_guid:gen(),
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId1, MsgId2]}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    {ok, Files1} = file:list_dir(Dir),
+    true = lists:member("0.rdq", Files1),
+    true = lists:any(fun(F) -> filename:extension(F) =:= ".sqs" end, Files1),
+
+    %% Both legacy messages must be readable through the live client API
+    %% (reader_open/reader_pread_parse_v1), not just the standalone scanner.
+    MSCState0 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+    {{ok, LegacyMsg1}, MSCState1} = rabbit_msg_store:read(MsgId1, MSCState0),
+    {{ok, LegacyMsg2}, MSCState2} = rabbit_msg_store:read(MsgId2, MSCState1),
+
+    %% A newly written message must roll into a fresh v2 file: v2 records
+    %% must never be appended into the v1 file (open_current_file/5).
+    NewMsgId = msg_id_bin(new_v2_msg),
+    NewMsg = {payload, <<"a new v2 message">>},
+    ok = rabbit_msg_store:write(make_ref(), NewMsgId, NewMsg, MSCState2),
+    {{ok, NewMsg}, MSCState3} = rabbit_msg_store:read(NewMsgId, MSCState2),
+    ok = rabbit_msg_store:client_terminate(MSCState3),
+
+    %% Restart cleanly: last_v1_file is now persisted in clean.dot rather
+    %% than recomputed from disk, and everything must still read correctly.
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {fun([]) -> finished end, []}),
+    true = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+    MSCState4 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+    {{ok, LegacyMsg1}, MSCState5} = rabbit_msg_store:read(MsgId1, MSCState4),
+    {{ok, LegacyMsg2}, MSCState6} = rabbit_msg_store:read(MsgId2, MSCState5),
+    {{ok, NewMsg}, MSCState7} = rabbit_msg_store:read(NewMsgId, MSCState6),
+
+    %% Removing the larger legacy message leaves the v1 file with live
+    %% data (the smaller one), so it goes through compact_file and
+    %% scan_and_vacuum_message_file dispatching to their v1 code paths,
+    %% not straight to deletion.
+    StorePid = rabbit_vhost_msg_store:vhost_store_pid(?VHOST, ?PERSISTENT_MSG_STORE),
+    GCPid = rabbit_msg_store:gc_pid(StorePid),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.rdq"),
+    SizeBeforeCompact = filelib:file_size(Path),
+    %% count_msg_refs registers refs via ets:update_counter/4, whose
+    %% Default already carries ref_count=1; on a fresh key the Increment
+    %% is added on top of that, so a message recovered this way starts
+    %% at ref_count=2 and needs two removes to be fully dereferenced.
+    {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId1}], MSCState7),
+    {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId1}], MSCState7),
+    timer:sleep(200),
+    ok = rabbit_msg_store_gc:compact(GCPid, 0),
+    timer:sleep(500),
+    true = filelib:is_regular(Path),
+    true = filelib:file_size(Path) < SizeBeforeCompact,
+    %% Unlike v2, v1 compaction zero-fills every removed message's bytes
+    %% up front (blank_holes_in_file_v1), so a raw scan of the compacted
+    %% file must find exactly the survivor, not just have it be readable
+    %% through the index: this is what actually proves do_compact_file_v1
+    %% moved MsgId2's bytes rather than leaving them untouched by luck.
+    {ok, [{MsgId2, _, _}]} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    {{ok, LegacyMsg2}, MSCState8} = rabbit_msg_store:read(MsgId2, MSCState7),
+
+    %% Removing the last legacy message empties the v1 file, which goes
+    %% through delete_file's v1 dispatch and disappears entirely.
+    {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId2}], MSCState8),
+    {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId2}], MSCState8),
+    timer:sleep(500),
+    {ok, Files2} = file:list_dir(Dir),
+    false = lists:member("0.rdq", Files2),
+
+    ok = rabbit_msg_store:client_terminate(MSCState8),
+    restart_msg_store_empty(),
+    passed.
+
+%% delete_file_if_empty/2 always exempts current_file, and build_index's
+%% dirty-recovery fold runs it over every file while the about-to-be-
+%% rolled-away-from v1 file is still current, so it's skipped there
+%% too. If that v1 file holds no valid messages, nothing revisits it
+%% once open_current_file/5 decides to roll to a fresh v2 file instead
+%% -- unless init/1 explicitly checks it right after making that
+%% decision, which is what this covers.
+msg_store_v1_current_file_emptied_before_crash(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_v1_current_file_emptied_before_crash1, [Config]).
+
+msg_store_v1_current_file_emptied_before_crash1(_Config) ->
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    ok = rabbit_file:recursive_delete([Dir]),
+    ok = filelib:ensure_dir(filename:join(Dir, "nothing")),
+
+    %% Hand-write a legacy v1 segment file (0.rdq) holding one message,
+    %% with no clean.dot present, so the next boot must go through
+    %% dirty recovery and discover it purely from what's on disk --
+    %% mirroring a store that predates the v2 format.
+    MsgId = msg_id_bin(v1_current_file_emptied),
+    LegacyMsg = {legacy, "already fully consumed before the crash"},
+    Bin = term_to_binary(LegacyMsg),
+    Size = byte_size(MsgId) + byte_size(Bin),
+    ok = file:write_file(filename:join(Dir, "0.rdq"),
+        [<<Size:64>>, MsgId, Bin, <<255>>]),
+
+    %% The ref-count generator reports no messages at all needed by any
+    %% queue: MsgId was already fully acked by every queue that had it
+    %% before the crash, so this file genuinely holds no live messages
+    %% by the time dirty recovery runs, even though it's still the
+    %% highest-numbered (and so, provisionally, "current") file on disk.
+    Ref = rabbit_guid:gen(),
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {fun([]) -> finished end, []}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+    timer:sleep(500),
+
+    %% The empty v1 file must be gone, not left behind forever: nothing
+    %% after boot ever points into it, and nothing after boot will ever
+    %% reconsider deleting it since it's no longer current.
+    {ok, Files} = file:list_dir(Dir),
+    false = lists:member("0.rdq", Files),
+    true = lists:any(fun(F) -> filename:extension(F) =:= ".sqs" end, Files),
+
+    %% The store is still fully usable: a new message goes into a fresh
+    %% v2 file and reads back correctly.
+    MSCState0 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+    NewMsgId = msg_id_bin(v1_current_file_emptied_new),
+    NewMsg = {payload, <<"written after the empty v1 file was reclaimed">>},
+    ok = rabbit_msg_store:write(make_ref(), NewMsgId, NewMsg, MSCState0),
+    {{ok, NewMsg}, MSCState1} = rabbit_msg_store:read(NewMsgId, MSCState0),
+
+    ok = rabbit_msg_store:client_terminate(MSCState1),
+    restart_msg_store_empty(),
+    passed.
+
+%% open_current_file/5 has three branches: roll a v1 current file to a
+%% fresh v2 one (covered by msg_store_v1_compat), recover a v2 current
+%% file that does hold valid messages (covered by every test that
+%% restarts a store with data, e.g. msg_store_v1_compat's second
+%% restart), and reopen a v2 current file that recovery determined
+%% holds no valid messages, truncating away anything past its header.
+%% That last one is reachable in an ordinary way: a crash partway
+%% through appending a message leaves exactly this shape (a header,
+%% then a torn write that scanning treats as a truncated last write,
+%% not as a real message). This covers it directly.
+msg_store_recovers_torn_current_file(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_recovers_torn_current_file1, [Config]).
+
+msg_store_recovers_torn_current_file1(_Config) ->
+    restart_msg_store_empty(),
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+
+    %% A fresh store's current file is 0.sqs with nothing but its
+    %% 64-byte header. Simulate a crash partway through appending a
+    %% message: a header claiming far more data than actually follows,
+    %% which scanning treats as a torn last write, not as real data.
+    {ok, Fd} = file:open(Path, [read, write, binary, raw]),
+    {ok, _} = file:position(Fd, eof),
+    ok = file:write(Fd, <<3:8, 999999:32, "torn append">>),
+    ok = file:close(Fd),
+    ok = file:delete(filename:join(Dir, "clean.dot")),
+
+    %% No matching client refs => dirty recovery, forcing a full rescan
+    %% from disk rather than trusting anything persisted.
+    Ref = rabbit_guid:gen(),
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {fun([]) -> finished end, []}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    %% The stale tail must be gone immediately: truncation happens as
+    %% part of startup (open_current_file/5), not lazily on first write.
+    64 = filelib:file_size(Path),
+
+    %% A new message must land right after the header, not after the
+    %% discarded tail, and must read back correctly. Writes must be
+    %% confirmed on disk before the raw scan below, or the message may
+    %% still be sitting unflushed in memory (see msg_store_compaction_v2).
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgId = msg_id_bin(after_torn_recovery),
+    Msg = {payload, <<"written after recovering a torn current file">>},
+    SeqId = make_ref(),
+    ok = rabbit_msg_store:write(SeqId, MsgId, Msg, MSCState0),
+    ok = on_disk_await(Cap, [{SeqId, MsgId}]),
+    {{ok, Msg}, MSCState1} = rabbit_msg_store:read(MsgId, MSCState0),
+    {ok, [{MsgId, _TotalSize, 64}]} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+
+    ok = rabbit_msg_store:client_terminate(MSCState1),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% Unlike a torn last write (msg_store_recovers_torn_current_file,
+%% tolerated silently, no data lost), a genuine hard corruption error
+%% must not crash the whole store during dirty recovery either: we
+%% cannot safely resync past it (that is exactly the byte-guessing v2
+%% was designed to avoid), so scan_file_recovering_corruption truncates
+%% the file at the point of the error instead, keeping everything
+%% scanned successfully before it.
+msg_store_recovers_from_corrupted_file(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_recovers_from_corrupted_file1, [Config]).
+
+msg_store_recovers_from_corrupted_file1(_Config) ->
+    restart_msg_store_empty(),
+    Ref0 = rabbit_guid:gen(),
+    {Cap0, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref0),
+    MsgId1 = msg_id_bin(corrupt_test_1),
+    MsgId2 = msg_id_bin(corrupt_test_2),
+    Msg1 = {payload, <<"kept before the corruption, message 1">>},
+    Msg2 = {payload, <<"kept before the corruption, message 2">>},
+    ok = rabbit_msg_store:write(1, MsgId1, Msg1, MSCState0),
+    ok = rabbit_msg_store:write(2, MsgId2, Msg2, MSCState0),
+    ok = on_disk_await(Cap0, [{1, MsgId1}, {2, MsgId2}]),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap0),
+
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    GoodSize = filelib:file_size(Path),
+
+    %% Append a record with an unrecognised type byte: definite
+    %% corruption, not a torn write (a torn write cannot fully flush a
+    %% valid type byte with a bogus value; see the comment above
+    %% scan_v2_data's catch-all clause).
+    {ok, Fd} = file:open(Path, [read, write, binary, raw]),
+    {ok, _} = file:position(Fd, eof),
+    ok = file:write(Fd, <<250:8, "this is not a valid v2 record">>),
+    ok = file:close(Fd),
+    ok = file:delete(filename:join(Dir, "clean.dot")),
+
+    %% No matching client refs => dirty recovery, forcing a full rescan
+    %% from disk rather than trusting anything persisted. The ref-count
+    %% generator must declare MsgId1/MsgId2 up front (mirroring what
+    %% rabbit_classic_queue_index_v2:queue_index_walker/1 reports for a
+    %% real queue) so build_index_worker's index_lookup has a
+    %% file = undefined entry to resolve them against; otherwise
+    %% neither one is ever considered valid, corruption or not.
+    Ref = rabbit_guid:gen(),
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId1, MsgId2]}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    %% The corrupted tail is gone: the file is truncated back to
+    %% exactly where the good data ended, not dropped entirely.
+    GoodSize = filelib:file_size(Path),
+
+    {Cap, MSCState1} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    {{ok, Msg1}, MSCState2} = rabbit_msg_store:read(MsgId1, MSCState1),
+    {{ok, Msg2}, MSCState3} = rabbit_msg_store:read(MsgId2, MSCState2),
+
+    %% A new message must land right after the truncation point, not
+    %% after the discarded corruption, and read back correctly.
+    MsgId3 = msg_id_bin(corrupt_test_3),
+    Msg3 = {payload, <<"written after truncating the corruption">>},
+    ok = rabbit_msg_store:write(3, MsgId3, Msg3, MSCState3),
+    ok = on_disk_await(Cap, [{3, MsgId3}]),
+    {{ok, Msg3}, MSCState4} = rabbit_msg_store:read(MsgId3, MSCState3),
+    {ok, ScannedEntries} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    ScannedOffsets = maps:from_list([{MsgId, Offset} || {MsgId, _TotalSize, Offset} <- ScannedEntries]),
+    3 = maps:size(ScannedOffsets),
+    GoodSize = maps:get(MsgId3, ScannedOffsets),
+
+    ok = rabbit_msg_store:client_terminate(MSCState4),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% scan_v2_file_for_valid_messages/2 did not close its fd on the
+%% exception path, only on success. scan_file_recovering_corruption/2
+%% retries a failed scan of the same file in a loop, so every retry
+%% before the one that finally succeeds leaked one fd. This forces
+%% exactly one such retry (the same corruption as
+%% msg_store_recovers_from_corrupted_file) and checks that every
+%% file:open/2 call against the target file is matched by a
+%% file:close/1 call once the store has fully stopped (which also
+%% closes the current file's own long-lived write handle, so the
+%% counts only balance if nothing else was left open).
+msg_store_recovers_from_corrupted_file_no_fd_leak(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_recovers_from_corrupted_file_no_fd_leak1, [Config]).
+
+msg_store_recovers_from_corrupted_file_no_fd_leak1(_Config) ->
+    restart_msg_store_empty(),
+    Ref0 = rabbit_guid:gen(),
+    {Cap0, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref0),
+    MsgId1 = msg_id_bin(corrupt_no_leak_1),
+    Msg1 = {payload, <<"kept before the corruption">>},
+    ok = rabbit_msg_store:write(1, MsgId1, Msg1, MSCState0),
+    ok = on_disk_await(Cap0, [{1, MsgId1}]),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap0),
+
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+
+    %% Same corruption as msg_store_recovers_from_corrupted_file: an
+    %% unrecognised type byte, definite corruption rather than a torn
+    %% write, forcing scan_file_recovering_corruption/2 to truncate
+    %% and retry exactly once.
+    {ok, CorruptFd} = file:open(Path, [read, write, binary, raw]),
+    {ok, _} = file:position(CorruptFd, eof),
+    ok = file:write(CorruptFd, <<250:8, "this is not a valid v2 record">>),
+    ok = file:close(CorruptFd),
+    ok = file:delete(filename:join(Dir, "clean.dot")),
+
+    Counters = counters:new(2, []),
+    OpenFds = ets:new(open_fds, [public, set]),
+    ok = meck:new(file, [unstick, passthrough, no_link]),
+    ok = meck:expect(file, open, fun(OpenPath, Modes) ->
+        Result = meck:passthrough([OpenPath, Modes]),
+        case {OpenPath, Result} of
+            {Path, {ok, Fd}} ->
+                counters:add(Counters, 1, 1),
+                ets:insert(OpenFds, {Fd}),
+                Result;
+            _ ->
+                Result
+        end
+    end),
+    ok = meck:expect(file, close, fun(Fd) ->
+        case ets:take(OpenFds, Fd) of
+            [_] -> counters:add(Counters, 2, 1);
+            []  -> ok
+        end,
+        meck:passthrough([Fd])
+    end),
+
+    %% Unloaded in the `after` clause below regardless of outcome: a
+    %% failure while file is mocked must not leave the mock (and the
+    %% OpenFds table it depends on) installed for every later test in
+    %% the group.
+    try
+        Ref = rabbit_guid:gen(),
+        Gen = fun
+            ([])  -> finished;
+            (Ids) -> {Ids, []}
+        end,
+        ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId1]}),
+        false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+        MSCState1 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+        {{ok, Msg1}, MSCState2} = rabbit_msg_store:read(MsgId1, MSCState1),
+        ok = rabbit_msg_store:client_terminate(MSCState2),
+
+        %% Stop the store so the current file's own long-lived write
+        %% handle (opened separately by open_current_file/5, and only
+        %% ever closed on shutdown) is closed too, leaving only
+        %% genuinely leaked handles open.
+        ok = rabbit_variable_queue:stop_msg_store(?VHOST)
+    after
+        ok = meck:unload(file)
+    end,
+
+    OpenCount = counters:get(Counters, 1),
+    CloseCount = counters:get(Counters, 2),
+    %% At least the failed attempt and the successful retry: proves
+    %% the corruption genuinely forced more than one open of this file.
+    true = OpenCount >= 2,
+    OpenCount = CloseCount,
+
+    %% The store was already stopped above; restart_msg_store_empty/0
+    %% would stop it a second time and fail, so start it back up directly.
+    ok = rabbit_variable_queue:start_msg_store(?VHOST,
+           undefined, {fun (ok) -> finished end, ok}),
+    passed.
+
+%% reader_pread_parse_v1/2 and reader_pread_parse_v2/2 attach the file
+%% number to a corrupted record's read error, but used to leave out the
+%% message's own id -- even though the id is already parsed out of the
+%% record before the corruption (a bad body, or a size that doesn't add
+%% up) is even detected. This confirms the id is included now, so a
+%% corrupted record can be located directly instead of requiring a full
+%% scan of the file to find which message is at fault.
+msg_store_read_error_includes_msg_id(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_read_error_includes_msg_id1, [Config]).
+
+msg_store_read_error_includes_msg_id1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    MsgId = msg_id_bin(read_error_includes_msg_id),
+    Msg = {payload, <<"corrupted on purpose after being written">>},
+    ok = rabbit_msg_store:write(1, MsgId, Msg, MSCState0),
+    ok = on_disk_await(Cap, [{1, MsgId}]),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap),
+
+    %% Restart cleanly (matching client refs) so the freshly-recreated
+    %% cur_file_cache_ets can't serve the read below from memory -- the
+    %% corruption must actually be read back from disk to be caught.
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {fun([]) -> finished end, []}),
+    true = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    %% Corrupt just the message body in place, leaving the record's own
+    %% type/size/msg_id header (the first 21 bytes of the record, right
+    %% after the 64-byte file header) untouched, so the parser reads out
+    %% MsgId before it gets to -- and fails to decode -- the body.
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    BodySize = byte_size(term_to_binary(Msg)),
+    Garbage = binary:copy(<<0>>, BodySize),
+    {ok, Fd} = file:open(Path, [read, write, binary, raw]),
+    ok = file:pwrite(Fd, 64 + 21, Garbage),
+    ok = file:close(Fd),
+
+    MSCState1 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+    ReadMsgId = try
+        rabbit_msg_store:read(MsgId, MSCState1),
+        unexpected_success
+    catch
+        error:{rabbit_msg_store_v2_read, invalid_message_body, _File, Id} ->
+            Id
+    end,
+    MsgId = ReadMsgId,
+
+    ok = rabbit_msg_store:client_terminate(MSCState1),
+    restart_msg_store_empty(),
+    passed.
+
+%% msg_store_recovers_from_corrupted_file above only ever corrupts the
+%% current (last) segment file, which gets a second, independent
+%% truncation pass via open_current_file/5 (writer_recover/3) on top
+%% of scan_file_recovering_corruption's own truncate. A file that has
+%% already been rolled past -- no longer current -- relies solely on
+%% scan_file_recovering_corruption: this covers that path by writing
+%% enough to roll over to a second file, then corrupting the first
+%% one, which by then is no longer being written to.
+msg_store_recovers_from_corrupted_non_current_file(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_recovers_from_corrupted_non_current_file1, [Config]).
+
+msg_store_recovers_from_corrupted_non_current_file1(_Config) ->
+    {ok, DefaultFileSizeLimit} = application:get_env(rabbit, msg_store_file_size_limit),
+    %% A tiny limit forces a rollover after a couple of small messages
+    %% instead of needing megabytes of writes to exercise the same
+    %% path. Restored in the `after` clause below regardless of
+    %% outcome, so a failure here can't leak this override into every
+    %% later test in the group.
+    ok = application:set_env(rabbit, msg_store_file_size_limit, 200),
+    try
+        msg_store_recovers_from_corrupted_non_current_file2()
+    after
+        ok = application:set_env(rabbit, msg_store_file_size_limit, DefaultFileSizeLimit)
+    end.
+
+msg_store_recovers_from_corrupted_non_current_file2() ->
+    restart_msg_store_empty(),
+    Ref0 = rabbit_guid:gen(),
+    {Cap0, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref0),
+    MsgId1 = msg_id_bin(corrupt_non_current_1),
+    MsgId2 = msg_id_bin(corrupt_non_current_2),
+    MsgId3 = msg_id_bin(corrupt_non_current_3),
+    Msg1 = {payload, <<"file 0, kept before the corruption, message 1">>},
+    Msg2 = {payload, <<"file 0, kept before the corruption, message 2">>},
+    Msg3 = {payload, <<"file 1, the current file, untouched by any of this">>},
+    ok = rabbit_msg_store:write(1, MsgId1, Msg1, MSCState0),
+    ok = rabbit_msg_store:write(2, MsgId2, Msg2, MSCState0),
+    ok = on_disk_await(Cap0, [{1, MsgId1}, {2, MsgId2}]),
+    %% MsgId2's write pushes file 0's offset past the 200-byte limit
+    %% (each of these two records is 83 bytes; 64 + 83 + 83 = 230), so
+    %% file 0 is already closed and file 1 already the current file by
+    %% the time this third message is written into it.
+    ok = rabbit_msg_store:write(3, MsgId3, Msg3, MSCState0),
+    ok = on_disk_await(Cap0, [{3, MsgId3}]),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap0),
+
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Path0 = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    Path1 = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "1.sqs"),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    true = filelib:is_regular(Path0),
+    true = filelib:is_regular(Path1),
+    GoodSize0 = filelib:file_size(Path0),
+    GoodSize1 = filelib:file_size(Path1),
+
+    %% Corrupt file 0 only, exactly as msg_store_recovers_from_corrupted_file
+    %% does for the current file: an unrecognised type byte, definite
+    %% corruption rather than a torn write.
+    {ok, Fd} = file:open(Path0, [read, write, binary, raw]),
+    {ok, _} = file:position(Fd, eof),
+    ok = file:write(Fd, <<250:8, "this is not a valid v2 record">>),
+    ok = file:close(Fd),
+    ok = file:delete(filename:join(Dir, "clean.dot")),
+
+    Ref = rabbit_guid:gen(),
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId1, MsgId2, MsgId3]}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    %% File 0's corrupted tail is truncated away; file 1, never
+    %% corrupted and never the target of open_current_file/5's own
+    %% truncate (that only applies to whichever file is current now,
+    %% file 1, and it does hold valid data), is untouched.
+    GoodSize0 = filelib:file_size(Path0),
+    GoodSize1 = filelib:file_size(Path1),
+
+    {Cap, MSCState1} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    {{ok, Msg1}, MSCState2} = rabbit_msg_store:read(MsgId1, MSCState1),
+    {{ok, Msg2}, MSCState3} = rabbit_msg_store:read(MsgId2, MSCState2),
+    {{ok, Msg3}, MSCState4} = rabbit_msg_store:read(MsgId3, MSCState3),
+
+    %% The store is still fully usable afterwards.
+    MsgId4 = msg_id_bin(corrupt_non_current_4),
+    Msg4 = {payload, <<"written after recovering file 0">>},
+    ok = rabbit_msg_store:write(4, MsgId4, Msg4, MSCState4),
+    ok = on_disk_await(Cap, [{4, MsgId4}]),
+    {{ok, Msg4}, MSCState5} = rabbit_msg_store:read(MsgId4, MSCState4),
+
+    ok = rabbit_msg_store:client_terminate(MSCState5),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% scan_v2_file_for_valid_messages/2 wraps *any* error raised while
+%% scanning, not just the tagged rabbit_msg_store_v2_scan errors it
+%% raises itself: an I/O error surfacing through file:read/2, for
+%% example, falls through the scanner's case clauses and comes out as
+%% a case_clause error instead. scan_file_recovering_corruption/2 must
+%% not mistake this for corruption it can safely truncate around: Fun
+%% has already updated the index for every message reached before the
+%% error, so guessing wrong would leave those entries pointing at a
+%% file a wrong guess then truncates out from under them. It must
+%% crash instead, the same as v1 does for the equivalent situation
+%% (see msg_store_v1_scan_failure_crashes_recovery).
+msg_store_v2_scan_failure_crashes_recovery(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_v2_scan_failure_crashes_recovery1, [Config]).
+
+msg_store_v2_scan_failure_crashes_recovery1(_Config) ->
+    restart_msg_store_empty(),
+    Ref0 = rabbit_guid:gen(),
+    {Cap0, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref0),
+    MsgId1 = msg_id_bin(v2_scan_failure_1),
+    MsgId2 = msg_id_bin(v2_scan_failure_2),
+    Msg1 = {payload, <<"untouched by the injected failure, message 1">>},
+    Msg2 = {payload, <<"untouched by the injected failure, message 2">>},
+    ok = rabbit_msg_store:write(1, MsgId1, Msg1, MSCState0),
+    ok = rabbit_msg_store:write(2, MsgId2, Msg2, MSCState0),
+    ok = on_disk_await(Cap0, [{1, MsgId1}, {2, MsgId2}]),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap0),
+
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.sqs"),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    OriginalSize = filelib:file_size(Path),
+    ok = file:delete(filename:join(Dir, "clean.dot")),
+
+    %% Fail exactly the first 4MB-sized file:read/2 call anywhere on
+    %% the node: the v2 scanner always reads in ?SCAN_BLOCK_SIZE (4MB)
+    %% chunks, and dirty recovery's very first scan is the first thing
+    %% to run one after clean.dot is gone, so this lands on the target
+    %% file's first read, before it has parsed anything.
+    Counter = counters:new(1, []),
+    ok = meck:new(file, [unstick, passthrough, no_link]),
+    ok = meck:expect(file, read, fun(Fd, Length) ->
+        case Length =:= 4194304 andalso counters:get(Counter, 1) =:= 0 of
+            true ->
+                counters:add(Counter, 1, 1),
+                {error, eio};
+            false ->
+                meck:passthrough([Fd, Length])
+        end
+    end),
+
+    %% No matching client refs => dirty recovery, forcing a full rescan
+    %% from disk. The ref-count generator declares MsgId1/MsgId2 up
+    %% front, mirroring msg_store_recovers_from_corrupted_file1.
+    Ref = rabbit_guid:gen(),
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    Outcome = try
+        rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId1, MsgId2]}),
+        recovered
+    catch
+        Class:Reason -> {crashed, Class, Reason}
+    end,
+    ok = meck:unload(file),
+
+    {crashed, _, CrashReason} = Outcome,
+    %% Pin the crash to the scanner, not just to "something went
+    %% wrong": a mis-targeted fault injection should not be able to
+    %% satisfy this test by crashing recovery some other way.
+    true = string:find(io_lib:format("~0p", [CrashReason]), "rabbit_msg_store_v2_scan_error") =/= nomatch,
+    %% The file must be untouched: recovery crashed before it ever got
+    %% the chance to (mis)truncate anything.
+    OriginalSize = filelib:file_size(Path),
+
+    %% start_msg_store/3 starts the transient store first, which
+    %% succeeded, then the persistent one, whose supervisor:start_child/2
+    %% call failed and so left no child spec behind to clean up: only
+    %% the transient store, which is still running, needs stopping
+    %% before starting fresh (see msg_store_v1_scan_failure_crashes_recovery).
+    ok = rabbit_vhost_msg_store:stop(?VHOST, ?TRANSIENT_MSG_STORE),
+
+    %% Starting it again, without the injected fault, must still
+    %% recover both messages normally.
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId1, MsgId2]}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    %% The store is fully usable: both original messages and a new one
+    %% written afterwards all read back correctly.
+    {Cap, MSCState1} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+    {{ok, Msg1}, MSCState1a} = rabbit_msg_store:read(MsgId1, MSCState1),
+    {{ok, Msg2}, MSCState1b} = rabbit_msg_store:read(MsgId2, MSCState1a),
+    MsgId3 = msg_id_bin(v2_scan_failure_3),
+    Msg3 = {payload, <<"written after the unexpected error">>},
+    ok = rabbit_msg_store:write(3, MsgId3, Msg3, MSCState1b),
+    ok = on_disk_await(Cap, [{3, MsgId3}]),
+    {{ok, Msg3}, MSCState2} = rabbit_msg_store:read(MsgId3, MSCState1b),
+    %% MsgId3 lands right after the two original messages, not after a
+    %% truncation: nothing was ever discarded.
+    {ok, ScannedEntries} = rabbit_msg_store:scan_file_for_valid_messages(Path),
+    ScannedOffsets = maps:from_list([{MsgId, Offset} || {MsgId, _TotalSize, Offset} <- ScannedEntries]),
+    3 = maps:size(ScannedOffsets),
+    OriginalSize = maps:get(MsgId3, ScannedOffsets),
+
+    ok = rabbit_msg_store:client_terminate(MSCState2),
+    ok = on_disk_stop(Cap),
+    restart_msg_store_empty(),
+    passed.
+
+%% v1 has no tagged corruption errors of its own (see the comment
+%% above scan_file_recovering_corruption/2): corruption there is
+%% handled silently, by byte-shifting forward, never by raising. So
+%% build_index_worker scans a v1 file directly, unwrapped, and a scan
+%% failure there -- which can now only mean an unanticipated error
+%% (an I/O failure, as injected below, or a bug in Fun), not on-disk
+%% corruption -- must crash recovery loudly instead of being mistaken
+%% for corruption and silently discarding the whole file.
+msg_store_v1_scan_failure_crashes_recovery(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_v1_scan_failure_crashes_recovery1, [Config]).
+
+msg_store_v1_scan_failure_crashes_recovery1(_Config) ->
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    ok = rabbit_file:recursive_delete([Dir]),
+    ok = filelib:ensure_dir(filename:join(Dir, "nothing")),
+
+    %% Hand-write a legacy v1 segment file, same as msg_store_v1_compat,
+    %% with no clean.dot present, forcing dirty recovery to scan it.
+    MsgId = msg_id_bin(v1_scan_failure),
+    LegacyMsg = {legacy, "a v1 message untouched by the injected failure"},
+    Bin = term_to_binary(LegacyMsg),
+    V1Record = [<<(byte_size(MsgId) + byte_size(Bin)):64>>, MsgId, Bin, <<255>>],
+    Path = filename:join(Dir, "0.rdq"),
+    ok = file:write_file(Path, V1Record),
+    OriginalSize = filelib:file_size(Path),
+
+    %% Fail exactly the first 4MB-sized file:read/2 call anywhere on
+    %% the node: v1 scanning, like v2, always reads in ?SCAN_BLOCK_SIZE
+    %% (4MB) chunks, and dirty recovery's very first scan is the first
+    %% thing to run one after clean.dot is gone.
+    Counter = counters:new(1, []),
+    ok = meck:new(file, [unstick, passthrough, no_link]),
+    ok = meck:expect(file, read, fun(Fd, Length) ->
+        case Length =:= 4194304 andalso counters:get(Counter, 1) =:= 0 of
+            true ->
+                counters:add(Counter, 1, 1),
+                {error, eio};
+            false ->
+                meck:passthrough([Fd, Length])
+        end
+    end),
+
+    Ref = rabbit_guid:gen(),
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    Outcome = try
+        rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId]}),
+        recovered
+    catch
+        Class:Reason -> {crashed, Class, Reason}
+    end,
+    ok = meck:unload(file),
+
+    {crashed, _, _} = Outcome,
+    %% The file must be untouched: recovery crashed before it ever got
+    %% the chance to (mis)truncate anything.
+    OriginalSize = filelib:file_size(Path),
+
+    %% start_msg_store/3 starts the transient store first, which
+    %% succeeded, then the persistent one, whose supervisor:start_child/2
+    %% call failed and so left no child spec behind to clean up: only
+    %% the transient store, which is still running, needs stopping
+    %% before starting fresh.
+    ok = rabbit_vhost_msg_store:stop(?VHOST, ?TRANSIENT_MSG_STORE),
+
+    %% Starting it again, without the injected fault, must still
+    %% recover the message normally.
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref], {Gen, [MsgId]}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+    MSCState0 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+    {{ok, LegacyMsg}, MSCState1} = rabbit_msg_store:read(MsgId, MSCState0),
+    ok = rabbit_msg_store:client_terminate(MSCState1),
+
+    restart_msg_store_empty(),
     passed.
 
 restart_msg_store_empty() ->
@@ -718,6 +1959,172 @@ msg_store_file_scan1(Config) ->
     %% All good!!
     passed.
 
+%% Same idea as msg_store_file_scan/1, but for the v2 (.sqs) shared
+%% store format: typed HOLE/SMALL_HOLE/MESSAGE records instead of
+%% zero-filled gaps, and no length-ambiguous scanning (format is
+%% inferred from the .sqs extension).
+msg_store_file_scan_v2(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_file_scan_v2_1, [Config]).
+
+msg_store_file_scan_v2_1(Config) ->
+    Scan = fun (Blocks) ->
+        Expected = gen_result_v2(Blocks),
+        Path = gen_msg_file_v2(Config, Blocks),
+        Result = rabbit_msg_store:scan_file_for_valid_messages(Path),
+        ok = file:delete(Path),
+        case Result of
+            Expected -> ok;
+            _ -> {expected, Expected, got, Result}
+        end
+    end,
+    %% Same as Scan/1, but for the corruption checks that must make the
+    %% scan crash instead of silently accepting or skipping bad data.
+    %% Only the reason atom is asserted on, not the exact offset. Every
+    %% such crash is wrapped with the file path (rabbit_msg_store_v2_scan_error)
+    %% by scan_v2_file_for_valid_messages/2, so that outer shape is
+    %% unwrapped here before matching the actual reason.
+    ScanError = fun (Blocks) ->
+        Path = gen_msg_file_v2(Config, Blocks),
+        Result = try
+            rabbit_msg_store:scan_file_for_valid_messages(Path),
+            unexpected_success
+        catch
+            error:{rabbit_msg_store_v2_scan_error, Path, {rabbit_msg_store_v2_scan, _Offset, Reason}} ->
+                Reason;
+            error:{rabbit_msg_store_v2_scan_error, Path, {rabbit_msg_store_v2_scan, _Offset, Reason, _}} ->
+                Reason
+        end,
+        ok = file:delete(Path),
+        Result
+    end,
+    %% Empty files (nothing but the header).
+    ok = Scan([]),
+    ok = Scan([{hole, 1024}]),
+    ok = Scan([{hole, 1024 * 1024}]),
+    %% One-message files, with and without surrounding holes.
+    ok = Scan([{msg, gen_id(), gen_msg()}]),
+    ok = Scan([{msg, gen_id(), term_to_binary(<<>>)}]),
+    ok = Scan([{small_hole, 3}, {msg, gen_id(), gen_msg()}]),
+    ok = Scan([{hole, 1024}, {msg, gen_id(), gen_msg()}]),
+    ok = Scan([{msg, gen_id(), gen_msg()}, {small_hole, 2}]),
+    ok = Scan([{msg, gen_id(), gen_msg()}, {hole, 1024}]),
+    %% Multiple messages, with and without holes in between.
+    ok = Scan([{msg, gen_id(), gen_msg()} || _ <- lists:seq(1, 20)]),
+    ok = Scan([
+        {hole, 1024},
+        {msg, gen_id(), gen_msg()},
+        {small_hole, 1},
+        {msg, gen_id(), gen_msg()},
+        {hole, 1024 * 1024},
+        {msg, gen_id(), gen_msg()}
+    ]),
+    %% Duplicate messages.
+    Msg = {msg, gen_id(), gen_msg()},
+    ok = Scan([Msg, Msg]),
+    ok = Scan([Msg, {hole, 1024}, Msg]),
+    %% A hole larger than the scan block size (exercises the seek-past path).
+    ok = Scan([{hole, 8 * 1024 * 1024}, {msg, gen_id(), gen_msg()}]),
+    %% Runs of SMALL_HOLE are bounded to at most 4 bytes by construction:
+    %% 4 in a row is fine, 5 is corruption.
+    ok = Scan([{small_hole, 4}, {msg, gen_id(), gen_msg()}]),
+    small_hole_run_too_long = ScanError([{bin, binary:copy(<<1:8>>, 5)}]),
+    %% The same run of 5 SMALL_HOLE bytes must still be caught when the
+    %% scanner's 4MB (4194304-byte) read buffer happens to end partway
+    %% through it. A filler message with a total on-disk record size of
+    %% 4194301 bytes ends the run 3 bytes before the buffer boundary
+    %% (64-byte header + 4194301 = 4194365; the buffer covers up to
+    %% 64 + 4194304 = 4194368), splitting the run into a 3-byte tail of
+    %% one buffer and a 2-byte head of the next, neither 5 bytes long
+    %% on its own. The record's body is 4194301 - 21 (record header) -
+    %% 6 (term_to_binary/1's own binary-term overhead) = 4194274 bytes.
+    small_hole_run_too_long = ScanError([
+        {msg, gen_id(), term_to_binary(crypto:strong_rand_bytes(4194274))},
+        {bin, binary:copy(<<1:8>>, 5)},
+        {msg, gen_id(), gen_msg()}
+    ]),
+    %% A hole is never immediately followed by another hole, in either
+    %% combination, whether both are fully buffered or the first is only
+    %% skipped via the seek-past path (too large to have been buffered).
+    hole_after_hole = ScanError([{small_hole, 1}, {hole, 10}]),
+    hole_after_hole = ScanError([{hole, 10}, {hole, 10}]),
+    hole_after_hole = ScanError([{hole, 10}, {small_hole, 2}]),
+    hole_after_hole = ScanError([{hole, 8 * 1024 * 1024}, {hole, 10}]),
+    %% A message body that doesn't decode via binary_to_term/1 is
+    %% corruption, regardless of how plausible its Type/Size/MsgId looked.
+    invalid_message_body = ScanError([{msg, gen_id(), <<"not a real term, just raw junk bytes">>}]),
+    %% A HOLE/MESSAGE Size field below the type's own minimum record
+    %% length is corruption, not a torn write (see the comment above the
+    %% Size < 5 / Size < 21 clauses: a torn write cannot fully flush a
+    %% valid header with a bogus size).
+    invalid_hole_size = ScanError([{bin, <<2:8, 3:32>>}]),
+    invalid_message_size = ScanError([{bin, <<3:8, 10:32>>}]),
+    %% Torn records at EOF.
+    ok = Scan([
+        {msg, gen_id(), gen_msg()},
+        {bin, <<3:8, 999999:32, (gen_id())/binary, "not enough bytes">>}
+    ]),
+    ok = Scan([
+        {msg, gen_id(), gen_msg()},
+        {bin, <<2:8, 999999:32>>}
+    ]),
+    %% Unrecognised record types, including the reserved 0 byte.
+    lists:foreach(fun(Type) ->
+        Path = gen_msg_file_v2(Config, [{bin, <<Type:8, "garbage">>}]),
+        ok = try
+            rabbit_msg_store:scan_file_for_valid_messages(Path),
+            {unexpected_success, Type}
+        catch
+            error:{rabbit_msg_store_v2_scan_error, Path,
+                   {rabbit_msg_store_v2_scan, 64, unrecognised_record_type, Type}} -> ok
+        end,
+        ok = file:delete(Path)
+    end, [0, 4, 5, 200, 255]),
+    passed.
+
+gen_msg_file_v2(Config, Blocks) ->
+    PrivDir = ?config(priv_dir, Config),
+    TmpFile = integer_to_list(erlang:unique_integer([positive])) ++ ".sqs",
+    Path = filename:join(PrivDir, TmpFile),
+    %% The header content itself is never validated on the read path;
+    %% any 64 bytes will do here.
+    Header = <<0:64/unit:8>>,
+    ok = file:write_file(Path, [Header | [case Block of
+        {bin, Bin} ->
+            Bin;
+        {hole, Size} ->
+            %% Inner bytes of a HOLE are never interpreted by the scanner.
+            [<<2:8, Size:32>>, <<0:(Size - 5)/unit:8>>];
+        {small_hole, Size} when Size >= 1, Size =< 4 ->
+            binary:copy(<<1:8>>, Size);
+        {msg, MsgId, Msg} ->
+            Size = 21 + byte_size(Msg),
+            [<<3:8, Size:32>>, MsgId, Msg]
+    end || Block <- Blocks]]),
+    Path.
+
+gen_result_v2(Blocks) ->
+    {ok, gen_result_v2(Blocks, 64, [])}.
+
+gen_result_v2([], _, Acc) ->
+    Acc;
+gen_result_v2([{bin, Bin}|Tail], Offset, Acc) ->
+    gen_result_v2(Tail, Offset + byte_size(Bin), Acc);
+gen_result_v2([{hole, Size}|Tail], Offset, Acc) ->
+    gen_result_v2(Tail, Offset + Size, Acc);
+gen_result_v2([{small_hole, Size}|Tail], Offset, Acc) ->
+    gen_result_v2(Tail, Offset + Size, Acc);
+gen_result_v2([{msg, MsgId, Msg}|Tail], Offset, Acc) ->
+    Size = 21 + byte_size(Msg),
+    %% Only the first MsgId found (lowest offset) is returned when
+    %% duplicates exist.
+    case lists:keymember(MsgId, 1, Acc) of
+        false ->
+            gen_result_v2(Tail, Offset + Size, [{MsgId, Size, Offset}|Acc]);
+        true ->
+            gen_result_v2(Tail, Offset + Size, Acc)
+    end.
+
 gen_id() ->
     rand:bytes(16).
 
@@ -869,7 +2276,11 @@ gen_msg(MaxSize) ->
     %% We remove 255 to avoid false positives. In a running
     %% rabbit node we will not get false positives because
     %% we also check messages against the index.
-    << <<case B of 255 -> 254; _ -> B end>> || <<B>> <= Bytes >>.
+    Bytes1 = << <<case B of 255 -> 254; _ -> B end>> || <<B>> <= Bytes >>,
+    %% A real message body is always term_to_binary/1-encoded (see
+    %% write_message/3): the v2 scanner now validates that, so a body
+    %% that isn't a real encoded term would be rejected as corruption.
+    term_to_binary(Bytes1).
 
 gen_msg_file(Config, Blocks) ->
     PrivDir = ?config(priv_dir, Config),

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -594,12 +594,12 @@ msg_store_compaction_v2_exact_fit1(_Config) ->
 %%
 %% The leftover space is deliberately *not* the last moved message's
 %% own source copy: at the point this write happens the index still
-%% points there (index_update_fields/3 only runs later, once every
-%% write has landed and the file has been synced), so overwriting it
-%% would make a concurrent read, or a crash before the index update
-%% lands, see a hole where it still expects that message. Only the
-%% torn remainder of whatever the move partially overwrote -- here,
-%% the tail of MsgIdDead's removed record -- gets marked; the last
+%% points there (index_update_offset_if_unchanged/5) only runs later,
+%% once every write has landed and the file has been synced), so
+%% overwriting it would make a concurrent read, or a crash before the
+%% index update lands, see a hole where it still expects that message.
+%% Only the torn remainder of whatever the move partially overwrote --
+%% here, the tail of MsgIdDead's removed record -- gets marked; the last
 %% moved message's own now-redundant source copy is left as a plain,
 %% untouched, still-valid (if stale) record instead, exactly like
 %% every earlier moved message's source copy already is. This checks


### PR DESCRIPTION
This was all written by Sonnet 5 in roughly one week. I only removed a few comments and reviewed many times with a lot of back and forth to get the code in the best shape possible.

* [CQ: Introduce a v2 file format for the shared store](https://github.com/rabbitmq/rabbitmq-server/pull/17166/changes/5568c86512e2b49e28ff1bec558f99c8e39ff7de): This is the main part, implementing the spec. Additional checks compared to the ticket were added.

* [CQ: Guard compaction's index offset update against a racing fan-out rewrite](https://github.com/rabbitmq/rabbitmq-server/pull/17166/changes/f132d59ca4812468364c48b3c89a900b2feb048d): This is a hypothetical race protection. The timing to hit this is super unlikely though so I don't think it should be backported.

* [CQ: Reject a truncated file_summary or index dump instead of loading it](https://github.com/rabbitmq/rabbitmq-server/pull/17166/changes/956101ca952d6a816e43349ab8682082fc62f7b5): An additional check in case ets tabs are truncated somehow.

* [CQ: Dispatch dirty-recovery index rebuild jobs inline](https://github.com/rabbitmq/rabbitmq-server/pull/17166/changes/b972543ad0e64733f34a7cebdd803e9081cf7b7f): Fix a potential hang at startup that could be caused via a crash elsewhere. Simplifies recovery in any case.

* [CQ: Update comments](https://github.com/rabbitmq/rabbitmq-server/pull/17166/changes/63a41130eefdcdd7f0f18deef871334776fe8d62): Last batch of AI comments removal.

First part of #16194