### PR TITLE
By @brianr2600: Native STOMP: handle acks that arrive after subscription cancellation gracefully

### DIFF
--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -673,11 +673,13 @@ tidy_canceled_subscription(ConsumerTag, Subscription,
 
 %% Client-initiated cancelations will pass an actual frame
 
-tidy_canceled_subscription(ConsumerTag, Subscription = #subscription{dest_hdr = DestHdr},
+tidy_canceled_subscription(ConsumerTag,
+                           Subscription = #subscription{dest_hdr = DestHdr,
+                                                        queue_name = QRes},
                            Frame, State0) ->
     {ok, State1} = tidy_canceled_subscription_state(ConsumerTag, Subscription, State0),
     {ok, Dest} = parse_endpoint(DestHdr),
-    maybe_delete_durable_sub_queue(Dest, Frame, State1).
+    maybe_delete_durable_sub_queue(Dest, QRes, Frame, State1).
 
 tidy_canceled_subscription_state(ConsumerTag,
                                  _Subscription = #subscription{queue_name = QName},
@@ -696,20 +698,27 @@ tidy_canceled_subscription_state(ConsumerTag,
     {ok, State#state{subscriptions = Subs1,
                           queue_consumers = QCons1}}.
 
-maybe_delete_durable_sub_queue({topic, Name}, Frame,
-                               State = #state{cfg = #cfg{auth_login = Username,
-                                                         vhost = VHost}}) ->
+%% Take the queue from the subscription, never from the UNSUBSCRIBE frame.
+maybe_delete_durable_sub_queue({topic, _Name}, QRes, Frame, State) ->
     case rabbit_stomp_util:has_durable_header(Frame) of
         true ->
-            {ok, Id} = rabbit_stomp_frame:header(Frame, ?HEADER_ID),
-            QName = rabbit_stomp_util:subscription_queue_name(Name, Id, Frame),
-            QRes = rabbit_misc:r(VHost, queue, QName),
-            delete_queue(QRes, Username),
-            ok(State);
+            delete_durable_sub_queue(QRes, State);
         false ->
             ok(State)
     end;
-maybe_delete_durable_sub_queue(_Destination, _Frame, State) ->
+maybe_delete_durable_sub_queue(_Destination, _QRes, _Frame, State) ->
+    ok(State).
+
+%% Same permission and delete path as queue.delete on a channel. The check
+%% is uncached: this module never invalidates its permission cache.
+-spec delete_durable_sub_queue(rabbit_amqqueue:name(), #state{}) ->
+          {ok, none, #state{}}.
+delete_durable_sub_queue(QRes, State = #state{user = #user{username = Username} = User,
+                                              authz_ctx = AuthzCtx}) ->
+    ok = rabbit_access_control:check_resource_access(
+           User, QRes, configure, AuthzCtx),
+    {ok, _} = rabbit_amqqueue:delete_with(QRes, self(), false, false,
+                                          Username, true),
     ok(State).
 
 with_destination(Command, Frame, State, Fun) ->

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -24,7 +24,11 @@
 -export([check_dead_letter_exchange_access/4,
          check_subscription_binding_access/5,
          ensure_exchange_exists/3,
-         check_user_id/2]).
+         check_user_id/2,
+         collect_acks/3,
+         pending_ack/3,
+         record_transaction_settlements/1,
+         unknown_delivery_tag/2]).
 -endif.
 
 -include_lib("kernel/include/logger.hrl").
@@ -68,7 +72,7 @@
                       queue :: rabbit_amqqueue:name(),
                       %% message ID used by queue and message store implementations
                       msg_id :: rabbit_amqqueue:msg_id(),
-                                            multi_ack :: boolean()
+                      multi_ack :: boolean()
                      }).
 
 -record(cfg,
@@ -320,6 +324,8 @@ process_request(ProcessFun, SuccessFun, State) ->
             {ok, SuccessFun(NewState)};
         {error, Message, Detail, NewState} ->
             {ok, send_error(Message, Detail, NewState)};
+        {stop, error_close, NewState} ->
+            {stop, normal, NewState};
         {stop, normal, NewState} ->
             {stop, normal, SuccessFun(NewState)};
         {stop, R, NewState} ->
@@ -560,7 +566,7 @@ ack_action(Command, Frame,
                     %% Settle using state's `unacked_message_q` and the `#pending_ack` records.
                     %% This handles two problematic scenarios: a delivery that outlived its
                     %% subscription and the original ack mode for the race condition case where
-                    %% a recently cancelled subscription is immediately recreated with the same the subscription ID.
+                    %% a recently cancelled subscription is immediately recreated with the same subscription ID.
                     Requeue = rabbit_stomp_frame:boolean_header(Frame, <<"requeue">>, DefaultNackRequeue),
                     case Fun({ConsumerTag, DeliveryTag}, Requeue, State) of
                         {error, _, _, _} = Err -> Err;
@@ -799,7 +805,7 @@ do_subscribe(Destination, DestHdr, Frame,
                     Detail = "A subscription identified by '~ts' already exists.",
                     _ = error(Message, Detail, [ConsumerTag], State),
                     _ = send_error(Message, Detail, [ConsumerTag], State),
-                    {stop, normal, close_connection(State)};
+                    {stop, error_close, close_connection(State)};
                 error ->
                     ExchangeAndKey = parse_routing(Destination, DfltTopicEx),
                     Arguments = subscribe_arguments(Frame),
@@ -1114,11 +1120,12 @@ unknown_delivery_tag(Ack, State) ->
     end.
 
 unknown_delivery_tag_error({_CTag, DeliveryTag}, State) ->
-    {error, "Message not found",
-     rabbit_misc:format("unknown delivery tag ~w~n", [DeliveryTag]),
-     State}.
+    error("Message not found", "unknown delivery tag ~w~n", [DeliveryTag], State).
 
-record_transaction_settlements(Acks) ->
+%% Only the older deliveries a multi-ack settled can make a later action in the
+%% same commit redundant. The delivery the client named is not recorded, so
+%% settling it twice remains an error.
+record_transaction_settlements([_Named | Older]) ->
     case get(tx_settled_delivery_tags) of
         undefined ->
             ok;
@@ -1127,7 +1134,7 @@ record_transaction_settlements(Acks) ->
                         fun(#pending_ack{tag = CTag,
                                          delivery_tag = DeliveryTag}, Acc) ->
                                 sets:add_element({CTag, DeliveryTag}, Acc)
-                        end, Settled0, Acks),
+                        end, Settled0, Older),
             put(tx_settled_delivery_tags, Settled),
             ok
     end.
@@ -1174,6 +1181,16 @@ collect_acks(OlderAcc, UAMQ, CTag, DeliveryTag) ->
         {empty, _} ->
             {error, not_found}
     end.
