### PR TITLE
MQTT: introduce limits for the retained message store

### DIFF
--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -13,6 +13,10 @@ define PROJECT_ENV
 	    {retained_message_store, rabbit_mqtt_retained_msg_store_dets},
 	    %% only used by DETS store
 	    {retained_message_store_dets_sync_interval, 2000},
+	    %% per virtual host limits, both accept 'infinity'
+	    {retained_message_store_max_messages, 100000},
+	    %% 1 GB
+	    {retained_message_store_max_size_bytes, 1073741824},
 	    {prefetch, 10},
 	    {ssl_listeners, []},
 	    {tcp_listeners, [1883]},

--- a/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
+++ b/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
@@ -95,6 +95,18 @@ end}.
 {mapping, "mqtt.retained_message_store_dets_sync_interval", "rabbitmq_mqtt.retained_message_store_dets_sync_interval",
     [{datatype, integer}]}.
 
+%% Maximum number of retained messages kept per virtual host, and the maximum
+%% total size of the store.
+%%
+%% {retained_message_store_max_messages, 100000},
+%% {retained_message_store_max_size_bytes, 1073741824},
+
+{mapping, "mqtt.retained_message_store.max_messages", "rabbitmq_mqtt.retained_message_store_max_messages",
+    [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
+
+{mapping, "mqtt.retained_message_store.max_size_bytes", "rabbitmq_mqtt.retained_message_store_max_size_bytes",
+    [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
+
 %% Whether or not to enable proxy protocol support.
 %%
 %% {proxy_protocol, false}

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store.erl
@@ -21,14 +21,17 @@
 -include("rabbit_mqtt.hrl").
 -include("rabbit_mqtt_packet.hrl").
 -include_lib("kernel/include/logger.hrl").
--export([start/1, insert/3, lookup/2, delete/2, terminate/1]).
+-export([start/1, insert/3, lookup/2, delete/2, info/1, terminate/1]).
 -export([expire/2]).
--export_type([state/0, expire/0]).
+-export_type([state/0, expire/0, store_info/0]).
 
 -define(STATE, ?MODULE).
 -record(?STATE, {store_mod :: module(),
                  store_state :: term()}).
 -opaque state() :: #?STATE{}.
+
+-type store_info() :: #{count := non_neg_integer(),
+                        size_bytes := non_neg_integer()}.
 
 -type expire() :: #{topic() :=
                     {InsertionTimestamp :: integer(),
@@ -49,6 +52,9 @@
 
 -callback delete(topic(), State :: any()) ->
     ok.
+
+-callback info(State :: any()) ->
+    store_info().
 
 -callback terminate(State :: any()) ->
     ok.
@@ -93,6 +99,11 @@ lookup(Topic, #?STATE{store_mod = Mod,
 delete(Topic, #?STATE{store_mod = Mod,
                       store_state = StoreState}) ->
     ok = Mod:delete(Topic, StoreState).
+
+-spec info(state()) -> store_info().
+info(#?STATE{store_mod = Mod,
+             store_state = StoreState}) ->
+    Mod:info(StoreState).
 
 -spec terminate(state()) -> ok.
 terminate(#?STATE{store_mod = Mod,

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_dets.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_dets.erl
@@ -9,10 +9,11 @@
 
 -behaviour(rabbit_mqtt_retained_msg_store).
 
+-include("rabbit_mqtt.hrl").
 -include("rabbit_mqtt_packet.hrl").
 -include_lib("kernel/include/logger.hrl").
 
--export([new/2, recover/2, insert/3, lookup/2, delete/2, terminate/1]).
+-export([new/2, recover/2, insert/3, lookup/2, delete/2, info/1, terminate/1]).
 
 -record(store_state, {table :: dets:tab_name()}).
 
@@ -53,6 +54,13 @@ lookup(Topic, #store_state{table = T}) ->
 delete(Topic, #store_state{table = T}) ->
   ok = dets:delete(T, Topic).
 
+-spec info(store_state()) -> rabbit_mqtt_retained_msg_store:store_info().
+info(#store_state{table = T}) ->
+  %% `dets:info/1` returns both items, `dets:info/2` would take two calls.
+  Info = dets:info(T),
+  #{count => proplists:get_value(size, Info),
+    size_bytes => proplists:get_value(file_size, Info)}.
+
 -spec terminate(store_state()) -> ok.
 terminate(#store_state{table = T}) ->
   ok = dets:close(T).
@@ -60,10 +68,10 @@ terminate(#store_state{table = T}) ->
 open_table(Dir, VHost) ->
     Tab = rabbit_mqtt_util:vhost_name_to_table_name(VHost),
     Path = rabbit_mqtt_util:path_for(Dir, VHost, ".dets"),
-    AutoSave = rabbit_misc:get_env(rabbit_mqtt, retained_message_store_dets_sync_interval, 2000),
+    AutoSave = rabbit_misc:get_env(?APP_NAME, retained_message_store_dets_sync_interval, 2000),
     dets:open_file(Tab, [{type, set},
                          {keypos, #retained_message.topic},
                          {file, Path},
-                         {ram_file, true},
+                         {ram_file, false},
                          {repair, true},
                          {auto_save, AutoSave}]).

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_ets.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_ets.erl
@@ -11,7 +11,7 @@
 
 -include("rabbit_mqtt_packet.hrl").
 
--export([new/2, recover/2, insert/3, lookup/2, delete/2, terminate/1]).
+-export([new/2, recover/2, insert/3, lookup/2, delete/2, info/1, terminate/1]).
 
 -record(store_state, {
           table :: ets:tid(),
@@ -59,6 +59,11 @@ lookup(Topic, #store_state{table = T}) ->
 delete(Topic, #store_state{table = T}) ->
   true = ets:delete(T, Topic),
   ok.
+
+-spec info(store_state()) -> rabbit_mqtt_retained_msg_store:store_info().
+info(#store_state{table = T}) ->
+  #{count => ets:info(T, size),
+    size_bytes => ets:info(T, memory) * erlang:system_info(wordsize)}.
 
 -spec terminate(store_state()) -> ok.
 terminate(#store_state{table = T, filename = Path}) ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_noop.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_noop.erl
@@ -9,7 +9,7 @@
 
 -behaviour(rabbit_mqtt_retained_msg_store).
 
--export([new/2, recover/2, insert/3, lookup/2, delete/2, terminate/1]).
+-export([new/2, recover/2, insert/3, lookup/2, delete/2, info/1, terminate/1]).
 
 new(_Dir, _VHost) ->
   ok.
@@ -25,6 +25,9 @@ lookup(_Topic, _State) ->
 
 delete(_Topic, _State) ->
   ok.
+
+info(_State) ->
+  #{count => 0, size_bytes => 0}.
 
 terminate(_State) ->
   ok.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retainer.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retainer.erl
@@ -7,7 +7,9 @@
 
 -module(rabbit_mqtt_retainer).
 
+-include("rabbit_mqtt.hrl").
 -include("rabbit_mqtt_packet.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -behaviour(gen_server).
 
@@ -17,10 +19,17 @@
 -export([retain/3, fetch/2, clear/2]).
 
 -define(TIMEOUT, 30_000).
+-define(LIMIT_LOG_INTERVAL_MS, 60_000).
+
+-type limit() :: non_neg_integer() | infinity.
 
 -define(STATE, ?MODULE).
 -record(?STATE, {store_state :: rabbit_mqtt_retained_msg_store:state(),
-                 expire :: #{topic() := TimerRef :: reference()}
+                 expire :: #{topic() := TimerRef :: reference()},
+                 vhost :: rabbit_types:vhost(),
+                 max_messages :: limit(),
+                 max_size_bytes :: limit(),
+                 last_limit_log :: integer() | undefined
                 }).
 -type state() :: #?STATE{}.
 
@@ -53,28 +62,18 @@ init(VHost) ->
                               start_timer(TimerSecs, Topic)
                       end, Expire0),
     {ok, #?STATE{store_state = StoreState,
-                 expire = Expire}}.
+                 expire = Expire,
+                 vhost = VHost,
+                 max_messages = get_limit(retained_message_store_max_messages),
+                 max_size_bytes = get_limit(retained_message_store_max_size_bytes)}}.
 
-handle_cast({retain, Topic, Msg0 = #mqtt_msg{props = Props}},
-            State = #?STATE{store_state = StoreState,
-                            expire = Expire0}) ->
-    Expire2 = case maps:take(Topic, Expire0) of
-                  {OldTimer, Expire1} ->
-                      cancel_timer(OldTimer),
-                      Expire1;
-                  error ->
-                      Expire0
-              end,
-    {Msg, Expire} = case maps:find('Message-Expiry-Interval', Props) of
-                        {ok, ExpirySeconds} ->
-                            Timer = start_timer(ExpirySeconds, Topic),
-                            {Msg0#mqtt_msg{timestamp = os:system_time(second)},
-                             maps:put(Topic, Timer, Expire2)};
-                        error ->
-                            {Msg0, Expire2}
-                    end,
-    ok = rabbit_mqtt_retained_msg_store:insert(Topic, Msg, StoreState),
-    {noreply, State#?STATE{expire = Expire}};
+handle_cast({retain, Topic, Msg}, State) ->
+    case retain_permitted(Topic, Msg, State) of
+        true ->
+            {noreply, do_retain(Topic, Msg, State)};
+        false ->
+            {noreply, log_limit_reached(State)}
+    end;
 handle_cast({clear, Topic}, State = #?STATE{store_state = StoreState,
                                             expire = Expire0}) ->
     Expire = case maps:take(Topic, Expire0) of
@@ -118,6 +117,87 @@ handle_info(Info, State) ->
 
 terminate(_Reason, #?STATE{store_state = StoreState}) ->
     rabbit_mqtt_retained_msg_store:terminate(StoreState).
+
+-spec do_retain(topic(), mqtt_msg(), state()) -> state().
+do_retain(Topic, Msg0 = #mqtt_msg{props = Props},
+          State = #?STATE{store_state = StoreState,
+                          expire = Expire0}) ->
+    Expire2 = case maps:take(Topic, Expire0) of
+                  {OldTimer, Expire1} ->
+                      cancel_timer(OldTimer),
+                      Expire1;
+                  error ->
+                      Expire0
+              end,
+    {Msg, Expire} = case maps:find('Message-Expiry-Interval', Props) of
+                        {ok, ExpirySeconds} ->
+                            Timer = start_timer(ExpirySeconds, Topic),
+                            {Msg0#mqtt_msg{timestamp = os:system_time(second)},
+                             maps:put(Topic, Timer, Expire2)};
+                        error ->
+                            {Msg0, Expire2}
+                    end,
+    ok = rabbit_mqtt_retained_msg_store:insert(Topic, Msg, StoreState),
+    State#?STATE{expire = Expire}.
+
+-spec get_limit(atom()) -> limit().
+get_limit(Key) ->
+    case application:get_env(?APP_NAME, Key, infinity) of
+        infinity -> infinity;
+        Int when is_integer(Int), Int >= 0 -> Int
+    end.
+
+%% Overwriting a topic that is already retained does not add an entry, so it
+%% stays permitted once the store holds `max_messages` entries.
+-spec retain_permitted(topic(), mqtt_msg(), state()) -> boolean().
+retain_permitted(_Topic, _Msg, #?STATE{max_messages = infinity,
+                                       max_size_bytes = infinity}) ->
+    true;
+retain_permitted(Topic, Msg,
+                 #?STATE{store_state = StoreState,
+                         max_messages = MaxMessages,
+                         max_size_bytes = MaxSizeBytes}) ->
+    #{count := Count,
+      size_bytes := SizeBytes} = rabbit_mqtt_retained_msg_store:info(StoreState),
+    Existing = rabbit_mqtt_retained_msg_store:lookup(Topic, StoreState),
+    %% The overwritten entry's size is subtracted so that overwrites are
+    %% not double-counted.
+    PreviousBytesVal = case Existing of
+                           undefined ->
+                               0;
+                           #mqtt_msg{} ->
+                               entry_size(Existing)
+                       end,
+    NewBytesVal = entry_size(Msg),
+    within_limit(SizeBytes - PreviousBytesVal + NewBytesVal, MaxSizeBytes) andalso
+    (Existing =/= undefined orelse within_limit(Count + 1, MaxMessages)).
+
+entry_size(Msg) ->
+    {MetadataSize, PayloadSize} = mc_mqtt:size(Msg),
+    MetadataSize + PayloadSize.
+
+-spec within_limit(non_neg_integer(), limit()) -> boolean().
+within_limit(_Value, infinity) ->
+    true;
+within_limit(Value, Limit) ->
+    Value =< Limit.
+
+-spec log_limit_reached(state()) -> state().
+log_limit_reached(State = #?STATE{vhost = VHost,
+                                  max_messages = MaxMessages,
+                                  max_size_bytes = MaxSizeBytes,
+                                  last_limit_log = LastLog}) ->
+    Now = erlang:monotonic_time(millisecond),
+    case LastLog =:= undefined orelse Now - LastLog >= ?LIMIT_LOG_INTERVAL_MS of
+        true ->
+            ?LOG_WARNING(
+               "MQTT retained message store for virtual host '~ts' reached its limit "
+               "(max_messages: ~p, max_size_bytes: ~p), new retained messages are dropped",
+               [VHost, MaxMessages, MaxSizeBytes]),
+            State#?STATE{last_limit_log = Now};
+        false ->
+            State
+    end.
 
 -spec start_timer(integer(), topic()) -> reference().
 start_timer(Seconds, Topic)

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
@@ -202,6 +202,22 @@
   {tcp_listen_options_none_disables_via_shortcut,
    "mqtt.tcp_listen_options = none",
    [{rabbitmq_mqtt,[{tcp_listen_options, []}]}],
+   [rabbitmq_mqtt]},
+
+  {retained_message_store_limits,
+   "mqtt.retained_message_store.max_messages = 5000
+    mqtt.retained_message_store.max_size_bytes = 1000000",
+   [{rabbitmq_mqtt,[{retained_message_store_max_messages, 5000},
+                    {retained_message_store_max_size_bytes, 1000000}]}],
+   [rabbitmq_mqtt]},
+
+  {retained_message_store_limits_infinity,
+   "mqtt.retained_message_store = rabbit_mqtt_retained_msg_store_ets
+    mqtt.retained_message_store.max_messages = infinity
+    mqtt.retained_message_store.max_size_bytes = infinity",
+   [{rabbitmq_mqtt,[{retained_message_store, rabbit_mqtt_retained_msg_store_ets},
+                    {retained_message_store_max_messages, infinity},
+                    {retained_message_store_max_size_bytes, infinity}]}],
    [rabbitmq_mqtt]}
 
 ].

--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -1919,7 +1919,9 @@ retained_message_conversion(Config) ->
     Payload = <<"my retained msg">>,
     OldMqttMsgFormat = {mqtt_msg, _Retain = true, _QoS = 1, Topic, _Dup = false, _PktId = 1, Payload},
     RetainerPid = rpc(Config, rabbit_mqtt_retainer_sup, start_child_for_vhost, [<<"/">>]),
-    {rabbit_mqtt_retainer, StoreState, _} = sys:get_state(RetainerPid),
+    RetainerState = sys:get_state(RetainerPid),
+    rabbit_mqtt_retainer = element(1, RetainerState),
+    StoreState = element(2, RetainerState),
     ok = rpc(Config, rabbit_mqtt_retained_msg_store, insert, [Topic, OldMqttMsgFormat, StoreState]),
 
     C = connect(?FUNCTION_NAME, Config),

--- a/deps/rabbitmq_mqtt/test/retainer_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/retainer_SUITE.erl
@@ -40,7 +40,10 @@ tests() ->
      should_translate_amqp2mqtt_on_retention,
      should_translate_amqp2mqtt_on_retention_search,
      recover,
-     recover_with_message_expiry_interval
+     recover_with_message_expiry_interval,
+     limit_max_messages,
+     limit_max_size_bytes,
+     limit_max_size_bytes_with_properties
     ].
 
 suite() ->
@@ -100,9 +103,22 @@ init_per_testcase(recover_with_message_expiry_interval = T, Config) ->
         v5 ->
             rabbit_ct_helpers:testcase_started(Config, T)
     end;
+init_per_testcase(limit_max_size_bytes_with_properties = T, Config) ->
+    case ?config(mqtt_version, Config) of
+        v4 ->
+            {skip, "Correlation-Data not supported in MQTT v4"};
+        v5 ->
+            rabbit_ct_helpers:testcase_started(Config, T)
+    end;
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
+end_per_testcase(Testcase, Config)
+  when Testcase =:= limit_max_messages;
+       Testcase =:= limit_max_size_bytes;
+       Testcase =:= limit_max_size_bytes_with_properties ->
+    ok = set_limits(Config, 100_000, 1_073_741_824),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
@@ -162,12 +178,7 @@ does_not_retain(Config) ->
     C = connect(atom_to_binary(?FUNCTION_NAME), Config, [{ack_timeout, 1}]),
     ok = emqtt:publish(C, <<"TopicA/Device.Field">>, #{},  <<"Payload">>, [{retain, true}]),
     {ok, _, _} = emqtt:subscribe(C, <<"TopicA/Device.Field">>, qos1),
-    receive
-        Unexpected ->
-            ct:fail("Unexpected message: ~p", [Unexpected])
-    after 1000 ->
-              ok
-    end,
+    ok = expect_nothing(),
     ok = emqtt:disconnect(C).
 
 recover(Config) ->
@@ -236,3 +247,98 @@ recover_with_message_expiry_interval(Config) ->
     end,
 
     ok = emqtt:disconnect(C2).
+
+%% A topic that is not in the store yet is refused once the store holds
+%% `max_messages` entries, while overwriting a topic already in it is not.
+limit_max_messages(Config) ->
+    ok = set_limits(Config, 2, infinity),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    C = connect(ClientId, Config),
+
+    {ok, _} = emqtt:publish(C, <<"limit/1">>, <<"m1">>, [{retain, true}, {qos, 1}]),
+    {ok, _} = emqtt:publish(C, <<"limit/2">>, <<"m2">>, [{retain, true}, {qos, 1}]),
+    {ok, _} = emqtt:publish(C, <<"limit/3">>, <<"m3">>, [{retain, true}, {qos, 1}]),
+    {ok, _} = emqtt:publish(C, <<"limit/1">>, <<"m1b">>, [{retain, true}, {qos, 1}]),
+
+    {ok, _, _} = emqtt:subscribe(C, <<"limit/1">>, qos1),
+    ok = expect_publishes(C, <<"limit/1">>, [<<"m1b">>]),
+    {ok, _, _} = emqtt:subscribe(C, <<"limit/2">>, qos1),
+    ok = expect_publishes(C, <<"limit/2">>, [<<"m2">>]),
+    {ok, _, _} = emqtt:subscribe(C, <<"limit/3">>, qos1),
+    ok = expect_nothing(),
+
+    ok = emqtt:disconnect(C).
+
+%% The limit is checked against the size of the store, which is never zero even
+%% when empty, so a limit of 0 refuses every retained message.
+limit_max_size_bytes(Config) ->
+    ok = set_limits(Config, infinity, 0),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    C1 = connect(ClientId, Config),
+    {ok, _} = emqtt:publish(C1, <<"size/1">>, <<"m1">>, [{retain, true}, {qos, 1}]),
+    {ok, _, _} = emqtt:subscribe(C1, <<"size/1">>, qos1),
+    ok = expect_nothing(),
+    ok = emqtt:disconnect(C1),
+
+    ok = set_limits(Config, infinity, infinity),
+    C2 = connect(ClientId, Config),
+    {ok, _} = emqtt:publish(C2, <<"size/1">>, <<"m1">>, [{retain, true}, {qos, 1}]),
+    {ok, _, _} = emqtt:subscribe(C2, <<"size/1">>, qos1),
+    ok = expect_publishes(C2, <<"size/1">>, [<<"m1">>]),
+    ok = emqtt:disconnect(C2).
+
+%% Message properties (e.g. MQTT 5.0 Correlation-Data, User-Property) count
+%% towards `max_size_bytes`, not just the topic and payload.
+limit_max_size_bytes_with_properties(Config) ->
+    ok = set_limits(Config, infinity, 10_000),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+
+    C1 = connect(<<ClientId/binary, "-1">>, Config),
+    LargeCorrelationData = binary:copy(<<"c">>, 20_000),
+    {ok, _} = emqtt:publish(C1, <<"size/props">>,
+                            #{'Correlation-Data' => LargeCorrelationData},
+                            <<"m1">>, [{retain, true}, {qos, 1}]),
+    {ok, _, _} = emqtt:subscribe(C1, <<"size/props">>, qos1),
+    ok = expect_nothing(),
+    ok = emqtt:disconnect(C1),
+
+    C2 = connect(<<ClientId/binary, "-2">>, Config),
+    {ok, _} = emqtt:publish(C2, <<"size/props">>, <<"m2">>, [{retain, true}, {qos, 1}]),
+    {ok, _, _} = emqtt:subscribe(C2, <<"size/props">>, qos1),
+    ok = expect_publishes(C2, <<"size/props">>, [<<"m2">>]),
+    ok = emqtt:disconnect(C2).
+
+%% -------------------------------------------------------------------
+%% Helpers
+%% -------------------------------------------------------------------
+
+%% The retainer reads its limits when it starts, so it is restarted here.
+%%
+%% The store is emptied as well: the tests in this group run in random order and
+%% the limits are counted against whatever the store already holds.
+set_limits(Config, MaxMessages, MaxSizeBytes) ->
+    VHost = <<"/">>,
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_mqtt, retained_message_store_max_messages, MaxMessages]),
+    ok = rpc(Config, application, set_env,
+             [rabbitmq_mqtt, retained_message_store_max_size_bytes, MaxSizeBytes]),
+    _ = rpc(Config, rabbit_mqtt_retainer_sup, start_child_for_vhost, [VHost]),
+    ok = rpc(Config, rabbit_mqtt_retainer_sup, delete_child_for_vhost, [VHost]),
+    Dir = rpc(Config, rabbit, data_dir, []),
+    DetsPath = rpc(Config, rabbit_mqtt_util, path_for, [Dir, VHost, ".dets"]),
+    EtsPath = rpc(Config, rabbit_mqtt_util, path_for, [Dir, VHost]),
+    _ = rpc(Config, file, delete, [DetsPath]),
+    _ = rpc(Config, file, delete, [EtsPath]),
+    _ = rpc(Config, rabbit_mqtt_retainer_sup, start_child_for_vhost, [VHost]),
+    ok.
+
+rpc(Config, Mod, Fun, Args) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, Mod, Fun, Args).
+
+expect_nothing() ->
+    receive
+        Unexpected ->
+            ct:fail("Unexpected message: ~p", [Unexpected])
+    after 1000 ->
+              ok
+    end.


### PR DESCRIPTION
This adds both size and message count limits to how much data can be retained via MQTT's retained messages feature. The protocol itself does not discuss any limits or safety protocols.

All retained messages flow through one code path, which is where the limits are applied.

The defaults are 100K messages (and as many topics [1]) per virtual host, or 1 GiB of data. I consider these to be very reasonable, even generous, for most MQTT workloads.

The accounting is not super precise because accounting for ETS/DETS metadata is hard but  the way we compute message footprint passes the common sense check: `mc_mqtt:size/1` returns the size of the topic plus message properties plus the payload, which is all we really need to account for to introduce a practical limit.

1. given how message retention works