### PR TITLE
Minor HTTP API fixes

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_consumers.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_consumers.erl
@@ -49,7 +49,7 @@ to_json(ReqData, Context = #context{user = User}) ->
     end.
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized(ReqData, Context).
+    rabbit_mgmt_util:is_authorized_vhost_visible_for_monitoring(ReqData, Context).
 
 filter_user(List, #user{username = Username, tags = Tags}) ->
     case rabbit_mgmt_util:is_monitor(Tags) of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders.erl
@@ -52,7 +52,7 @@ failure(Message, Qs, ReqData, Context) ->
     {stop, cowboy_req:reply(503, #{}, Response, ReqData1), Context1}.
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized(ReqData, Context).
+    rabbit_mgmt_util:is_authorized_vhost_visible_for_monitoring(ReqData, Context).
 
 %%
 %% Implementation

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -179,6 +179,7 @@ all_tests() -> [
     permissions_connection_channel_consumer_test,
     consumers_cq_test,
     consumers_qq_test,
+    consumers_require_virtual_host_access_test,
     arguments_test,
     arguments_table_test,
     queue_purge_test,
@@ -2007,6 +2008,23 @@ consumers_cq_test(Config) ->
 
 consumers_qq_test(Config) ->
     consumers_test(Config, [{'x-queue-type', <<"quorum">>}]).
+
+consumers_require_virtual_host_access_test(Config) ->
+    VHost = <<"consumers-vh">>,
+    User = <<"consumers-user">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VHost),
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+
+    http_get(Config, "/consumers/consumers-vh", User, User, ?NOT_FOUND),
+    http_get(Config, "/consumers/no-such-vhost", User, User, ?NOT_FOUND),
+
+    rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
+    [] = http_get(Config, "/consumers/consumers-vh", User, User, ?OK),
+
+    rabbit_ct_broker_helpers:delete_user(Config, User),
+    rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
+    passed.
 
 consumers_test(Config, Args) ->
     QArgs = [{auto_delete, false}, {durable, true},

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl").
 
 -import(rabbit_mgmt_test_util, [http_get/3,
+                                http_get/5,
                                 req/4,
                                 auth_header/2]).
 
@@ -39,7 +40,8 @@ groups() ->
                         metadata_store_initialized_with_data_test,
                         is_quorum_critical_single_node_test,
                         quorum_queues_without_elected_leader_single_node_test,
-                        quorum_queues_without_elected_leader_across_all_virtual_hosts_single_node_test
+                        quorum_queues_without_elected_leader_across_all_virtual_hosts_single_node_test,
+                        quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_test
      ]}
     ].
 
@@ -344,6 +346,29 @@ quorum_queues_without_elected_leader_across_all_virtual_hosts_single_node_test(C
         end),
 
     rabbit_ct_broker_helpers:delete_vhost(Config, VH2),
+
+    passed.
+
+quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_test(Config) ->
+    VHost = <<"health-check-vh">>,
+    User = <<"health-check-user">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VHost),
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+
+    http_get(Config, "/health/checks/quorum-queues-without-elected-leaders/vhost/health-check-vh/",
+             User, User, ?NOT_FOUND),
+    Check0 = http_get(Config, "/health/checks/quorum-queues-without-elected-leaders/vhost/no-such-vhost/",
+                      User, User, ?OK),
+    ?assertEqual(<<"ok">>, maps:get(status, Check0)),
+
+    rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
+    Check1 = http_get(Config, "/health/checks/quorum-queues-without-elected-leaders/vhost/health-check-vh/",
+                      User, User, ?OK),
+    ?assertEqual(<<"ok">>, maps:get(status, Check1)),
+
+    rabbit_ct_broker_helpers:delete_user(Config, User),
+    rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
 
     passed.
 


### PR DESCRIPTION
e.g. avoid an exception in the (deprecated)
original coarse-grained health check endpoint.
