### PR TITLE
STOMP, Web STOMP: enforce credential expiry like the other protocols do

### DIFF
--- a/deps/rabbitmq_stomp/Makefile
+++ b/deps/rabbitmq_stomp/Makefile
@@ -31,7 +31,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 DEPS = ranch rabbit_common rabbit amqp_client
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management proper
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management proper meck
 
 PLT_APPS += rabbitmq_cli elixir ssl
 

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -9,7 +9,8 @@
 
 -compile({no_auto_import, [error/3]}).
 
--export([initial_state/2, process_frame/2, flush_and_die/1, is_authenticated/1]).
+-export([initial_state/2, process_frame/2, flush_and_die/1, is_authenticated/1,
+         send_credential_expired_error/1]).
 -export([flush_pending_receipts/3,
          handle_exit/3,
          cancel_consumer/2,
@@ -162,6 +163,12 @@ initial_state(Configuration,
 
 is_authenticated(#proc_state{connection = none}) -> false;
 is_authenticated(#proc_state{}) -> true.
+
+-spec send_credential_expired_error(#proc_state{}) -> #proc_state{}.
+send_credential_expired_error(State) ->
+    send_error("Credential expired",
+               "The credential used to authenticate this connection has expired",
+               State).
 
 
 command({"STOMP", Frame}, State) ->
@@ -583,6 +590,17 @@ without_headers([Hdr | Hdrs], Command, Frame, State, Fun) ->
 without_headers([], Command, Frame, State, Fun) ->
     Fun(Command, Frame, State).
 
+maybe_start_credential_expiry_timer(Connection) ->
+    [{internal_user, User}] = amqp_connection:info(Connection, [internal_user]),
+    case rabbit_access_control:expiry_timestamp(User) of
+        never ->
+            ok;
+        Ts when is_integer(Ts) ->
+            Time = (Ts - os:system_time(second)) * 1000,
+            _ = erlang:send_after(max(Time, 0), self(), credential_expired),
+            ok
+    end.
+
 do_login(undefined, _, _, _, _, _, State) ->
     error("Bad CONNECT", "Missing login or passcode header(s)", State);
 do_login(Username, Passwd, VirtualHost, Heartbeat, AdapterInfo, Version,
@@ -600,6 +618,7 @@ do_login(Username, Passwd, VirtualHost, Heartbeat, AdapterInfo, Version,
             amqp_channel:enable_delivery_flow_control(Channel),
             SessionId = rabbit_guid:string(rabbit_guid:gen_secure(), "session"),
             {SendTimeout, ReceiveTimeout} = ensure_heartbeats(Heartbeat),
+            ok = maybe_start_credential_expiry_timer(Connection),
 
           Headers = [{?HEADER_SESSION, SessionId},
                      {?HEADER_HEART_BEAT,

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
@@ -166,6 +166,11 @@ handle_info({bump_credit, Msg}, State) ->
 handle_info(client_timeout, State) ->
     {stop, {shutdown, client_heartbeat_timeout}, State};
 
+handle_info(credential_expired, State) ->
+    ProcState = processor_state(State),
+    NewProcState = rabbit_stomp_processor:send_credential_expired_error(ProcState),
+    {stop, {shutdown, credential_expired}, processor_state(NewProcState, State)};
+
 handle_info(login_timeout, State) ->
     ProcState = processor_state(State),
     case rabbit_stomp_processor:info(channel, ProcState) of
@@ -397,6 +402,11 @@ log_reason({shutdown, client_heartbeat_timeout},
     AdapterName = rabbit_stomp_processor:adapter_name(ProcState),
     ?LOG_WARNING("STOMP detected missed client heartbeat(s) "
                                   "on connection ~ts, closing it", [AdapterName]);
+
+log_reason({shutdown, credential_expired},
+           #reader_state{conn_name = ConnName}) ->
+    ?LOG_WARNING("closing STOMP connection ~tp (~ts): credential has expired",
+                 [self(), ConnName]);
 
 log_reason({shutdown, {server_initiated_close, Reason}},
            #reader_state{conn_name = ConnName}) ->

--- a/deps/rabbitmq_stomp/test/connections_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/connections_SUITE.erl
@@ -23,6 +23,7 @@ all() ->
         stats,
         heartbeat,
         login_timeout,
+        credential_expires,
         frame_size,
         frame_size_huge,
         unauthenticated_frame_size_limited
@@ -186,6 +187,29 @@ login_timeout(Config) ->
         rabbit_ct_broker_helpers:rpc(
           Config, 0,
           application, unset_env, [rabbitmq_stomp, login_timeout])
+    end.
+
+credential_expires(Config) ->
+    Mod = rabbit_auth_backend_internal,
+    ExpiryTimestamp = os:system_time(second) + 5,
+    rabbit_ct_broker_helpers:setup_meck(Config),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, new, [Mod, [no_link, passthrough]]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, expect, [Mod, expiry_timestamp, 1, ExpiryTimestamp]),
+    StompPort = get_stomp_port(Config),
+    try
+        {ok, {Socket, _}} = rabbit_stomp_client:connect("1.2", "guest", "guest",
+                                                        StompPort, []),
+        {error, timeout} = gen_tcp:recv(Socket, 0, 2000),
+        {ok, Data} = gen_tcp:recv(Socket, 0, 30000),
+        {ok, Frame, _} = rabbit_stomp_frame:parse(
+                           Data, rabbit_stomp_frame:initial_state()),
+        "ERROR" = Frame#stomp_frame.command,
+        {ok, "Credential expired"} = rabbit_stomp_frame:header(Frame, "message"),
+        {error, closed} = gen_tcp:recv(Socket, 0, 30000)
+    after
+        ok = rabbit_ct_broker_helpers:rpc(Config, 0, meck, unload, [Mod])
     end.
 
 frame_size(Config) ->

--- a/deps/rabbitmq_web_stomp/Makefile
+++ b/deps/rabbitmq_web_stomp/Makefile
@@ -20,7 +20,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 DEPS = cowboy rabbit_common rabbit rabbitmq_stomp
-TEST_DEPS = gun rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = gun rabbitmq_ct_helpers rabbitmq_ct_client_helpers meck
 
 PLT_APPS += cowlib
 

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -289,6 +289,13 @@ websocket_info({start_heartbeats, {SendTimeout, ReceiveTimeout}},
 websocket_info(client_timeout, State) ->
     stop(State);
 
+websocket_info(credential_expired, State = #state{proc_state = ProcState}) ->
+    ?LOG_WARNING("Web STOMP: closing connection ~ts: credential has expired",
+                 [rabbit_stomp_processor:adapter_name(ProcState)]),
+    ProcState1 = rabbit_stomp_processor:send_credential_expired_error(ProcState),
+    self() ! close_websocket,
+    {[], State#state{proc_state = ProcState1}};
+
 %%----------------------------------------------------------------------------
 websocket_info({'EXIT', From, Reason},
                State=#state{ proc_state = ProcState0 }) ->

--- a/deps/rabbitmq_web_stomp/test/credential_expiry_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/credential_expiry_SUITE.erl
@@ -1,0 +1,60 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(credential_expiry_SUITE).
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [connection_is_closed_when_credential_expires].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(Config,
+                                           [{rmq_nodename_suffix, ?MODULE},
+                                            {protocol, "ws"}]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config,
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+connection_is_closed_when_credential_expires(Config) ->
+    Mod = rabbit_auth_backend_internal,
+    ExpiryTimestamp = os:system_time(second) + 5,
+    rabbit_ct_broker_helpers:setup_meck(Config),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, new, [Mod, [no_link, passthrough]]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, meck, expect, [Mod, expiry_timestamp, 1, ExpiryTimestamp]),
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    WS = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws", self()),
+    try
+        {ok, _} = rfc6455_client:open(WS),
+        ok = raw_send(WS, "CONNECT", [{"login", "guest"}, {"passcode", "guest"}]),
+        {ok, Connected} = rfc6455_client:recv(WS),
+        {<<"CONNECTED">>, _, <<>>} = stomp:unmarshal(Connected),
+        {error, timeout} = rfc6455_client:recv(WS, 2000),
+        {ok, Payload} = rfc6455_client:recv(WS, 30000),
+        {<<"ERROR">>, Headers, _} = stomp:unmarshal(Payload),
+        <<"Credential expired">> = proplists:get_value(<<"message">>, Headers),
+        {close, _} = rfc6455_client:recv(WS, 30000)
+    after
+        ok = rabbit_ct_broker_helpers:rpc(Config, 0, meck, unload, [Mod])
+    end.
+
+raw_send(WS, Command, Headers) ->
+    Frame = stomp:marshal(Command, Headers, <<>>),
+    rfc6455_client:send(WS, Frame).


### PR DESCRIPTION
The 4.3 edition. `main` has a meaningfully different STOMP implementation (and the same problem addressed earlier).
