### PR TITLE
ldap: escape down-level logon names by parts

### DIFF
--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -934,20 +934,18 @@ simple_bind_fill_pattern(none, Username) ->
 simple_bind_fill_pattern(Pattern, Username) ->
     fill_bind_dn(Pattern, Username).
 
-%% Fills a bind-identity DN pattern (`user_dn_pattern' or
-%% `user_bind_pattern'). `${username}' is pre-filled via
-%% `escaped_username_value/2' so AD down-level logon names ("DOMAIN\user")
-%% are escaped by component, not as a whole value.
+%% Fills `user_dn_pattern' or `user_bind_pattern'. `${username}' is
+%% pre-filled so AD down-level logon names ("DOMAIN\user") are escaped by
+%% component, not as a whole value.
 fill_bind_dn(Pattern, Username) ->
     ADArgs = safe_ad_args(
                rabbit_auth_backend_ldap_util:get_active_directory_args(Username)),
     Pattern1 = fill(Pattern, [{username, escaped_username_value(Username, ADArgs)}]),
     fill_dn(Pattern1, ADArgs).
 
-%% Fills an authorisation-query DN pattern (the `evaluate0/4' DN clauses)
-%% the same way `fill_bind_dn/2' fills a bind DN. Other query variables in
-%% `Args' are escaped by `fill_dn/2' as before; the caller's AD args are
-%% replaced with the `safe_ad_args/1'-vetted ones.
+%% Same as `fill_bind_dn/2', for the `evaluate0/4' DN patterns. Other
+%% query variables in `Args' are escaped as before; the caller's AD args
+%% are replaced with the vetted ones.
 fill_dn_with_username(DNPattern, Args) ->
     Username = pget(username, Args),
     ADArgs = safe_ad_args(
@@ -957,13 +955,11 @@ fill_dn_with_username(DNPattern, Args) ->
                        K =/= username, K =/= ad_domain, K =/= ad_user],
     fill_dn(DNPattern1, ADArgs ++ OtherArgs).
 
-%% Rejects an unusable "DOMAIN\user" split. A user part containing a
-%% backslash makes the separator ambiguous. A user part whose escaped form
-%% starts with a backslash would pair with a preceding literal backslash
-%% (in the rejoined name or in a "${ad_domain}\${ad_user}" pattern),
-%% un-escaping the special character after it -- a DN injection. With no
-%% AD args, `${username}' falls back to whole-value escaping and AD
-%% variables stay unfilled, so the DN cannot bind.
+%% Rejects an unusable "DOMAIN\user" split: a backslash in the user part
+%% makes the separator ambiguous, and an escaped user part starting with a
+%% backslash would pair with a preceding literal one, un-escaping the
+%% character after it (a DN injection). With no AD args, `${username}'
+%% falls back to whole-value escaping and AD variables stay unfilled.
 safe_ad_args([{ad_domain, _}, {ad_user, User}] = ADArgs) ->
     UserList = rabbit_data_coercion:to_list(User),
     EscapedUser = rabbit_ldap_rfc4514:escape_value(UserList),
@@ -974,10 +970,10 @@ safe_ad_args([{ad_domain, _}, {ad_user, User}] = ADArgs) ->
 safe_ad_args([]) ->
     [].
 
-%% RFC 4514-escaping the down-level separator backslash would double it and
-%% break the bind against AD (RMQ-4282), so the domain and user components
-%% are escaped independently and rejoined with a bare backslash. The AD
-%% args have already passed `safe_ad_args/1'.
+%% Escaping the down-level separator backslash would break the bind
+%% against AD (RMQ-4282), so the two components are escaped independently
+%% and rejoined with a bare backslash. The split has already passed
+%% `safe_ad_args/1'.
 escaped_username_value(_Username, [{ad_domain, Domain}, {ad_user, User}]) ->
     rabbit_ldap_rfc4514:escape_value(rabbit_data_coercion:to_list(Domain)) ++
         "\\" ++ rabbit_ldap_rfc4514:escape_value(rabbit_data_coercion:to_list(User));

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -934,59 +934,53 @@ simple_bind_fill_pattern(none, Username) ->
 simple_bind_fill_pattern(Pattern, Username) ->
     fill_bind_dn(Pattern, Username).
 
-%% Fills a bind-identity DN pattern (`user_dn_pattern'/`user_bind_pattern')
-%% with an RFC 4514-escaped `username', then any remaining `ad_domain'/
-%% `ad_user' substitutions.
-%%
-%% `${username}' is pre-filled separately (rather than via `fill_dn') so
-%% that AD down-level logon names ("DOMAIN\user") can be escaped
-%% component-wise: see escaped_username_value/2.
+%% Fills a bind-identity DN pattern (`user_dn_pattern' or
+%% `user_bind_pattern'). `${username}' is pre-filled via
+%% `escaped_username_value/2' so AD down-level logon names ("DOMAIN\user")
+%% are escaped by component, not as a whole value.
 fill_bind_dn(Pattern, Username) ->
-    ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
+    ADArgs = safe_ad_args(
+               rabbit_auth_backend_ldap_util:get_active_directory_args(Username)),
     Pattern1 = fill(Pattern, [{username, escaped_username_value(Username, ADArgs)}]),
     fill_dn(Pattern1, ADArgs).
 
-%% Fills an authorisation-query DN pattern (`vhost_access_query',
-%% `resource_access_query', `topic_access_query', `tag_queries' --
-%% the `exists', `in_group', `in_group_nested' and `attribute' clauses
-%% of evaluate0/4) the same way fill_bind_dn/2 fills a bind DN: `username'
-%% is pre-filled component-wise so an AD down-level logon name in the
-%% pattern isn't broken by whole-value escaping (RMQ-4282). `Args' also
-%% carries `user_dn', `vhost', and other query variables, which fill_dn/2
-%% still escapes as usual.
+%% Fills an authorisation-query DN pattern (the `evaluate0/4' DN clauses)
+%% the same way `fill_bind_dn/2' fills a bind DN. Other query variables in
+%% `Args' are escaped by `fill_dn/2' as before; the caller's AD args are
+%% replaced with the `safe_ad_args/1'-vetted ones.
 fill_dn_with_username(DNPattern, Args) ->
     Username = pget(username, Args),
-    ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
+    ADArgs = safe_ad_args(
+               rabbit_auth_backend_ldap_util:get_active_directory_args(Username)),
     DNPattern1 = fill(DNPattern, [{username, escaped_username_value(Username, ADArgs)}]),
-    fill_dn(DNPattern1, lists:keydelete(username, 1, Args)).
+    OtherArgs = [KV || {K, _} = KV <- Args,
+                       K =/= username, K =/= ad_domain, K =/= ad_user],
+    fill_dn(DNPattern1, ADArgs ++ OtherArgs).
 
-%% AD down-level logon names ("DOMAIN\user") use backslash as a domain
-%% separator, not DN-attribute data. Escaping it per RFC 4514 would double
-%% it, breaking the bind against AD (RMQ-4282). Escape the domain and user
-%% components independently instead, and rejoin them with a literal
-%% backslash, so any other RFC 4514-special character in either component
-%% is still escaped.
-%%
-%% A username with more than one backslash isn't a valid down-level logon
-%% name -- which one would be the separator is ambiguous -- so it falls
-%% through to whole-value escaping, same as a username with none.
-%%
-%% The same fallback applies when the escaped user part starts with a
-%% backslash (its first character is itself RFC 4514-special): that
-%% backslash would sit right after the domain-separator backslash, and a
-%% DN parser reads the pair as one escaped literal backslash, leaving the
-%% special character that follows unescaped and able to inject a new DN
-%% component.
-escaped_username_value(Username, [{ad_domain, Domain}, {ad_user, User}]) ->
+%% Rejects an unusable "DOMAIN\user" split. A user part containing a
+%% backslash makes the separator ambiguous. A user part whose escaped form
+%% starts with a backslash would pair with a preceding literal backslash
+%% (in the rejoined name or in a "${ad_domain}\${ad_user}" pattern),
+%% un-escaping the special character after it -- a DN injection. With no
+%% AD args, `${username}' falls back to whole-value escaping and AD
+%% variables stay unfilled, so the DN cannot bind.
+safe_ad_args([{ad_domain, _}, {ad_user, User}] = ADArgs) ->
     UserList = rabbit_data_coercion:to_list(User),
     EscapedUser = rabbit_ldap_rfc4514:escape_value(UserList),
     case lists:member($\\, UserList) orelse lists:prefix("\\", EscapedUser) of
-        false ->
-            rabbit_ldap_rfc4514:escape_value(rabbit_data_coercion:to_list(Domain)) ++
-            "\\" ++ EscapedUser;
-        true ->
-            escaped_username_value(Username, [])
+        false -> ADArgs;
+        true  -> []
     end;
+safe_ad_args([]) ->
+    [].
+
+%% RFC 4514-escaping the down-level separator backslash would double it and
+%% break the bind against AD (RMQ-4282), so the domain and user components
+%% are escaped independently and rejoined with a bare backslash. The AD
+%% args have already passed `safe_ad_args/1'.
+escaped_username_value(_Username, [{ad_domain, Domain}, {ad_user, User}]) ->
+    rabbit_ldap_rfc4514:escape_value(rabbit_data_coercion:to_list(Domain)) ++
+        "\\" ++ rabbit_ldap_rfc4514:escape_value(rabbit_data_coercion:to_list(User));
 escaped_username_value(Username, []) ->
     rabbit_ldap_rfc4514:escape_value(Username).
 

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -26,7 +26,8 @@
 
 %% for tests
 -export([purge_connections/0,
-         fill_user_dn_pattern/1, escaped_user_dn/1, simple_bind_fill_pattern/1]).
+         fill_user_dn_pattern/1, escaped_user_dn/1, simple_bind_fill_pattern/1,
+         fill_dn_with_username/2]).
 
 -define(L(F, A),  log("LDAP "         ++ F, A)).
 -define(L1(F, A), log("    LDAP "     ++ F, A)).
@@ -247,7 +248,7 @@ evaluate0({for, []}, _Args, _User, _LDAP) ->
 evaluate0({exists, DNPattern}, Args, _User, LDAP) ->
     %% eldap forces us to have a filter. objectClass should always be there.
     Filter = eldap:present("objectClass"),
-    DN = fill_dn(DNPattern, Args),
+    DN = fill_dn_with_username(DNPattern, Args),
     R = object_exists(DN, Filter, LDAP),
     ?L1("evaluated exists for \"~ts\": ~tp", [DN, R]),
     R;
@@ -259,7 +260,7 @@ evaluate0({in_group, DNPattern, Desc}, Args,
           #auth_user{impl = ImplFun}, LDAP) ->
     UserDN = (ImplFun())#impl.user_dn,
     Filter = eldap:equalityMatch(Desc, UserDN),
-    DN = fill_dn(DNPattern, Args),
+    DN = fill_dn_with_username(DNPattern, Args),
     R = object_exists(DN, Filter, LDAP),
     ?L1("evaluated in_group for \"~ts\": ~tp", [DN, R]),
     R;
@@ -278,7 +279,7 @@ evaluate0({in_group_nested, DNPattern, Desc, Scope}, Args,
                      B ->
                          B
                  end,
-    GroupDN = fill_dn(DNPattern, Args),
+    GroupDN = fill_dn_with_username(DNPattern, Args),
     EldapScope =
         case Scope of
             subtree      -> eldap:wholeSubtree();
@@ -369,7 +370,7 @@ evaluate0({string, StringPattern}, Args, _User, _LDAP) ->
     R;
 
 evaluate0({attribute, DNPattern, AttributeName}, Args, _User, LDAP) ->
-    DN = fill_dn(DNPattern, Args),
+    DN = fill_dn_with_username(DNPattern, Args),
     R = attribute(DN, AttributeName, LDAP),
     ?L1("evaluated attribute \"~ts\" for \"~ts\": ~tp",
         [AttributeName, DN, format_multi_attr(R)]),
@@ -944,6 +945,20 @@ fill_bind_dn(Pattern, Username) ->
     ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
     Pattern1 = fill(Pattern, [{username, escaped_username_value(Username, ADArgs)}]),
     fill_dn(Pattern1, ADArgs).
+
+%% Fills an authorisation-query DN pattern (`vhost_access_query',
+%% `resource_access_query', `topic_access_query', `tag_queries' --
+%% the `exists', `in_group', `in_group_nested' and `attribute' clauses
+%% of evaluate0/4) the same way fill_bind_dn/2 fills a bind DN: `username'
+%% is pre-filled component-wise so an AD down-level logon name in the
+%% pattern isn't broken by whole-value escaping (RMQ-4282). `Args' also
+%% carries `user_dn', `vhost', and other query variables, which fill_dn/2
+%% still escapes as usual.
+fill_dn_with_username(DNPattern, Args) ->
+    Username = pget(username, Args),
+    ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
+    DNPattern1 = fill(DNPattern, [{username, escaped_username_value(Username, ADArgs)}]),
+    fill_dn(DNPattern1, lists:keydelete(username, 1, Args)).
 
 %% AD down-level logon names ("DOMAIN\user") use backslash as a domain
 %% separator, not DN-attribute data. Escaping it per RFC 4514 would double

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -26,7 +26,7 @@
 
 %% for tests
 -export([purge_connections/0,
-         fill_user_dn_pattern/1, escaped_user_dn/1]).
+         fill_user_dn_pattern/1, escaped_user_dn/1, simple_bind_fill_pattern/1]).
 
 -define(L(F, A),  log("LDAP "         ++ F, A)).
 -define(L1(F, A), log("    LDAP "     ++ F, A)).