+
+-ifdef(TEST).
+pending_ack(ConsumerTag, DeliveryTag, MultiAck) ->
+    #pending_ack{delivery_tag = DeliveryTag,
+                 tag          = ConsumerTag,
+                 delivered_at = 0,
+                 queue        = undefined,
+                 msg_id       = DeliveryTag,
+                 multi_ack    = MultiAck}.
+-endif.
 
 foreach_per_queue(F, [#pending_ack{tag = CTag,
                                    queue = QName,
@@ -1529,11 +1546,8 @@ abort_transaction(Transaction, State0) ->
 
 perform_transaction_action(_, {stop, _, _} = Res) ->
     Res;
-perform_transaction_action({Frame, Fun}, {ok, State}) ->
-    process_request(
-      Fun,
-      fun(StateM) -> ensure_receipt(Frame, StateM) end,
-      State).
+perform_transaction_action({_Frame, Fun}, {ok, State}) ->
+    process_request(Fun, State).
 
 %%--------------------------------------------------------------------
 %% Heartbeat Management
@@ -1604,12 +1618,12 @@ ok(Command, Headers, BodyFragments, State) ->
 amqp_death(ErrorName, Explanation, State) when is_atom(ErrorName) ->
     ErrorDesc = rabbit_misc:format("~ts", [Explanation]),
     log_error(ErrorName, ErrorDesc, none),
-    {stop, normal, close_connection(send_error(atom_to_list(ErrorName), ErrorDesc, State))};
+    {stop, error_close, close_connection(send_error(atom_to_list(ErrorName), ErrorDesc, State))};
 amqp_death(ReplyCode, Explanation, State) ->
     ErrorName = rabbit_framing_amqp_0_9_1:amqp_exception(ReplyCode),
     ErrorDesc = rabbit_misc:format("~ts", [Explanation]),
     log_error(ErrorName, ErrorDesc, none),
-    {stop, normal, close_connection(send_error(atom_to_list(ErrorName), ErrorDesc, State))}.
+    {stop, error_close, close_connection(send_error(atom_to_list(ErrorName), ErrorDesc, State))}.
 
 error(Message, Detail, State) ->
     priv_error(Message, Detail, none, State).

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -68,8 +68,7 @@
                       queue :: rabbit_amqqueue:name(),
                       %% message ID used by queue and message store implementations
                       msg_id :: rabbit_amqqueue:msg_id(),
-                      %% Ack mode at delivery; it outlives the subscription.
-                      multi_ack :: boolean()
+                                            multi_ack :: boolean()
                      }).
 
 -record(cfg,
@@ -558,9 +557,10 @@ ack_action(Command, Frame,
         {ok, AckValue} ->
             case rabbit_stomp_util:parse_message_id(AckValue) of
                 {ok, {ConsumerTag, _SessionId, DeliveryTag}} ->
-                    %% Settle from the delivery ledger because the delivery
-                    %% may outlive its subscription. The ledger also preserves
-                    %% the original ack mode if the subscription ID is reused.
+                    %% Settle using state's `unacked_message_q` and the `#pending_ack` records.
+                    %% This handles two problematic scenarios: a delivery that outlived its
+                    %% subscription and the original ack mode for the race condition case where
+                    %% a recently cancelled subscription is immediately recreated with the same the subscription ID.
                     Requeue = rabbit_stomp_frame:boolean_header(Frame, <<"requeue">>, DefaultNackRequeue),
                     case Fun({ConsumerTag, DeliveryTag}, Requeue, State) of
                         {error, _, _, _} = Err -> Err;
@@ -707,8 +707,10 @@ maybe_delete_durable_sub_queue({topic, _Name}, QRes, Frame, State) ->
 maybe_delete_durable_sub_queue(_Destination, _QRes, _Frame, State) ->
     ok(State).
 
-%% Same permission and delete path as queue.delete on a channel. The check
-%% is uncached: this module never invalidates its permission cache.
+%% Matches the check performed during a queue deletion.
+%%
+%% This module never invalidates the permission cache, therefore here the cache
+%% is intentionally bypassed.
 -spec delete_durable_sub_queue(rabbit_amqqueue:name(), #state{}) ->
           {ok, none, #state{}}.
 delete_durable_sub_queue(QRes, State = #state{user = #user{username = Username} = User,
@@ -1133,8 +1135,7 @@ record_transaction_settlements(Acks) ->
 %% Records a client-sent acknowledgement. Handles both single delivery acks
 %% and multi-acks.
 %%
-%% The ack mode comes from the settled delivery's own ledger entry; entries
-%% walked past it are all older, so one accumulator serves both modes.
+%% The ack mode comes from the `state.unacked_message_q` entry.
 %%
 %% Returns a tuple of acknowledged pending acks and remaining pending acks.
 %% Sorts each group in the youngest-first order (descending by delivery tag).
@@ -1164,8 +1165,7 @@ collect_acks(OlderAcc, UAMQ, CTag, DeliveryTag) ->
                              end}
                     end;
                CurrentDT == DeliveryTag ->
-                    %% The same tag from another subscription does not name
-                    %% this delivery.
+                    %% Same delivery tag, different subscription.
                     {error, not_found};
                true ->
                     collect_acks([UnackedMsg | OlderAcc], UAMQTail,
@@ -1501,7 +1501,12 @@ commit_transaction(Transaction, State0) ->
     with_transaction(
       Transaction, State0,
       fun (Funs, State) ->
-              %% A cumulative settlement can make a later action redundant.
+              %% A multi-ack settles several deliveries at once, which can make a later
+              %% queued action redundant.
+              %%
+              %% Track settled tags for this commit only.
+              %% This value is erased in the `after` clause below so it can't leak into another
+              %% commit or a non-transactional ack operation.
               put(tx_settled_delivery_tags, sets:new([{version, 2}])),
               FinalState = try
                                lists:foldr(fun perform_transaction_action/2,

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -67,7 +67,9 @@
                       %% queue name
                       queue :: rabbit_amqqueue:name(),
                       %% message ID used by queue and message store implementations
-                      msg_id :: rabbit_amqqueue:msg_id()
+                      msg_id :: rabbit_amqqueue:msg_id(),
+                      %% Ack mode at delivery; it outlives the subscription.
+                      multi_ack :: boolean()
                      }).
 
 -record(cfg,
@@ -516,7 +518,7 @@ handle_frame('ACK', Frame, State) ->
     maybe_with_transaction(
       Frame,
       fun(State0) ->
-              ack_action('ACK', Frame, State0, fun handle_ack/4)
+              ack_action('ACK', Frame, State0, fun handle_ack/3)
       end,
       State);
 
@@ -524,7 +526,7 @@ handle_frame('NACK', Frame, State) ->
     maybe_with_transaction(
       Frame,
       fun(State0) ->
-              ack_action('NACK', Frame, State0, fun handle_nack/4)
+              ack_action('NACK', Frame, State0, fun handle_nack/3)
       end,
       State);
 
@@ -548,8 +550,7 @@ handle_frame(Command, _Frame, State) ->
 %%----------------------------------------------------------------------------
 
 ack_action(Command, Frame,
-           State = #state{subscriptions = Subs,
-                          cfg = #cfg{
+           State = #state{cfg = #cfg{
                                    version              = Version,
                                    default_nack_requeue = DefaultNackRequeue}}, Fun) ->
     AckHeader = rabbit_stomp_util:ack_header_name(Version),
@@ -557,16 +558,13 @@ ack_action(Command, Frame,
         {ok, AckValue} ->
             case rabbit_stomp_util:parse_message_id(AckValue) of
                 {ok, {ConsumerTag, _SessionId, DeliveryTag}} ->
-                    case maps:find(ConsumerTag, Subs) of
-                        {ok, Sub} ->
-                            Requeue = rabbit_stomp_frame:boolean_header(Frame, <<"requeue">>, DefaultNackRequeue),
-                            State1 = Fun(DeliveryTag, Sub, Requeue, State),
-                            ok(State1);
-                        error ->
-                            error("Subscription not found",
-                                  "Message with id ~tp has no subscription",
-                                  [AckValue],
-                                  State)
+                    %% Settle from the delivery ledger because the delivery
+                    %% may outlive its subscription. The ledger also preserves
+                    %% the original ack mode if the subscription ID is reused.
+                    Requeue = rabbit_stomp_frame:boolean_header(Frame, <<"requeue">>, DefaultNackRequeue),
+                    case Fun({ConsumerTag, DeliveryTag}, Requeue, State) of
+                        {error, _, _, _} = Err -> Err;
+                        State1 -> ok(State1)
                     end;
                 _ ->
                     error("Invalid header",
@@ -1074,48 +1072,107 @@ coalesce_and_send(MsgSeqNos, NegativeMsgSeqNos, MkMsgFun, State = #state{unconfi
                         MkMsgFun(SeqNo, false, StateN)
                 end, State1, Ss).
 
-handle_ack(DeliveryTag, #subscription{multi_ack = IsMulti}, _, State = #state{unacked_message_q = UAMQ}) ->
-    {Acked, Remaining} = collect_acks(UAMQ, DeliveryTag, IsMulti),
-    State1 = State#state{unacked_message_q = Remaining},
-    {State2, Actions} = settle_acks(Acked, State1),
-    handle_queue_actions(Actions, State2).
+handle_ack(Ack = {CTag, DeliveryTag}, _Requeue,
+           State = #state{unacked_message_q = UAMQ}) ->
+    case collect_acks(UAMQ, CTag, DeliveryTag) of
+        {error, not_found} ->
+            unknown_delivery_tag(Ack, State);
+        {Acked, Remaining} ->
+            State1 = State#state{unacked_message_q = Remaining},
+            {State2, Actions} = settle_acks(Acked, State1),
+            State3 = handle_queue_actions(Actions, State2),
+            record_transaction_settlements(Acked),
+            State3
+    end.
 
-handle_nack(DeliveryTag, #subscription{multi_ack = IsMulti}, Requeue, State = #state{unacked_message_q = UAMQ}) ->
-    {Acked, Remaining} = collect_acks(UAMQ, DeliveryTag, IsMulti),
-    State1 = State#state{unacked_message_q = Remaining},
-    {State2, Actions} = internal_reject(Requeue, Acked, State1),
-    handle_queue_actions(Actions, State2).
+handle_nack(Ack = {CTag, DeliveryTag}, Requeue,
+            State = #state{unacked_message_q = UAMQ}) ->
+    case collect_acks(UAMQ, CTag, DeliveryTag) of
+        {error, not_found} ->
+            unknown_delivery_tag(Ack, State);
+        {Acked, Remaining} ->
+            State1 = State#state{unacked_message_q = Remaining},
+            {State2, Actions} = internal_reject(Requeue, Acked, State1),
+            State3 = handle_queue_actions(Actions, State2),
+            record_transaction_settlements(Acked),
+            State3
+    end.
+
+unknown_delivery_tag(Ack, State) ->
+    case get(tx_settled_delivery_tags) of
+        undefined ->
+            unknown_delivery_tag_error(Ack, State);
+        Settled ->
+            case sets:is_element(Ack, Settled) of
+                true ->
+                    State;
+                false ->
+                    unknown_delivery_tag_error(Ack, State)
+            end
+    end.
+
+unknown_delivery_tag_error({_CTag, DeliveryTag}, State) ->
+    {error, "Message not found",
+     rabbit_misc:format("unknown delivery tag ~w~n", [DeliveryTag]),
+     State}.
+
+record_transaction_settlements(Acks) ->
+    case get(tx_settled_delivery_tags) of
+        undefined ->
+            ok;
+        Settled0 ->
+            Settled = lists:foldl(
+                        fun(#pending_ack{tag = CTag,
+                                         delivery_tag = DeliveryTag}, Acc) ->
+                                sets:add_element({CTag, DeliveryTag}, Acc)
+                        end, Settled0, Acks),
+            put(tx_settled_delivery_tags, Settled),
+            ok
+    end.
 
 %% Records a client-sent acknowledgement. Handles both single delivery acks
 %% and multi-acks.
 %%
+%% The ack mode comes from the settled delivery's own ledger entry; entries
+%% walked past it are all older, so one accumulator serves both modes.
+%%
 %% Returns a tuple of acknowledged pending acks and remaining pending acks.
 %% Sorts each group in the youngest-first order (descending by delivery tag).
-collect_acks(UAMQ, DeliveryTag, Multiple) ->
-    collect_acks([], [], UAMQ, DeliveryTag, Multiple).
+collect_acks(UAMQ, CTag, DeliveryTag) ->
+    collect_acks([], UAMQ, CTag, DeliveryTag).
 
-collect_acks(AcknowledgedAcc, RemainingAcc, UAMQ, DeliveryTag, Multiple) ->
+collect_acks(OlderAcc, UAMQ, CTag, DeliveryTag) ->
     case ?QUEUE:out(UAMQ) of
-        {{value, UnackedMsg = #pending_ack{delivery_tag = CurrentDT}},
+        {{value, UnackedMsg = #pending_ack{delivery_tag = CurrentDT,
+                                           tag = CurrentCTag,
+                                           multi_ack = Multiple}},
          UAMQTail} ->
-            if CurrentDT == DeliveryTag ->
-                    {[UnackedMsg | AcknowledgedAcc],
-                     case RemainingAcc of
-                         [] -> UAMQTail;
-                         _  -> ?QUEUE:join(
-                                  ?QUEUE:from_list(lists:reverse(RemainingAcc)),
-                                  UAMQTail)
-                     end};
-               Multiple ->
-                    collect_acks([UnackedMsg | AcknowledgedAcc], RemainingAcc,
-                                 UAMQTail, DeliveryTag, Multiple);
+            if CurrentDT == DeliveryTag andalso CurrentCTag == CTag ->
+                    case Multiple of
+                        true ->
+                            %% Prune older deliveries across subscriptions, as
+                            %% cumulative basic.ack does on an AMQP channel.
+                            {[UnackedMsg | OlderAcc], UAMQTail};
+                        false ->
+                            {[UnackedMsg],
+                             case OlderAcc of
+                                 [] -> UAMQTail;
+                                 _  -> ?QUEUE:join(
+                                          ?QUEUE:from_list(
+                                            lists:reverse(OlderAcc)),
+                                          UAMQTail)
+                             end}
+                    end;
+               CurrentDT == DeliveryTag ->
+                    %% The same tag from another subscription does not name
+                    %% this delivery.
+                    {error, not_found};
                true ->
-                    collect_acks(AcknowledgedAcc, [UnackedMsg | RemainingAcc],
-                                 UAMQTail, DeliveryTag, Multiple)
+                    collect_acks([UnackedMsg | OlderAcc], UAMQTail,
+                                 CTag, DeliveryTag)
             end;
         {empty, _} ->
-            error("Unknown delivery tag",
-                  "unknown delivery tag ~w", [DeliveryTag])
+            {error, not_found}
     end.
 
 foreach_per_queue(F, [#pending_ack{tag = CTag,
@@ -1221,7 +1278,8 @@ send_delivery(QName, MsgId,
                          subscriptions = Subs,
                          unacked_message_q = UAMQ}) ->
     case maps:find(ConsumerTag, Subs) of
-        {ok, #subscription{ack_mode = AckMode}} ->
+        {ok, #subscription{ack_mode = AckMode,
+                           multi_ack = IsMulti}} ->
             NewState = send_frame(
                          'MESSAGE',
                          rabbit_stomp_util:headers(
@@ -1239,7 +1297,8 @@ send_delivery(QName, MsgId,
                                                               tag = ConsumerTag,
                                                               delivered_at = DeliveredAt,
                                                               queue = QName,
-                                                              msg_id = MsgId}, UAMQ)};
+                                                              msg_id = MsgId,
+                                                              multi_ack = IsMulti}, UAMQ)};
                 _ -> NewState
             end;
         error ->
@@ -1442,9 +1501,15 @@ commit_transaction(Transaction, State0) ->
     with_transaction(
       Transaction, State0,
       fun (Funs, State) ->
-              FinalState = lists:foldr(fun perform_transaction_action/2,
-                                       {ok, State},
-                                       Funs),
+              %% A cumulative settlement can make a later action redundant.
+              put(tx_settled_delivery_tags, sets:new([{version, 2}])),
+              FinalState = try
+                               lists:foldr(fun perform_transaction_action/2,
+                                           {ok, State},
+                                           Funs)
+                           after
+                               erase(tx_settled_delivery_tags)
+                           end,
               erase({transaction, Transaction}),
               FinalState
       end).

--- a/deps/rabbitmq_stomp/test/system_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/system_SUITE.erl
@@ -31,6 +31,16 @@
 -define(AUTHZ_PASSWORD, <<"pass">>).
 %% Least privilege for a durable topic subscriber: its own subscription queues.
 -define(AUTHZ_CONFIGURE, <<"^stomp-subscription-.*">>).
+-define(UNSUBSCRIBE_QUEUE, <<"TestUnsubscribeQueue">>).
+-define(UNSUBSCRIBE_QUEUE_QQ, <<"TestUnsubscribeQueueQQ">>).
+-define(UNSUBSCRIBE_STREAM, <<"TestUnsubscribeStream">>).
+-define(MULTIACK_QUEUE_A, <<"TestMultiAckQueueA">>).
+-define(MULTIACK_QUEUE_B, <<"TestMultiAckQueueB">>).
+-define(UNSUBSCRIBE_DESTINATION, <<"/amq/queue/TestUnsubscribeQueue">>).
+-define(UNSUBSCRIBE_DESTINATION_QQ, <<"/amq/queue/TestUnsubscribeQueueQQ">>).
+-define(UNSUBSCRIBE_STREAM_DESTINATION, <<"/amq/queue/TestUnsubscribeStream">>).
+-define(MULTIACK_DESTINATION_A, <<"/amq/queue/TestMultiAckQueueA">>).
+-define(MULTIACK_DESTINATION_B, <<"/amq/queue/TestMultiAckQueueB">>).
 
 all() ->
     [{group, version_to_group_name(V)} || V <- ?SUPPORTED_VERSIONS].
@@ -46,7 +56,15 @@ groups() ->
         subscribe,
         subscribe_with_x_priority,
         unsubscribe_ack,
+        unsubscribe_multiack_prune,
+        multiack_prune_is_connection_wide,
+        unsubscribe_transaction_ack,
+        unsubscribe_transaction_multiack_prune,
+        unsubscribe_nack_individual,
+        unsubscribe_ack_stream,
         subscribe_ack,
+        ack_auto_delivery_errors,
+        reused_subscription_id_keeps_ack_mode,
         send,
         delete_queue_subscribe,
         temp_destination_queue,
@@ -108,6 +126,7 @@ init_per_testcase(TestCase, Config) ->
     init_per_testcase0(TestCase, Config1).
 
 end_per_testcase(TestCase, Config) ->
+    cleanup_per_testcase0(TestCase, Config),
     Connection = ?config(amqp_connection, Config),
     Channel = ?config(amqp_channel, Config),
     Client = ?config(stomp_client, Config),
@@ -206,6 +225,49 @@ end_per_testcase0(TestCase, Config)
 end_per_testcase0(_, Config) ->
     Config.
 
+%% Remove test queues before the client and AMQP connection are closed.
+cleanup_per_testcase0(unsubscribe_ack, Config) ->
+    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
+cleanup_per_testcase0(unsubscribe_multiack_prune, Config) ->
+    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
+cleanup_per_testcase0(unsubscribe_transaction_ack, Config) ->
+    delete_test_queue(?UNSUBSCRIBE_QUEUE_QQ, Config);
+cleanup_per_testcase0(unsubscribe_transaction_multiack_prune, Config) ->
+    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
+cleanup_per_testcase0(unsubscribe_nack_individual, Config) ->
+    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
+cleanup_per_testcase0(unsubscribe_ack_stream, Config) ->
+    delete_test_queue(?UNSUBSCRIBE_STREAM, Config);
+cleanup_per_testcase0(multiack_prune_is_connection_wide, Config) ->
+    delete_test_queue(?MULTIACK_QUEUE_A, Config),
+    delete_test_queue(?MULTIACK_QUEUE_B, Config);
+cleanup_per_testcase0(reused_subscription_id_keeps_ack_mode, Config) ->
+    delete_test_queue(?MULTIACK_QUEUE_A, Config),
+    delete_test_queue(?MULTIACK_QUEUE_B, Config);
+cleanup_per_testcase0(delete_queue_subscribe, Config) ->
+    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
+cleanup_per_testcase0(_, Config) ->
+    Config.
+
+delete_test_queue(Queue, Config) ->
+    VHost = ?config(rmq_vhost, Config),
+    QName = rabbit_misc:r(VHost, queue, Queue),
+    case rabbit_ct_broker_helpers:rpc(
+           Config, 0, rabbit_amqqueue, lookup, [QName]) of
+        {ok, _} ->
+            Connection = ?config(amqp_connection, Config),
+            case amqp_connection:open_channel(Connection) of
+                {ok, Channel} ->
+                    _ = catch amqp_channel:call(
+                                Channel, #'queue.delete'{queue = Queue}),
+                    _ = catch amqp_channel:close(Channel),
+                    Config;
+                _ ->
+                    Config
+            end;
+        _ ->
+            Config
+    end.
 transaction_limit(Config) ->
     Client = ?config(stomp_client, Config),
     %% Open 16 transactions (the limit)
@@ -388,38 +450,373 @@ unsubscribe_ack(Config) ->
     Client = ?config(stomp_client, Config),
     Version = ?config(version, Config),
     #'queue.declare_ok'{} =
-        amqp_channel:call(Channel, #'queue.declare'{queue       = ?QUEUE,
-                                                    durable     = true,
-                                                    auto_delete = true}),
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?UNSUBSCRIBE_QUEUE,
+                                    durable = true}),
     %% subscribe and wait for receipt
     rabbit_stomp_client:send(
-      Client, 'SUBSCRIBE', [{<<"destination">>, ?DESTINATION},
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
                             {<<"receipt">>, <<"rcpt1">>},
                             {<<"ack">>, <<"client">>},
+                            {<<"prefetch-count">>, <<"1">>},
                             {<<"id">>, <<"subscription-id">>}]),
     {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
 
     %% send from amqp
-    Method = #'basic.publish'{exchange = <<"">>, routing_key = ?QUEUE},
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_QUEUE},
 
     amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
                                                  payload = <<"hello">>}),
 
     {ok, Client2, Hdrs1, [<<"hello">>]} = stomp_receive(Client1, 'MESSAGE'),
 
-    rabbit_stomp_client:send(
-      Client2, 'UNSUBSCRIBE', [{<<"destination">>, ?DESTINATION},
-                               {<<"id">>, <<"subscription-id">>}]),
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"goodbye">>}),
 
     rabbit_stomp_client:send(
-      Client2, 'ACK', [{rabbit_stomp_util:ack_header_name(Version),
+      Client2, 'UNSUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                               {<<"id">>, <<"subscription-id">>},
+                               {<<"receipt">>, <<"rcpt2">>}]),
+
+    {ok, Client3, _, _} = stomp_receive(Client2, 'RECEIPT'),
+
+    rabbit_stomp_client:send(
+      Client3, 'ACK', [{rabbit_stomp_util:ack_header_name(Version),
                         maps:get(
                           rabbit_stomp_util:msg_header_name(Version), Hdrs1)},
-                       {<<"receipt">>, <<"rcpt2">>}]),
+                       {<<"receipt">>, <<"rcpt3">>}]),
 
-    {ok, _Client3, Hdrs2, _Body2} = stomp_receive(Client2, 'ERROR'),
-    ?assertEqual(<<"Subscription not found">>,
-                 maps:get(<<"message">>, Hdrs2)),
+    {ok, _Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 1, 0, 0),
+    ok.
+
+unsubscribe_multiack_prune(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?UNSUBSCRIBE_QUEUE,
+                                    durable = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client">>},
+                            {<<"prefetch-count">>, <<"5">>},
+                            {<<"id">>, <<"subscription-id">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_QUEUE},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"one">>}),
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"two">>}),
+    {ok, Client2, Headers1, [<<"one">>]} = stomp_receive(Client1, 'MESSAGE'),
+    {ok, Client3, Headers2, [<<"two">>]} = stomp_receive(Client2, 'MESSAGE'),
+    MessageHeader = rabbit_stomp_util:msg_header_name(Version),
+    AckHeader = rabbit_stomp_util:ack_header_name(Version),
+    Ack1 = {AckHeader, maps:get(MessageHeader, Headers1)},
+    Ack2 = {AckHeader, maps:get(MessageHeader, Headers2)},
+
+    rabbit_stomp_client:send(
+      Client3, 'UNSUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                               {<<"id">>, <<"subscription-id">>},
+                               {<<"receipt">>, <<"rcpt2">>}]),
+    {ok, Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+
+    %% A cumulative ACK of the first delivery leaves the second pending.
+    rabbit_stomp_client:send(Client4, 'ACK', [Ack1, {<<"receipt">>, <<"rcpt3">>}]),
+    {ok, Client5, _, _} = stomp_receive(Client4, 'RECEIPT'),
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 1, 0),
+    rabbit_stomp_client:send(Client5, 'ACK', [Ack2, {<<"receipt">>, <<"rcpt4">>}]),
+    {ok, Client6, _, _} = stomp_receive(Client5, 'RECEIPT'),
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 0, 0),
+    rabbit_stomp_client:send(Client6, 'ACK', [Ack2]),
+    {ok, _Client7, ErrorHeaders, _} = stomp_receive(Client6, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
+    ok.
+
+unsubscribe_transaction_ack(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    %% Exercise the same transition against a quorum queue.
+    #'queue.declare_ok'{} =
+        amqp_channel:call(Channel, #'queue.declare'{queue     = ?UNSUBSCRIBE_QUEUE_QQ,
+                                                    durable   = true,
+                                                    arguments = [{<<"x-queue-type">>, longstr, <<"quorum">>}]}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION_QQ},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client">>},
+                            {<<"prefetch-count">>, <<"1">>},
+                            {<<"id">>, <<"subscription-id">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_QUEUE_QQ},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"hello">>}),
+    {ok, Client2, Hdrs1, [<<"hello">>]} = stomp_receive(Client1, 'MESSAGE'),
+    AckHeader = {rabbit_stomp_util:ack_header_name(Version),
+                 maps:get(
+                   rabbit_stomp_util:msg_header_name(Version), Hdrs1)},
+
+    rabbit_stomp_client:send(
+      Client2, 'UNSUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION_QQ},
+                               {<<"id">>, <<"subscription-id">>},
+                               {<<"receipt">>, <<"rcpt2">>}]),
+    Client3 = stomp_receive_receipt(Client2, <<"rcpt2">>),
+
+    rabbit_stomp_client:send(
+      Client3, 'BEGIN', [{<<"transaction">>, <<"abort-me">>}, {<<"receipt">>, <<"rcpt3">>}]),
+    Client4 = stomp_receive_receipt(Client3, <<"rcpt3">>),
+    rabbit_stomp_client:send(
+      Client4, 'ACK', [AckHeader,
+                       {<<"transaction">>, <<"abort-me">>},
+                       {<<"receipt">>, <<"rcpt4">>}]),
+    Client5 = stomp_receive_receipt(Client4, <<"rcpt4">>),
+    rabbit_stomp_client:send(
+      Client5, 'ABORT', [{<<"transaction">>, <<"abort-me">>}, {<<"receipt">>, <<"rcpt5">>}]),
+    Client6 = stomp_receive_receipt(Client5, <<"rcpt5">>),
+
+    %% ABORT leaves the message held by the canceled consumer.
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE_QQ, 0, 1, 1, 30_000),
+    rabbit_stomp_client:send(
+      Client6, 'BEGIN', [{<<"transaction">>, <<"commit-me">>}, {<<"receipt">>, <<"rcpt6">>}]),
+    Client7 = stomp_receive_receipt(Client6, <<"rcpt6">>),
+    rabbit_stomp_client:send(
+      Client7, 'ACK', [AckHeader,
+                       {<<"transaction">>, <<"commit-me">>},
+                       {<<"receipt">>, <<"rcpt7">>}]),
+    Client8 = stomp_receive_receipt(Client7, <<"rcpt7">>),
+    rabbit_stomp_client:send(
+      Client8, 'COMMIT', [{<<"transaction">>, <<"commit-me">>}, {<<"receipt">>, <<"rcpt8">>}]),
+    %% the queued ACK's receipt is sent again as the transaction replays it
+    Client9 = stomp_receive_receipt(Client8, <<"rcpt7">>),
+    _Client10 = stomp_receive_receipt(Client9, <<"rcpt8">>),
+
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE_QQ, 0, 0, 0, 30_000),
+    ok.
+
+unsubscribe_transaction_multiack_prune(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?UNSUBSCRIBE_QUEUE,
+                                    durable = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client">>},
+                            {<<"prefetch-count">>, <<"2">>},
+                            {<<"id">>, <<"subscription-id">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_QUEUE},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"one">>}),
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"two">>}),
+    {ok, Client2, Headers1, [<<"one">>]} = stomp_receive(Client1, 'MESSAGE'),
+    {ok, Client3, Headers2, [<<"two">>]} = stomp_receive(Client2, 'MESSAGE'),
+    MessageHeader = rabbit_stomp_util:msg_header_name(Version),
+    AckHeader = rabbit_stomp_util:ack_header_name(Version),
+    Ack1 = {AckHeader, maps:get(MessageHeader, Headers1)},
+    Ack2 = {AckHeader, maps:get(MessageHeader, Headers2)},
+
+    rabbit_stomp_client:send(
+      Client3, 'UNSUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                               {<<"id">>, <<"subscription-id">>},
+                               {<<"receipt">>, <<"rcpt2">>}]),
+    Client4 = stomp_receive_receipt(Client3, <<"rcpt2">>),
+    rabbit_stomp_client:send(
+      Client4, 'BEGIN', [{<<"transaction">>, <<"tx">>}, {<<"receipt">>, <<"rcpt3">>}]),
+    Client5 = stomp_receive_receipt(Client4, <<"rcpt3">>),
+    rabbit_stomp_client:send(
+      Client5, 'ACK', [Ack2, {<<"transaction">>, <<"tx">>},
+                       {<<"receipt">>, <<"rcpt4">>}]),
+    Client6 = stomp_receive_receipt(Client5, <<"rcpt4">>),
+    rabbit_stomp_client:send(
+      Client6, 'ACK', [Ack1, {<<"transaction">>, <<"tx">>},
+                       {<<"receipt">>, <<"rcpt5">>}]),
+    Client7 = stomp_receive_receipt(Client6, <<"rcpt5">>),
+    rabbit_stomp_client:send(
+      Client7, 'COMMIT', [{<<"transaction">>, <<"tx">>}, {<<"receipt">>, <<"rcpt6">>}]),
+    %% the queued ACKs' receipts are sent again as the transaction replays
+    %% them, in the order they were queued
+    Client8 = stomp_receive_receipt(Client7, <<"rcpt4">>),
+    Client9 = stomp_receive_receipt(Client8, <<"rcpt5">>),
+    Client10 = stomp_receive_receipt(Client9, <<"rcpt6">>),
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 0, 0),
+
+    %% A broker round trip proves the duplicate settlement did not close the
+    %% shared AMQP channel after the COMMIT receipt was sent.
+    rabbit_stomp_client:send(
+      Client10, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                              {<<"receipt">>, <<"rcpt7">>},
+                              {<<"id">>, <<"roundtrip">>}]),
+    Client11 = stomp_receive_receipt(Client10, <<"rcpt7">>),
+
+    %% A settlement is redundant only when an earlier action in the same
+    %% COMMIT removed it.
+    rabbit_stomp_client:send(
+      Client11, 'BEGIN', [{<<"transaction">>, <<"tx2">>},
+                          {<<"receipt">>, <<"rcpt8">>}]),
+    Client12 = stomp_receive_receipt(Client11, <<"rcpt8">>),
+    rabbit_stomp_client:send(
+      Client12, 'ACK', [Ack1, {<<"transaction">>, <<"tx2">>},
+                        {<<"receipt">>, <<"rcpt9">>}]),
+    Client13 = stomp_receive_receipt(Client12, <<"rcpt9">>),
+    rabbit_stomp_client:send(
+      Client13, 'COMMIT', [{<<"transaction">>, <<"tx2">>}]),
+    {ok, _Client14, ErrorHeaders, _} = stomp_receive(Client13, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
+    ok.
+
+unsubscribe_nack_individual(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?UNSUBSCRIBE_QUEUE,
+                                    durable = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client-individual">>},
+                            {<<"prefetch-count">>, <<"1">>},
+                            {<<"id">>, <<"subscription-id">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_QUEUE},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"hello">>}),
+    {ok, Client2, Headers, [<<"hello">>]} = stomp_receive(Client1, 'MESSAGE'),
+    NackHeader = {rabbit_stomp_util:ack_header_name(Version),
+                  maps:get(
+                    rabbit_stomp_util:msg_header_name(Version), Headers)},
+
+    rabbit_stomp_client:send(
+      Client2, 'UNSUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                               {<<"id">>, <<"subscription-id">>},
+                               {<<"receipt">>, <<"rcpt2">>}]),
+    {ok, Client3, _, _} = stomp_receive(Client2, 'RECEIPT'),
+    rabbit_stomp_client:send(
+      Client3, 'NACK', [NackHeader,
+                        {<<"requeue">>, <<"true">>},
+                        {<<"receipt">>, <<"rcpt3">>}]),
+    {ok, Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 1, 0, 0),
+
+    rabbit_stomp_client:send(Client4, 'NACK', [NackHeader]),
+    {ok, _Client5, ErrorHeaders, _} = stomp_receive(Client4, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
+    ok.
+
+unsubscribe_ack_stream(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel,
+          #'queue.declare'{queue = ?UNSUBSCRIBE_STREAM,
+                           durable = true,
+                           arguments = [{<<"x-queue-type">>, longstr,
+                                         <<"stream">>}]}),
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_STREAM},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"hello">>}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_STREAM_DESTINATION},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client">>},
+                            {<<"prefetch-count">>, <<"1">>},
+                            {<<"x-stream-offset">>, <<"first">>},
+                            {<<"id">>, <<"subscription-id">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+    {ok, Client2, Headers, [<<"hello">>]} = stomp_receive(Client1, 'MESSAGE'),
+    AckHeader = {rabbit_stomp_util:ack_header_name(Version),
+                 maps:get(
+                   rabbit_stomp_util:msg_header_name(Version), Headers)},
+
+    rabbit_stomp_client:send(
+      Client2, 'UNSUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_STREAM_DESTINATION},
+                               {<<"id">>, <<"subscription-id">>},
+                               {<<"receipt">>, <<"rcpt2">>}]),
+    {ok, Client3, _, _} = stomp_receive(Client2, 'RECEIPT'),
+    %% A stream ACK is accepted even though no reader remains to credit.
+    rabbit_stomp_client:send(
+      Client3, 'ACK', [AckHeader, {<<"receipt">>, <<"rcpt3">>}]),
+    {ok, _Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+    ok.
+
+%% Cumulative ACK prunes across the whole connection, not just the
+%% subscription the acked delivery arrived on: pre-existing AMQP 0-9-1 channel
+%% semantics, and a deliberate deviation from STOMP 1.2, which scopes a
+%% cumulative ack:client to the same subscription. Pinned here so settlement
+%% changes cannot narrow it silently; doing so would be a breaking change.
+%% https://stomp.github.io/stomp-specification-1.2.html#SUBSCRIBE_ack_Header
+multiack_prune_is_connection_wide(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?MULTIACK_QUEUE_A,
+                                    durable = true}),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?MULTIACK_QUEUE_B,
+                                    durable = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?MULTIACK_DESTINATION_B},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client-individual">>},
+                            {<<"id">>, <<"sub-b">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+    rabbit_stomp_client:send(
+      Client1, 'SUBSCRIBE', [{<<"destination">>, ?MULTIACK_DESTINATION_A},
+                             {<<"receipt">>, <<"rcpt2">>},
+                             {<<"ack">>, <<"client">>},
+                             {<<"id">>, <<"sub-a">>}]),
+    {ok, Client2, _, _} = stomp_receive(Client1, 'RECEIPT'),
+
+    PublishB = #'basic.publish'{exchange = <<"">>,
+                                routing_key = ?MULTIACK_QUEUE_B},
+    amqp_channel:call(Channel, PublishB, #amqp_msg{props = #'P_basic'{},
+                                                   payload = <<"one">>}),
+    {ok, Client3, HeadersB, [<<"one">>]} = stomp_receive(Client2, 'MESSAGE'),
+    PublishA = #'basic.publish'{exchange = <<"">>,
+                                routing_key = ?MULTIACK_QUEUE_A},
+    amqp_channel:call(Channel, PublishA, #amqp_msg{props = #'P_basic'{},
+                                                   payload = <<"two">>}),
+    {ok, Client4, HeadersA, [<<"two">>]} = stomp_receive(Client3, 'MESSAGE'),
+    MessageHeader = rabbit_stomp_util:msg_header_name(Version),
+    AckHeader = rabbit_stomp_util:ack_header_name(Version),
+    AckB = {AckHeader, maps:get(MessageHeader, HeadersB)},
+    AckA = {AckHeader, maps:get(MessageHeader, HeadersA)},
+
+    %% Mirror the shared AMQP channel's settlement across consumers.
+    rabbit_stomp_client:send(Client4, 'ACK', [AckA, {<<"receipt">>, <<"rcpt3">>}]),
+    {ok, Client5, _, _} = stomp_receive(Client4, 'RECEIPT'),
+    ok = await_queue_state(Config, ?MULTIACK_QUEUE_B, 0, 0, 1),
+    rabbit_stomp_client:send(Client5, 'ACK', [AckB]),
+    {ok, _Client6, ErrorHeaders, _} = stomp_receive(Client5, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
     ok.
 
 %% A durable UNSUBSCRIBE must delete the queue this connection subscribed to,
@@ -546,6 +943,135 @@ subscribe_ack(Config) ->
         amqp_channel:call(Channel, #'basic.get'{queue = ?QUEUE}),
     ok.
 
+ack_auto_delivery_errors(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel,
+          #'queue.declare'{queue       = ?QUEUE,
+                           durable     = true,
+                           auto_delete = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?DESTINATION},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"auto">>},
+                            {<<"id">>, <<"auto">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+
+    Method = #'basic.publish'{exchange = <<>>, routing_key = ?QUEUE},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"hello">>}),
+    {ok, Client2, Headers, [<<"hello">>]} =
+        stomp_receive(Client1, 'MESSAGE'),
+    MessageId = maps:get(?HEADER_MESSAGE_ID, Headers),
+    rabbit_stomp_client:send(
+      Client2, 'ACK',
+      [{rabbit_stomp_util:ack_header_name(Version), MessageId}]),
+    {ok, Client3, ErrorHeaders, _} = stomp_receive(Client2, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
+
+    rabbit_stomp_client:send(
+      Client3, 'SUBSCRIBE', [{<<"destination">>, ?DESTINATION},
+                              {<<"receipt">>, <<"rcpt2">>},
+                              {<<"id">>, <<"roundtrip">>}]),
+    {ok, _Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+    ok.
+
+reused_subscription_id_keeps_ack_mode(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?MULTIACK_QUEUE_A,
+                                    durable = true}),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?MULTIACK_QUEUE_B,
+                                    durable = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?MULTIACK_DESTINATION_B},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client-individual">>},
+                            {<<"id">>, <<"sub-b">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+    rabbit_stomp_client:send(
+      Client1, 'SUBSCRIBE', [{<<"destination">>, ?MULTIACK_DESTINATION_A},
+                             {<<"receipt">>, <<"rcpt2">>},
+                             {<<"ack">>, <<"client-individual">>},
+                             {<<"id">>, <<"reused">>}]),
+    {ok, Client2, _, _} = stomp_receive(Client1, 'RECEIPT'),
+
+    PublishB = #'basic.publish'{exchange = <<>>,
+                                routing_key = ?MULTIACK_QUEUE_B},
+    amqp_channel:call(Channel, PublishB,
+                      #amqp_msg{props = #'P_basic'{}, payload = <<"one">>}),
+    {ok, Client3, HeadersB, [<<"one">>]} =
+        stomp_receive(Client2, 'MESSAGE'),
+    PublishA = #'basic.publish'{exchange = <<>>,
+                                routing_key = ?MULTIACK_QUEUE_A},
+    amqp_channel:call(Channel, PublishA,
+                      #amqp_msg{props = #'P_basic'{}, payload = <<"two">>}),
+    {ok, Client4, HeadersA, [<<"two">>]} =
+        stomp_receive(Client3, 'MESSAGE'),
+    MessageHeader = rabbit_stomp_util:msg_header_name(Version),
+    AckHeader = rabbit_stomp_util:ack_header_name(Version),
+    AckValueB = maps:get(MessageHeader, HeadersB),
+    AckValueA = maps:get(MessageHeader, HeadersA),
+
+    ForgedAckValue = ack_value_with_consumer(AckValueB, AckValueA),
+    rabbit_stomp_client:send(
+      Client4, 'ACK', [{AckHeader, ForgedAckValue}]),
+    {ok, Client5, ErrorHeaders, _} = stomp_receive(Client4, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
+
+    rabbit_stomp_client:send(
+      Client5, 'UNSUBSCRIBE', [{<<"destination">>, ?MULTIACK_DESTINATION_A},
+                                {<<"id">>, <<"reused">>},
+                                {<<"receipt">>, <<"rcpt3">>}]),
+    {ok, Client6, _, _} = stomp_receive(Client5, 'RECEIPT'),
+    rabbit_stomp_client:send(
+      Client6, 'SUBSCRIBE', [{<<"destination">>, ?MULTIACK_DESTINATION_A},
+                              {<<"receipt">>, <<"rcpt4">>},
+                              {<<"ack">>, <<"client">>},
+                              {<<"id">>, <<"reused">>}]),
+    {ok, Client7, _, _} = stomp_receive(Client6, 'RECEIPT'),
+
+    rabbit_stomp_client:send(
+      Client7, 'ACK', [{AckHeader, AckValueA}, {<<"receipt">>, <<"rcpt5">>}]),
+    {ok, Client8, _, _} = stomp_receive(Client7, 'RECEIPT'),
+    ok = await_queue_state(Config, ?MULTIACK_QUEUE_A, 0, 0, 1),
+    ok = await_queue_state(Config, ?MULTIACK_QUEUE_B, 0, 1, 1),
+    rabbit_stomp_client:send(
+      Client8, 'ACK', [{AckHeader, AckValueB}, {<<"receipt">>, <<"rcpt6">>}]),
+    {ok, Client9, _, _} = stomp_receive(Client8, 'RECEIPT'),
+    ok = await_queue_state(Config, ?MULTIACK_QUEUE_B, 0, 0, 1),
+
+    amqp_channel:call(Channel, PublishA,
+                      #amqp_msg{props = #'P_basic'{}, payload = <<"three">>}),
+    {ok, Client10, HeadersA1, [<<"three">>]} =
+        stomp_receive(Client9, 'MESSAGE'),
+    amqp_channel:call(Channel, PublishA,
+                      #amqp_msg{props = #'P_basic'{}, payload = <<"four">>}),
+    {ok, Client11, HeadersA2, [<<"four">>]} =
+        stomp_receive(Client10, 'MESSAGE'),
+    AckValueA1 = maps:get(MessageHeader, HeadersA1),
+    AckValueA2 = maps:get(MessageHeader, HeadersA2),
+    rabbit_stomp_client:send(
+      Client11, 'ACK', [{AckHeader, AckValueA2}, {<<"receipt">>, <<"rcpt7">>}]),
+    {ok, Client12, _, _} = stomp_receive(Client11, 'RECEIPT'),
+    ok = await_queue_state(Config, ?MULTIACK_QUEUE_A, 0, 0, 1),
+    rabbit_stomp_client:send(
+      Client12, 'ACK', [{AckHeader, AckValueA1}]),
+    {ok, _Client13, ErrorHeaders2, _} = stomp_receive(Client12, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders2)),
+    ok.
+
 send(Config) ->
     Channel = ?config(amqp_channel, Config),
     Client = ?config(stomp_client, Config),
@@ -569,30 +1095,60 @@ send(Config) ->
 delete_queue_subscribe(Config) ->
     Channel = ?config(amqp_channel, Config),
     Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
     #'queue.declare_ok'{} =
         amqp_channel:call(Channel, #'queue.declare'{queue       = ?QUEUE,
                                                     durable     = true,
                                                     auto_delete = true}),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?UNSUBSCRIBE_QUEUE,
+                                    durable = true}),
 
     %% subscribe and wait for receipt
     rabbit_stomp_client:send(
-      Client, 'SUBSCRIBE', [{<<"destination">>, ?DESTINATION}, {<<"receipt">>, <<"bah">>}]),
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?DESTINATION},
+                            {<<"receipt">>, <<"bah">>},
+                            {<<"ack">>, <<"client-individual">>}]),
     {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+
+    Method = #'basic.publish'{exchange = <<"">>, routing_key = ?QUEUE},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"hello">>}),
+    {ok, Client2, MessageHeaders, [<<"hello">>]} =
+        stomp_receive(Client1, 'MESSAGE'),
+    AckHeader =
+        {rabbit_stomp_util:ack_header_name(Version),
+         maps:get(
+           rabbit_stomp_util:msg_header_name(Version), MessageHeaders)},
 
     %% delete queue while subscribed
     #'queue.delete_ok'{} =
         amqp_channel:call(Channel, #'queue.delete'{queue = ?QUEUE}),
 
-    {ok, _Client2, Headers, _} = stomp_receive(Client1, 'ERROR'),
+    {ok, Client3, Headers, _} = stomp_receive(Client2, 'ERROR'),
 
     ?DESTINATION = maps:get(<<"subscription">>, Headers),
 
-    % server closes connection
+    %% RabbitMQ keeps the session open after this server-cancel ERROR so an
+    %% in-flight delivery can still be settled.
+    rabbit_stomp_client:send(
+      Client3, 'ACK', [AckHeader, {<<"receipt">>, <<"rcpt2">>}]),
+    {ok, Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+
+    %% A broker round trip proves the late settlement did not close the shared
+    %% AMQP channel after the ACK receipt was sent.
+    rabbit_stomp_client:send(
+      Client4, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                             {<<"receipt">>, <<"rcpt3">>},
+                             {<<"id">>, <<"roundtrip">>}]),
+    {ok, _Client5, _, _} = stomp_receive(Client4, 'RECEIPT'),
     ok.
 
 temp_destination_queue(Config) ->
     Channel = ?config(amqp_channel, Config),
     Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
     #'queue.declare_ok'{} =
         amqp_channel:call(Channel, #'queue.declare'{queue       = ?QUEUE,
                                                     durable     = true,
@@ -609,7 +1165,19 @@ temp_destination_queue(Config) ->
     ok = amqp_channel:call(Channel,
                            #'basic.publish'{routing_key = ReplyTo},
                            #amqp_msg{payload = <<"pong">>}),
-    {ok, _Client1, _, [<<"pong">>]} = stomp_receive(Client, 'MESSAGE'),
+    {ok, Client1, Headers, [<<"pong">>]} =
+        stomp_receive(Client, 'MESSAGE'),
+    MessageId = maps:get(?HEADER_MESSAGE_ID, Headers),
+    rabbit_stomp_client:send(
+      Client1, 'ACK',
+      [{rabbit_stomp_util:ack_header_name(Version), MessageId}]),
+    {ok, Client2, ErrorHeaders, _} = stomp_receive(Client1, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
+    rabbit_stomp_client:send(
+      Client2, 'SEND', [{<<"destination">>, ?DESTINATION},
+                         {<<"receipt">>, <<"roundtrip">>}], ["still alive"]),
+    {ok, _Client3, _, _} = stomp_receive(Client2, 'RECEIPT'),
     ok.
 
 temp_destination_in_send(Config) ->
@@ -791,3 +1359,45 @@ stomp_receive(Client, Command) ->
                   body_iolist_rev = Body},   Client1} =
     rabbit_stomp_client:recv(Client),
     {ok, Client1, Hdrs, Body}.
+
+%% Receive the next RECEIPT and assert which frame it acknowledges: a COMMIT
+%% replays its queued frames through the request path, so several receipts can
+%% be in flight and the command alone does not identify them.
+stomp_receive_receipt(Client, ReceiptId) ->
+    {ok, Client1, Hdrs, _} = stomp_receive(Client, 'RECEIPT'),
+    ?assertEqual(ReceiptId, maps:get(<<"receipt-id">>, Hdrs)),
+    Client1.
+
+ack_value_with_consumer(ConsumerAckValue, DeliveryAckValue) ->
+    {ok, {ConsumerTag, _ConsumerSession, _ConsumerDeliveryTag}} =
+        rabbit_stomp_util:parse_message_id(ConsumerAckValue),
+    {ok, {_DeliveryConsumerTag, SessionId, DeliveryTag}} =
+        rabbit_stomp_util:parse_message_id(DeliveryAckValue),
+    iolist_to_binary(
+      [ConsumerTag, ?MESSAGE_ID_SEPARATOR, SessionId,
+       ?MESSAGE_ID_SEPARATOR, integer_to_list(DeliveryTag)]).
+
+await_queue_state(Config, Queue, Ready, Unacknowledged, Consumers) ->
+    await_queue_state(Config, Queue, Ready, Unacknowledged, Consumers, 5_000).
+
+await_queue_state(Config, Queue, Ready, Unacknowledged, Consumers, Timeout) ->
+    VHost = ?config(rmq_vhost, Config),
+    QName = rabbit_misc:r(VHost, queue, Queue),
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+              case rabbit_ct_broker_helpers:rpc(
+                     Config, 0, rabbit_amqqueue, lookup, [QName]) of
+                  {ok, Q} ->
+                      Info = rabbit_ct_broker_helpers:rpc(
+                               Config, 0, rabbit_amqqueue, info,
+                               [Q, [messages_ready,
+                                    messages_unacknowledged,
+                                    consumers]]),
+                      lists:sort(Info) =:=
+                          lists:sort([{messages_ready, Ready},
+                                      {messages_unacknowledged, Unacknowledged},
+                                      {consumers, Consumers}]);
+                  _ ->
+                      false
+              end
+      end, Timeout).

--- a/deps/rabbitmq_stomp/test/system_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/system_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 -include("rabbit_stomp.hrl").
 -include("rabbit_stomp_frame.hrl").
 -include("rabbit_stomp_headers.hrl").
@@ -20,6 +21,16 @@
 -define(QUEUE_QQ, <<"TestQueueQQ">>).
 -define(DESTINATION, <<"/amq/queue/TestQueue">>).
 -define(DESTINATION_QQ, <<"/amq/queue/TestQueueQQ">>).
+-define(AUTHZ_TOPIC, <<"TestUnsubscribeAuthzTopic">>).
+-define(AUTHZ_TOPIC_DESTINATION, <<"/topic/TestUnsubscribeAuthzTopic">>).
+-define(AUTHZ_SUBSCRIPTION_ID, <<"authz-subscription">>).
+%% Stands in for another connection's durable subscription queue: it matches
+%% the same configure pattern, so a configure check alone would not protect it.
+-define(AUTHZ_BYSTANDER_QUEUE, <<"stomp-subscription-bystander">>).
+-define(AUTHZ_USER, <<"stomp-authz-user">>).
+-define(AUTHZ_PASSWORD, <<"pass">>).
+%% Least privilege for a durable topic subscriber: its own subscription queues.
+-define(AUTHZ_CONFIGURE, <<"^stomp-subscription-.*">>).
 
 all() ->
     [{group, version_to_group_name(V)} || V <- ?SUPPORTED_VERSIONS].
@@ -46,8 +57,14 @@ groups() ->
         global_counters
     ],
 
-    [{version_to_group_name(V), [sequence], Tests}
-     || V <- ?SUPPORTED_VERSIONS].
+    %% Not a `sequence` group: one failing case must not auto_skip the other.
+    AuthzTests = [durable_unsubscribe_ignores_frame_queue_name,
+                  durable_unsubscribe_requires_configure_permission],
+
+    [{version_to_group_name(V), [sequence],
+      Tests ++ [{group, unsubscribe_authz}]}
+     || V <- ?SUPPORTED_VERSIONS] ++
+    [{unsubscribe_authz, [], AuthzTests}].
 
 version_to_group_name(V) ->
     list_to_atom(re:replace("version_" ++ V,
@@ -66,6 +83,8 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,
       rabbit_ct_broker_helpers:teardown_steps()).
 
+init_per_group(unsubscribe_authz, Config) ->
+    Config;
 init_per_group(Group, Config) ->
     Suffix = string:sub_string(atom_to_list(Group), 9),
     Version = re:replace(Suffix, "_", ".", [global, {return, list}]),
@@ -127,9 +146,48 @@ init_per_testcase0(TestCase, Config)
     StompPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
     {ok, ClientFoo} = rabbit_stomp_client:connect(Version, "stompuser", "pass", StompPort),
     rabbit_ct_helpers:set_config(Config, [{client_foo, ClientFoo}]);
+init_per_testcase0(TestCase, Config)
+  when TestCase =:= durable_unsubscribe_ignores_frame_queue_name;
+       TestCase =:= durable_unsubscribe_requires_configure_permission ->
+    Channel = ?config(amqp_channel, Config),
+    %% a queue this connection never subscribes to
+    #'queue.declare_ok'{} =
+        amqp_channel:call(Channel,
+                          #'queue.declare'{queue       = ?AUTHZ_BYSTANDER_QUEUE,
+                                           durable     = true,
+                                           auto_delete = false}),
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0, rabbit_auth_backend_internal, add_user,
+      [?AUTHZ_USER, ?AUTHZ_PASSWORD, <<"acting-user">>]),
+    ok = rabbit_ct_broker_helpers:set_permissions(
+           Config, ?AUTHZ_USER, ?config(rmq_vhost, Config),
+           ?AUTHZ_CONFIGURE, <<".*">>, <<".*">>),
+    Version = ?config(version, Config),
+    StompPort = rabbit_ct_broker_helpers:get_node_config(
+                  Config, 0, tcp_port_stomp),
+    {ok, AuthzClient} = rabbit_stomp_client:connect(
+                          Version,
+                          binary_to_list(?AUTHZ_USER),
+                          binary_to_list(?AUTHZ_PASSWORD),
+                          StompPort),
+    rabbit_ct_helpers:set_config(
+      Config, [{authz_client, AuthzClient},
+               {authz_sub_queue, authz_subscription_queue(Config)}]);
 init_per_testcase0(_, Config) ->
     Config.
 
