### PR TITLE
By @Vampirebyte: add a direct consumer owner (connection) link for "channelless" protocols

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -18,7 +18,16 @@ const CONSUMER_OWNER_FORMATTERS = [
         }
     }},
     {order: 100, formatter: function(consumer) {
-        return link_channel(consumer.channel_details.name);
+        var cd = consumer.channel_details;
+        if (cd.name) {
+            return link_channel(cd.name);
+        }
+        // Consumers of channel-less protocols (e.g. MQTT) belong
+        // directly to a connection.
+        if (cd.connection_name) {
+            return link_conn(cd.connection_name);
+        }
+        return UNKNOWN_REPR;
     }}
 ];
 

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -519,11 +519,11 @@ var HELP = {
     When single active consumer is enabled for the queue, only one consumer at a time is active. \
     When single active consumer is disabled for the queue, consumers are active by default. \
     For a quorum queue, a consumer can be inactive because its owning node is suspected down. <br/><br/> \
-    (<a href="https://www.rabbitmq.com/consumers.html#active-consumer" target="_blank">Documentation</a>)',
+    (<a href="https://www.rabbitmq.com/docs/consumers#active-consumer" target="_blank">Documentation</a>)',
 
     'consumer-owner' :
-    '<a href="https://www.rabbitmq.com/consumers.html">AMQP 0-9-1 consumers</a> belong to a channel, \
-    <a href="https://www.rabbitmq.com/stream.html">stream consumers</a> belong to a stream connection, \
+    '<a href="https://www.rabbitmq.com/docs/consumers" target="_blank">AMQP 0-9-1 consumers</a> belong to a channel, \
+    <a href="https://www.rabbitmq.com/docs/stream" target="_blank">stream consumers</a> belong to a stream connection, \
     and consumers of channel-less protocols (e.g. MQTT) belong to a connection.',
 
     'plugins' :

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -523,7 +523,8 @@ var HELP = {
 
     'consumer-owner' :
     '<a href="https://www.rabbitmq.com/consumers.html">AMQP 0-9-1 consumers</a> belong to a channel, \
-    and <a href="https://www.rabbitmq.com/stream.html">stream consumers</a> belong to a stream connection.',
+    <a href="https://www.rabbitmq.com/stream.html">stream consumers</a> belong to a stream connection, \
+    and consumers of channel-less protocols (e.g. MQTT) belong to a connection.',
 
     'plugins' :
     'Note that only plugins which are both explicitly enabled and running are shown here.',

--- a/deps/rabbitmq_management/priv/www/js/tmpl/consumers.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/consumers.ejs
@@ -3,7 +3,7 @@
       <thead>
         <tr>
 <% if (mode == 'queue') { %>
-          <th>Channel <span class="help" id="consumer-owner"></th>
+          <th>Owner <span class="help" id="consumer-owner"></th>
           <th>Consumer tag</th>
 <% } else { %>
           <th>Consumer tag</th>


### PR DESCRIPTION
This is #17160 by @Vampirebyte with a small cosmetic tweak from me.