@@ -923,8 +923,7 @@ fill_user_dn_pattern(Username) ->
 %% The user DN built from `user_dn_pattern' with RFC 4514-escaped
 %% substitutions. A no-op for usernames without DN-special characters.
 escaped_user_dn(Username) ->
-    ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
-    fill_dn(env(user_dn_pattern), [{username, Username}] ++ ADArgs).
+    fill_bind_dn(env(user_dn_pattern), Username).
 
 simple_bind_fill_pattern(Username) ->
     simple_bind_fill_pattern(env(user_bind_pattern), Username).
@@ -932,8 +931,49 @@ simple_bind_fill_pattern(Username) ->
 simple_bind_fill_pattern(none, Username) ->
     escaped_user_dn(Username);
 simple_bind_fill_pattern(Pattern, Username) ->
+    fill_bind_dn(Pattern, Username).
+
+%% Fills a bind-identity DN pattern (`user_dn_pattern'/`user_bind_pattern')
+%% with an RFC 4514-escaped `username', then any remaining `ad_domain'/
+%% `ad_user' substitutions.
+%%
+%% `${username}' is pre-filled separately (rather than via `fill_dn') so
+%% that AD down-level logon names ("DOMAIN\user") can be escaped
+%% component-wise: see escaped_username_value/2.
+fill_bind_dn(Pattern, Username) ->
     ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