+end_per_testcase0(TestCase, Config)
+  when TestCase =:= durable_unsubscribe_ignores_frame_queue_name;
+       TestCase =:= durable_unsubscribe_requires_configure_permission ->
+    AuthzClient = ?config(authz_client, Config),
+    catch rabbit_stomp_client:disconnect(AuthzClient),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, rabbit_auth_backend_internal, delete_user,
+           [?AUTHZ_USER, <<"acting-user">>]),
+    _ = [delete_queue_if_present(QRes, Config)
+         || QRes <- [authz_bystander_queue(Config),
+                     ?config(authz_sub_queue, Config)]],
+    Config;
 end_per_testcase0(publish_unauthorized_error, Config) ->
     ClientFoo = ?config(client_foo, Config),
     rabbit_stomp_client:disconnect(ClientFoo),
@@ -363,6 +421,96 @@ unsubscribe_ack(Config) ->
     ?assertEqual(<<"Subscription not found">>,
                  maps:get(<<"message">>, Hdrs2)),
     ok.
+
+%% A durable UNSUBSCRIBE must delete the queue this connection subscribed to,
+%% not the one x-queue-name names on the UNSUBSCRIBE frame.
+durable_unsubscribe_ignores_frame_queue_name(Config) ->
+    Client = ?config(authz_client, Config),
+    Bystander = authz_bystander_queue(Config),
+    SubQueue = ?config(authz_sub_queue, Config),
+    Client1 = authz_subscribe(Client),
+    ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
+    ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
+    %% the id alone resolves the subscription the delete targets
+    rabbit_stomp_client:send(
+      Client1, 'UNSUBSCRIBE',
+      [{<<"destination">>, ?AUTHZ_TOPIC_DESTINATION},
+       {<<"id">>, ?AUTHZ_SUBSCRIPTION_ID},
+       {<<"durable">>, <<"true">>},
+       {<<"x-queue-name">>, ?AUTHZ_BYSTANDER_QUEUE},
+       {<<"receipt">>, <<"rcpt2">>}]),
+    {Frame, _Client2} = rabbit_stomp_client:recv(Client1),
+    ?assertMatch(#stomp_frame{command = 'RECEIPT',
+                              headers = #{<<"receipt-id">> := <<"rcpt2">>}},
+                 Frame),
+    %% a misdirected delete would land before the RECEIPT, so check it first
+    ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
+    ?awaitMatch({error, not_found}, lookup_queue(SubQueue, Config), 30_000),
+    ok.
+
+%% Deleting the subscription's queue requires configure permission on it, so a
+%% permission revoked after the subscription was created must take effect.
+durable_unsubscribe_requires_configure_permission(Config) ->
+    Client = ?config(authz_client, Config),
+    Bystander = authz_bystander_queue(Config),
+    SubQueue = ?config(authz_sub_queue, Config),
+    Client1 = authz_subscribe(Client),
+    ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
+    ok = rabbit_ct_broker_helpers:set_permissions(
+           Config, ?AUTHZ_USER, ?config(rmq_vhost, Config),
+           <<"^$">>, <<".*">>, <<".*">>),
+    rabbit_stomp_client:send(
+      Client1, 'UNSUBSCRIBE',
+      [{<<"destination">>, ?AUTHZ_TOPIC_DESTINATION},
+       {<<"id">>, ?AUTHZ_SUBSCRIPTION_ID},
+       {<<"durable">>, <<"true">>},
+       {<<"x-queue-name">>, ?AUTHZ_BYSTANDER_QUEUE},
+       {<<"receipt">>, <<"rcpt2">>}]),
+    {Frame, _Client2} = rabbit_stomp_client:recv(Client1),
+    ?assertMatch(#stomp_frame{command = 'ERROR',
+                              headers = #{<<"message">> := <<"access_refused">>}},
+                 Frame),
+    ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
+    ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
+    ok.
+
+%% auto-delete:false, so the queue outlives its consumer.
+authz_subscribe(Client) ->
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE',
+      [{<<"destination">>, ?AUTHZ_TOPIC_DESTINATION},
+       {<<"durable">>, <<"true">>},
+       {<<"auto-delete">>, <<"false">>},
+       {<<"id">>, ?AUTHZ_SUBSCRIPTION_ID},
+       {<<"receipt">>, <<"rcpt1">>}]),
+    {ok, Client1, ReceiptHeaders, _} = stomp_receive(Client, 'RECEIPT'),
+    ?assertEqual(<<"rcpt1">>, maps:get(<<"receipt-id">>, ReceiptHeaders)),
+    Client1.
+
+%% The queue name SUBSCRIBE derives, computed the way the processor does.
+authz_subscription_queue(Config) ->
+    QNameBin = rabbit_ct_broker_helpers:rpc(
+                 Config, 0, rabbit_stomp_util, subscription_queue_name,
+                 [?AUTHZ_TOPIC, ?AUTHZ_SUBSCRIPTION_ID,
+                  #stomp_frame{headers = #{}}]),
+    rabbit_misc:r(?config(rmq_vhost, Config), queue, QNameBin).
+
+authz_bystander_queue(Config) ->
+    rabbit_misc:r(?config(rmq_vhost, Config), queue, ?AUTHZ_BYSTANDER_QUEUE).
+
+lookup_queue(QRes, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0, rabbit_amqqueue, lookup, [QRes]).
+
+delete_queue_if_present(QRes, Config) ->
+    case lookup_queue(QRes, Config) of
+        {ok, _} ->
+            rabbit_ct_broker_helpers:rpc(
+              Config, 0, rabbit_amqqueue, delete_with,
+              [QRes, false, false, <<"acting-user">>]);
+        _ ->
+            ok
+    end.
 
 subscribe_ack(Config) ->
     Channel = ?config(amqp_channel, Config),

--- a/deps/rabbitmq_stomp/test/system_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/system_SUITE.erl
@@ -75,7 +75,7 @@ groups() ->
         global_counters
     ],
 
-    %% Not a `sequence` group: one failing case must not auto_skip the other.
+    %% Even if one case fails, we want to run the other.
     AuthzTests = [durable_unsubscribe_ignores_frame_queue_name,
                   durable_unsubscribe_requires_configure_permission],
 
@@ -225,7 +225,6 @@ end_per_testcase0(TestCase, Config)
 end_per_testcase0(_, Config) ->
     Config.
 
-%% Remove test queues before the client and AMQP connection are closed.
 cleanup_per_testcase0(unsubscribe_ack, Config) ->
     delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
 cleanup_per_testcase0(unsubscribe_multiack_prune, Config) ->
@@ -526,7 +525,7 @@ unsubscribe_multiack_prune(Config) ->
                                {<<"receipt">>, <<"rcpt2">>}]),
     {ok, Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
 
-    %% A cumulative ACK of the first delivery leaves the second pending.
+    %% A multiple-at-once ack of the first delivery leaves the second one pending
     rabbit_stomp_client:send(Client4, 'ACK', [Ack1, {<<"receipt">>, <<"rcpt3">>}]),
     {ok, Client5, _, _} = stomp_receive(Client4, 'RECEIPT'),
     ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 1, 0),
