### PR TITLE
Management: make a few 500s correctly return 400s

### DIFF
--- a/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
+++ b/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
@@ -51,10 +51,15 @@ resource_exists(ReqData, Context) ->
      end, ReqData, Context}.
 
 to_json(ReqData, {Filter, Context}) ->
-    Chs = rabbit_mgmt_db:get_all_channels(
-            rabbit_mgmt_util:range(ReqData)),
-    rabbit_mgmt_util:reply_list(
-      filter_vhost(status(Chs, ReqData, Context, Filter), ReqData), ReqData, Context);
+    try
+        Chs = rabbit_mgmt_db:get_all_channels(
+                rabbit_mgmt_util:range(ReqData)),
+        rabbit_mgmt_util:reply_list(
+          filter_vhost(status(Chs, ReqData, Context, Filter), ReqData), ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end;
 to_json(ReqData, Context) ->
     to_json(ReqData, {all, Context}).
 

--- a/deps/rabbitmq_federation_management/test/federation_mgmt_SUITE.erl
+++ b/deps/rabbitmq_federation_management/test/federation_mgmt_SUITE.erl
@@ -101,7 +101,10 @@ federation_links(Config) ->
                                   maps:get(upstream, Link),
                                   maps:get(status, Link)} || Link <- AllLinks],
                        Verify(Result)
-               end).
+               end),
+
+    http_get(Config, "/federation-links?lengths_age=60&lengths_incr=1", ?OK),
+    http_get(Config, "/federation-links?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST).
 
 federation_down_links(Config) ->
     DefaultExchanges = [<<"amq.direct">>, <<"amq.fanout">>, <<"amq.headers">>,

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -20,7 +20,7 @@
 -export([user/1]).
 -export([bad_request/3, bad_request/4, service_unavailable/3, bad_request_exception/4,
          internal_server_error/3, internal_server_error/4, precondition_failed/3,
-         id/2, parse_bool/1, parse_int/1, redirect_to_home/3]).
+         id/2, parse_bool/1, parse_int/1, redirect_to_home/3, timeout/2]).
 -export([with_decode/4, with_ids/4, not_found/3]).
 -export([with_channel/4, with_channel/5]).
 -export([props_to_method/2, props_to_method/4]).
@@ -69,6 +69,9 @@
 
 -define(MAX_RANGE, 500).
 -define(MAX_FILTER_LENGTH, 1024).
+
+%% Erlang's own ceiling for a receive/gen_server/gen_event/rpc timeout value.
+-define(MAX_HTTP_TIMEOUT, 4294967295).
 
 -record(pagination, {page = undefined, page_size = undefined,
                      name = undefined, use_regex = undefined}).
@@ -1315,6 +1318,22 @@ int(Name, ReqData) ->
                      catch
                          _:_ -> undefined
                      end
+    end.
+
+%% Parses the "timeout" request header, used by the various health check
+%% endpoints. Throws {error, {not_integer, Val}} for a value that isn't a
+%% valid receive/gen_server/gen_event/rpc timeout, same as parse_int/1 does
+%% for a non-numeric one, so callers only need a single catch clause.
+timeout(ReqData, Default) ->
+    case cowboy_req:header(<<"timeout">>, ReqData) of
+        undefined -> Default;
+        Val ->
+            case parse_int(Val) of
+                Timeout when Timeout >= 0, Timeout =< ?MAX_HTTP_TIMEOUT ->
+                    Timeout;
+                _ ->
+                    throw({error, {not_integer, Val}})
+            end
     end.
 
 -spec qs_val(binary(), cowboy_req:req()) -> any() | undefined.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_alarms.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_alarms.erl