-    fill_dn(Pattern, [{username, Username}] ++ ADArgs).
+    Pattern1 = fill(Pattern, [{username, escaped_username_value(Username, ADArgs)}]),
+    fill_dn(Pattern1, ADArgs).
+
+%% AD down-level logon names ("DOMAIN\user") use backslash as a domain
+%% separator, not DN-attribute data. Escaping it per RFC 4514 would double
+%% it, breaking the bind against AD (RMQ-4282). Escape the domain and user
+%% components independently instead, and rejoin them with a literal
+%% backslash, so any other RFC 4514-special character in either component
+%% is still escaped.
+%%
+%% A username with more than one backslash isn't a valid down-level logon
+%% name -- which one would be the separator is ambiguous -- so it falls
+%% through to whole-value escaping, same as a username with none.
+%%
+%% The same fallback applies when the escaped user part starts with a
+%% backslash (its first character is itself RFC 4514-special): that
+%% backslash would sit right after the domain-separator backslash, and a
+%% DN parser reads the pair as one escaped literal backslash, leaving the
+%% special character that follows unescaped and able to inject a new DN
+%% component.
+escaped_username_value(Username, [{ad_domain, Domain}, {ad_user, User}]) ->
+    UserList = rabbit_data_coercion:to_list(User),
+    EscapedUser = rabbit_ldap_rfc4514:escape_value(UserList),
+    case lists:member($\\, UserList) orelse lists:prefix("\\", EscapedUser) of
+        false ->
+            rabbit_ldap_rfc4514:escape_value(rabbit_data_coercion:to_list(Domain)) ++
+            "\\" ++ EscapedUser;
+        true ->
+            escaped_username_value(Username, [])
+    end;
+escaped_username_value(Username, []) ->
+    rabbit_ldap_rfc4514:escape_value(Username).
 
 creds(User) -> creds(User, env(other_bind)).
 

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_util.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_util.erl
@@ -27,14 +27,22 @@ to_repl([$&  | T])           -> [$\\, $&  | to_repl(T)];
 to_repl([H   | T])           -> [H        | to_repl(T)];
 to_repl(_)                   -> []. % fancy variables like peer IP are just ignored
 