@@ -595,7 +594,7 @@ unsubscribe_transaction_ack(Config) ->
     Client8 = stomp_receive_receipt(Client7, <<"rcpt7">>),
     rabbit_stomp_client:send(
       Client8, 'COMMIT', [{<<"transaction">>, <<"commit-me">>}, {<<"receipt">>, <<"rcpt8">>}]),
-    %% the queued ACK's receipt is sent again as the transaction replays it
+    %% the queued ack's receipt is sent again during a replay
     Client9 = stomp_receive_receipt(Client8, <<"rcpt7">>),
     _Client10 = stomp_receive_receipt(Client9, <<"rcpt8">>),
 
@@ -649,23 +648,21 @@ unsubscribe_transaction_multiack_prune(Config) ->
     Client7 = stomp_receive_receipt(Client6, <<"rcpt5">>),
     rabbit_stomp_client:send(
       Client7, 'COMMIT', [{<<"transaction">>, <<"tx">>}, {<<"receipt">>, <<"rcpt6">>}]),
-    %% the queued ACKs' receipts are sent again as the transaction replays
+    %% the queued ack receipts are sent again as the transaction replays
     %% them, in the order they were queued
     Client8 = stomp_receive_receipt(Client7, <<"rcpt4">>),
     Client9 = stomp_receive_receipt(Client8, <<"rcpt5">>),
     Client10 = stomp_receive_receipt(Client9, <<"rcpt6">>),
     ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 0, 0),
 
