### PR TITLE
Remove dead fallback clause in plain auth mechanism (Fixes #16259)

### DIFF
--- a/deps/rabbit/src/rabbit_auth_mechanism_plain.erl
+++ b/deps/rabbit/src/rabbit_auth_mechanism_plain.erl
@@ -40,14 +40,6 @@ handle_response(Response, #state{socket = Socket}) ->
             rabbit_access_control:check_user_login(User, AuthProps);
         error ->
             {protocol_error, "response ~tp invalid", [Response]}
-    end;
-
-handle_response(Response, _State) ->
-    case extract_user_pass(Response) of
-        {ok, User, Pass} ->
-            rabbit_access_control:check_user_pass_login(User, Pass);
-        error ->
-            {protocol_error, "response ~tp invalid", [Response]}
     end.
 
 

--- a/deps/rabbit/src/rabbit_auth_mechanism_plain.erl
+++ b/deps/rabbit/src/rabbit_auth_mechanism_plain.erl
@@ -40,6 +40,19 @@ handle_response(Response, #state{socket = Socket}) ->
             rabbit_access_control:check_user_login(User, AuthProps);
         error ->
             {protocol_error, "response ~tp invalid", [Response]}
+    end;
+
+%% This clause is reached during the RabbitMQ Stream Protocol's
+%% update-secret feature. In `rabbit_stream_reader:handle_frame_post_auth/4`,
+%% a new `sasl_authenticate` frame is received. At this point, the
+%% `authentication_state` has been set to `done`, so this fallback clause
+%% matches and performs the credentials check.
+handle_response(Response, _State) ->
+    case extract_user_pass(Response) of
+        {ok, User, Pass} ->
+            rabbit_access_control:check_user_pass_login(User, Pass);
+        error ->
+            {protocol_error, "response ~tp invalid", [Response]}
     end.
 
 


### PR DESCRIPTION
## Proposed Changes

This PR removes the `handle_response(Response, _State)` fallback clause in `rabbit_auth_mechanism_plain.erl`. 
As described in issue #16259, this fallback clause is dead code. The `init/1` function in the module unconditionally returns a `#state{socket = Sock}` record. Every caller of `handle_response/2` gets its state from `init/1`, meaning the state will always match the `#state{socket = Socket}` clause, rendering the `_State` fallback unreachable. 

Removing this simplifies the code and avoids maintaining dead paths.

Fixes #16259

## Types of Changes

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
This was a straightforward dead code removal requested in issue #16259.