-get_active_directory_args([ADDomain, ADUser]) ->
-    [{ad_domain, ADDomain}, {ad_user, ADUser}];
-get_active_directory_args(Parts) when is_list(Parts) ->
-    [];
+%% If Username is in Domain\User format, provide additional fill template
+%% arguments.
+%%
+%% Only binary Usernames are split: a 2-element split/1 result is only
+%% meaningful for a genuine Domain\User binary, and matching on any
+%% 2-element list here would also (mis)fire for an unrelated plain-string
+%% Username of exactly two characters.
 get_active_directory_args(Username) when is_binary(Username) ->
-    % If Username is in Domain\User format, provide additional fill
-    % template arguments
-    get_active_directory_args(binary:split(Username, <<"\\">>, [trim_all])).
+    split_active_directory_args(binary:split(Username, <<"\\">>, [trim_all]));
+get_active_directory_args(_Username) ->
+    [].
+
+split_active_directory_args([ADDomain, ADUser]) ->
+    [{ad_domain, ADDomain}, {ad_user, ADUser}];
+split_active_directory_args(_Parts) ->
+    [].
 
 parse_query(Query) when is_binary(Query) ->
     parse_query(rabbit_data_coercion:to_unicode_charlist(Query));

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_util.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_util.erl
@@ -27,13 +27,9 @@ to_repl([$&  | T])           -> [$\\, $&  | to_repl(T)];
 to_repl([H   | T])           -> [H        | to_repl(T)];
 to_repl(_)                   -> []. % fancy variables like peer IP are just ignored
 
-%% If Username is in Domain\User format, provide additional fill template
-%% arguments.
-%%
-%% Only binary Usernames are split: a 2-element split/1 result is only
-%% meaningful for a genuine Domain\User binary, and matching on any
-%% 2-element list here would also (mis)fire for an unrelated plain-string
-%% Username of exactly two characters.
+%% If a binary Username is in Domain\User format, provide additional fill
+%% template arguments. Lists are not split: any 2-element list would also
+%% match a plain 2-character username.
 get_active_directory_args(Username) when is_binary(Username) ->
     split_active_directory_args(binary:split(Username, <<"\\">>, [trim_all]));
 get_active_directory_args(_Username) ->

--- a/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
@@ -24,6 +24,7 @@ all() ->
      user_bind_pattern_escaping_rmq_4282,
      leading_special_char_no_dn_injection_rmq_4282,
      authz_query_dn_pattern_escaping_rmq_4282,
+     ad_variable_pattern_escaping_rmq_4282,
      user_dn_pattern_gh_7161,
      format_different_types_of_ldap_attribute_values,
      ldap_log_domain_routing,
@@ -258,6 +259,50 @@ authz_query_dn_pattern_escaping_rmq_4282(_Config) ->
     ?assertEqual("cn=" ++ rabbit_ldap_rfc4514:escape_value("DOMAIN\\,ou=Finance") ++ ",ou=a\\,b",
                  rabbit_auth_backend_ldap:fill_dn_with_username(
                    "cn=${username},ou=${vhost}", Args(<<"DOMAIN\\,ou=Finance">>))),