-    %% A broker round trip proves the duplicate settlement did not close the
-    %% shared AMQP channel after the COMMIT receipt was sent.
     rabbit_stomp_client:send(
       Client10, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
                               {<<"receipt">>, <<"rcpt7">>},
                               {<<"id">>, <<"roundtrip">>}]),
     Client11 = stomp_receive_receipt(Client10, <<"rcpt7">>),
 
-    %% A settlement is redundant only when an earlier action in the same
-    %% COMMIT removed it.
+    %% An ack op is redundant only when an earlier action in the same
+    %% commit removed it.
     rabbit_stomp_client:send(
       Client11, 'BEGIN', [{<<"transaction">>, <<"tx2">>},
                           {<<"receipt">>, <<"rcpt8">>}]),
@@ -757,18 +754,18 @@ unsubscribe_ack_stream(Config) ->
                                {<<"id">>, <<"subscription-id">>},
                                {<<"receipt">>, <<"rcpt2">>}]),
     {ok, Client3, _, _} = stomp_receive(Client2, 'RECEIPT'),
-    %% A stream ACK is accepted even though no reader remains to credit.
+    %% A stream ack is accepted even though the consumer is gone.
     rabbit_stomp_client:send(
       Client3, 'ACK', [AckHeader, {<<"receipt">>, <<"rcpt3">>}]),
     {ok, _Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
     ok.
 
-%% Cumulative ACK prunes across the whole connection, not just the
-%% subscription the acked delivery arrived on: pre-existing AMQP 0-9-1 channel
-%% semantics, and a deliberate deviation from STOMP 1.2, which scopes a
-%% cumulative ack:client to the same subscription. Pinned here so settlement
-%% changes cannot narrow it silently; doing so would be a breaking change.
+%% This multi-ack behavior is a known RabbitMQ deviation from the spec:
 %% https://stomp.github.io/stomp-specification-1.2.html#SUBSCRIBE_ack_Header
+%% introduced in `300dcee219`.
+%%
+%% It won't affect a significant majority of the users but these tests document the behavior for
+%% the core team's own understanding.
 multiack_prune_is_connection_wide(Config) ->
     Channel = ?config(amqp_channel, Config),
     Client = ?config(stomp_client, Config),
@@ -809,7 +806,6 @@ multiack_prune_is_connection_wide(Config) ->
     AckB = {AckHeader, maps:get(MessageHeader, HeadersB)},
     AckA = {AckHeader, maps:get(MessageHeader, HeadersA)},
 
-    %% Mirror the shared AMQP channel's settlement across consumers.
     rabbit_stomp_client:send(Client4, 'ACK', [AckA, {<<"receipt">>, <<"rcpt3">>}]),
     {ok, Client5, _, _} = stomp_receive(Client4, 'RECEIPT'),
     ok = await_queue_state(Config, ?MULTIACK_QUEUE_B, 0, 0, 1),
@@ -819,8 +815,9 @@ multiack_prune_is_connection_wide(Config) ->
                  maps:get(<<"message">>, ErrorHeaders)),
     ok.
 
