### PR TITLE
Expose quorum-queue WAL and segment writer metrics via Prometheus

### DIFF
--- a/deps/rabbitmq_prometheus/metrics.md
+++ b/deps/rabbitmq_prometheus/metrics.md
@@ -259,6 +259,8 @@ These metrics are specific to the stream protocol.
 | rabbitmq_raft_mem_tables                 | Number of in-memory tables handled                                                  |
 | rabbitmq_raft_entries                    | Number of entries written                                                           |
 | rabbitmq_raft_bytes_written              | Number of bytes written                                                             |
+| rabbitmq_raft_batches                    | Number of write-ahead log batches flushed. Each batch is one fsync                  |
+| rabbitmq_raft_writes                     | Number of write-ahead log writes. Many writes are batched into a single fsync        |
 
 ### Federation
 

--- a/deps/rabbitmq_prometheus/metrics.md
+++ b/deps/rabbitmq_prometheus/metrics.md
@@ -261,6 +261,8 @@ These metrics are specific to the stream protocol.
 | rabbitmq_raft_bytes_written              | Number of bytes written                                                             |
 | rabbitmq_raft_batches                    | Number of write-ahead log batches flushed. Each batch is one fsync                  |
 | rabbitmq_raft_writes                     | Number of write-ahead log writes. Many writes are batched into a single fsync        |
+| rabbitmq_raft_current_file_size          | Current size in bytes of the write-ahead log file being written                      |
+| rabbitmq_raft_max_file_size              | Size in bytes at which the write-ahead log file is rolled                            |
 
 ### Federation
 

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
@@ -156,7 +156,11 @@ collect_key_component_metrics(Prefix, Callback) ->
     %% coordination (Khepri) and quorum_queues rows are exposed. Without the
     %% quorum_queues rows there is no way to observe quorum-queue WAL write,
     %% batch (fsync) or bytes-written activity from the Prometheus endpoint.
-    WALMetrics = [batches, writes, bytes_written, wal_files, mem_tables],
+    %% current_file_size and max_file_size make the WAL's fill state visible.
+    %% wal_files only increments after a roll, so on its own it reports the
+    %% fsync spike after the fact rather than the approach to it.
+    WALMetrics = [batches, writes, bytes_written, wal_files, mem_tables,
+                  current_file_size, max_file_size],
     SegmentWriterMetrics = [entries, segments],
     QQComponentResult =
         seshat:format(ra,

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
@@ -149,9 +149,26 @@ collect_max_values(Prefix, Callback) ->
                       filter_fun => fun does_belong_to_quorum_queue/1})).
 
 collect_key_component_metrics(Prefix, Callback) ->
-    %% quorum queue metrics
-    WALMetrics = [wal_files, bytes_written, mem_tables],
+    %% The write-ahead log and segment writer are per-node processes shared by
+    %% all Raft servers of a given Ra system. Their counters are labelled by
+    %% ra_system (and module) but carry no `queue` label, so the per-queue
+    %% filter does not match them. Select them by ra_system so that both the
+    %% coordination (Khepri) and quorum_queues rows are exposed. Without the
+    %% quorum_queues rows there is no way to observe quorum-queue WAL write,
+    %% batch (fsync) or bytes-written activity from the Prometheus endpoint.
+    WALMetrics = [batches, writes, bytes_written, wal_files, mem_tables],
     SegmentWriterMetrics = [entries, segments],
