### PR TITLE
STOMP, Web STOMP: enforce credential expiry like the other protocols do

### DIFF
--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -13,7 +13,8 @@
          process_frame/2,
          flush_and_die/1,
          info/2,
-         is_authenticated/1]).
+         is_authenticated/1,
+         send_credential_expired_error/1]).
 
 -export([flush_pending_receipts/3,
          cancel_consumer/2,
@@ -237,10 +238,26 @@ info(Other, _) -> throw({bad_argument, Other}).
 is_authenticated(#state{user = undefined}) -> false;
 is_authenticated(#state{}) -> true.
 
+-spec send_credential_expired_error(#state{}) -> #state{}.
+send_credential_expired_error(State) ->
+    send_error("Credential expired",
+               "The credential used to authenticate this connection has expired",
+               State).
+
 
 %%----------------------------------------------------------------------------
 %% Private Parts (Including callbacks)
 %%----------------------------------------------------------------------------
+
+maybe_start_credential_expiry_timer(User) ->
+    case rabbit_access_control:expiry_timestamp(User) of
+        never ->
+            ok;
+        Ts when is_integer(Ts) ->
+            Time = (Ts - os:system_time(second)) * 1000,
+            _ = erlang:send_after(max(Time, 0), self(), credential_expired),
+            ok
+    end.
 
 command({'STOMP', Frame}, State) ->
     process_connect(no_implicit, Frame, State);
@@ -370,6 +387,7 @@ process_connect(Implicit, Frame,
                                  connection_name => ConnInfo#conn_info.conn_name},
                   SessionId = rabbit_guid:string(rabbit_guid:gen_secure(), "session"),
                   {SendTimeout, ReceiveTimeout} = ensure_heartbeats(Heartbeat),
+                  ok = maybe_start_credential_expiry_timer(User),
 
                   Headers0 = #{?HEADER_SESSION => list_to_binary(SessionId),
                                ?HEADER_HEART_BEAT =>

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
@@ -215,6 +215,11 @@ handle_info({'DOWN', _MRef, process, QPid, _Reason}, State) ->
 handle_info(client_timeout, State) ->
     {stop, {shutdown, client_heartbeat_timeout}, State};
 
+handle_info(credential_expired, State) ->
+    ProcState = processor_state(State),
+    NewProcState = rabbit_stomp_processor:send_credential_expired_error(ProcState),
+    {stop, {shutdown, credential_expired}, processor_state(NewProcState, State)};
+
 handle_info(login_timeout, State) ->
     ProcState = processor_state(State),
     case rabbit_stomp_processor:info(user, ProcState) of
@@ -408,6 +413,13 @@ log_reason({shutdown, client_heartbeat_timeout},
     AdapterName = rabbit_stomp_processor:adapter_name(ProcState),
     ?LOG_WARNING("STOMP detected missed client heartbeat(s) "
                                   "on connection ~ts, closing it", [AdapterName]);
+
+log_reason({shutdown, credential_expired},
+           #reader_state{conn_name = ConnName, processor_state = ProcState}) ->
+    ?LOG_WARNING("closing STOMP connection ~tp (~ts) of user '~ts': "
+                 "credential has expired",
+                 [self(), ConnName,
+                  rabbit_stomp_processor:info(user, ProcState)]);
 
 log_reason({shutdown, {server_initiated_close, Reason}},
            #reader_state{conn_name = ConnName}) ->

--- a/deps/rabbitmq_stomp/test/connections_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/connections_SUITE.erl
@@ -23,6 +23,7 @@ all() ->
         stats,
         heartbeat,
         login_timeout,
+        credential_expires,
         frame_size,
         frame_size_huge,
         unauthenticated_frame_size_limited,
@@ -187,6 +188,30 @@ login_timeout(Config) ->
         rabbit_ct_broker_helpers:rpc(
           Config, 0,
           application, unset_env, [rabbitmq_stomp, login_timeout])
+    end.
+
+credential_expires(Config) ->
+    Mod = rabbit_auth_backend_internal,
+    ExpiryTimestamp = os:system_time(second) + 5,
+    rabbit_ct_broker_helpers:setup_meck(Config),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, new, [Mod, [no_link, passthrough]]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, expect, [Mod, expiry_timestamp, 1, ExpiryTimestamp]),
+    StompPort = get_stomp_port(Config),
+    try
+        {ok, {Socket, _}} = rabbit_stomp_client:connect("1.2", "guest", "guest",
+                                                        StompPort, []),
+        {error, timeout} = gen_tcp:recv(Socket, 0, 2000),
+        {ok, Data} = gen_tcp:recv(Socket, 0, 30000),
+        {ok, Frame, _} = rabbit_stomp_frame:parse(
+                           Data, rabbit_stomp_frame:initial_state()),
+        'ERROR' = Frame#stomp_frame.command,
+        {ok, <<"Credential expired">>} = rabbit_stomp_frame:header(
+                                           Frame, <<"message">>),
+        {error, closed} = gen_tcp:recv(Socket, 0, 30000)
+    after
+        ok = rabbit_ct_broker_helpers:rpc(Config, 0, meck, unload, [Mod])
     end.
 
 frame_size(Config) ->

--- a/deps/rabbitmq_web_stomp/Makefile
+++ b/deps/rabbitmq_web_stomp/Makefile
@@ -20,7 +20,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 DEPS = cowboy rabbit_common rabbit rabbitmq_stomp
-TEST_DEPS = gun rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = gun rabbitmq_ct_helpers rabbitmq_ct_client_helpers meck
 
 PLT_APPS += cowlib
 

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -308,6 +308,15 @@ websocket_info({start_heartbeats, {SendTimeout, ReceiveTimeout}},
 websocket_info(client_timeout, State) ->
     stop(State);
 
+websocket_info(credential_expired, State = #state{proc_state = ProcState}) ->
+    ?LOG_WARNING("Web STOMP: closing connection ~ts of user '~ts': "
+                 "credential has expired",
+                 [rabbit_stomp_processor:adapter_name(ProcState),
+                  rabbit_stomp_processor:info(user, ProcState)]),
+    ProcState1 = rabbit_stomp_processor:send_credential_expired_error(ProcState),
+    self() ! close_websocket,
+    {[], State#state{proc_state = ProcState1}};
+
 %%----------------------------------------------------------------------------
 websocket_info({'EXIT', _From, _Reason}, State) ->
     stop(State);

--- a/deps/rabbitmq_web_stomp/test/raw_websocket_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/raw_websocket_SUITE.erl
@@ -30,6 +30,7 @@ groups() ->
         connection_with_protocols,
         pubsub,
         disconnect,
+        credential_expires,
         http_auth
     ],
     [{https_tests, [], Tests},
@@ -156,6 +157,30 @@ disconnect(Config) ->
     {close, {1000, _}} = rfc6455_client:recv(WS),
 
     ok.
+
+credential_expires(Config) ->
+    Mod = rabbit_auth_backend_internal,
+    ExpiryTimestamp = os:system_time(second) + 5,
+    rabbit_ct_broker_helpers:setup_meck(Config),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, new, [Mod, [no_link, passthrough]]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, expect, [Mod, expiry_timestamp, 1, ExpiryTimestamp]),
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Protocol = ?config(protocol, Config),
+    WS = rfc6455_client:new(Protocol ++ "://127.0.0.1:" ++ PortStr ++ "/ws", self()),
+    try
+        {ok, _} = rfc6455_client:open(WS),
+        ok = raw_send(WS, "CONNECT", [{"login", "guest"}, {"passcode", "guest"}]),
+        {<<"CONNECTED">>, _, <<>>} = raw_recv(WS),
+        {error, timeout} = rfc6455_client:recv(WS, 2000),
+        {ok, Payload} = rfc6455_client:recv(WS, 30000),
+        {<<"ERROR">>, Headers, _} = stomp:unmarshal(Payload),
+        <<"Credential expired">> = proplists:get_value(<<"message">>, Headers),
+        {close, _} = rfc6455_client:recv(WS, 30000)
+    after
+        ok = rabbit_ct_broker_helpers:rpc(Config, 0, meck, unload, [Mod])
+    end.
 
 http_auth(Config) ->
     %% Intentionally put bad credentials in the CONNECT frame,


### PR DESCRIPTION
Note: `v4.3.x` will need a different implementation that I will submit soon.