### PR TITLE
Management UI: do not coerce x-argument values to strings

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -183,7 +183,10 @@ function args_to_features(obj) {
     var res = {};
     for (var k in obj.arguments) {
         if (k in KNOWN_ARGS) {
-            res[k] = fmt_escape_feature(obj.arguments[k]);
+            // Exclude SAC which is the only boolean feature
+            if (obj.arguments[k] !== false) {
+                res[k] = obj.arguments[k];
+            }
         }
         else {
             if (res.arguments == undefined) res.arguments = {};
@@ -498,15 +501,6 @@ function fmt_strip_tags(txt) {
         return "";
     }
     return ("" + txt).replace(/<(?:.|\n)*?>/gm, '');
-}
-
-function fmt_escape_feature(txt) {
-    // Exclude SAC which is the only boolean feature
-    if(txt === false) {
-        return undefined;
-    } else {
-        return fmt_escape_html0(txt).replace(/\n/g, '<br/>');
-    }
 }
 
 function fmt_escape_html(txt) {

--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -187,7 +187,7 @@ function args_to_features(obj) {
         }
         else {
             if (res.arguments == undefined) res.arguments = {};
-            res.arguments[fmt_escape_html(k)] = fmt_escape_html(obj.arguments[k]);
+            res.arguments[fmt_escape_html(k)] = obj.arguments[k];
         }
     }
     if (obj.exclusive) {


### PR DESCRIPTION
A note on XSS safety: the key is escaped as before, and the value is escaped by `fmt_amqp_value` (depending on the value type).

In other words, the issue in #17176 was a double encoding one. And with this change we make
the value encoding type-aware, as it should be.

References #17176.