@@ -30,16 +30,20 @@ resource_exists(ReqData, Context) ->
     {true, ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    Timeout = case cowboy_req:header(<<"timeout">>, ReqData) of
-                  undefined -> 70000;
-                  Val       -> list_to_integer(binary_to_list(Val))
-              end,
-    case rabbit_alarm:get_alarms(Timeout) of
-        [] ->
-            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
-        Xs when length(Xs) > 0 ->
-            Msg = "There are alarms in effect in the cluster",
-            failure(Msg, Xs, ReqData, Context)
+    try
+        Timeout = rabbit_mgmt_util:timeout(ReqData, 70000),
+        case rabbit_alarm:get_alarms(Timeout) of
+            [] ->
+                rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+            Xs when length(Xs) > 0 ->
+                Msg = "There are alarms in effect in the cluster",
+                failure(Msg, Xs, ReqData, Context)
+        end
+    catch
+        {error, {not_integer, _}} ->
+            rabbit_mgmt_util:bad_request(<<"Invalid timeout parameter">>, ReqData, Context);
+        exit:{timeout, {gen_event, call, _}} ->
+            failure("Alarms check timed out", [], ReqData, Context)
     end.
 
 failure(Message, Alarms0, ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_local_alarms.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_local_alarms.erl
@@ -30,16 +30,20 @@ resource_exists(ReqData, Context) ->
     {true, ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    Timeout = case cowboy_req:header(<<"timeout">>, ReqData) of
-                  undefined -> 70000;
-                  Val       -> list_to_integer(binary_to_list(Val))
-              end,
-    case rabbit_alarm:get_local_alarms(Timeout) of
-        [] ->
-            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
-        Xs when length(Xs) > 0 ->
-            Msg = "There are alarms in effect on the node",
-            failure(Msg, Xs, ReqData, Context)
+    try
+        Timeout = rabbit_mgmt_util:timeout(ReqData, 70000),
+        case rabbit_alarm:get_local_alarms(Timeout) of
+            [] ->
+                rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+            Xs when length(Xs) > 0 ->
+                Msg = "There are alarms in effect on the node",
+                failure(Msg, Xs, ReqData, Context)
+        end
+    catch
+        {error, {not_integer, _}} ->
+            rabbit_mgmt_util:bad_request(<<"Invalid timeout parameter">>, ReqData, Context);
+        exit:{timeout, {gen_event, call, _}} ->
+            failure("Local alarms check timed out", [], ReqData, Context)
     end.
 
 failure(Message, Alarms0, ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
@@ -28,10 +28,15 @@ content_types_provided(ReqData, Context) ->
    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
-    {case node0(ReqData) of
-         not_found -> false;
-         _         -> true
-     end, ReqData, Context}.
+    try
+        {case node0(ReqData) of
+             not_found -> false;
+             _         -> true
+         end, ReqData, Context}
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 to_json(ReqData, Context) ->
     Node = node0(ReqData),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
@@ -39,22 +39,24 @@ resource_exists(ReqData, Context) ->
     end.
 
 to_json(ReqData, Context) ->
-    Node = node0(ReqData),
-    Timeout = case cowboy_req:header(<<"timeout">>, ReqData) of
-                  undefined -> 70000;
-                  Val       -> list_to_integer(binary_to_list(Val))
-              end,
-    case rabbit_health_check:node(Node, Timeout) of
-        ok ->
-            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
-        {badrpc, timeout} ->
-            ErrMsg = rabbit_mgmt_format:print("node ~tp health check timed out", [Node]),
-            failure(ErrMsg, ReqData, Context);
-        {badrpc, Err} ->
-            failure(rabbit_mgmt_format:print("~tp", Err), ReqData, Context);
-        {error_string, Err} ->
-            S = rabbit_mgmt_format:print(Err),
-            failure(S, ReqData, Context)
+    try
+        Node = node0(ReqData),
+        Timeout = rabbit_mgmt_util:timeout(ReqData, 70000),
+        case rabbit_health_check:node(Node, Timeout) of
+            ok ->
+                rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+            {badrpc, timeout} ->
+                ErrMsg = rabbit_mgmt_format:print("node ~tp health check timed out", [Node]),
+                failure(ErrMsg, ReqData, Context);
+            {badrpc, Err} ->
+                failure(rabbit_mgmt_format:print("~tp", Err), ReqData, Context);
+            {error_string, Err} ->
+                S = rabbit_mgmt_format:print(Err),
+                failure(S, ReqData, Context)
+        end
+    catch
+        {error, {not_integer, _}} ->
+            rabbit_mgmt_util:bad_request(<<"Invalid timeout parameter">>, ReqData, Context)
     end.
 
 failure(Message, ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_node.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_node.erl
@@ -27,7 +27,12 @@ resource_exists(ReqData, Context) ->
     {rabbit_mgmt_nodes:node_exists(ReqData), ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    rabbit_mgmt_util:reply(node0(ReqData), ReqData, Context).
+    try
+        rabbit_mgmt_util:reply(node0(ReqData), ReqData, Context)
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized_monitor(ReqData, Context).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -3271,6 +3271,11 @@ samples_range_test(Config) ->
     http_get(Config, "/nodes?lengths_age=60&lengths_incr=1", ?OK),
     http_get(Config, "/nodes?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST),
 
+    [SamplesRangeNode] = http_get(Config, "/nodes"),
+    SamplesRangeNodeName = binary_to_list(maps:get(name, SamplesRangeNode)),
+    http_get(Config, "/nodes/" ++ SamplesRangeNodeName ++ "?lengths_age=60&lengths_incr=1", ?OK),
+    http_get(Config, "/nodes/" ++ SamplesRangeNodeName ++ "?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST),
+
     %% Overview
     http_get(Config, "/overview?lengths_age=60&lengths_incr=1", ?OK),
     http_get(Config, "/overview?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST),

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -3276,6 +3276,12 @@ samples_range_test(Config) ->
     http_get(Config, "/nodes/" ++ SamplesRangeNodeName ++ "?lengths_age=60&lengths_incr=1", ?OK),
     http_get(Config, "/nodes/" ++ SamplesRangeNodeName ++ "?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST),
 
+    %% Healthchecks
+    http_get(Config, "/healthchecks/node?lengths_age=60&lengths_incr=1", ?OK),
+    http_get(Config, "/healthchecks/node?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST),
+    http_get(Config, "/healthchecks/node/" ++ SamplesRangeNodeName ++ "?lengths_age=60&lengths_incr=1", ?OK),
+    http_get(Config, "/healthchecks/node/" ++ SamplesRangeNodeName ++ "?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST),
+
     %% Overview
     http_get(Config, "/overview?lengths_age=60&lengths_incr=1", ?OK),
     http_get(Config, "/overview?lengths_age=6000&lengths_incr=1", ?BAD_REQUEST),

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -15,7 +15,8 @@
 -import(rabbit_mgmt_test_util, [http_get/3,
                                 http_get/5,
                                 req/4,
-                                auth_header/2]).
+                                auth_header/2,
+                                assert_code/5]).
 
 -define(PATH_PREFIX, "/custom-prefix").
 
@@ -36,6 +37,11 @@ groups() ->
      {single_node, [], [
                         alarms_test,
                         local_alarms_test,
+                        alarms_invalid_timeout_test,
+                        local_alarms_invalid_timeout_test,
+                        healthchecks_node_invalid_timeout_test,
+                        alarms_expired_timeout_test,
+                        local_alarms_expired_timeout_test,
                         metadata_store_initialized_test,
                         metadata_store_initialized_with_data_test,
                         is_quorum_critical_single_node_test,
@@ -174,6 +180,60 @@ local_alarms_test(Config) ->
     ),
 
     passed.
+
+-define(INVALID_TIMEOUTS, ["not-a-number", "-1", "99999999999999999999",
+                           %% one past the maximum receive/gen_server/gen_event/rpc timeout
+                           "4294967296"]).
+
+alarms_invalid_timeout_test(Config) ->
+    assert_invalid_timeouts_rejected(Config, "/health/checks/alarms"),
+    %% the maximum timeout itself is valid
+    http_get_with_header(Config, "/health/checks/alarms",
+                         {"timeout", "4294967295"}, ?OK),
+    passed.
+
+local_alarms_invalid_timeout_test(Config) ->
+    assert_invalid_timeouts_rejected(Config, "/health/checks/local-alarms"),
+    http_get_with_header(Config, "/health/checks/local-alarms",
+                         {"timeout", "4294967295"}, ?OK),
+    passed.
+
+healthchecks_node_invalid_timeout_test(Config) ->
+    assert_invalid_timeouts_rejected(Config, "/healthchecks/node"),
+    passed.
+
+assert_invalid_timeouts_rejected(Config, EndpointPath) ->
+    [http_get_with_header(Config, EndpointPath, {"timeout", Timeout}, ?BAD_REQUEST)
+     || Timeout <- ?INVALID_TIMEOUTS].
+
+http_get_with_header(Config, EndpointPath, Header, CodeExp) ->
+    {ok, {{_, Code, _}, _Headers, Body}} =
+        req(Config, get, EndpointPath, [auth_header("guest", "guest"), Header]),
+    assert_code(CodeExp, Code, "GET", EndpointPath, Body).
+
+%% A timeout of 0 is a valid value, but whether the gen_event:call to
+%% the rabbit_alarm handler actually expires before getting a reply is
+%% a race. Suspend the rabbit_alarm process so it can't reply at all,
+%% making the timeout deterministic and exercising the gen_event:call
+%% timeout path rather than the invalid-parameter path above.
+alarms_expired_timeout_test(Config) ->
+    assert_expired_timeout_rejected(Config, "/health/checks/alarms"),
+    passed.
+
+local_alarms_expired_timeout_test(Config) ->
+    assert_expired_timeout_rejected(Config, "/health/checks/local-alarms"),
+    passed.
+
+assert_expired_timeout_rejected(Config, EndpointPath) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, sys, suspend, [rabbit_alarm]),
+    try
+        {ok, {{_, Code, _}, _Headers, Body}} =
+            req(Config, get, EndpointPath,
+                [auth_header("guest", "guest"), {"timeout", "0"}]),
+        assert_code(?HEALTH_CHECK_FAILURE_STATUS, Code, "GET", EndpointPath, Body)
+    after
+        ok = rabbit_ct_broker_helpers:rpc(Config, 0, sys, resume, [rabbit_alarm])
+    end.
 
 is_quorum_critical_single_node_test(Config) ->
     EndpointPath = "/health/checks/node-is-quorum-critical",


### PR DESCRIPTION
First 3 commits mirror what is already done for many other handlers that use ranges. 4th commit fixes a separate issue elsewhere.

All Sonnet 5 powered.