### PR TITLE
By @jiangranwang: #17213 Support customize_hostname_check in AMQP URI query parameters (e.g. for shovels)

### DIFF
--- a/deps/amqp10_client/src/amqp10_client.erl
+++ b/deps/amqp10_client/src/amqp10_client.erl
@@ -515,6 +515,13 @@ parse_tls_opt("server_name_indication", "disable", Acc) ->
     [{server_name_indication, disable} | Acc];
 parse_tls_opt("server_name_indication", V, Acc) ->
     [{server_name_indication, V} | Acc];
+%% The value cannot be expressed in a URI, so only the
+%% Erlang/tOTP-provided HTTPS match fun is supported.
+parse_tls_opt("customize_hostname_check", "https", Acc) ->
+    [{customize_hostname_check,
+      [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | Acc];
+parse_tls_opt("customize_hostname_check", _V, _Acc) ->
+    throw({invalid_option, customize_hostname_check});
 parse_tls_opt(_K, _V, Acc) ->
     Acc.
 
@@ -638,7 +645,20 @@ parse_uri_test_() ->
                sasl => external}},
         parse_uri("amqp://my_proxy:9876?sasl=external")),
      ?_assertEqual({error, path_segment_not_supported},
-                   parse_uri("amqp://my_host/my_path_segment:9876"))
+                   parse_uri("amqp://my_host/my_path_segment:9876")),
+     ?_test(begin
+                {ok, #{tls_opts := {secure_port, TlsOpts}}} =
+                    parse_uri("amqps://my_host?cacertfile=/etc/cacert.pem&"
+                              "verify=verify_peer&"
+                              "customize_hostname_check=https"),
+                {customize_hostname_check, HostnameCheckOpts} =
+                    lists:keyfind(customize_hostname_check, 1, TlsOpts),
+                {match_fun, MatchFun} =
+                    lists:keyfind(match_fun, 1, HostnameCheckOpts),
+                ?assert(is_function(MatchFun, 2))
+            end),
+     ?_assertEqual({error, {invalid_option, customize_hostname_check}},
+                   parse_uri("amqps://my_host?customize_hostname_check=bogus"))
     ].
 
 -endif.

--- a/deps/amqp_client/src/amqp_uri.erl
+++ b/deps/amqp_client/src/amqp_uri.erl
@@ -63,7 +63,8 @@ remove_credentials(URI) ->
 %% frame_max, heartbeat and auth_mechanism (the latter can appear more
 %% than once).  The extra parameters that may be specified for an SSL
 %% connection are cacertfile, certfile, keyfile, verify,
-%% fail_if_no_peer_cert, password, and depth.
+%% fail_if_no_peer_cert, password, depth, server_name_indication,
+%% and customize_hostname_check.
 -type parse_result() :: {ok, #amqp_params_network{}} |
                         {ok, #amqp_params_direct{}} |
                         {error, {any(), string()}}.
@@ -189,7 +190,9 @@ build_ssl_broker(ParsedUri, DefaultVHost) ->
                        {fun find_boolean_parameter/1, fail_if_no_peer_cert},
                        {fun find_identity_parameter/1, password},
                        {fun find_sni_parameter/1, server_name_indication},
-                       {fun find_integer_parameter/1, depth}]],
+                       {fun find_integer_parameter/1, depth},
+                       {fun find_customize_hostname_check_parameter/1,
+                        customize_hostname_check}]],
           []),
     Params1 = Params0#amqp_params_network{ssl_options = SSLOptions},
     amqp_ssl:maybe_enhance_ssl_options(Params1).
@@ -248,6 +251,13 @@ find_sni_parameter("disable") ->
     disable;
 find_sni_parameter(Value) ->
     find_identity_parameter(Value).
+
+%% The value is a fun and cannot be expressed in a URI, so only the
+%% OTP-provided HTTPS match fun is exposed.
+find_customize_hostname_check_parameter("https") ->
+    return([{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]);
+find_customize_hostname_check_parameter(Value) ->
+    fail({unsupported_customize_hostname_check, Value}).
 
 find_identity_parameter(Value) -> return(Value).
 

--- a/deps/amqp_client/test/unit_SUITE.erl
+++ b/deps/amqp_client/test/unit_SUITE.erl
@@ -191,6 +191,18 @@ amqp_uri_parsing(_Config) ->
              {verify, verify_none}],
     ?assertEqual(lists:usort(Exp10), lists:usort(TLSOpts10)),
 
+    {ok, #amqp_params_network{host = "host11", ssl_options = TLSOpts11}} =
+        amqp_uri:parse("amqps://host11/%2f?cacertfile=/path/to/cacertfile.pem"
+                       "&verify=verify_peer"
+                       "&customize_hostname_check=https"),
+    ?assertEqual({cacertfile, "/path/to/cacertfile.pem"},
+                 lists:keyfind(cacertfile, 1, TLSOpts11)),
+    ?assertEqual({verify, verify_peer}, lists:keyfind(verify, 1, TLSOpts11)),
+    {customize_hostname_check, HostnameCheckOpts11} =
+        lists:keyfind(customize_hostname_check, 1, TLSOpts11),
+    {match_fun, MatchFun11} = lists:keyfind(match_fun, 1, HostnameCheckOpts11),
+    ?assert(is_function(MatchFun11, 2)),
+
     %% Various failure cases
     ?assertMatch({error, _}, amqp_uri:parse("https://www.rabbitmq.com")),
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo:bar:baz")),
@@ -204,6 +216,10 @@ amqp_uri_parsing(_Config) ->
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo%1")),
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo%1x")),
     ?assertMatch({error, _}, amqp_uri:parse("amqp://foo%xy")),
+
+    ?assertMatch({error, _},
+                 amqp_uri:parse(
+                   "amqps://host/%2f?customize_hostname_check=bogus")),
 
     ok.
 


### PR DESCRIPTION
This is #17213 by @jiangranwang with an addition from me: there is no reason not to support this new key in the AMQP 1.0 client, for shovel's needs alone.

Closes #17213.