-%% A durable UNSUBSCRIBE must delete the queue this connection subscribed to,
-%% not the one x-queue-name names on the UNSUBSCRIBE frame.
+%% An UNSUBSCRIBE frame of a topic subscription with a durable header set to `true`
+%% must delete the queue recorded on the subscription,
+%% not the one named in the frame's x-queue-name header.
 durable_unsubscribe_ignores_frame_queue_name(Config) ->
     Client = ?config(authz_client, Config),
     Bystander = authz_bystander_queue(Config),
@@ -828,7 +825,7 @@ durable_unsubscribe_ignores_frame_queue_name(Config) ->
     Client1 = authz_subscribe(Client),
     ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
     ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
-    %% the id alone resolves the subscription the delete targets
+    %% the ID alone identifies the subscription
     rabbit_stomp_client:send(
       Client1, 'UNSUBSCRIBE',
       [{<<"destination">>, ?AUTHZ_TOPIC_DESTINATION},
@@ -840,7 +837,7 @@ durable_unsubscribe_ignores_frame_queue_name(Config) ->
     ?assertMatch(#stomp_frame{command = 'RECEIPT',
                               headers = #{<<"receipt-id">> := <<"rcpt2">>}},
                  Frame),
-    %% a misdirected delete would land before the RECEIPT, so check it first
+
     ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
     ?awaitMatch({error, not_found}, lookup_queue(SubQueue, Config), 30_000),
     ok.

--- a/deps/rabbitmq_stomp/test/system_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/system_SUITE.erl
@@ -43,7 +43,8 @@
 -define(MULTIACK_DESTINATION_B, <<"/amq/queue/TestMultiAckQueueB">>).
 
 all() ->
-    [{group, version_to_group_name(V)} || V <- ?SUPPORTED_VERSIONS].
+    [{group, version_to_group_name(V)} || V <- ?SUPPORTED_VERSIONS] ++
+    [{group, unsubscribe_authz}].
 
 groups() ->
     Tests = [
@@ -60,7 +61,9 @@ groups() ->
         multiack_prune_is_connection_wide,
         unsubscribe_transaction_ack,
         unsubscribe_transaction_multiack_prune,
+        transaction_ack_then_nack_same_delivery,
         unsubscribe_nack_individual,
+        unsubscribe_nack_discard,
         unsubscribe_ack_stream,
         subscribe_ack,
         ack_auto_delivery_errors,
@@ -75,12 +78,10 @@ groups() ->
         global_counters
     ],
 
-    %% Even if one case fails, we want to run the other.
     AuthzTests = [durable_unsubscribe_ignores_frame_queue_name,
                   durable_unsubscribe_requires_configure_permission],
 
-    [{version_to_group_name(V), [sequence],
-      Tests ++ [{group, unsubscribe_authz}]}
+    [{version_to_group_name(V), [sequence], Tests}
      || V <- ?SUPPORTED_VERSIONS] ++
     [{unsubscribe_authz, [], AuthzTests}].
 
@@ -102,7 +103,8 @@ end_per_suite(Config) ->
       rabbit_ct_broker_helpers:teardown_steps()).
 
 init_per_group(unsubscribe_authz, Config) ->
-    Config;
+    rabbit_ct_helpers:set_config(
+      Config, [{version, lists:last(?SUPPORTED_VERSIONS)}]);
 init_per_group(Group, Config) ->
     Suffix = string:sub_string(atom_to_list(Group), 9),
     Version = re:replace(Suffix, "_", ".", [global, {return, list}]),
@@ -225,27 +227,10 @@ end_per_testcase0(TestCase, Config)
 end_per_testcase0(_, Config) ->
     Config.
 
-cleanup_per_testcase0(unsubscribe_ack, Config) ->
-    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
-cleanup_per_testcase0(unsubscribe_multiack_prune, Config) ->
-    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
-cleanup_per_testcase0(unsubscribe_transaction_ack, Config) ->
-    delete_test_queue(?UNSUBSCRIBE_QUEUE_QQ, Config);
-cleanup_per_testcase0(unsubscribe_transaction_multiack_prune, Config) ->
-    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
-cleanup_per_testcase0(unsubscribe_nack_individual, Config) ->
-    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
-cleanup_per_testcase0(unsubscribe_ack_stream, Config) ->
-    delete_test_queue(?UNSUBSCRIBE_STREAM, Config);
-cleanup_per_testcase0(multiack_prune_is_connection_wide, Config) ->
-    delete_test_queue(?MULTIACK_QUEUE_A, Config),
-    delete_test_queue(?MULTIACK_QUEUE_B, Config);
-cleanup_per_testcase0(reused_subscription_id_keeps_ack_mode, Config) ->
-    delete_test_queue(?MULTIACK_QUEUE_A, Config),
-    delete_test_queue(?MULTIACK_QUEUE_B, Config);
-cleanup_per_testcase0(delete_queue_subscribe, Config) ->
-    delete_test_queue(?UNSUBSCRIBE_QUEUE, Config);
 cleanup_per_testcase0(_, Config) ->
+    _ = [delete_test_queue(Q, Config)
+         || Q <- [?UNSUBSCRIBE_QUEUE, ?UNSUBSCRIBE_QUEUE_QQ, ?UNSUBSCRIBE_STREAM,
+                  ?MULTIACK_QUEUE_A, ?MULTIACK_QUEUE_B]],
     Config.
 
 delete_test_queue(Queue, Config) ->
@@ -594,9 +579,7 @@ unsubscribe_transaction_ack(Config) ->
     Client8 = stomp_receive_receipt(Client7, <<"rcpt7">>),
     rabbit_stomp_client:send(
       Client8, 'COMMIT', [{<<"transaction">>, <<"commit-me">>}, {<<"receipt">>, <<"rcpt8">>}]),
-    %% the queued ack's receipt is sent again during a replay
-    Client9 = stomp_receive_receipt(Client8, <<"rcpt7">>),
-    _Client10 = stomp_receive_receipt(Client9, <<"rcpt8">>),
+    _Client9 = stomp_receive_receipt(Client8, <<"rcpt8">>),
 
     ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE_QQ, 0, 0, 0, 30_000),
     ok.
@@ -648,34 +631,82 @@ unsubscribe_transaction_multiack_prune(Config) ->
     Client7 = stomp_receive_receipt(Client6, <<"rcpt5">>),
     rabbit_stomp_client:send(
       Client7, 'COMMIT', [{<<"transaction">>, <<"tx">>}, {<<"receipt">>, <<"rcpt6">>}]),
-    %% the queued ack receipts are sent again as the transaction replays
-    %% them, in the order they were queued
-    Client8 = stomp_receive_receipt(Client7, <<"rcpt4">>),
-    Client9 = stomp_receive_receipt(Client8, <<"rcpt5">>),
-    Client10 = stomp_receive_receipt(Client9, <<"rcpt6">>),
+    Client8 = stomp_receive_receipt(Client7, <<"rcpt6">>),
     ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 0, 0),
 
     rabbit_stomp_client:send(
-      Client10, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
-                              {<<"receipt">>, <<"rcpt7">>},
-                              {<<"id">>, <<"roundtrip">>}]),
-    Client11 = stomp_receive_receipt(Client10, <<"rcpt7">>),
+      Client8, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                             {<<"receipt">>, <<"rcpt7">>},
+                             {<<"id">>, <<"roundtrip">>}]),
+    Client9 = stomp_receive_receipt(Client8, <<"rcpt7">>),
 
     %% An ack op is redundant only when an earlier action in the same
     %% commit removed it.
     rabbit_stomp_client:send(
-      Client11, 'BEGIN', [{<<"transaction">>, <<"tx2">>},
-                          {<<"receipt">>, <<"rcpt8">>}]),
-    Client12 = stomp_receive_receipt(Client11, <<"rcpt8">>),
+      Client9, 'BEGIN', [{<<"transaction">>, <<"tx2">>},
+                         {<<"receipt">>, <<"rcpt8">>}]),
+    Client10 = stomp_receive_receipt(Client9, <<"rcpt8">>),
     rabbit_stomp_client:send(
-      Client12, 'ACK', [Ack1, {<<"transaction">>, <<"tx2">>},
+      Client10, 'ACK', [Ack1, {<<"transaction">>, <<"tx2">>},
                         {<<"receipt">>, <<"rcpt9">>}]),
-    Client13 = stomp_receive_receipt(Client12, <<"rcpt9">>),
+    Client11 = stomp_receive_receipt(Client10, <<"rcpt9">>),
     rabbit_stomp_client:send(
-      Client13, 'COMMIT', [{<<"transaction">>, <<"tx2">>}]),
-    {ok, _Client14, ErrorHeaders, _} = stomp_receive(Client13, 'ERROR'),
+      Client11, 'COMMIT', [{<<"transaction">>, <<"tx2">>}]),
+    {ok, _Client12, ErrorHeaders, _} = stomp_receive(Client11, 'ERROR'),
     ?assertEqual(<<"Message not found">>,
                  maps:get(<<"message">>, ErrorHeaders)),