+    QQComponentResult =
+        seshat:format(ra,
+                      #{labels => as_binary,
+                        metrics => WALMetrics ++ SegmentWriterMetrics,
+                        filter_fun => fun does_belong_to_quorum_queue_system/1}),
+    %% Khepri and other coordination metrics, including the coordination system's
+    %% own WAL and segment writer counters.
+    CoordinationResult =
+        seshat:format(ra,
+                      #{labels => as_binary,
+                        filter_fun => fun does_belong_to_coordination_system/1}),
     maps:foreach(
       fun(Name, #{type := Type, help := Help, values := Values}) ->
               Callback(
@@ -160,22 +177,7 @@ collect_key_component_metrics(Prefix, Callback) ->
                           Type,
                           Values))
       end,
-      seshat:format(ra,
-                    #{labels => as_binary,
-                      metrics => WALMetrics ++ SegmentWriterMetrics,
-                      filter_fun => fun does_belong_to_quorum_queue/1})),
-    %% Khepri and other coordination metrics
-    maps:foreach(
-      fun(Name, #{type := Type, help := Help, values := Values}) ->
-              Callback(
-                create_mf(<<Prefix/binary, (prometheus_model_helpers:metric_name(Name))/binary>>,
-                          Help,
-                          Type,
-                          Values))
-      end,
-      seshat:format(ra,
-                    #{labels => as_binary,
-                      filter_fun => fun does_belong_to_coordination_system/1})).
+      merge_format_results(CoordinationResult, QQComponentResult)).
 
 %% Merges two `seshat:format/2` results, combining
 %% values under a single metric family entry.
@@ -195,3 +197,6 @@ does_belong_to_coordination_system(_) -> false.
 
 does_belong_to_quorum_queue(#{queue := _}) -> true;
 does_belong_to_quorum_queue(_) -> false.
+
+does_belong_to_quorum_queue_system(#{ra_system := quorum_queues}) -> true;
+does_belong_to_quorum_queue_system(_) -> false.

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -453,7 +453,11 @@ aggregated_metrics_test(Config) ->
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_bytes_written.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_writes.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_batches.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
-    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])).
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    %% The WAL size gauges make the fill state observable. wal_files above only
+    %% increments after a roll, so it reports the fsync spike after the fact.
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_current_file_size.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_max_file_size.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])).
 
 %% Verify that the aggregated endpoint does not emit duplicate TYPE
 %% lines for Raft metrics that belong to different Ra systems.
@@ -471,7 +475,9 @@ aggregated_endpoint_no_duplicate_raft_type_lines(Config) ->
                                     "rabbitmq_raft_entries",
                                     "rabbitmq_raft_mem_tables",
                                     "rabbitmq_raft_segments",
