### PR TITLE
Extend quorum queue membership reconciliation to periodically retry failed QQ force deletions

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2729,6 +2729,10 @@ end}.
     {datatype, {integer, non_negative}}
 ]}.
 
+{mapping, "quorum_queue.force_delete_retry_interval", "rabbit.quorum_queue_force_delete_retry_interval", [
+    {datatype, {integer, non_negative}}
+]}.
+
 
 %%
 %% Runtime parameters

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2730,7 +2730,7 @@ end}.
 ]}.
 
 {mapping, "quorum_queue.force_delete_retry_interval", "rabbit.quorum_queue_force_delete_retry_interval", [
-    {datatype, {integer, non_negative}}
+    {datatype, {integer, positive}}
 ]}.
 
 

--- a/deps/rabbit/src/rabbit_quorum_event_subscriber.erl
+++ b/deps/rabbit/src/rabbit_quorum_event_subscriber.erl
@@ -53,7 +53,7 @@ handle_event(#event{type = queue_force_deleted, props = Props}, State) ->
         [{{rabbit_misc:pget(ra_name, M), rabbit_misc:pget(node, M)},
           rabbit_misc:pget(uid, M)}
          || M <- rabbit_misc:pget(pending_members, Props, [])],
-    rabbit_quorum_queue_periodic_membership_reconciliation:schedule(QName, PendingMembers),
+    rabbit_quorum_queue_periodic_membership_reconciliation:schedule_force_delete(QName, PendingMembers),
     {ok, State};
 handle_event(_, State) ->
     {ok, State}.

--- a/deps/rabbit/src/rabbit_quorum_event_subscriber.erl
+++ b/deps/rabbit/src/rabbit_quorum_event_subscriber.erl
@@ -47,6 +47,14 @@ handle_event(#event{type = policy_set}, State) ->
 handle_event(#event{type = operator_policy_set}, State) ->
     rabbit_quorum_queue_periodic_membership_reconciliation:policy_set(),
     {ok, State};
+handle_event(#event{type = queue_force_deleted, props = Props}, State) ->
+    QName = rabbit_misc:pget(name, Props),
+    PendingMembers =
+        [{{rabbit_misc:pget(ra_name, M), rabbit_misc:pget(node, M)},
+          rabbit_misc:pget(uid, M)}
+         || M <- rabbit_misc:pget(pending_members, Props, [])],
+    rabbit_quorum_queue_periodic_membership_reconciliation:schedule(QName, PendingMembers),
+    {ok, State};
 handle_event(_, State) ->
     {ok, State}.
 

--- a/deps/rabbit/src/rabbit_quorum_event_subscriber.erl
+++ b/deps/rabbit/src/rabbit_quorum_event_subscriber.erl
@@ -47,14 +47,6 @@ handle_event(#event{type = policy_set}, State) ->
 handle_event(#event{type = operator_policy_set}, State) ->
     rabbit_quorum_queue_periodic_membership_reconciliation:policy_set(),
     {ok, State};
-handle_event(#event{type = queue_force_deleted, props = Props}, State) ->
-    QName = rabbit_misc:pget(name, Props),
-    PendingMembers =
-        [{{rabbit_misc:pget(ra_name, M), rabbit_misc:pget(node, M)},
-          rabbit_misc:pget(uid, M)}
-         || M <- rabbit_misc:pget(pending_members, Props, [])],
-    rabbit_quorum_queue_periodic_membership_reconciliation:schedule_force_delete(QName, PendingMembers),
-    {ok, State};
 handle_event(_, State) ->
     {ok, State}.
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -176,10 +176,14 @@
 -define(START_CLUSTER_RPC_TIMEOUT, 60_000). %% needs to be longer than START_CLUSTER_TIMEOUT
 -define(TICK_INTERVAL, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
--define(FORCE_DELETE_TIMEOUT, 30_000).
+%% Applied per member, and members are force deleted one at a time, so this
+%% bounds a fraction of the total and not the whole operation.
+-define(FORCE_DELETE_TIMEOUT, ?DELETE_TIMEOUT).
 %% Bounds the call that carries out the UID check and the force delete on the
 %% member's node, so it has to outlive the force delete it wraps.
--define(FORCE_DELETE_RPC_TIMEOUT, ?FORCE_DELETE_TIMEOUT + 5_000).
+%% `ra:force_delete_server/3' spends the timeout twice, once to stop the member
+%% and once to delete its data, hence the multiplier.
+-define(FORCE_DELETE_RPC_TIMEOUT, (2 * ?FORCE_DELETE_TIMEOUT) + 5_000).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 %% setting a low default here to allow quorum queues to better chose themselves

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -47,6 +47,7 @@
          add_member/4,
          add_member/5]).
 -export([delete_member/3, delete_member/2]).
+-export([force_delete_member/1]).
 -export([policy_changed/1]).
 -export([format_ra_event/3]).
 -export([cleanup_data_dir/0]).
@@ -174,6 +175,7 @@
 -define(START_CLUSTER_RPC_TIMEOUT, 60_000). %% needs to be longer than START_CLUSTER_TIMEOUT
 -define(TICK_INTERVAL, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
+-define(FORCE_DELETE_TIMEOUT, 30_000).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 %% setting a low default here to allow quorum queues to better chose themselves
@@ -1129,11 +1131,11 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
                 {'DOWN', MRef, process, _, _} ->
                     %% leader is down,
                     %% force delete remaining members
-                    ok = force_delete_queue(lists:delete(Leader, Servers)),
+                    ok = force_delete_queue(Q, lists:delete(Leader, Servers)),
                     ok
             after Timeout ->
                     erlang:demonitor(MRef, [flush]),
-                    ok = force_delete_queue(Servers)
+                    ok = force_delete_queue(Q, Servers)
             end,
             notify_decorators(QName, shutdown),
             case delete_queue_data(Q, ActingUser) of
@@ -1172,7 +1174,7 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
                        " online to reach a quorum: ~255p."
                        " Attempting force delete.",
                       [rabbit_misc:rs(QName), Errs]),
-                    ok = force_delete_queue(Servers),
+                    ok = force_delete_queue(Q, Servers),
                     notify_decorators(QName, shutdown)
             end,
             case delete_queue_data(Q, ActingUser) of
@@ -1183,21 +1185,82 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
             end
     end.
 
-force_delete_queue(Servers) ->
-    [begin
-         case try ra:force_delete_server(?RA_SYSTEM, S)
-              catch _:E -> {error, E}
-              end of
-             ok -> ok;
+%% Force delete of every member. `ra:force_delete_server/3' is an RPC to each
+%% member's node, so a member on a down or unreachable node is left behind and
+%% the Ra name stays poisoned for the next declare.
+%%
+%% Retrying those leaked members requires the per-member UIDs recorded under the
+%% `track_qq_members_uids' feature flag: without them a retry cannot tell a
+%% leaked member apart from a newer incarnation of the same queue name, so the
+%% force delete stays best-effort until the flag is enabled.
+force_delete_queue(Q, Servers) ->
+    case rabbit_feature_flags:is_enabled(track_qq_members_uids) of
+        true ->
+            force_delete_members_with_retry(Q, Servers);
+        false ->
+            force_delete_members(Servers)
+    end.
+
+force_delete_members(Servers) ->
+    _ = [case force_delete_member(S) of
+             ok ->
+                 ok;
              Err ->
                  ?LOG_WARNING(
                    "Force delete of ~w failed with: ~w"
                    "This may require manual data clean up",
                    [S, Err]),
                  ok
-         end
-     end || S <- Servers],
+         end || S <- Servers],
     ok.
+
+%% The members whose force delete did not complete are emitted as a
+%% `queue_force_deleted' event so that
+%% `rabbit_quorum_queue_periodic_membership_reconciliation' keeps retrying until
+%% they are gone.
+force_delete_members_with_retry(Q, Servers) ->
+    QName = amqqueue:get_name(Q),
+    UIdMap = case amqqueue:get_type_state(Q) of
+                 #{nodes := Nodes} when is_map(Nodes) ->
+                     Nodes;
+                 _ ->
+                     #{}
+             end,
+    %% Each failed member is described as a proplist with atom keys so that the
+    %% event props stay serializable for consumers such as the event exchange
+    %% plugin.
+    Failed = lists:filtermap(
+               fun({RaName, Node} = S) ->
+                       case force_delete_member(S) of
+                           ok ->
+                               false;
+                           Err ->
+                               ?LOG_WARNING(
+                                 "Force delete of ~w failed with: ~w. "
+                                 "Scheduling retry until the member is removed.",
+                                 [S, Err]),
+                               {true, [{ra_name, RaName},
+                                       {node, Node},
+                                       {uid, maps:get(Node, UIdMap, undefined)}]}
+                       end
+               end, Servers),
+    case Failed of
+        [] ->
+            ok;
+        _ ->
+            rabbit_event:notify(queue_force_deleted,
+                                [{name, QName},
+                                 {pending_members, Failed}]),
+            ok
+    end.
+
+%% The timeout is bounded on purpose: callers run this inline, to avoid the `infinity'
+%% default which could block them for as long as the member's node stays unreachable.
+-spec force_delete_member(ra:server_id()) -> ok | {error, term()}.
+force_delete_member(ServerId) ->
+    try ra:force_delete_server(?RA_SYSTEM, ServerId, ?FORCE_DELETE_TIMEOUT)
+    catch _:E -> {error, E}
+    end.
 
 -spec delete_queue_data(Queue, ActingUser) -> Ret when
       Queue :: amqqueue:amqqueue(),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -47,7 +47,8 @@
          add_member/4,
          add_member/5]).
 -export([delete_member/3, delete_member/2]).
--export([force_delete_member/1]).
+-export([force_delete_member/1, force_delete_member/2,
+         force_delete_local_member/2]).
 -export([policy_changed/1]).
 -export([format_ra_event/3]).
 -export([cleanup_data_dir/0]).
@@ -176,6 +177,9 @@
 -define(TICK_INTERVAL, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
 -define(FORCE_DELETE_TIMEOUT, 30_000).
+%% Bounds the call that carries out the UID check and the force delete on the
+%% member's node, so it has to outlive the force delete it wraps.
+-define(FORCE_DELETE_RPC_TIMEOUT, ?FORCE_DELETE_TIMEOUT + 5_000).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 %% setting a low default here to allow quorum queues to better chose themselves
@@ -1260,6 +1264,35 @@ force_delete_members_with_retry(Q, Servers) ->
 force_delete_member(ServerId) ->
     try ra:force_delete_server(?RA_SYSTEM, ServerId, ?FORCE_DELETE_TIMEOUT)
     catch _:E -> {error, E}
+    end.
+
+%% Force delete a member only when the UID registered for its Ra name still
+%% matches the incarnation the caller means to delete.
+%%
+%% `ra:force_delete_server/3' resolves the Ra name to a UID on the member's own
+%% node, so the guard has to be evaluated there too: performing it in the caller
+%% would leave a window in which the member is replaced by a newer incarnation
+%% of the same queue name, which the delete would then remove. Both steps are
+%% therefore carried out in a single call on the member's node.
+-spec force_delete_member(ra:server_id(), binary()) ->
+    ok | {skipped, gone | superseded} | {error, term()}.
+force_delete_member({RaName, Node}, ExpectedUId) when is_binary(ExpectedUId) ->
+    try erpc:call(Node, ?MODULE, force_delete_local_member,
+                  [RaName, ExpectedUId], ?FORCE_DELETE_RPC_TIMEOUT)
+    catch _:E -> {error, E}
+    end.
+
+%% Runs on the member's own node, called by force_delete_member/2.
+-spec force_delete_local_member(atom(), binary()) ->
+    ok | {skipped, gone | superseded} | {error, term()}.
+force_delete_local_member(RaName, ExpectedUId) ->
+    case ra_directory:uid_of(?RA_SYSTEM, RaName) of
+        undefined ->
+            {skipped, gone};
+        ExpectedUId ->
+            force_delete_member({RaName, node()});
+        _OtherUId ->
+            {skipped, superseded}
     end.
 
 -spec delete_queue_data(Queue, ActingUser) -> Ret when

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1211,17 +1211,22 @@ force_delete_members(Servers) ->
                  ok;
              Err ->
                  ?LOG_WARNING(
-                   "Force delete of ~w failed with: ~w"
+                   "Force delete of ~w failed with: ~w. "
                    "This may require manual data clean up",
                    [S, Err]),
                  ok
          end || S <- Servers],
     ok.
 
-%% The members whose force delete did not complete are emitted as a
-%% `queue_force_deleted' event so that
-%% `rabbit_quorum_queue_periodic_membership_reconciliation' keeps retrying until
-%% they are gone.
+%% The members whose force delete did not complete are recorded for retry by
+%% `rabbit_quorum_queue_periodic_membership_reconciliation', which keeps retrying
+%% until they are gone.
+%%
+%% That record is written and synced to disk before this function returns: it is
+%% the only trace of the leaked members left once the queue record is gone, so
+%% losing it to a node crash would leave them behind for good. The
+%% `queue_force_deleted' event is emitted for observers only and carries no part
+%% of the retry mechanism.
 force_delete_members_with_retry(Q, Servers) ->
     QName = amqqueue:get_name(Q),
     UIdMap = case amqqueue:get_type_state(Q) of
@@ -1230,33 +1235,36 @@ force_delete_members_with_retry(Q, Servers) ->
                  _ ->
                      #{}
              end,
-    %% Each failed member is described as a proplist with atom keys so that the
-    %% event props stay serializable for consumers such as the event exchange
-    %% plugin.
     Failed = lists:filtermap(
-               fun({RaName, Node} = S) ->
+               fun({_RaName, Node} = S) ->
                        case force_delete_member(S) of
                            ok ->
                                false;
                            Err ->
-                               ?LOG_WARNING(
-                                 "Force delete of ~w failed with: ~w. "
-                                 "Scheduling retry until the member is removed.",
-                                 [S, Err]),
-                               {true, [{ra_name, RaName},
-                                       {node, Node},
-                                       {uid, maps:get(Node, UIdMap, undefined)}]}
+                               %% Whether this member can be retried, and hence
+                               %% whether it needs manual clean up, is reported
+                               %% by the module that records it.
+                               ?LOG_WARNING("Force delete of ~w failed with: ~w",
+                                            [S, Err]),
+                               {true, {S, maps:get(Node, UIdMap, undefined)}}
                        end
                end, Servers),
     case Failed of
         [] ->
             ok;
         _ ->
+            ok = rabbit_quorum_queue_periodic_membership_reconciliation:record_pending_force_deletes(QName, Failed),
             rabbit_event:notify(queue_force_deleted,
                                 [{name, QName},
-                                 {pending_members, Failed}]),
+                                 {pending_members, pending_member_props(Failed)}]),
             ok
     end.
+
+%% Each pending member is described as a proplist with atom keys so that the
+%% event props stay serializable for consumers such as the event exchange plugin.
+pending_member_props(PendingMembers) ->
+    [[{ra_name, RaName}, {node, Node}, {uid, UId}]
+     || {{RaName, Node}, UId} <- PendingMembers].
 
 %% The timeout is bounded on purpose: callers run this inline, to avoid the `infinity'
 %% default which could block them for as long as the member's node stays unreachable.

--- a/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
@@ -10,7 +10,7 @@
 -behaviour(gen_server).
 
 -export([on_node_up/1, on_node_down/1, queue_created/1, policy_set/0,
-         schedule/2]).
+         schedule_force_delete/2]).
 
 -export([start_link/0]).
 
@@ -84,10 +84,11 @@ policy_set() ->
 %%
 %% Those UIDs only exist once `track_qq_members_uids' is enabled, so the retry
 %% is not supported without it.
--spec schedule(rabbit_amqqueue:name(), [{server_id(), member_uid()}]) -> ok.
-schedule(_QName, []) ->
+-spec schedule_force_delete(rabbit_amqqueue:name(),
+                            [{server_id(), member_uid()}]) -> ok.
+schedule_force_delete(_QName, []) ->
     ok;
-schedule(QName, PendingMembers) ->
+schedule_force_delete(QName, PendingMembers) ->
     case rabbit_feature_flags:is_enabled(track_qq_members_uids) of
         true ->
             gen_server:cast(?SERVER, {schedule_force_delete, QName, PendingMembers});
@@ -325,7 +326,7 @@ select_node(Nodes) ->
 %% orphans (`{already_started, _}' on every member) and cannot form a cluster, so
 %% the name stays poisoned.
 %%
-%% Leaked members arrive via a `queue_force_deleted' event (see `schedule/2'),
+%% Leaked members arrive via a `queue_force_deleted' event (see `schedule_force_delete/2'),
 %% are persisted in a node-local DETS table, and `ra:force_delete_server/3' is
 %% retried until each member is gone. The pending set survives a broker restart
 %% because it is persisted.

--- a/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
@@ -9,7 +9,8 @@
 
 -behaviour(gen_server).
 
--export([on_node_up/1, on_node_down/1, queue_created/1, policy_set/0]).
+-export([on_node_up/1, on_node_down/1, queue_created/1, policy_set/0,
+         schedule/2]).
 
 -export([start_link/0]).
 
@@ -30,12 +31,25 @@
 
 -define(EVAL_MSG, membership_reconciliation).
 
+%% Force delete retry: retrying force deletes of quorum queue members that were
+%% left behind on unreachable nodes during a force delete.
+-define(RA_SYSTEM, quorum_queues).
+-define(FORCE_DELETE_TABLE, rabbit_qq_force_delete_pending).
+-define(DEFAULT_FORCE_DELETE_RETRY_INTERVAL, 30_000).
+-define(FORCE_DELETE_TABLE_OPEN_RETRIES, 10).
+-define(UID_QUERY_TIMEOUT, 5_000).
+
 -record(state, {timer_ref :: reference() | undefined,
                 interval :: non_neg_integer(),
                 trigger_interval :: non_neg_integer(),
                 target_group_size :: non_neg_integer() | undefined,
                 enabled :: boolean(),
-                auto_remove :: boolean()}).
+                auto_remove :: boolean(),
+                force_delete_timer_ref :: reference() | undefined,
+                force_delete_interval :: non_neg_integer()}).
+
+-type server_id() :: {atom(), node()}.
+-type member_uid() :: binary() | undefined.
 
 %%----------------------------------------------------------------------------
 %% Start
@@ -49,7 +63,11 @@ start_link() -> gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 %%----------------------------------------------------------------------------
 
 on_node_up(Node) ->
-    gen_server:cast(?SERVER, {membership_reconciliation_trigger, {node_up, Node}}).
+    gen_server:cast(?SERVER, {membership_reconciliation_trigger, {node_up, Node}}),
+    %% A returning node may host members left behind by an earlier force delete;
+    %% retry now instead of waiting for the next tick. This runs regardless of
+    %% whether reconciliation is enabled.
+    gen_server:cast(?SERVER, force_delete_retry).
 
 on_node_down(Node) ->
     gen_server:cast(?SERVER, {membership_reconciliation_trigger, {node_down, Node}}).
@@ -59,6 +77,23 @@ queue_created(Q) ->
 
 policy_set() ->
     gen_server:cast(?SERVER, {membership_reconciliation_trigger, policy_set}).
+
+%% Schedule leaked members of a force-deleted queue for retry. Each member is
+%% tagged with the UID of the incarnation being deleted so a newer incarnation
+%% of the same queue name is never touched.
+%%
+%% Those UIDs only exist once `track_qq_members_uids' is enabled, so the retry
+%% is not supported without it.
+-spec schedule(rabbit_amqqueue:name(), [{server_id(), member_uid()}]) -> ok.
+schedule(_QName, []) ->
+    ok;
+schedule(QName, PendingMembers) ->
+    case rabbit_feature_flags:is_enabled(track_qq_members_uids) of
+        true ->
+            gen_server:cast(?SERVER, {schedule_force_delete, QName, PendingMembers});
+        false ->
+            ok
+    end.
 
 %%----------------------------------------------------------------------------
 %% gen_server callbacks
@@ -75,11 +110,19 @@ init([]) ->
                                         ?DEFAULT_TRIGGER_INTERVAL),
     TargetGroupSize = rabbit_misc:get_env(rabbit, quorum_membership_reconciliation_target_group_size,
                                           undefined),
-    State = #state{interval = Interval,
-                   trigger_interval = TriggerInterval,
-                   target_group_size = TargetGroupSize,
-                   enabled = Enabled,
-                   auto_remove = AutoRemove},
+    ForceDeleteInterval = rabbit_misc:get_env(rabbit,
+                                              quorum_queue_force_delete_retry_interval,
+                                              ?DEFAULT_FORCE_DELETE_RETRY_INTERVAL),
+    ok = open_force_delete_table(),
+    State0 = #state{interval = Interval,
+                    trigger_interval = TriggerInterval,
+                    target_group_size = TargetGroupSize,
+                    enabled = Enabled,
+                    auto_remove = AutoRemove,
+                    force_delete_interval = ForceDeleteInterval},
+    %% The force delete retry path runs regardless of the reconciliation toggle;
+    %% resume any pending force deletes that did not complete before a restart.
+    State = ensure_force_delete_timer_if_pending(State0),
     case Enabled of
         true ->
             Ref = erlang:send_after(Interval, self(), ?EVAL_MSG),
@@ -91,6 +134,13 @@ init([]) ->
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
 
+handle_cast({schedule_force_delete, QName, PendingMembers}, State) ->
+    _ = [dets:insert(?FORCE_DELETE_TABLE, {ServerId, {QName, UId}})
+         || {ServerId, UId} <- PendingMembers],
+    _ = dets:sync(?FORCE_DELETE_TABLE),
+    {noreply, ensure_force_delete_timer(State)};
+handle_cast(force_delete_retry, State) ->
+    {noreply, retry_force_deletes(State)};
 handle_cast({membership_reconciliation_trigger, _Reason}, #state{enabled = false} = State) ->
     {noreply, State, hibernate};
 handle_cast({membership_reconciliation_trigger, Reason}, #state{timer_ref = OldRef,
@@ -113,12 +163,15 @@ handle_info(?EVAL_MSG, #state{interval = Interval,
                  end,
     Ref = erlang:send_after(NewTimeout, self(), ?EVAL_MSG),
     {noreply, State#state{timer_ref = Ref}};
+handle_info(force_delete_retry, State) ->
+    {noreply, retry_force_deletes(State#state{force_delete_timer_ref = undefined})};
 handle_info(_Info, #state{enabled = false} = State) ->
     {noreply, State, hibernate};
 handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
+    _ = dets:close(?FORCE_DELETE_TABLE),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -262,3 +315,133 @@ select_node([Node]) ->
     Node;
 select_node(Nodes) ->
     lists:nth(rand:uniform(length(Nodes)), Nodes).
+
+%%----------------------------------------------------------------------------
+%% Force delete retry
+%%
+%% When a quorum queue is force-deleted while one or more of its member nodes are
+%% unreachable, `ra:force_delete_server/3' fails on those nodes and the Ra members
+%% are left behind. The next declare under the same Ra name then collides with the
+%% orphans (`{already_started, _}' on every member) and cannot form a cluster, so
+%% the name stays poisoned.
+%%
+%% Leaked members arrive via a `queue_force_deleted' event (see `schedule/2'),
+%% are persisted in a node-local DETS table, and `ra:force_delete_server/3' is
+%% retried until each member is gone. The pending set survives a broker restart
+%% because it is persisted.
+%%
+%% This requires the `track_qq_members_uids' feature flag: each pending member is
+%% tagged with the UID of the incarnation being deleted, and those UIDs are only
+%% recorded once the flag is enabled.
+%%
+%% Before a retry the member's currently registered UID on the target node is read
+%% and the force delete is only performed when it still matches, so a member
+%% belonging to a newer incarnation of the same queue name is never deleted. A
+%% member that cannot be verified this way is dropped rather than deleted, and is
+%% reported so that it can be cleaned up manually.
+%%----------------------------------------------------------------------------
+
+open_force_delete_table() ->
+    open_force_delete_table(?FORCE_DELETE_TABLE_OPEN_RETRIES).
+
+open_force_delete_table(RetriesLeft) ->
+    File = filename:join(rabbit:data_dir(), "qq_force_delete_retry.dets"),
+    Opts = [{file, File}, {auto_save, infinity}],
+    case dets:open_file(?FORCE_DELETE_TABLE, Opts) of
+        {ok, _} ->
+            ok;
+        {error, Error} when RetriesLeft > 0 ->
+            _ = file:delete(File),
+            ?LOG_WARNING("Failed to open the quorum queue force delete retry DETS "
+                         "file at ~tp: ~tp. Deleting it and retrying (~b retries "
+                         "left)", [File, Error, RetriesLeft]),
+            timer:sleep(1000),
+            open_force_delete_table(RetriesLeft - 1);
+        {error, Error} ->
+            {error, Error}
+    end.
+
+retry_force_deletes(State) ->
+    %% Collect first, then mutate: DETS tables must not be modified during a
+    %% foldl traversal.
+    Entries = dets:foldl(fun(Entry, Acc) -> [Entry | Acc] end, [],
+                         ?FORCE_DELETE_TABLE),
+    _ = [retry_member(Entry) || Entry <- Entries],
+    _ = dets:sync(?FORCE_DELETE_TABLE),
+    ensure_force_delete_timer_if_pending(State).
+
+retry_member({{RaName, Node} = ServerId, {QName, ExpectedUId}}) ->
+    case member_status(Node, RaName, ExpectedUId) of
+        delete ->
+            case rabbit_quorum_queue:force_delete_member(ServerId) of
+                ok ->
+                    ?LOG_INFO("Force delete of leaked member ~w of ~ts "
+                              "succeeded on retry", [ServerId, rabbit_misc:rs(QName)]),
+                    dets:delete(?FORCE_DELETE_TABLE, ServerId);
+                Err ->
+                    ?LOG_DEBUG("Force delete retry of member ~w of ~ts failed "
+                               "with ~w, will retry", [ServerId, rabbit_misc:rs(QName), Err]),
+                    ok
+            end;
+        gone ->
+            ?LOG_INFO("Leaked member ~w of ~ts is no longer present, dropping "
+                      "from the force delete retry set", [ServerId, rabbit_misc:rs(QName)]),
+            dets:delete(?FORCE_DELETE_TABLE, ServerId);
+        superseded ->
+            ?LOG_INFO("Member ~w of ~ts belongs to a newer incarnation, dropping "
+                      "from the force delete retry set", [ServerId, rabbit_misc:rs(QName)]),
+            dets:delete(?FORCE_DELETE_TABLE, ServerId);
+        unverifiable ->
+            ?LOG_INFO("Member ~w of ~ts has no recorded UID to verify against, "
+                      "dropping from the force delete retry set. This member may "
+                      "need manual data clean up",
+                      [ServerId, rabbit_misc:rs(QName)]),
+            dets:delete(?FORCE_DELETE_TABLE, ServerId);
+        unreachable ->
+            ok
+    end.
+
+%% Decide what to do with a pending member by comparing the UID currently
+%% registered on the target node with the UID of the incarnation we intended to
+%% delete. This mirrors the UID handling in rabbit_quorum_queue:recover/2.
+-spec member_status(node(), atom(), member_uid()) ->
+    delete | gone | superseded | unverifiable | unreachable.
+member_status(Node, RaName, ExpectedUId) ->
+    case remote_uid(Node, RaName) of
+        {error, _} ->
+            unreachable;
+        undefined ->
+            gone;
+        _CurrentUId when ExpectedUId =:= undefined ->
+            %% A queue record that predates the feature flag can still carry no
+            %% UID for this node. Deleting a member that cannot be verified risks
+            %% removing a newer incarnation of the same queue name, so leave it.
+            unverifiable;
+        ExpectedUId ->
+            delete;
+        _OtherUId ->
+            superseded
+    end.
+
+remote_uid(Node, RaName) ->
+    try erpc:call(Node, ra_directory, uid_of, [?RA_SYSTEM, RaName],
+                  ?UID_QUERY_TIMEOUT) of
+        UId ->
+            UId
+    catch
+        _:Reason ->
+            {error, Reason}
+    end.
+
+ensure_force_delete_timer_if_pending(State) ->
+    case dets:info(?FORCE_DELETE_TABLE, size) of
+        0 -> State;
+        _ -> ensure_force_delete_timer(State)
+    end.
+
+ensure_force_delete_timer(#state{force_delete_timer_ref = Ref} = State)
+  when is_reference(Ref) ->
+    State;
+ensure_force_delete_timer(#state{force_delete_interval = Interval} = State) ->
+    Ref = erlang:send_after(Interval, self(), force_delete_retry),
+    State#state{force_delete_timer_ref = Ref}.

--- a/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
@@ -33,11 +33,9 @@
 
 %% Force delete retry: retrying force deletes of quorum queue members that were
 %% left behind on unreachable nodes during a force delete.
--define(RA_SYSTEM, quorum_queues).
 -define(FORCE_DELETE_TABLE, rabbit_qq_force_delete_pending).
 -define(DEFAULT_FORCE_DELETE_RETRY_INTERVAL, 30_000).
 -define(FORCE_DELETE_TABLE_OPEN_RETRIES, 10).
--define(UID_QUERY_TIMEOUT, 5_000).
 
 -record(state, {timer_ref :: reference() | undefined,
                 interval :: non_neg_integer(),
@@ -335,10 +333,11 @@ select_node(Nodes) ->
 %% tagged with the UID of the incarnation being deleted, and those UIDs are only
 %% recorded once the flag is enabled.
 %%
-%% Before a retry the member's currently registered UID on the target node is read
-%% and the force delete is only performed when it still matches, so a member
-%% belonging to a newer incarnation of the same queue name is never deleted. A
-%% member that cannot be verified this way is dropped rather than deleted, and is
+%% A retry is guarded by that UID: `rabbit_quorum_queue:force_delete_member/2'
+%% compares it against the UID currently registered on the member's node and only
+%% deletes when the two still match, so a member belonging to a newer incarnation
+%% of the same queue name is never deleted. A pending member recorded without a
+%% UID cannot be guarded this way, so it is dropped rather than deleted, and is
 %% reported so that it can be cleaned up manually.
 %%----------------------------------------------------------------------------
 
@@ -371,67 +370,33 @@ retry_force_deletes(State) ->
     _ = dets:sync(?FORCE_DELETE_TABLE),
     ensure_force_delete_timer_if_pending(State).
 
-retry_member({{RaName, Node} = ServerId, {QName, ExpectedUId}}) ->
-    case member_status(Node, RaName, ExpectedUId) of
-        delete ->
-            case rabbit_quorum_queue:force_delete_member(ServerId) of
-                ok ->
-                    ?LOG_INFO("Force delete of leaked member ~w of ~ts "
-                              "succeeded on retry", [ServerId, rabbit_misc:rs(QName)]),
-                    dets:delete(?FORCE_DELETE_TABLE, ServerId);
-                Err ->
-                    ?LOG_DEBUG("Force delete retry of member ~w of ~ts failed "
-                               "with ~w, will retry", [ServerId, rabbit_misc:rs(QName), Err]),
-                    ok
-            end;
-        gone ->
+%% A queue record that predates the feature flag can still carry no UID for this
+%% node. Deleting a member that cannot be guarded by a UID risks removing a newer
+%% incarnation of the same queue name, so leave it in place.
+retry_member({ServerId, {QName, undefined}}) ->
+    ?LOG_INFO("Member ~w of ~ts has no recorded UID to verify against, "
+              "dropping from the force delete retry set. This member may "
+              "need manual data clean up",
+              [ServerId, rabbit_misc:rs(QName)]),
+    dets:delete(?FORCE_DELETE_TABLE, ServerId);
+retry_member({ServerId, {QName, ExpectedUId}}) ->
+    case rabbit_quorum_queue:force_delete_member(ServerId, ExpectedUId) of
+        ok ->
+            ?LOG_INFO("Force delete of leaked member ~w of ~ts "
+                      "succeeded on retry", [ServerId, rabbit_misc:rs(QName)]),
+            dets:delete(?FORCE_DELETE_TABLE, ServerId);
+        {skipped, gone} ->
             ?LOG_INFO("Leaked member ~w of ~ts is no longer present, dropping "
                       "from the force delete retry set", [ServerId, rabbit_misc:rs(QName)]),
             dets:delete(?FORCE_DELETE_TABLE, ServerId);
-        superseded ->
+        {skipped, superseded} ->
             ?LOG_INFO("Member ~w of ~ts belongs to a newer incarnation, dropping "
                       "from the force delete retry set", [ServerId, rabbit_misc:rs(QName)]),
             dets:delete(?FORCE_DELETE_TABLE, ServerId);
-        unverifiable ->
-            ?LOG_INFO("Member ~w of ~ts has no recorded UID to verify against, "
-                      "dropping from the force delete retry set. This member may "
-                      "need manual data clean up",
-                      [ServerId, rabbit_misc:rs(QName)]),
-            dets:delete(?FORCE_DELETE_TABLE, ServerId);
-        unreachable ->
+        {error, Reason} ->
+            ?LOG_DEBUG("Force delete retry of member ~w of ~ts failed "
+                       "with ~w, will retry", [ServerId, rabbit_misc:rs(QName), Reason]),
             ok
-    end.
-
-%% Decide what to do with a pending member by comparing the UID currently
-%% registered on the target node with the UID of the incarnation we intended to
-%% delete. This mirrors the UID handling in rabbit_quorum_queue:recover/2.
--spec member_status(node(), atom(), member_uid()) ->
-    delete | gone | superseded | unverifiable | unreachable.
-member_status(Node, RaName, ExpectedUId) ->
-    case remote_uid(Node, RaName) of
-        {error, _} ->
-            unreachable;
-        undefined ->
-            gone;
-        _CurrentUId when ExpectedUId =:= undefined ->
-            %% A queue record that predates the feature flag can still carry no
-            %% UID for this node. Deleting a member that cannot be verified risks
-            %% removing a newer incarnation of the same queue name, so leave it.
-            unverifiable;
-        ExpectedUId ->
-            delete;
-        _OtherUId ->
-            superseded
-    end.
-
-remote_uid(Node, RaName) ->
-    try erpc:call(Node, ra_directory, uid_of, [?RA_SYSTEM, RaName],
-                  ?UID_QUERY_TIMEOUT) of
-        UId ->
-            UId
-    catch
-        _:Reason ->
-            {error, Reason}
     end.
 
 ensure_force_delete_timer_if_pending(State) ->

--- a/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
@@ -10,7 +10,7 @@
 -behaviour(gen_server).
 
 -export([on_node_up/1, on_node_down/1, queue_created/1, policy_set/0,
-         schedule_force_delete/2]).
+         record_pending_force_deletes/2]).
 
 -export([start_link/0]).
 
@@ -76,23 +76,66 @@ queue_created(Q) ->
 policy_set() ->
     gen_server:cast(?SERVER, {membership_reconciliation_trigger, policy_set}).
 
-%% Schedule leaked members of a force-deleted queue for retry. Each member is
+%% Record leaked members of a force-deleted queue for retry. Each member is
 %% tagged with the UID of the incarnation being deleted so a newer incarnation
 %% of the same queue name is never touched.
 %%
 %% Those UIDs only exist once `track_qq_members_uids' is enabled, so the retry
-%% is not supported without it.
--spec schedule_force_delete(rabbit_amqqueue:name(),
-                            [{server_id(), member_uid()}]) -> ok.
-schedule_force_delete(_QName, []) ->
+%% is not supported without it. A queue record that predates the flag can also
+%% carry no UID for an individual member even when the flag is enabled. Such a
+%% member is not recorded at all: a retry could not tell it apart from a newer
+%% incarnation of the same queue name, so there is nothing the retry loop could
+%% safely do with the entry. It is reported instead, for manual clean up.
+%%
+%% The entries are written and synced in the calling process rather than handed
+%% to the owner of the table. The caller is deleting the queue, and once the
+%% queue record is gone these entries are the only remaining trace of the leaked
+%% members, so they have to reach disk before the delete completes.
+%%
+%% A failure to write them is logged rather than raised: the queue is already
+%% being removed, so the delete has to carry on regardless.
+-spec record_pending_force_deletes(rabbit_amqqueue:name(),
+                                   [{server_id(), member_uid()}]) -> ok.
+record_pending_force_deletes(_QName, []) ->
     ok;
-schedule_force_delete(QName, PendingMembers) ->
+record_pending_force_deletes(QName, PendingMembers) ->
     case rabbit_feature_flags:is_enabled(track_qq_members_uids) of
         true ->
-            gen_server:cast(?SERVER, {schedule_force_delete, QName, PendingMembers});
+            {Verifiable, Unverifiable} =
+                lists:partition(fun({_ServerId, UId}) -> is_binary(UId) end,
+                                PendingMembers),
+            _ = [?LOG_WARNING(
+                   "Leaked member ~w of ~ts has no recorded UID to verify "
+                   "against, so it cannot be force-deleted on retry without "
+                   "risking a newer incarnation of the same queue name. This "
+                   "member may need manual data clean up",
+                   [ServerId, rabbit_misc:rs(QName)])
+                 || {ServerId, _} <- Unverifiable],
+            record_verifiable_force_deletes(QName, Verifiable);
         false ->
             ok
     end.
+
+record_verifiable_force_deletes(_QName, []) ->
+    ok;
+record_verifiable_force_deletes(QName, PendingMembers) ->
+    case persist_pending_force_deletes(QName, PendingMembers) of
+        ok ->
+            ?LOG_INFO("Recorded ~b leaked member(s) of ~ts for force delete "
+                      "retry: ~w",
+                      [length(PendingMembers), rabbit_misc:rs(QName),
+                       [ServerId || {ServerId, _UId} <- PendingMembers]]),
+            %% Arming the retry timer can be asynchronous: the entries are on
+            %% disk, and the owner arms the timer from `init/1' for anything
+            %% still pending after a restart.
+            gen_server:cast(?SERVER, force_delete_recorded);
+        {error, Reason} ->
+            ?LOG_WARNING(
+              "Failed to record ~b leaked member(s) of ~ts for force delete "
+              "retry: ~tp. These members may need manual data clean up",
+              [length(PendingMembers), rabbit_misc:rs(QName), Reason])
+    end,
+    ok.
 
 %%----------------------------------------------------------------------------
 %% gen_server callbacks
@@ -133,10 +176,7 @@ init([]) ->
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
 
-handle_cast({schedule_force_delete, QName, PendingMembers}, State) ->
-    _ = [dets:insert(?FORCE_DELETE_TABLE, {ServerId, {QName, UId}})
-         || {ServerId, UId} <- PendingMembers],
-    _ = dets:sync(?FORCE_DELETE_TABLE),
+handle_cast(force_delete_recorded, State) ->
     {noreply, ensure_force_delete_timer(State)};
 handle_cast(force_delete_retry, State) ->
     {noreply, retry_force_deletes(State)};
@@ -324,10 +364,10 @@ select_node(Nodes) ->
 %% orphans (`{already_started, _}' on every member) and cannot form a cluster, so
 %% the name stays poisoned.
 %%
-%% Leaked members arrive via a `queue_force_deleted' event (see `schedule_force_delete/2'),
-%% are persisted in a node-local DETS table, and `ra:force_delete_server/3' is
-%% retried until each member is gone. The pending set survives a broker restart
-%% because it is persisted.
+%% Leaked members are recorded by the force delete itself (see
+%% `record_pending_force_deletes/2') in a node-local DETS table, and
+%% `ra:force_delete_server/3' is retried until each member is gone. The pending
+%% set survives a broker restart because it is persisted.
 %%
 %% This requires the `track_qq_members_uids' feature flag: each pending member is
 %% tagged with the UID of the incarnation being deleted, and those UIDs are only
@@ -336,9 +376,9 @@ select_node(Nodes) ->
 %% A retry is guarded by that UID: `rabbit_quorum_queue:force_delete_member/2'
 %% compares it against the UID currently registered on the member's node and only
 %% deletes when the two still match, so a member belonging to a newer incarnation
-%% of the same queue name is never deleted. A pending member recorded without a
-%% UID cannot be guarded this way, so it is dropped rather than deleted, and is
-%% reported so that it can be cleaned up manually.
+%% of the same queue name is never deleted. A member with no UID cannot be
+%% guarded this way, so it never enters the table: it is reported at force delete
+%% time so that it can be cleaned up manually.
 %%----------------------------------------------------------------------------
 
 open_force_delete_table() ->
@@ -361,6 +401,18 @@ open_force_delete_table(RetriesLeft) ->
             {error, Error}
     end.
 
+persist_pending_force_deletes(QName, PendingMembers) ->
+    Objects = [{ServerId, {QName, UId}} || {ServerId, UId} <- PendingMembers],
+    try dets:insert(?FORCE_DELETE_TABLE, Objects) of
+        ok ->
+            dets:sync(?FORCE_DELETE_TABLE);
+        {error, _} = Err ->
+            Err
+    catch
+        _:Reason ->
+            {error, Reason}
+    end.
+
 retry_force_deletes(State) ->
     %% Collect first, then mutate: DETS tables must not be modified during a
     %% foldl traversal.
@@ -370,9 +422,11 @@ retry_force_deletes(State) ->
     _ = dets:sync(?FORCE_DELETE_TABLE),
     ensure_force_delete_timer_if_pending(State).
 
-%% A queue record that predates the feature flag can still carry no UID for this
-%% node. Deleting a member that cannot be guarded by a UID risks removing a newer
-%% incarnation of the same queue name, so leave it in place.
+%% Entries without a UID are refused by `record_pending_force_deletes/2', but
+%% the table outlives the code that wrote it, so one can still be read back from
+%% a file written by an earlier version. Deleting a member that cannot be guarded
+%% by a UID risks removing a newer incarnation of the same queue name, so leave
+%% it in place.
 retry_member({ServerId, {QName, undefined}}) ->
     ?LOG_INFO("Member ~w of ~ts has no recorded UID to verify against, "
               "dropping from the force delete retry set. This member may "

--- a/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
@@ -52,7 +52,7 @@ groups() ->
       [
        {quorum_queue_3, [], [leaked_member_is_eventually_force_deleted,
                              stale_incarnation_is_not_deleted,
-                             unverifiable_member_is_dropped,
+                             unverifiable_member_is_not_recorded,
                              force_delete_member_uid_guard]}
       ]}
     ].
@@ -296,10 +296,12 @@ leaked_member_is_eventually_force_deleted(Config) ->
     ok = rabbit_ct_broker_helpers:stop_node(Config, Server2),
     #'queue.delete_ok'{} = amqp_channel:call(Ch, #'queue.delete'{queue = QQ}),
 
-    %% The leaked member is recorded for retry on Server0.
-    wait_until(fun() ->
-                       [] =/= pending_lookup(Config, Server0, RaName, Server2)
-               end),
+    %% The leaked member is on disk on Server0 by the time the delete returns:
+    %% the queue record is already gone, so a crash from here on must not lose
+    %% the only record of the member left behind.
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+    ?assertEqual([{{RaName, Server2}, {QName, UId}}],
+                 pending_lookup(Config, Server0, RaName, Server2)),
 
     %% Bring Server2 back and the retry loop must eventually remove the member
     %% and drop the pending entry.
@@ -330,14 +332,14 @@ stale_incarnation_is_not_deleted(Config) ->
     CurrentUId = uid_of(Config, Server2, RaName),
     ?assert(is_binary(CurrentUId)),
 
-    %% Schedule a retry for Server2's member but tagged with a UID that does not
+    %% Record a retry for Server2's member but tagged with a UID that does not
     %% match the live incarnation.
     StaleUId = <<"stale-incarnation-uid">>,
     ?assertNotEqual(StaleUId, CurrentUId),
-    ok = rabbit_ct_broker_helpers:rpc(
-           Config, Server0,
-           rabbit_quorum_queue_periodic_membership_reconciliation, schedule_force_delete,
-           [QName, [{{RaName, Server2}, StaleUId}]]),
+    ok = record_pending_force_deletes(Config, Server0, QName,
+                                      [{{RaName, Server2}, StaleUId}]),
+    ?assertEqual([{{RaName, Server2}, {QName, StaleUId}}],
+                 pending_lookup(Config, Server0, RaName, Server2)),
 
     %% The stale entry is dropped without touching the live member.
     wait_until(fun() ->
@@ -347,9 +349,9 @@ stale_incarnation_is_not_deleted(Config) ->
     ?assertEqual(3, length(element(2, ra:members({RaName, Server0})))).
 
 %% A member with no recorded UID cannot be told apart from a newer incarnation,
-%% so it is dropped from the retry set rather than deleted.
-unverifiable_member_is_dropped(Config) ->
-    [Server0, _Server1, Server2] =
+%% so it is never recorded for retry.
+unverifiable_member_is_not_recorded(Config) ->
+    [Server0, Server1, Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     QQ = ?config(queue_name, Config),
@@ -365,17 +367,20 @@ unverifiable_member_is_dropped(Config) ->
     CurrentUId = uid_of(Config, Server2, RaName),
     ?assert(is_binary(CurrentUId)),
 
-    %% Schedule a retry for Server2's member with no UID, as a queue record
-    %% predating the feature flag would produce.
-    ok = rabbit_ct_broker_helpers:rpc(
-           Config, Server0,
-           rabbit_quorum_queue_periodic_membership_reconciliation, schedule_force_delete,
-           [QName, [{{RaName, Server2}, undefined}]]),
+    %% Record a retry for Server2's member with no UID, as a queue record
+    %% predating the feature flag would produce, alongside one that does carry a
+    %% UID. Only the latter is persisted: an entry that no retry could ever act
+    %% on must not enter the table in the first place. The second entry also
+    %% shows that the write happened at all.
+    OtherUId = <<"other-incarnation-uid">>,
+    ok = record_pending_force_deletes(Config, Server0, QName,
+                                      [{{RaName, Server2}, undefined},
+                                       {{RaName, Server1}, OtherUId}]),
+    ?assertEqual([], pending_lookup(Config, Server0, RaName, Server2)),
+    ?assertEqual([{{RaName, Server1}, {QName, OtherUId}}],
+                 pending_lookup(Config, Server0, RaName, Server1)),
 
-    %% The entry is dropped and the live member is left alone.
-    wait_until(fun() ->
-                       [] =:= pending_lookup(Config, Server0, RaName, Server2)
-               end),
+    %% The live member on Server2 is left alone.
     ?assertEqual(CurrentUId, uid_of(Config, Server2, RaName)),
     ?assertEqual(3, length(element(2, ra:members({RaName, Server0})))).
 
@@ -422,6 +427,11 @@ is_force_delete_group(Config) ->
 uid_of(Config, Node, RaName) ->
     rabbit_ct_broker_helpers:rpc(Config, Node, ra_directory, uid_of,
                                  [?RA_SYSTEM, RaName]).
+
+record_pending_force_deletes(Config, Node, QName, PendingMembers) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, Node, rabbit_quorum_queue_periodic_membership_reconciliation,
+      record_pending_force_deletes, [QName, PendingMembers]).
 
 force_delete_member(Config, Node, ServerId, ExpectedUId) ->
     rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_quorum_queue,

--- a/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
@@ -14,6 +14,9 @@
 
 -import(rabbit_ct_helpers, [consistently/3]).
 
+-define(RA_SYSTEM, quorum_queues).
+-define(FORCE_DELETE_TABLE, rabbit_qq_force_delete_pending).
+
 %% The reconciler has two modes of triggering itself
 %% - timer based
 %% - event based
@@ -27,7 +30,8 @@
 all() ->
     [
      {group, unclustered},
-     {group, unclustered_triggers}
+     {group, unclustered_triggers},
+     {group, clustered_force_delete}
     ].
 
 groups() ->
@@ -41,6 +45,14 @@ groups() ->
       [
        %% see also `auto_grow_drained_node`
        {quorum_queue_3, [], [auto_grow, auto_shrink]}
+      ]},
+     %% Unlike the groups above, these need a formed cluster: a member is leaked
+     %% by taking one of its nodes down during a force delete.
+     {clustered_force_delete, [],
+      [
+       {quorum_queue_3, [], [leaked_member_is_eventually_force_deleted,
+                             stale_incarnation_is_not_deleted,
+                             unverifiable_member_is_dropped]}
       ]}
     ].
 
@@ -79,6 +91,12 @@ init_per_group(unclustered_triggers, Config0) ->
     rabbit_ct_helpers:set_config(Config1, [{rmq_nodes_clustered, false},
                                            {quorum_membership_reconciliation_interval, 50000},
                                            {shrink_timeout, 2000}]);
+init_per_group(clustered_force_delete, Config0) ->
+    Config1 = rabbit_ct_helpers:merge_app_env(
+                Config0, {rabbit, [{quorum_tick_interval, 1000},
+                                   {quorum_queue_force_delete_retry_interval, 3000}]}),
+    rabbit_ct_helpers:set_config(Config1, [{rmq_nodes_clustered, true},
+                                           {force_delete_group, true}]);
 init_per_group(Group, Config) ->
     ClusterSize = 3,
     Config1 = rabbit_ct_helpers:set_config(Config,
@@ -93,11 +111,23 @@ end_per_group(unclustered, Config) ->
     Config;
 end_per_group(unclustered_triggers, Config) ->
     Config;
+end_per_group(clustered_force_delete, Config) ->
+    Config;
 end_per_group(_, Config) ->
     rabbit_ct_helpers:run_steps(Config,
                                 rabbit_ct_broker_helpers:teardown_steps()).
 
 init_per_testcase(Testcase, Config) ->
+    case is_force_delete_group(Config) andalso
+        not rabbit_ct_broker_helpers:is_feature_flag_enabled(
+              Config, track_qq_members_uids) of
+        true ->
+            {skip, "force delete retry requires track_qq_members_uids ff"};
+        false ->
+            init_per_testcase0(Testcase, Config)
+    end.
+
+init_per_testcase0(Testcase, Config) ->
     Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
     Q = rabbit_data_coercion:to_binary(Testcase),
@@ -109,11 +139,20 @@ init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:run_steps(Config2, rabbit_ct_client_helpers:setup_steps()).
 
 end_per_testcase(Testcase, Config) ->
-    [Server0, Server1, Server2] =
-        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
-    amqp_channel:call(Ch, #'queue.delete'{queue = rabbit_data_coercion:to_binary(Testcase)}),
-    reset_nodes([Server2, Server0], Server1),
+    %% The reconciliation groups start unclustered and join nodes as they go, so
+    %% they have to be put back. The force delete group runs against a cluster
+    %% that must stay formed for the next case.
+    case is_force_delete_group(Config) of
+        true ->
+            ok;
+        false ->
+            [Server0, Server1, Server2] =
+                rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+            Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
+            amqp_channel:call(Ch, #'queue.delete'{
+                                     queue = rabbit_data_coercion:to_binary(Testcase)}),
+            reset_nodes([Server2, Server0], Server1)
+    end,
     Config1 = rabbit_ct_helpers:run_steps(
                 Config,
                 rabbit_ct_client_helpers:teardown_steps()),
@@ -231,9 +270,128 @@ auto_shrink(Config) ->
                        2 =:= length(M)
                end).
 
+%% A quorum queue member left behind on a node that was down during a force
+%% delete is eventually force-deleted once the node returns.
+leaked_member_is_eventually_force_deleted(Config) ->
+    [Server0, _Server1, Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    RaName = queue_utils:ra_name(QQ),
+
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    wait_until(fun() ->
+                       3 =:= length(element(2, ra:members({RaName, Server0})))
+               end),
+
+    %% Server2's member is present before we take the node down.
+    UId = uid_of(Config, Server2, RaName),
+    ?assert(is_binary(UId)),
+
+    %% Take Server2 down, then delete the queue from Server0. The delete still
+    %% reaches quorum (2 of 3), so the record is removed, but the force delete of
+    %% Server2's member fails because the node is unreachable.
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Server2),
+    #'queue.delete_ok'{} = amqp_channel:call(Ch, #'queue.delete'{queue = QQ}),
+
+    %% The leaked member is recorded for retry on Server0.
+    wait_until(fun() ->
+                       [] =/= pending_lookup(Config, Server0, RaName, Server2)
+               end),
+
+    %% Bring Server2 back and the retry loop must eventually remove the member
+    %% and drop the pending entry.
+    ok = rabbit_ct_broker_helpers:start_node(Config, Server2),
+    wait_until(fun() ->
+                       undefined =:= uid_of(Config, Server2, RaName)
+               end),
+    wait_until(fun() ->
+                       [] =:= pending_lookup(Config, Server0, RaName, Server2)
+               end).
+
+%% A retry must never delete a member that belongs to a newer incarnation of the
+%% same queue name: the UID guard drops the stale entry instead.
+stale_incarnation_is_not_deleted(Config) ->
+    [Server0, _Server1, Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    RaName = queue_utils:ra_name(QQ),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    wait_until(fun() ->
+                       3 =:= length(element(2, ra:members({RaName, Server0})))
+               end),
+
+    CurrentUId = uid_of(Config, Server2, RaName),
+    ?assert(is_binary(CurrentUId)),
+
+    %% Schedule a retry for Server2's member but tagged with a UID that does not
+    %% match the live incarnation.
+    StaleUId = <<"stale-incarnation-uid">>,
+    ?assertNotEqual(StaleUId, CurrentUId),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, Server0,
+           rabbit_quorum_queue_periodic_membership_reconciliation, schedule,
+           [QName, [{{RaName, Server2}, StaleUId}]]),
+
+    %% The stale entry is dropped without touching the live member.
+    wait_until(fun() ->
+                       [] =:= pending_lookup(Config, Server0, RaName, Server2)
+               end),
+    ?assertEqual(CurrentUId, uid_of(Config, Server2, RaName)),
+    ?assertEqual(3, length(element(2, ra:members({RaName, Server0})))).
+
+%% A member with no recorded UID cannot be told apart from a newer incarnation,
+%% so it is dropped from the retry set rather than deleted.
+unverifiable_member_is_dropped(Config) ->
+    [Server0, _Server1, Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    RaName = queue_utils:ra_name(QQ),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    wait_until(fun() ->
+                       3 =:= length(element(2, ra:members({RaName, Server0})))
+               end),
+
+    CurrentUId = uid_of(Config, Server2, RaName),
+    ?assert(is_binary(CurrentUId)),
+
+    %% Schedule a retry for Server2's member with no UID, as a queue record
+    %% predating the feature flag would produce.
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, Server0,
+           rabbit_quorum_queue_periodic_membership_reconciliation, schedule,
+           [QName, [{{RaName, Server2}, undefined}]]),
+
+    %% The entry is dropped and the live member is left alone.
+    wait_until(fun() ->
+                       [] =:= pending_lookup(Config, Server0, RaName, Server2)
+               end),
+    ?assertEqual(CurrentUId, uid_of(Config, Server2, RaName)),
+    ?assertEqual(3, length(element(2, ra:members({RaName, Server0})))).
+
 %% -------------------------------------------------------------------
 %% Helpers.
 %% -------------------------------------------------------------------
+
+is_force_delete_group(Config) ->
+    true =:= rabbit_ct_helpers:get_config(Config, force_delete_group, false).
+
+uid_of(Config, Node, RaName) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, ra_directory, uid_of,
+                                 [?RA_SYSTEM, RaName]).
+
+pending_lookup(Config, Node, RaName, MemberNode) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, dets, lookup,
+                                 [?FORCE_DELETE_TABLE, {RaName, MemberNode}]).
 
 merge_app_env(Config) ->
     rabbit_ct_helpers:merge_app_env(

--- a/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
@@ -335,7 +335,7 @@ stale_incarnation_is_not_deleted(Config) ->
     ?assertNotEqual(StaleUId, CurrentUId),
     ok = rabbit_ct_broker_helpers:rpc(
            Config, Server0,
-           rabbit_quorum_queue_periodic_membership_reconciliation, schedule,
+           rabbit_quorum_queue_periodic_membership_reconciliation, schedule_force_delete,
            [QName, [{{RaName, Server2}, StaleUId}]]),
 
     %% The stale entry is dropped without touching the live member.
@@ -368,7 +368,7 @@ unverifiable_member_is_dropped(Config) ->
     %% predating the feature flag would produce.
     ok = rabbit_ct_broker_helpers:rpc(
            Config, Server0,
-           rabbit_quorum_queue_periodic_membership_reconciliation, schedule,
+           rabbit_quorum_queue_periodic_membership_reconciliation, schedule_force_delete,
            [QName, [{{RaName, Server2}, undefined}]]),
 
     %% The entry is dropped and the live member is left alone.

--- a/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
@@ -52,7 +52,8 @@ groups() ->
       [
        {quorum_queue_3, [], [leaked_member_is_eventually_force_deleted,
                              stale_incarnation_is_not_deleted,
-                             unverifiable_member_is_dropped]}
+                             unverifiable_member_is_dropped,
+                             force_delete_member_uid_guard]}
       ]}
     ].
 
@@ -378,6 +379,39 @@ unverifiable_member_is_dropped(Config) ->
     ?assertEqual(CurrentUId, uid_of(Config, Server2, RaName)),
     ?assertEqual(3, length(element(2, ra:members({RaName, Server0})))).
 
+%% The UID guard that protects a retry from deleting a newer incarnation is
+%% evaluated on the member's own node, in the same call as the delete.
+force_delete_member_uid_guard(Config) ->
+    [Server0, _Server1, Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    RaName = queue_utils:ra_name(QQ),
+    ServerId = {RaName, Server2},
+
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    wait_until(fun() ->
+                       3 =:= length(element(2, ra:members({RaName, Server0})))
+               end),
+
+    CurrentUId = uid_of(Config, Server2, RaName),
+    ?assert(is_binary(CurrentUId)),
+
+    %% A UID that does not match the live incarnation leaves the member alone.
+    ?assertEqual({skipped, superseded},
+                 force_delete_member(Config, Server0, ServerId,
+                                     <<"stale-incarnation-uid">>)),
+    ?assertEqual(CurrentUId, uid_of(Config, Server2, RaName)),
+
+    %% The matching UID deletes it.
+    ?assertEqual(ok, force_delete_member(Config, Server0, ServerId, CurrentUId)),
+    ?assertEqual(undefined, uid_of(Config, Server2, RaName)),
+
+    %% A member that is already gone is reported as such rather than deleted again.
+    ?assertEqual({skipped, gone},
+                 force_delete_member(Config, Server0, ServerId, CurrentUId)).
+
 %% -------------------------------------------------------------------
 %% Helpers.
 %% -------------------------------------------------------------------
@@ -388,6 +422,10 @@ is_force_delete_group(Config) ->
 uid_of(Config, Node, RaName) ->
     rabbit_ct_broker_helpers:rpc(Config, Node, ra_directory, uid_of,
                                  [?RA_SYSTEM, RaName]).
+
+force_delete_member(Config, Node, ServerId, ExpectedUId) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_quorum_queue,
+                                 force_delete_member, [ServerId, ExpectedUId]).
 
 pending_lookup(Config, Node, RaName, MemberNode) ->
     rabbit_ct_broker_helpers:rpc(Config, Node, dets, lookup,


### PR DESCRIPTION
## Proposed Changes

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/17137 

When normal QQ deletion attempt fails, e.g. due to node down or bad network,
force deletion `rabbit_quorum_queue:force_delete_queue/1` is called and never
guaranteed to succeed. As a result, QQ member leaks remain on some of
the unreachable cluster nodes - leading to indefinite failed re-declaration attempts
of the same queue name cluster-wide, as explained in https://github.com/rabbitmq/rabbitmq-server/issues/17137. This PR fixes
this issue as follows:

- failed `force_delete_queue` list of `PendingMembers` are recorded in DETS by `rabbit_quorum_queue_periodic_membership_reconciliation` 
- the `rabbit_quorum_queue_periodic_membership_reconciliation` schedules periodic force deletion retries for `PendingMembers` via gen_server:cast/2 message `force_delete_recorded` 
- a `queue_force_deleted` event is emitted with list of `PendingMembers` which failed delete
- `PendingMembers` to be retried are held in node local DETS to survive broker restarts
- `PendingMembers` are tracked and deleted with their UIDs to avoid deleting new incarnations of the queue
   (i.e. requires `track_qq_members_uids` feature flag to be enabled).
- this now uses `ra:force_delete_server/3` with a bounded timeout, to avoid the problems
  reported in https://github.com/rabbitmq/rabbitmq-server/issues/17137 where force deletions took over
  a minute to complete leading to inconsistencies in the queue's ra member state across the cluster
- deletion retries are configurable via `rabbit.quorum_queue_force_delete_retry_interval` - the force delete timer runs only if there are any `PendingMembers` in the dets table. If empty, no periodic force deletions are scheduled.

**NOTE:** These changes also depend on https://github.com/rabbitmq/ra/pull/652 (will also be required for all tests to pass)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