+    ok.
+
+%% Patterns can use `${ad_domain}' and `${ad_user}' directly. When the AD
+%% split is unsafe (see `safe_ad_args/1'), both variables stay unfilled.
+ad_variable_pattern_escaping_rmq_4282(_Config) ->
+    PrevBindPattern = application:get_env(rabbitmq_auth_backend_ldap, user_bind_pattern),
+    PrevLog = application:get_env(rabbitmq_auth_backend_ldap, log),
+    ok = application:set_env(rabbitmq_auth_backend_ldap, log, false),
+    try
+        SetPattern = fun(P) ->
+            ok = application:set_env(rabbitmq_auth_backend_ldap, user_bind_pattern, P)
+        end,
+        SetPattern("${ad_user}-${ad_domain}"),
+        ?assertEqual("alice-CORP",
+                     rabbit_auth_backend_ldap:simple_bind_fill_pattern(
+                       <<"CORP\\alice">>)),
+        %% A special character inside the user part is escaped as usual.
+        ?assertEqual("a\\,b-CORP",
+                     rabbit_auth_backend_ldap:simple_bind_fill_pattern(
+                       <<"CORP\\a,b">>)),
+        SetPattern("${ad_domain}\\${ad_user}"),
+        ?assertEqual("CORP\\alice",
+                     rabbit_auth_backend_ldap:simple_bind_fill_pattern(
+                       <<"CORP\\alice">>)),
+        %% A leading special character in the user part would pair its
+        %% escape backslash with the pattern's literal one.
+        ?assertEqual("${ad_domain}\\${ad_user}",
+                     rabbit_auth_backend_ldap:simple_bind_fill_pattern(
+                       <<"CORP\\,ou=Evil">>)),
+        %% The authz-query path uses the same vetted AD args.
+        ?assertEqual("cn=alice,ou=CORP",
+                     rabbit_auth_backend_ldap:fill_dn_with_username(
+                       "cn=${ad_user},ou=${ad_domain}",
+                       [{username, <<"CORP\\alice">>},
+                        {ad_domain, <<"CORP">>}, {ad_user, <<"alice">>}])),
+        ?assertEqual("ou=Groups\\${ad_user}",
+                     rabbit_auth_backend_ldap:fill_dn_with_username(
+                       "ou=Groups\\${ad_user}",
+                       [{username, <<"CORP\\,ou=Evil">>},
+                        {ad_domain, <<"CORP">>}, {ad_user, <<",ou=Evil">>}]))
+    after
+        restore_env(user_bind_pattern, PrevBindPattern),
+        restore_env(log, PrevLog)
+    end,
     ok.
 
 restore_env(Key, {ok, V}) -> application:set_env(rabbitmq_auth_backend_ldap, Key, V);

--- a/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
@@ -23,6 +23,7 @@ all() ->
      user_dn_pattern_escaping_rmq_4282,
      user_bind_pattern_escaping_rmq_4282,
      leading_special_char_no_dn_injection_rmq_4282,
+     authz_query_dn_pattern_escaping_rmq_4282,
      user_dn_pattern_gh_7161,
      format_different_types_of_ldap_attribute_values,
      ldap_log_domain_routing,
@@ -201,15 +202,17 @@ user_bind_pattern_escaping_rmq_4282(_Config) ->
     end,
     ok.
 
-%% RMQ-4282 follow-up: escaped_username_value/2 rejoins the escaped domain
-%% and user components with a literal, unescaped separator backslash. If the
-%% user part's first character is itself RFC 4514-special (comma, plus,
-%% quote, semicolon, or angle bracket), escaping it produces a value that
+%% `escaped_username_value/2` (re)joins the escaped domain
+%% and user components with a literal, unescaped separator backslash.
+%%
+%% If the user part's first character is itself RFC 4514-special (a comma, a plus,
+%% a quote, a semicolon, or an angle bracket), escaping it produces a value that
 %% also starts with a backslash. That backslash pairs up with the separator
 %% backslash under RFC 4514's own parsing rule (a backslash always starts a
 %% two-character escape), leaving the special character right after the
-%% pair completely unescaped -- letting it act as a fresh RDN separator and
-%% splice an attacker-chosen RDN into the bind DN. This must fall back to
+%% pair completely unescaped and letting it act as a fresh RDN separator.
+%%
+%% In this case we must fall back to
 %% whole-value escaping instead, exactly like the "more than one backslash"
 %% and "leading/trailing backslash" cases above.
 leading_special_char_no_dn_injection_rmq_4282(_Config) ->
@@ -236,6 +239,25 @@ leading_special_char_no_dn_injection_rmq_4282(_Config) ->
         restore_env(user_dn_pattern, PrevPattern),
         restore_env(log, PrevLog)
     end,
+    ok.
+
+%% RMQ-4282 follow-up: `check_vhost_access', `check_resource_access',
+%% `check_topic_access' and `do_tag_queries' build the same `${username}'
+%% substitution for `exists', `in_group', `in_group_nested' and `attribute'
+%% DN patterns (evaluate0/4) as the bind-DN path, so an AD down-level logon
+%% name must round-trip there too, and the other query variables (e.g.
+%% `${vhost}') must still be RFC 4514-escaped as before.
+authz_query_dn_pattern_escaping_rmq_4282(_Config) ->
+    Args = fun(Username) -> [{username, Username}, {vhost, <<"a,b">>}] end,
+    ?assertEqual("cn=foo\\bar,ou=a\\,b",
+                 rabbit_auth_backend_ldap:fill_dn_with_username(
+                   "cn=${username},ou=${vhost}", Args(<<"foo\\bar">>))),
+    ?assertEqual("cn=" ++ rabbit_ldap_rfc4514:escape_value("A\\B\\C") ++ ",ou=a\\,b",
+                 rabbit_auth_backend_ldap:fill_dn_with_username(
+                   "cn=${username},ou=${vhost}", Args(<<"A\\B\\C">>))),
+    ?assertEqual("cn=" ++ rabbit_ldap_rfc4514:escape_value("DOMAIN\\,ou=Finance") ++ ",ou=a\\,b",
+                 rabbit_auth_backend_ldap:fill_dn_with_username(
+                   "cn=${username},ou=${vhost}", Args(<<"DOMAIN\\,ou=Finance">>))),
     ok.
 
 restore_env(Key, {ok, V}) -> application:set_env(rabbitmq_auth_backend_ldap, Key, V);

--- a/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
@@ -130,17 +130,11 @@ dn_lookup_fallback_dn_escaping(_Config) ->
     end,
     ok.
 
-%% RMQ-4282: a user using the default `user_dn_pattern` ("${username}")
-%% with AD down-level logon names ("DOMAIN\username") got "Access Refused"
-%% after PR #16101 started RFC 4514-escaping DN template substitutions: the
-%% backslash separating domain and user is itself RFC 4514-special, so it
-%% was escaped to a literal double backslash, which no longer matched the
-%% single-backslash down-level logon name AD expects.
+%% RMQ-4282: AD down-level logon names ("DOMAIN\user") failed to bind
+%% after PR #16101 escaped the separator backslash into a double one.
 %%
-%% get_active_directory_args/1 only recognises the "DOMAIN\user" split for
-%% binary usernames (a plain list/string always yields no AD args), and a
-%% binary is what every real login supplies (see rabbit_auth_mechanism_plain),
-%% so these tests use binaries throughout.
+%% Real logins supply binary usernames (only binaries are split into AD
+%% args), so these tests use binaries throughout.
 user_dn_pattern_escaping_rmq_4282(_Config) ->
     PrevPattern = application:get_env(rabbitmq_auth_backend_ldap, user_dn_pattern),
     PrevLog = application:get_env(rabbitmq_auth_backend_ldap, log),
@@ -148,33 +142,28 @@ user_dn_pattern_escaping_rmq_4282(_Config) ->
     ok = application:set_env(rabbitmq_auth_backend_ldap, user_dn_pattern, "${username}"),
     try
         Username = <<"foo\\bar">>,
-        %% Bare fill (used for filter values, e.g. dn_lookup) was already
-        %% unescaped, and remains so.
+        %% Bare fill (filter values, e.g. dn_lookup) remains unescaped.
         ?assertEqual("foo\\bar",
                      rabbit_auth_backend_ldap:fill_user_dn_pattern(Username)),
-        %% Used as a bind DN, the domain-separator backslash is no longer
-        %% doubled: the down-level logon name reaches AD unchanged.
+        %% As a bind DN, the separator backslash is no longer doubled.
         ?assertEqual("foo\\bar",
                      rabbit_auth_backend_ldap:escaped_user_dn(Username)),
-        %% A comma inside the user part is still RFC 4514-escaped -- only the
-        %% domain-separator backslash is exempted, not DN injection generally.
+        %% Only the separator backslash is exempted; a comma inside the
+        %% user part is still escaped.
         ?assertEqual("foo\\evil\\,ou=admins",
                      rabbit_auth_backend_ldap:escaped_user_dn(
                        <<"foo\\evil,ou=admins">>)),
-        %% More than one backslash is not a valid down-level logon name --
-        %% which one is the separator is ambiguous -- so the whole value
-        %% falls back to ordinary (fully escaped) DN-attribute treatment.
+        %% More than one backslash: the separator is ambiguous, so the
+        %% whole value is escaped.
         ?assertEqual("A\\\\B\\\\C",
                      rabbit_auth_backend_ldap:escaped_user_dn(<<"A\\B\\C">>)),
-        %% A leading or trailing backslash has no domain or user part to
-        %% split on (get_active_directory_args/1 yields no AD args for
-        %% either), so it also falls back to whole-value escaping.
+        %% A leading or trailing backslash leaves no split: the whole value
+        %% is escaped.
         ?assertEqual("\\\\user",
                      rabbit_auth_backend_ldap:escaped_user_dn(<<"\\user">>)),
         ?assertEqual("DOMAIN\\\\",
                      rabbit_auth_backend_ldap:escaped_user_dn(<<"DOMAIN\\">>)),
-        %% UPN format (user@domain) has no RFC 4514-special characters, so it
-        %% passes through unchanged.
+        %% UPN format (user@domain) has no special characters: unchanged.
         ?assertEqual("foo@example.test",
                      rabbit_auth_backend_ldap:escaped_user_dn(
                        <<"foo@example.test">>)),
@@ -186,8 +175,7 @@ user_dn_pattern_escaping_rmq_4282(_Config) ->
     end,
     ok.
 
-%% The same fix applies to `user_bind_pattern` (used for simple binds when
-%% `dn_lookup_when/0` is not `prebind`), not just `user_dn_pattern`.
+%% The same fix applies to `user_bind_pattern', not just `user_dn_pattern'.
 user_bind_pattern_escaping_rmq_4282(_Config) ->
     PrevBindPattern = application:get_env(rabbitmq_auth_backend_ldap, user_bind_pattern),
     PrevLog = application:get_env(rabbitmq_auth_backend_ldap, log),
@@ -203,19 +191,9 @@ user_bind_pattern_escaping_rmq_4282(_Config) ->
     end,
     ok.
 
-%% `escaped_username_value/2` (re)joins the escaped domain
-%% and user components with a literal, unescaped separator backslash.
-%%
-%% If the user part's first character is itself RFC 4514-special (a comma, a plus,
-%% a quote, a semicolon, or an angle bracket), escaping it produces a value that
-%% also starts with a backslash. That backslash pairs up with the separator
-%% backslash under RFC 4514's own parsing rule (a backslash always starts a
-%% two-character escape), leaving the special character right after the
-%% pair completely unescaped and letting it act as a fresh RDN separator.
-%%
-%% In this case we must fall back to
-%% whole-value escaping instead, exactly like the "more than one backslash"
-%% and "leading/trailing backslash" cases above.
+%% An escaped user part starting with a backslash would pair with the
+%% separator backslash, un-escaping the special character after it. Such
+%% usernames fall back to whole-value escaping.
 leading_special_char_no_dn_injection_rmq_4282(_Config) ->
     PrevPattern = application:get_env(rabbitmq_auth_backend_ldap, user_dn_pattern),
     PrevLog = application:get_env(rabbitmq_auth_backend_ldap, log),
