### PR TITLE
Local shovel with `src-delete-after`: a minor correctness fix

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
@@ -539,12 +539,6 @@ ack(DeliveryTag, Multiple, State) ->
 nack(DeliveryTag, Multiple, State) ->
     maybe_grant_credit(settle(requeue, DeliveryTag, Multiple, State)).
 
-forward(_, _, #{source := #{remaining_unacked := 0}} = State) ->
-    %% We are in on-confirm mode, and are autodelete. We have
-    %% published all the messages we need to; we just wait for acks to
-    %% come back. So drop subsequent messages on the floor to be
-    %% requeued later
-    State;
 forward(Tag, Msg, State) ->
     case is_blocked(State) of
         true ->
@@ -554,6 +548,12 @@ forward(Tag, Msg, State) ->
             do_forward(Tag, Msg, State)
     end.
 
+do_forward(_, _, #{source := #{remaining_unacked := 0}} = State) ->
+    %% We are in on-confirm mode, and are autodelete. We have
+    %% published all the messages we need to; we just wait for acks to
+    %% come back. So drop subsequent messages on the floor to be
+    %% requeued later
+    State;
 do_forward(Tag, Msg0, #{dest := #{current := #{queue_states := QState} = Current} = Dest,
                      ack_mode := AckMode} = State0) ->
     {Options, #{dest := #{current := Current1} = Dest1} = State} =


### PR DESCRIPTION
Which a test reproduced some of the time, so the investigation has started as a flake one but it turns out to be
a minor bug that affected only shovels with `src-delete-after` set: in some cases it could transfer more messages than N.