+    ok.
+
+transaction_ack_then_nack_same_delivery(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?UNSUBSCRIBE_QUEUE,
+                                    durable = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client-individual">>},
+                            {<<"id">>, <<"subscription-id">>}]),
+    Client1 = stomp_receive_receipt(Client, <<"rcpt1">>),
+
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_QUEUE},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"hello">>}),
+    {ok, Client2, Headers, [<<"hello">>]} = stomp_receive(Client1, 'MESSAGE'),
+    AckHeader = {rabbit_stomp_util:ack_header_name(Version),
+                 maps:get(
+                   rabbit_stomp_util:msg_header_name(Version), Headers)},
+
+    rabbit_stomp_client:send(
+      Client2, 'BEGIN', [{<<"transaction">>, <<"tx">>},
+                         {<<"receipt">>, <<"rcpt2">>}]),
+    Client3 = stomp_receive_receipt(Client2, <<"rcpt2">>),
+    rabbit_stomp_client:send(
+      Client3, 'ACK', [AckHeader, {<<"transaction">>, <<"tx">>},
+                       {<<"receipt">>, <<"rcpt3">>}]),
+    Client4 = stomp_receive_receipt(Client3, <<"rcpt3">>),
+    rabbit_stomp_client:send(
+      Client4, 'NACK', [AckHeader, {<<"transaction">>, <<"tx">>},
+                        {<<"requeue">>, <<"true">>},
+                        {<<"receipt">>, <<"rcpt4">>}]),
+    Client5 = stomp_receive_receipt(Client4, <<"rcpt4">>),
+    rabbit_stomp_client:send(
+      Client5, 'COMMIT', [{<<"transaction">>, <<"tx">>}]),
+
+    %% The ACK settled the delivery, so the NACK has nothing left to reject.
+    {ok, Client6, ErrorHeaders, _} = stomp_receive(Client5, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 0, 1),
+
+    rabbit_stomp_client:send(
+      Client6, 'SEND', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                        {<<"receipt">>, <<"rcpt5">>}], ["roundtrip"]),
+    _Client7 = stomp_receive_receipt(Client6, <<"rcpt5">>),
     ok.
 
 unsubscribe_nack_individual(Config) ->
@@ -721,6 +752,44 @@ unsubscribe_nack_individual(Config) ->
                  maps:get(<<"message">>, ErrorHeaders)),
     ok.
 