@@ -231,8 +209,8 @@ leading_special_char_no_dn_injection_rmq_4282(_Config) ->
         [?assertEqual(rabbit_ldap_rfc4514:escape_value(binary_to_list(Username)),
                        rabbit_auth_backend_ldap:escaped_user_dn(Username))
          || Username <- Injections],
-        %% A user part that does NOT start with an RFC 4514 special still
-        %% takes the (safe) domain/user split path, unaffected by the fix.
+        %% A user part not starting with a special character still takes
+        %% the split path.
         ?assertEqual("foo\\evil\\,ou=admins",
                      rabbit_auth_backend_ldap:escaped_user_dn(
                        <<"foo\\evil,ou=admins">>))
@@ -242,12 +220,8 @@ leading_special_char_no_dn_injection_rmq_4282(_Config) ->
     end,
     ok.
 
-%% RMQ-4282 follow-up: `check_vhost_access', `check_resource_access',
-%% `check_topic_access' and `do_tag_queries' build the same `${username}'
-%% substitution for `exists', `in_group', `in_group_nested' and `attribute'
-%% DN patterns (evaluate0/4) as the bind-DN path, so an AD down-level logon
-%% name must round-trip there too, and the other query variables (e.g.
-%% `${vhost}') must still be RFC 4514-escaped as before.
+%% The `evaluate0/4' DN patterns fill `${username}' like the bind-DN path,
+%% while other query variables stay escaped.
 authz_query_dn_pattern_escaping_rmq_4282(_Config) ->
     Args = fun(Username) -> [{username, Username}, {vhost, <<"a,b">>}] end,
     ?assertEqual("cn=foo\\bar,ou=a\\,b",
@@ -283,8 +257,7 @@ ad_variable_pattern_escaping_rmq_4282(_Config) ->
         ?assertEqual("CORP\\alice",
                      rabbit_auth_backend_ldap:simple_bind_fill_pattern(
                        <<"CORP\\alice">>)),
-        %% A leading special character in the user part would pair its
-        %% escape backslash with the pattern's literal one.
+        %% An unsafe user part leaves the variables unfilled.
         ?assertEqual("${ad_domain}\\${ad_user}",
                      rabbit_auth_backend_ldap:simple_bind_fill_pattern(
                        <<"CORP\\,ou=Evil">>)),

--- a/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
@@ -20,6 +20,9 @@ all() ->
      rfc4514_escape_value,
      rfc4514_fill_dn,
      dn_lookup_fallback_dn_escaping,
+     user_dn_pattern_escaping_rmq_4282,
+     user_bind_pattern_escaping_rmq_4282,
+     leading_special_char_no_dn_injection_rmq_4282,
      user_dn_pattern_gh_7161,
      format_different_types_of_ldap_attribute_values,
      ldap_log_domain_routing,
@@ -119,6 +122,116 @@ dn_lookup_fallback_dn_escaping(_Config) ->
         %% Bare fill leaves the substituted value unescaped
         ?assertEqual("cn=evil,ou=admins,ou=People,dc=example,dc=com",
                      rabbit_auth_backend_ldap:fill_user_dn_pattern("evil,ou=admins"))
+    after
+        restore_env(user_dn_pattern, PrevPattern),
+        restore_env(log, PrevLog)
+    end,
+    ok.
+
+%% RMQ-4282: a user using the default `user_dn_pattern` ("${username}")
+%% with AD down-level logon names ("DOMAIN\username") got "Access Refused"
+%% after PR #16101 started RFC 4514-escaping DN template substitutions: the
+%% backslash separating domain and user is itself RFC 4514-special, so it
+%% was escaped to a literal double backslash, which no longer matched the
+%% single-backslash down-level logon name AD expects.
+%%
+%% get_active_directory_args/1 only recognises the "DOMAIN\user" split for
+%% binary usernames (a plain list/string always yields no AD args), and a
+%% binary is what every real login supplies (see rabbit_auth_mechanism_plain),
+%% so these tests use binaries throughout.
+user_dn_pattern_escaping_rmq_4282(_Config) ->
+    PrevPattern = application:get_env(rabbitmq_auth_backend_ldap, user_dn_pattern),
+    PrevLog = application:get_env(rabbitmq_auth_backend_ldap, log),
+    ok = application:set_env(rabbitmq_auth_backend_ldap, log, false),
+    ok = application:set_env(rabbitmq_auth_backend_ldap, user_dn_pattern, "${username}"),
+    try
+        Username = <<"foo\\bar">>,
+        %% Bare fill (used for filter values, e.g. dn_lookup) was already
+        %% unescaped, and remains so.
+        ?assertEqual("foo\\bar",
+                     rabbit_auth_backend_ldap:fill_user_dn_pattern(Username)),
+        %% Used as a bind DN, the domain-separator backslash is no longer
+        %% doubled: the down-level logon name reaches AD unchanged.
+        ?assertEqual("foo\\bar",
+                     rabbit_auth_backend_ldap:escaped_user_dn(Username)),
+        %% A comma inside the user part is still RFC 4514-escaped -- only the
+        %% domain-separator backslash is exempted, not DN injection generally.
+        ?assertEqual("foo\\evil\\,ou=admins",
+                     rabbit_auth_backend_ldap:escaped_user_dn(
+                       <<"foo\\evil,ou=admins">>)),
+        %% More than one backslash is not a valid down-level logon name --
+        %% which one is the separator is ambiguous -- so the whole value
+        %% falls back to ordinary (fully escaped) DN-attribute treatment.
+        ?assertEqual("A\\\\B\\\\C",
+                     rabbit_auth_backend_ldap:escaped_user_dn(<<"A\\B\\C">>)),
+        %% A leading or trailing backslash has no domain or user part to
+        %% split on (get_active_directory_args/1 yields no AD args for
+        %% either), so it also falls back to whole-value escaping.
+        ?assertEqual("\\\\user",
+                     rabbit_auth_backend_ldap:escaped_user_dn(<<"\\user">>)),
+        ?assertEqual("DOMAIN\\\\",
+                     rabbit_auth_backend_ldap:escaped_user_dn(<<"DOMAIN\\">>)),
+        %% UPN format (user@domain) has no RFC 4514-special characters, so it
+        %% passes through unchanged.
+        ?assertEqual("foo@example.test",
+                     rabbit_auth_backend_ldap:escaped_user_dn(
+                       <<"foo@example.test">>)),
+        %% A bare username (no backslash) is unaffected.
+        ?assertEqual("alice", rabbit_auth_backend_ldap:escaped_user_dn(<<"alice">>))
+    after
+        restore_env(user_dn_pattern, PrevPattern),
+        restore_env(log, PrevLog)
+    end,
+    ok.
+
+%% The same fix applies to `user_bind_pattern` (used for simple binds when
+%% `dn_lookup_when/0` is not `prebind`), not just `user_dn_pattern`.
+user_bind_pattern_escaping_rmq_4282(_Config) ->
+    PrevBindPattern = application:get_env(rabbitmq_auth_backend_ldap, user_bind_pattern),
+    PrevLog = application:get_env(rabbitmq_auth_backend_ldap, log),
+    ok = application:set_env(rabbitmq_auth_backend_ldap, log, false),
+    ok = application:set_env(rabbitmq_auth_backend_ldap, user_bind_pattern, "${username}"),
+    try
+        ?assertEqual("foo\\bar",
+                     rabbit_auth_backend_ldap:simple_bind_fill_pattern(
+                       <<"foo\\bar">>))
+    after
+        restore_env(user_bind_pattern, PrevBindPattern),
+        restore_env(log, PrevLog)
+    end,
+    ok.
+
+%% RMQ-4282 follow-up: escaped_username_value/2 rejoins the escaped domain
+%% and user components with a literal, unescaped separator backslash. If the
+%% user part's first character is itself RFC 4514-special (comma, plus,
+%% quote, semicolon, or angle bracket), escaping it produces a value that
+%% also starts with a backslash. That backslash pairs up with the separator
+%% backslash under RFC 4514's own parsing rule (a backslash always starts a
+%% two-character escape), leaving the special character right after the
+%% pair completely unescaped -- letting it act as a fresh RDN separator and
+%% splice an attacker-chosen RDN into the bind DN. This must fall back to
+%% whole-value escaping instead, exactly like the "more than one backslash"
+%% and "leading/trailing backslash" cases above.
+leading_special_char_no_dn_injection_rmq_4282(_Config) ->
+    PrevPattern = application:get_env(rabbitmq_auth_backend_ldap, user_dn_pattern),
+    PrevLog = application:get_env(rabbitmq_auth_backend_ldap, log),
+    ok = application:set_env(rabbitmq_auth_backend_ldap, log, false),
+    ok = application:set_env(rabbitmq_auth_backend_ldap, user_dn_pattern, "${username}"),
+    try
+        Injections = [<<"DOMAIN\\,ou=Evil,dc=example,dc=com">>,
+                      <<"DOMAIN\\+ou=Evil">>,
+                      <<"DOMAIN\\\"ou=Evil">>,
+                      <<"DOMAIN\\;ou=Evil">>,
+                      <<"DOMAIN\\<ou=Evil">>,
+                      <<"DOMAIN\\>ou=Evil">>],
+        [?assertEqual(rabbit_ldap_rfc4514:escape_value(binary_to_list(Username)),
+                       rabbit_auth_backend_ldap:escaped_user_dn(Username))
+         || Username <- Injections],
+        %% A user part that does NOT start with an RFC 4514 special still
+        %% takes the (safe) domain/user split path, unaffected by the fix.
+        ?assertEqual("foo\\evil\\,ou=admins",
+                     rabbit_auth_backend_ldap:escaped_user_dn(
+                       <<"foo\\evil,ou=admins">>))
     after
         restore_env(user_dn_pattern, PrevPattern),
         restore_env(log, PrevLog)


### PR DESCRIPTION
## Proposed Changes

In Active Directory, it is still possible to login using the Down-Level Logon name (DOMAIN\username). Prior to applying RFC 4514 DN escaping, the plugin passed the username verbatim, allowing the DL Logon name to succeed. After escaping all username unconditionally, valid DL Logon names are unable to login via LDAP plugin.

This commit fixes this regression by detecting a Down-Level Logon name, escaping each part separately, and then joining them. Any other form of username is escaped as before.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it