-                                    "rabbitmq_raft_wal_files"]).
+                                    "rabbitmq_raft_wal_files",
+                                    "rabbitmq_raft_current_file_size",
+                                    "rabbitmq_raft_max_file_size"]).
 
 endpoint_per_object_metrics(Config) ->
     per_object_metrics_test(Config, "/metrics/per-object").

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -445,7 +445,15 @@ aggregated_metrics_test(Config) ->
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_entries{", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_mem_tables{", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_segments{", [{capture, none}, multiline])),
-    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files{", [{capture, none}, multiline])).
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files{", [{capture, none}, multiline])),
+    %% The write-ahead log and segment writer counters must be exposed for the
+    %% quorum_queues Ra system, not only for coordination (Khepri). Without
+    %% these rows there is no way to observe quorum-queue WAL write, batch
+    %% (fsync) or bytes-written activity from the Prometheus endpoint.
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_bytes_written.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_writes.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_batches.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])).
 
 %% Verify that the aggregated endpoint does not emit duplicate TYPE
 %% lines for Raft metrics that belong to different Ra systems.
@@ -458,6 +466,8 @@ aggregated_endpoint_no_duplicate_raft_type_lines(Config) ->
                                     "rabbitmq_raft_max_commit_latency_seconds",
                                     "rabbitmq_raft_max_num_segments",
                                     "rabbitmq_raft_bytes_written",
+                                    "rabbitmq_raft_batches",
+                                    "rabbitmq_raft_writes",
                                     "rabbitmq_raft_entries",
                                     "rabbitmq_raft_mem_tables",
                                     "rabbitmq_raft_segments",


### PR DESCRIPTION
## Proposed Changes

The write-ahead log and the segment writer are per-node processes shared by all Ra servers
within a Ra system. Their seshat counters are labelled by `ra_system` and `module`, and they
carry no `queue` label.

`collect_key_component_metrics/2` selected the quorum-queue side of those counters with
`does_belong_to_quorum_queue/1`, which matches on the presence of a `queue` label. No WAL or
segment-writer counter has one, so the entire `quorum_queues` Ra system was filtered out. The
only rows that reached the endpoint came from the coordination (Khepri) branch, which passes no
`metrics` key and therefore selects everything for `ra_system="coordination"`.

The practical effect is that `/metrics` gave no way to observe quorum-queue WAL activity. There
were no write, batch (fsync) or bytes-written rows for the Ra system that actually carries queue
traffic, only for Khepri, which is close to idle on most nodes. On a broker where quorum queues
are the write path, the busiest component in the durability chain was invisible.

This changes the selection for that branch to filter by `ra_system` instead:

- `does_belong_to_quorum_queue_system/1` matches `#{ra_system := quorum_queues}`.
- The coordination and `quorum_queues` results are combined with the existing
  `merge_format_results/2` so each metric name is emitted as a single metric family. Emitting
  them as two separate families would repeat `HELP` and `TYPE` lines for the same name, which
  breaks strict Prometheus parsers.
- The selected WAL metric list gains `batches` and `writes`, so the fsync count and the write
  count are both available, and `current_file_size` and `max_file_size`.

The two size gauges are the reason for the second commit. The WAL rolls on size, and `wal_files`
only increments once the roll has already happened, so on its own it reports the fsync spike
after the fact rather than the approach to it. With both gauges present, WAL fill state is a
ratio that can be alerted on before the roll:

```
rabbitmq_raft_current_file_size{ra_system="quorum_queues"}
  / rabbitmq_raft_max_file_size{ra_system="quorum_queues"}
```

`does_belong_to_quorum_queue/1` is unchanged and still used by the per-queue and max-value
collectors, where the `queue` label is the correct selector.

### Scope of the observable change

No existing series changes meaning, and no series is removed or renamed. `rabbitmq_raft_batches`,
`rabbitmq_raft_writes`, `rabbitmq_raft_current_file_size` and `rabbitmq_raft_max_file_size` were
already exposed for `ra_system="coordination"`; they were simply absent from `metrics.md`, which
this change corrects. What is new is the `ra_system="quorum_queues"` rows within these and the
other affected families.

Added cardinality is a fixed handful of rows per node, not per queue, because these are
per-node component counters.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

There is no tracking issue for this, so no number is linked above.

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

`ct-rabbit_prometheus_http` passes locally at this commit, rebased onto current `main`:
59 ok, 0 failed of 59 test cases, on Erlang/OTP 27.3.1 with Elixir 1.17.3.

`aggregated_metrics_test` gains assertions that each WAL and segment-writer counter appears with
`ra_system="quorum_queues"`, which fails against the previous behaviour. The existing
`aggregated_endpoint_no_duplicate_raft_type_lines` case is extended to cover the four additional
names, so the single-metric-family requirement is enforced rather than assumed.

## Further Comments

One naming point, raised here rather than left for review to find.

These names come from the seshat and Ra field atoms, not from this collector, so
`rabbitmq_raft_current_file_size` and `rabbitmq_raft_max_file_size` lack the `_bytes` suffix that
Prometheus convention asks for on byte-valued gauges. Correcting that here would mean either
renaming the fields in Ra, which has other consumers and already-shipped names, or adding a
name-mapping layer in this collector. Neither seemed right to bundle into a visibility fix, so
the change keeps the field names as they are. The same departure already exists on the endpoint:
`rabbitmq_raft_bytes_written` is a counter without the `_total` suffix.

Happy to follow up with a mapping layer, or to rename in Ra first and rebase this on top, if the
core team prefers either over consistency with the current field names.
