### PR TITLE
Support customize_hostname_check in AMQP URI query parameters

### DIFF
--- a/deps/amqp_client/src/amqp_uri.erl
+++ b/deps/amqp_client/src/amqp_uri.erl
@@ -63,7 +63,8 @@ remove_credentials(URI) ->
 %% frame_max, heartbeat and auth_mechanism (the latter can appear more
 %% than once).  The extra parameters that may be specified for an SSL
 %% connection are cacertfile, certfile, keyfile, verify,
-%% fail_if_no_peer_cert, password, and depth.
+%% fail_if_no_peer_cert, password, depth, server_name_indication,
+%% and customize_hostname_check.
 -type parse_result() :: {ok, #amqp_params_network{}} |
                         {ok, #amqp_params_direct{}} |
                         {error, {any(), string()}}.
@@ -189,7 +190,9 @@ build_ssl_broker(ParsedUri, DefaultVHost) ->
                        {fun find_boolean_parameter/1, fail_if_no_peer_cert},
                        {fun find_identity_parameter/1, password},
                        {fun find_sni_parameter/1, server_name_indication},
-                       {fun find_integer_parameter/1, depth}]],
+                       {fun find_integer_parameter/1, depth},
+                       {fun find_customize_hostname_check_parameter/1,
+                        customize_hostname_check}]],
           []),
     Params1 = Params0#amqp_params_network{ssl_options = SSLOptions},
     amqp_ssl:maybe_enhance_ssl_options(Params1).
@@ -248,6 +251,13 @@ find_sni_parameter("disable") ->
     disable;
 find_sni_parameter(Value) ->
     find_identity_parameter(Value).
+
+%% The value is a fun and cannot be expressed in a URI, so only the
+%% OTP-provided HTTPS match fun is exposed.
+find_customize_hostname_check_parameter("https") ->
+    return([{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]);
+find_customize_hostname_check_parameter(Value) ->
+    fail({unsupported_customize_hostname_check, Value}).
 
 find_identity_parameter(Value) -> return(Value).
 

--- a/deps/amqp_client/test/unit_SUITE.erl
+++ b/deps/amqp_client/test/unit_SUITE.erl
@@ -191,6 +191,18 @@ amqp_uri_parsing(_Config) ->
              {verify, verify_none}],
     ?assertEqual(lists:usort(Exp10), lists:usort(TLSOpts10)),
 
+    {ok, #amqp_params_network{host = "host11", ssl_options = TLSOpts11}} =
+        amqp_uri:parse("amqps://host11/%2f?cacertfile=/path/to/cacertfile.pem"
+                       "&verify=verify_peer"
+                       "&customize_hostname_check=https"),
+    ?assertEqual({cacertfile, "/path/to/cacertfile.pem"},
+                 lists:keyfind(cacertfile, 1, TLSOpts11)),
+    ?assertEqual({verify, verify_peer}, lists:keyfind(verify, 1, TLSOpts11)),
+    {customize_hostname_check, HostnameCheckOpts11} =
+        lists:keyfind(customize_hostname_check, 1, TLSOpts11),
+    {match_fun, MatchFun11} = lists:keyfind(match_fun, 1, HostnameCheckOpts11),
+    ?assert(is_function(MatchFun11, 2)),
+
     %% Various failure cases
     ?assertMatch({error, _}, amqp_uri:parse("https://www.rabbitmq.com")),
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo:bar:baz")),
@@ -204,6 +216,10 @@ amqp_uri_parsing(_Config) ->
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo%1")),
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo%1x")),
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo%xy")),
+
+    ?assertMatch({error, _},
+                 amqp_uri:parse(
+                   "amqps://host/%2f?customize_hostname_check=bogus")),
 
     ok.
 


### PR DESCRIPTION
## Proposed Changes

This PR adds support for specifying `customize_hostname_check` query parameter in AMQP URI strings, by extending  `amqp_uri:parse/{1,2}`. Setting this parameter to `https` with `&customize_hostname_check=https` will configure the TLS option `match_fun` to `public_key:pkix_verify_hostname_match_fun(https)` (which cannot be directly specified as part of the AMQP URI string), allowing wildcard certificates to be matched using the same hostname rules as HTTPS clients. 
Ref: [https://www.erlang.org/doc/apps/ssl/ssl.html#t:client_option_cert/0](https://www.erlang.org/doc/apps/ssl/ssl.html#t:client_option_cert/0:~:text=%7B-,customize_hostname_check,-%2C%20%5B%7B)

Without this, a client connecting to a server presenting a valid wildcard certificate (e.g. `*.example.com`) fails hostname verification during the TLS handshake, since the default match function doesn't apply wildcard rules, as follows:

```
2026-08-10 20:38:22.770920+00:00 [error] <0.3977248.0> Shovel 'xxxxxxxxx' failed to connect (URI: amqps://xxxxxxxxx): {tls_alert,{handshake_failure,"TLS client: In state certify at ssl_handshake.erl:2140 generated CLIENT ALERT: Fatal - Handshake Failure\n {bad_cert,hostname_check_failed}"}}
```

Also fixes the doc for `parse` by adding the missing SSL query parameter `server_name_indication`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
