### PR TITLE
Add metrics_labels to make_mutable_config to introduce the value in 3.13 migrated queues, in line with 4.2 queues

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -2453,6 +2453,7 @@ make_ra_conf(Q, ServerId, TickTimeout,
 
 make_mutable_config(Q) ->
     QName = amqqueue:get_name(Q),
+    #resource{name = QNameBin} = QName,
     TickTimeout = application:get_env(rabbit, quorum_tick_interval,
                                       ?TICK_INTERVAL),
     MinRecoveryCheckpointInterval =
@@ -2461,7 +2462,9 @@ make_mutable_config(Q) ->
     Formatter = {?MODULE, format_ra_event, [QName]},
     #{tick_timeout => TickTimeout,
       min_recovery_checkpoint_interval => MinRecoveryCheckpointInterval,
-      ra_event_formatter => Formatter}.
+      ra_event_formatter => Formatter,
+      metrics_labels => #{vhost => amqqueue:get_vhost(Q),
+                          queue => QNameBin}}.
 
 get_nodes(Q) when ?is_amqqueue(Q) ->
     #{nodes := Nodes} = amqqueue:get_type_state(Q),


### PR DESCRIPTION
## Proposed Changes

The mutable ra config is re-injected at every ra_server:start (I think it's start at least!), this will inject the missing `metrics_labels` that will let 3.13 queues emit raft metrics in 4.2/4.3.
While it is aggressively re-injecting it, I have seen no place where it is overwritten, and the config should not get re-written to disk if it doesn't change (`ra_log:write_config` is gated behind `#{has_changed := true}`).

This has to be paired with a `ra` PR (incoming) that makes the `metrics_labels` mutable.
Paired `ra` change: https://github.com/rabbitmq/ra/pull/651

As far as tests go, it seems hard to test, as it requires a 3.13 era queue.
I have made local tests pass on 4.2.9, and did a "live" check by introducing a patched 4.2.9, then going to an unpatched 4.3.4, and the queues still behaved, so by all means, this solution is overkill - it is a one-time mutate then write, once it is in there, the queue is similar to a 4.2 era queue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #17183)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I am not sure of the status of our CA/CLA, we have contributed code before, but my knowledgable people are on leave.
