### PR TITLE
Consul peer discovery: gracefully handle 404 responses

### DIFF
--- a/deps/rabbitmq_peer_discovery_consul/src/rabbit_peer_discovery_consul.erl
+++ b/deps/rabbitmq_peer_discovery_consul/src/rabbit_peer_discovery_consul.erl
@@ -51,7 +51,7 @@ init() ->
     rabbit_peer_discovery_httpc:maybe_configure_proxy(),
     rabbit_peer_discovery_httpc:maybe_configure_inet6().
 
--spec list_nodes() -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} | {error, Reason :: string()}.
+-spec list_nodes() -> {ok, {SelectedNode :: node() | [], NodeType :: rabbit_types:node_type()}} | {error, Reason :: string()}.
 
 list_nodes() ->
     Fun0 = fun() -> {ok, {[], disc}} end,
@@ -290,7 +290,7 @@ sort_nodes(Nodes) ->
         IndexA =< IndexB
     end, Nodes).
 
--spec extract_node(ConsulResult :: [#{binary() => term()}]) -> list().
+-spec extract_node(ConsulResult :: [#{binary() => term()}]) -> node() | [].
 extract_node([]) ->
     [];
 extract_node([H | _]) ->
@@ -608,27 +608,26 @@ send_health_check_pass() ->
       ok
   end.
 
+%% `list_nodes/0' returns the single node Consul selected, not the full
+%% membership list (see `extract_node/1').
 maybe_re_register({error, Reason}) ->
     ?LOG_ERROR(
        "Internal error in Consul while updating health check. "
        "Cannot obtain list of nodes registered in Consul either: ~tp",
        [Reason],
        #{domain => ?RMQLOG_DOMAIN_PEER_DISC});
-maybe_re_register({ok, {Members, _NodeType}}) ->
-    maybe_re_register(Members);
-maybe_re_register(Members) ->
-    case lists:member(node(), Members) of
-        true ->
-            ?LOG_ERROR(
-               "Internal error in Consul while updating health check",
-               #{domain => ?RMQLOG_DOMAIN_PEER_DISC});
-        false ->
-            ?LOG_ERROR(
-               "Internal error in Consul while updating health check, "
-               "node is not registered. Re-registering",
-               #{domain => ?RMQLOG_DOMAIN_PEER_DISC}),
-            register()
-    end.
+maybe_re_register({ok, {SelectedNode, _NodeType}}) ->
+    maybe_re_register(SelectedNode);
+maybe_re_register(SelectedNode) when SelectedNode =:= node() ->
+    ?LOG_ERROR(
+       "Internal error in Consul while updating health check",
+       #{domain => ?RMQLOG_DOMAIN_PEER_DISC});
+maybe_re_register(_SelectedNodeOrNone) ->
+    ?LOG_ERROR(
+       "Internal error in Consul while updating health check, "
+       "node is not registered. Re-registering",
+       #{domain => ?RMQLOG_DOMAIN_PEER_DISC}),
+    register().
 
 wait_for_list_nodes() ->
     wait_for_list_nodes(60).

--- a/deps/rabbitmq_peer_discovery_consul/src/rabbitmq_peer_discovery_consul.erl
+++ b/deps/rabbitmq_peer_discovery_consul/src/rabbitmq_peer_discovery_consul.erl
@@ -22,7 +22,7 @@
 init() ->
     ?DELEGATE:init().
 
--spec list_nodes() -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} | {error, Reason :: string()}.
+-spec list_nodes() -> {ok, {Nodes :: [node()] | node(), NodeType :: rabbit_types:node_type()}} | {error, Reason :: string()}.
 list_nodes() ->
     ?DELEGATE:list_nodes().
 

--- a/deps/rabbitmq_peer_discovery_consul/test/rabbitmq_peer_discovery_consul_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_consul/test/rabbitmq_peer_discovery_consul_SUITE.erl
@@ -71,7 +71,10 @@ groups() ->
                  health_check_with_all_defaults_test,
                  health_check_without_acl_token_test,
                  health_check_with_acl_token_test,
-                 health_check_error_handling_test
+                 health_check_error_handling_test,
+                 health_check_404_triggers_re_registration_without_crashing_test,
+                 maybe_re_register_ignores_own_node_test,
+                 maybe_re_register_reregisters_when_node_list_is_empty_test
                 ]}
     , {lock_tests, [], [
                         startup_lock_path_with_prefix_test,
@@ -763,6 +766,50 @@ health_check_error_handling_test(_Config) ->
            end),
          ?assertEqual(ok, rabbit_peer_discovery_consul:send_health_check_pass()),
          ?assert(meck:validate(rabbit_peer_discovery_httpc)).
+
+health_check_404_triggers_re_registration_without_crashing_test(_Config) ->
+    application:set_env(rabbit, cluster_formation,
+                        [
+                         {peer_discovery_backend,         rabbit_peer_discovery_consul},
+                         {peer_discovery_consul,          [
+                                                           {consul_host, "localhost"},
+                                                           {consul_port, 8500}
+                                                          ]}
+                        ]),
+    meck:expect(rabbit_peer_discovery_httpc, put,
+             fun
+                 (_, _, _, "v1/agent/check/pass/service:rabbitmq", _, _, _, _) ->
+                     {error, "404"};
+                 (_, _, _, "v1/session/create", _, _, _, _) ->
+                     Body = "{\"ID\":\"some-session-id\"}",
+                     rabbit_json:try_decode(rabbit_data_coercion:to_binary(Body));
+                 (_, _, _, "v1/kv/rabbitmq/default/startup_lock", _, _, _, _) ->
+                     Body = "true",
+                     rabbit_json:try_decode(rabbit_data_coercion:to_binary(Body));
+                 (_, _, _, "v1/agent/service/register", _, _, _, _) ->
+                     {ok, []}
+             end),
+    meck:expect(rabbit_peer_discovery_httpc, get,
+             fun(_, _, _, _, _, _, _) ->
+               Body = "[{\"Node\": {\"Node\": \"peer.internal.domain\", \"Address\": \"10.20.16.160\"}, \"Checks\": [], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": []}}]",
+               rabbit_json:try_decode(rabbit_data_coercion:to_binary(Body))
+             end),
+    meck:expect(rabbit_nodes, name_type, fun() -> shortnames end),
+    ?assertEqual(ok, rabbit_peer_discovery_consul:send_health_check_pass()),
+    ?assert(meck:validate(rabbit_peer_discovery_httpc)).
+
+maybe_re_register_ignores_own_node_test(_Config) ->
+    ?assertEqual(ok, rabbit_peer_discovery_consul:maybe_re_register({error, "some reason"})),
+    ?assertEqual(ok, rabbit_peer_discovery_consul:maybe_re_register({ok, {node(), disc}})),
+    ?assertEqual(0, meck:num_calls(rabbit_peer_discovery_httpc, put, '_')).
+
+maybe_re_register_reregisters_when_node_list_is_empty_test(_Config) ->
+    meck:expect(rabbit_peer_discovery_httpc, put,
+             fun(_, _, _, "v1/agent/service/register", _, _, _, _) ->
+                     {ok, []}
+             end),
+    ?assertEqual(ok, rabbit_peer_discovery_consul:maybe_re_register({ok, {[], disc}})),
+    ?assert(meck:validate(rabbit_peer_discovery_httpc)).
 
 
 unregistration_with_all_defaults_test(_Config) ->


### PR DESCRIPTION
from the Consul API.

Not throwing is enough to let the peer discovery
process to be retried and for the node to continue booting (assuming eventual success).

Closes #17211.