+unsubscribe_nack_discard(Config) ->
+    Channel = ?config(amqp_channel, Config),
+    Client = ?config(stomp_client, Config),
+    Version = ?config(version, Config),
+    #'queue.declare_ok'{} =
+        amqp_channel:call(
+          Channel, #'queue.declare'{queue   = ?UNSUBSCRIBE_QUEUE,
+                                    durable = true}),
+    rabbit_stomp_client:send(
+      Client, 'SUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                            {<<"receipt">>, <<"rcpt1">>},
+                            {<<"ack">>, <<"client-individual">>},
+                            {<<"prefetch-count">>, <<"1">>},
+                            {<<"id">>, <<"subscription-id">>}]),
+    {ok, Client1, _, _} = stomp_receive(Client, 'RECEIPT'),
+
+    Method = #'basic.publish'{exchange = <<"">>,
+                              routing_key = ?UNSUBSCRIBE_QUEUE},
+    amqp_channel:call(Channel, Method, #amqp_msg{props = #'P_basic'{},
+                                                 payload = <<"hello">>}),
+    {ok, Client2, Headers, [<<"hello">>]} = stomp_receive(Client1, 'MESSAGE'),
+    NackHeader = {rabbit_stomp_util:ack_header_name(Version),
+                  maps:get(
+                    rabbit_stomp_util:msg_header_name(Version), Headers)},
+
+    rabbit_stomp_client:send(
+      Client2, 'UNSUBSCRIBE', [{<<"destination">>, ?UNSUBSCRIBE_DESTINATION},
+                               {<<"id">>, <<"subscription-id">>},
+                               {<<"receipt">>, <<"rcpt2">>}]),
+    {ok, Client3, _, _} = stomp_receive(Client2, 'RECEIPT'),
+    rabbit_stomp_client:send(
+      Client3, 'NACK', [NackHeader,
+                        {<<"requeue">>, <<"false">>},
+                        {<<"receipt">>, <<"rcpt3">>}]),
+    {ok, _Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+    ok = await_queue_state(Config, ?UNSUBSCRIBE_QUEUE, 0, 0, 0),
+    ok.
+
 unsubscribe_ack_stream(Config) ->
     Channel = ?config(amqp_channel, Config),
     Client = ?config(stomp_client, Config),
@@ -757,7 +826,11 @@ unsubscribe_ack_stream(Config) ->
     %% A stream ack is accepted even though the consumer is gone.
     rabbit_stomp_client:send(
       Client3, 'ACK', [AckHeader, {<<"receipt">>, <<"rcpt3">>}]),
-    {ok, _Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+    {ok, Client4, _, _} = stomp_receive(Client3, 'RECEIPT'),
+    rabbit_stomp_client:send(Client4, 'ACK', [AckHeader]),
+    {ok, _Client5, ErrorHeaders, _} = stomp_receive(Client4, 'ERROR'),
+    ?assertEqual(<<"Message not found">>,
+                 maps:get(<<"message">>, ErrorHeaders)),
     ok.
 
 %% This multi-ack behavior is a known RabbitMQ deviation from the spec:
@@ -1357,9 +1430,6 @@ stomp_receive(Client, Command) ->
     rabbit_stomp_client:recv(Client),
     {ok, Client1, Hdrs, Body}.
 
-%% Receive the next RECEIPT and assert which frame it acknowledges: a COMMIT
-%% replays its queued frames through the request path, so several receipts can
-%% be in flight and the command alone does not identify them.
 stomp_receive_receipt(Client, ReceiptId) ->
     {ok, Client1, Hdrs, _} = stomp_receive(Client, 'RECEIPT'),
     ?assertEqual(ReceiptId, maps:get(<<"receipt-id">>, Hdrs)),

--- a/deps/rabbitmq_stomp/test/unit_ack_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/unit_ack_SUITE.erl
@@ -1,0 +1,110 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(unit_ack_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    [
+     individual_ack_keeps_older_deliveries,
+     individual_ack_preserves_order,
+     multi_ack_prunes_older_deliveries,
+     multi_ack_prunes_across_subscriptions,
+     other_subscription_delivery_tag_is_not_found,
+     unknown_delivery_tag_is_not_found,
+     empty_queue_is_not_found,
+     settlement_outside_a_transaction_is_not_found,
+     multi_ack_pruned_delivery_is_absorbed,
+     named_delivery_is_not_absorbed,
+     individual_ack_records_nothing
+    ].
+
+individual_ack_keeps_older_deliveries(_Config) ->
+    [PA1, PA2] = Ds = [pa(<<"ctag">>, 1, false), pa(<<"ctag">>, 2, false)],
+    {Acked, Remaining} = collect(Ds, <<"ctag">>, 2),
+    ?assertEqual([PA2], Acked),
+    ?assertEqual([PA1], lqueue:to_list(Remaining)).
+
+individual_ack_preserves_order(_Config) ->
+    [PA1, PA2, PA3, PA4] = Ds = [pa(<<"ctag">>, N, false) || N <- [1, 2, 3, 4]],
+    {Acked, Remaining} = collect(Ds, <<"ctag">>, 3),
+    ?assertEqual([PA3], Acked),
+    ?assertEqual([PA1, PA2, PA4], lqueue:to_list(Remaining)).
+
+multi_ack_prunes_older_deliveries(_Config) ->
+    [PA1, PA2, PA3] = Ds = [pa(<<"ctag">>, N, true) || N <- [1, 2, 3]],
+    {Acked, Remaining} = collect(Ds, <<"ctag">>, 2),
+    ?assertEqual([PA2, PA1], Acked),
+    ?assertEqual([PA3], lqueue:to_list(Remaining)).
+
+multi_ack_prunes_across_subscriptions(_Config) ->
+    [PA1, PA2] = Ds = [pa(<<"other">>, 1, false), pa(<<"ctag">>, 2, true)],
+    {Acked, Remaining} = collect(Ds, <<"ctag">>, 2),
+    ?assertEqual([PA2, PA1], Acked),
+    ?assertEqual([], lqueue:to_list(Remaining)).
+
+other_subscription_delivery_tag_is_not_found(_Config) ->
+    ?assertEqual({error, not_found},
+                 collect([pa(<<"other">>, 1, false)], <<"ctag">>, 1)).
+
+unknown_delivery_tag_is_not_found(_Config) ->
+    ?assertEqual({error, not_found},
+                 collect([pa(<<"ctag">>, 1, false)], <<"ctag">>, 7)).
+
+empty_queue_is_not_found(_Config) ->
+    ?assertEqual({error, not_found}, collect([], <<"ctag">>, 1)).
+
+settlement_outside_a_transaction_is_not_found(_Config) ->
+    erase(tx_settled_delivery_tags),
+    ?assertMatch({error, "Message not found", _, state},
+                 settle_again({<<"ctag">>, 1})).
+
+multi_ack_pruned_delivery_is_absorbed(_Config) ->
+    in_transaction(
+      fun() ->
+              record([pa(<<"ctag">>, 2, true), pa(<<"ctag">>, 1, true)]),
+              ?assertEqual(state, settle_again({<<"ctag">>, 1}))
+      end).
+
+named_delivery_is_not_absorbed(_Config) ->
+    in_transaction(
+      fun() ->
+              record([pa(<<"ctag">>, 2, true), pa(<<"ctag">>, 1, true)]),
+              ?assertMatch({error, "Message not found", _, state},
+                           settle_again({<<"ctag">>, 2}))
+      end).
+
+individual_ack_records_nothing(_Config) ->
+    in_transaction(
+      fun() ->
+              record([pa(<<"ctag">>, 1, false)]),
+              ?assertMatch({error, "Message not found", _, state},
+                           settle_again({<<"ctag">>, 1}))
+      end).
+
+in_transaction(Fun) ->
+    put(tx_settled_delivery_tags, sets:new([{version, 2}])),
+    try Fun()
+    after
+        erase(tx_settled_delivery_tags)
+    end.
+
+record(Acked) ->
+    rabbit_stomp_processor:record_transaction_settlements(Acked).
+
+settle_again(Ack) ->
+    rabbit_stomp_processor:unknown_delivery_tag(Ack, state).
+
+collect(Deliveries, ConsumerTag, DeliveryTag) ->
+    rabbit_stomp_processor:collect_acks(
+      lqueue:from_list(Deliveries), ConsumerTag, DeliveryTag).
+
+pa(ConsumerTag, DeliveryTag, MultiAck) ->
+    rabbit_stomp_processor:pending_ack(ConsumerTag, DeliveryTag, MultiAck).

--- a/deps/rabbitmq_web_stomp/test/unsubscribe_authz_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/unsubscribe_authz_SUITE.erl
@@ -2,12 +2,14 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
 
 %% The durable UNSUBSCRIBE cleanup lives in rabbit_stomp_processor, which this
 %% plugin drives directly: the same authorization must hold over a WebSocket.
 -module(unsubscribe_authz_SUITE).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -121,9 +123,7 @@ durable_unsubscribe_requires_configure_permission(Config) ->
                  proplists:get_value(<<"message">>, ErrorHeaders)),
     ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
     ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
-    %% the receipt for the refused frame still follows the ERROR, because
-    %% process_request/3 runs the success continuation on the stop path
-    {<<"RECEIPT">>, _, <<>>} = raw_recv(WS),
+    %% no RECEIPT for the refused frame: the close follows the ERROR directly
     {close, _} = raw_recv(WS),
     ok.
 

--- a/deps/rabbitmq_web_stomp/test/unsubscribe_authz_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/unsubscribe_authz_SUITE.erl
@@ -1,0 +1,180 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+
+%% The durable UNSUBSCRIBE cleanup lives in rabbit_stomp_processor, which this
+%% plugin drives directly: the same authorization must hold over a WebSocket.
+-module(unsubscribe_authz_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+
+-define(TOPIC_DESTINATION, "/topic/WsUnsubscribeAuthzTopic").
+-define(SUBSCRIPTION_ID, "ws-authz-sub").
+-define(SUB_QUEUE, <<"stomp-subscription-ws-sub">>).
+%% Stands in for another connection's durable subscription queue: it matches
+%% the same configure pattern, so a configure check alone would not protect it.
+-define(BYSTANDER_QUEUE, <<"stomp-subscription-ws-bystander">>).
+-define(USER, <<"ws-authz-user">>).
+-define(PASSWORD, <<"pass">>).
+%% Least privilege for a durable topic subscriber: its own subscription queues.
+-define(CONFIGURE, <<"^stomp-subscription-.*">>).
+
+all() ->
+    [
+     durable_unsubscribe_ignores_frame_queue_name,
+     durable_unsubscribe_requires_configure_permission
+    ].
+
+init_per_suite(Config) ->
+    Config1 = rabbit_ct_helpers:set_config(Config,
+                                           [{rmq_nodename_suffix, ?MODULE},
+                                            {protocol, "ws"}]),
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config,
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
+    {ok, Connection} = amqp_connection:start(#amqp_params_direct{
+        node = rabbit_ct_broker_helpers:get_node_config(Config1, 0, nodename)
+    }),
+    {ok, Channel} = amqp_connection:open_channel(Connection),
+    %% a queue this connection never subscribes to
+    #'queue.declare_ok'{} =
+        amqp_channel:call(Channel,
+                          #'queue.declare'{queue       = ?BYSTANDER_QUEUE,
+                                           durable     = true,
+                                           auto_delete = false}),
+    rabbit_ct_broker_helpers:add_user(Config1, ?USER, ?PASSWORD),
+    ok = rabbit_ct_broker_helpers:set_permissions(
+           Config1, ?USER, ?config(rmq_vhost, Config1),
+           ?CONFIGURE, <<".*">>, <<".*">>),
+    rabbit_ct_helpers:set_config(Config1, [
+        {amqp_connection, Connection},
+        {amqp_channel, Channel}
+    ]).
+
+end_per_testcase(Testcase, Config) ->
+    Connection = ?config(amqp_connection, Config),
+    Channel = ?config(amqp_channel, Config),
+    amqp_channel:close(Channel),
+    amqp_connection:close(Connection),
+    ok = rabbit_ct_broker_helpers:delete_user(Config, ?USER),
+    _ = [delete_queue_if_present(QRes, Config)
+         || QRes <- [queue_resource(?BYSTANDER_QUEUE, Config),
+                     queue_resource(?SUB_QUEUE, Config)]],
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% A durable UNSUBSCRIBE must delete the queue this connection subscribed to,
+%% not the one x-queue-name names on the UNSUBSCRIBE frame.
+durable_unsubscribe_ignores_frame_queue_name(Config) ->
+    Bystander = queue_resource(?BYSTANDER_QUEUE, Config),
+    SubQueue = queue_resource(?SUB_QUEUE, Config),
+    WS = authz_subscribe(Config),
+    ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
+    ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
+    %% the id alone resolves the subscription the delete targets
+    ok = raw_send(WS, "UNSUBSCRIBE",
+                  [{"destination", ?TOPIC_DESTINATION},
+                   {"id", ?SUBSCRIPTION_ID},
+                   {"durable", "true"},
+                   {"x-queue-name", ?BYSTANDER_QUEUE},
+                   {"receipt", "rcpt2"}]),
+    {<<"RECEIPT">>, ReceiptHeaders, <<>>} = raw_recv(WS),
+    ?assertEqual(<<"rcpt2">>,
+                 proplists:get_value(<<"receipt-id">>, ReceiptHeaders)),
+    %% a misdirected delete would land before the RECEIPT, so check it first
+    ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
+    ?awaitMatch({error, not_found}, lookup_queue(SubQueue, Config), 30_000),
+    {close, _} = rfc6455_client:close(WS),
+    ok.
+
+%% Deleting the subscription's queue requires configure permission on it, so a
+%% permission revoked after the subscription was created must take effect.
+durable_unsubscribe_requires_configure_permission(Config) ->
+    Bystander = queue_resource(?BYSTANDER_QUEUE, Config),
+    SubQueue = queue_resource(?SUB_QUEUE, Config),
+    WS = authz_subscribe(Config),
+    ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
+    ok = rabbit_ct_broker_helpers:set_permissions(
+           Config, ?USER, ?config(rmq_vhost, Config),
+           <<"^$">>, <<".*">>, <<".*">>),
+    ok = raw_send(WS, "UNSUBSCRIBE",
+                  [{"destination", ?TOPIC_DESTINATION},
+                   {"id", ?SUBSCRIPTION_ID},
+                   {"durable", "true"},
+                   {"x-queue-name", ?BYSTANDER_QUEUE},
+                   {"receipt", "rcpt2"}]),
+    {<<"ERROR">>, ErrorHeaders, _} = raw_recv(WS),
+    ?assertEqual(<<"access_refused">>,
+                 proplists:get_value(<<"message">>, ErrorHeaders)),
+    ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
+    ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
+    %% the receipt for the refused frame still follows the ERROR, because
+    %% process_request/3 runs the success continuation on the stop path
+    {<<"RECEIPT">>, _, <<>>} = raw_recv(WS),
+    {close, _} = raw_recv(WS),
+    ok.
+
+%% auto-delete:false, so the queue outlives its consumer. x-queue-name is
+%% legitimate here: on SUBSCRIBE it is checked against configure permission.
+authz_subscribe(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Protocol = ?config(protocol, Config),
+    WS = rfc6455_client:new(
+           Protocol ++ "://127.0.0.1:" ++ PortStr ++ "/ws", self()),
+    {ok, _} = rfc6455_client:open(WS),
+    ok = raw_send(WS, "CONNECT", [{"login", ?USER},
+                                  {"passcode", ?PASSWORD}]),
+    {<<"CONNECTED">>, _, <<>>} = raw_recv(WS),
+    ok = raw_send(WS, "SUBSCRIBE",
+                  [{"destination", ?TOPIC_DESTINATION},
+                   {"id", ?SUBSCRIPTION_ID},
+                   {"durable", "true"},
+                   {"auto-delete", "false"},
+                   {"x-queue-name", ?SUB_QUEUE},
+                   {"receipt", "rcpt1"}]),
+    {<<"RECEIPT">>, ReceiptHeaders, <<>>} = raw_recv(WS),
+    ?assertEqual(<<"rcpt1">>,
+                 proplists:get_value(<<"receipt-id">>, ReceiptHeaders)),
+    WS.
+
+queue_resource(QNameBin, Config) ->
+    rabbit_misc:r(?config(rmq_vhost, Config), queue, QNameBin).
+
+lookup_queue(QRes, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0, rabbit_amqqueue, lookup, [QRes]).
+
+delete_queue_if_present(QRes, Config) ->
+    case lookup_queue(QRes, Config) of
+        {ok, _} ->
+            rabbit_ct_broker_helpers:rpc(
+              Config, 0, rabbit_amqqueue, delete_with,
+              [QRes, false, false, <<"acting-user">>]);
+        _ ->
+            ok
+    end.
+
+raw_send(WS, Command, Headers) ->
+    raw_send(WS, Command, Headers, <<>>).
+
+raw_send(WS, Command, Headers, Body) ->
+    Frame = stomp:marshal(Command, Headers, Body),
+    rfc6455_client:send(WS, Frame).
+
+raw_recv(WS) ->
+    case rfc6455_client:recv(WS) of
+        {ok, P} -> stomp:unmarshal(P);
+        Other   -> Other
+    end.

--- a/deps/rabbitmq_web_stomp/test/unsubscribe_authz_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/unsubscribe_authz_SUITE.erl
@@ -75,15 +75,16 @@ end_per_testcase(Testcase, Config) ->
                      queue_resource(?SUB_QUEUE, Config)]],
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
-%% A durable UNSUBSCRIBE must delete the queue this connection subscribed to,
-%% not the one x-queue-name names on the UNSUBSCRIBE frame.
+%% An UNSUBSCRIBE frame of a topic subscription with a durable header set to `true`
+%% must delete the queue recorded on the subscription,
+%% not the one named in the frame's x-queue-name header.
 durable_unsubscribe_ignores_frame_queue_name(Config) ->
     Bystander = queue_resource(?BYSTANDER_QUEUE, Config),
     SubQueue = queue_resource(?SUB_QUEUE, Config),
     WS = authz_subscribe(Config),
     ?assertMatch({ok, _}, lookup_queue(SubQueue, Config)),
     ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
-    %% the id alone resolves the subscription the delete targets
+    %% the ID alone identifies the subscription
     ok = raw_send(WS, "UNSUBSCRIBE",
                   [{"destination", ?TOPIC_DESTINATION},
                    {"id", ?SUBSCRIPTION_ID},
@@ -93,7 +94,7 @@ durable_unsubscribe_ignores_frame_queue_name(Config) ->
     {<<"RECEIPT">>, ReceiptHeaders, <<>>} = raw_recv(WS),
     ?assertEqual(<<"rcpt2">>,
                  proplists:get_value(<<"receipt-id">>, ReceiptHeaders)),
-    %% a misdirected delete would land before the RECEIPT, so check it first
+
     ?assertMatch({ok, _}, lookup_queue(Bystander, Config)),
     ?awaitMatch({error, not_found}, lookup_queue(SubQueue, Config), 30_000),
     {close, _} = rfc6455_client:close(WS),


### PR DESCRIPTION
This is #17202 by @brianr2600 with some minor changes from me plus a rebase.

See #17162 for background.

Since STOMP in `main` and `v4.3.x` are architecturally different, this PR must not be backported. For `4.3`, we'd need a separate implementation.