### PR TITLE
A few related fixes around binding deletion

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -705,8 +705,19 @@ delete_for_destination_in_khepri(#resource{virtual_host = VHost, kind = Kind, na
                                  Acc
                          end
                  end, [], BindingsMap),
-    rabbit_binding:group_bindings_fold(fun maybe_auto_delete_exchange_in_khepri/4,
-                                       lists:keysort(#binding.source, Bindings), OnlyDurable).
+    %% Deleting a source exchange's last route here can leave its
+    %% `keep_while' condition unmet, so Khepri auto-deletes the exchange as
+    %% a side effect of this same delete.
+    %% `maybe_auto_delete_exchange_in_khepri/4' cannot detect that: by the
+    %% time it re-reads the source exchange, the record is already gone.
+    %% `BindingsMap' still has it, since indirect deletes are reported back.
+    IndirectDeletions = node_props_to_deletions_in_khepri_tx(
+                          BindingsMap, OnlyDurable),
+    rabbit_binding:combine_deletions(
+      IndirectDeletions,
+      rabbit_binding:group_bindings_fold(
+        fun maybe_auto_delete_exchange_in_khepri/4,
+        lists:keysort(#binding.source, Bindings), OnlyDurable)).
 
 node_props_to_deletions(NodeProps, OnlyDurable) ->
     node_props_to_deletions(NodeProps, OnlyDurable, fun lookup_resource/1).

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -615,19 +615,23 @@ match_routing_key(Src, RoutingKeys) ->
 
 delete_all_for_exchange_in_khepri(X = #exchange{name = XName}, OnlyDurable, RemoveBindingsForSource) ->
     Bindings = case RemoveBindingsForSource of
-                   true  -> delete_for_source_in_khepri(XName);
+                   true  -> get_for_source_in_khepri(XName);
                    false -> []
                end,
     {deleted, X, Bindings, delete_for_destination_in_khepri(XName, OnlyDurable)}.
 
-delete_for_source_in_khepri(#resource{virtual_host = VHost, name = SrcName}) ->
+%% A read, not a delete: the exchange record's own deletion, right after
+%% this in the same transaction, recursively removes these routes already.
+%% Deleting them here first leaves the `rabbit_khepri_exchange' projection
+%% stale for the exchange. See rabbitmq/rabbitmq-server#17255.
+get_for_source_in_khepri(#resource{virtual_host = VHost, name = SrcName}) ->
     Pattern = khepri_route_path(
                 VHost,
                 SrcName,
                 ?KHEPRI_WILDCARD_STAR, %% Kind
                 ?KHEPRI_WILDCARD_STAR, %% DstName
                 #if_has_data{}), %% RoutingKey
-    {ok, Bindings} = khepri_tx_adv:delete_many(Pattern),
+    {ok, Bindings} = khepri_tx_adv:get_many(Pattern),
     maps:fold(
       fun(Path, Props, Acc) ->
               case {Path, Props} of

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -146,6 +146,8 @@ create(#binding{source = SrcName,
                                                               RoutePath,
                                                               sets:add_element(Binding, Set),
                                                               PutOptions),
+                                                       ok = maybe_tie_source_in_khepri_tx(
+                                                              FeatureFlag, Src),
                                                        serial_in_khepri(MaybeSerial, Src)
                                                end;
                                            _ ->
@@ -153,6 +155,8 @@ create(#binding{source = SrcName,
                                                       RoutePath,
                                                       sets:add_element(Binding, sets:new([{version, 2}])),
                                                       PutOptions),
+                                               ok = maybe_tie_source_in_khepri_tx(
+                                                      FeatureFlag, Src),
                                                serial_in_khepri(MaybeSerial, Src)
                                        end
                                end, rw),
@@ -170,6 +174,23 @@ create(#binding{source = SrcName,
         Errs ->
             not_found_errs_in_khepri(not_found(Errs, SrcName, DstName))
     end.
+
+%% An auto-delete exchange skipped by the feature flag migration for
+%% having no source bindings (#16823) carries no `keep_while' condition,
+%% so it would never be auto-deleted. Attach the condition now that a
+%% source binding exists.
+maybe_tie_source_in_khepri_tx(true, #exchange{name = XName,
+                                              auto_delete = true}) ->
+    XPath = rabbit_db_exchange:khepri_exchange_path(XName),
+    case khepri_tx:get(XPath) of
+        {ok, X} ->
+            PutOptions = rabbit_db_exchange:put_options(X),
+            ok = khepri_tx:put(XPath, X, PutOptions);
+        _ ->
+            ok
+    end;
+maybe_tie_source_in_khepri_tx(_FeatureFlag, _Src) ->
+    ok.
 
 lookup_resource(#resource{kind = queue} = Name) ->
     case rabbit_db_queue:get(Name) of

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -33,7 +33,8 @@
          delete_all_for_exchange_in_khepri/3,
          has_for_source_in_khepri/1,
          match_source_and_destination_in_khepri_tx/2,
-         khepri_ret_to_deletions/2,
+         node_props_to_deletions/2,
+         node_props_to_deletions_in_khepri_tx/2,
          put_options/1
         ]).
 
@@ -302,7 +303,7 @@ delete_v2(#binding{source = SrcName,
         {error, _} = Err ->
             Err;
         {ok, Deleted} ->
-            Deletions = khepri_ret_to_deletions(Deleted, false),
+            Deletions = node_props_to_deletions(Deleted, false),
             ok = rabbit_binding:process_deletions(Deletions),
             {ok, Deletions}
     end.
@@ -682,7 +683,14 @@ delete_for_destination_in_khepri(#resource{virtual_host = VHost, kind = Kind, na
     rabbit_binding:group_bindings_fold(fun maybe_auto_delete_exchange_in_khepri/4,
                                        lists:keysort(#binding.source, Bindings), OnlyDurable).
 
-khepri_ret_to_deletions(Deleted, OnlyDurable) ->
+node_props_to_deletions(NodeProps, OnlyDurable) ->
+    node_props_to_deletions(NodeProps, OnlyDurable, fun lookup_resource/1).
+
+node_props_to_deletions_in_khepri_tx(NodeProps, OnlyDurable) ->
+    node_props_to_deletions(
+      NodeProps, OnlyDurable, fun lookup_resource_in_khepri_tx/1).
+
+node_props_to_deletions(NodeProps, OnlyDurable, LookupFun) ->
     Bindings0 = maps:fold(
                   fun(Path, Props, Acc) ->
                           case {Path, Props} of
@@ -693,21 +701,21 @@ khepri_ret_to_deletions(Deleted, OnlyDurable) ->
                               {_, _} ->
                                   Acc
                           end
-                  end, [], Deleted),
+                  end, [], NodeProps),
     Bindings1 = lists:keysort(#binding.source, Bindings0),
     rabbit_binding:group_bindings_fold(
       fun(XName, Bindings, Deletions, _OnlyDurable) ->
               ExchangePath = rabbit_db_exchange:khepri_exchange_path(XName),
-              case Deleted of
+              case NodeProps of
                   #{ExchangePath := #{data := X}} ->
                       rabbit_binding:add_deletion(
                         XName, X, deleted, Bindings, Deletions);
                   _ ->
-                      case rabbit_db_exchange:get(XName) of
-                          {ok, X} ->
+                      case LookupFun(XName) of
+                          [X] ->
                               rabbit_binding:add_deletion(
                                 XName, X, not_deleted, Bindings, Deletions);
-                          _ ->
+                          [] ->
                               Deletions
                       end
               end

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -448,11 +448,29 @@ unconditional_delete_in_khepri(X, OnlyDurable) ->
     delete_in_khepri(X, OnlyDurable, true).
 
 delete_in_khepri(X = #exchange{name = XName}, OnlyDurable, RemoveBindingsForSource) ->
-    Ret = rabbit_db_binding:delete_all_for_exchange_in_khepri(
-            X, OnlyDurable, RemoveBindingsForSource),
-    %% See rabbitmq/rabbitmq-server#17255
-    ok = khepri_tx:delete(khepri_exchange_path(XName)),
-    Ret.
+    UsesUniformWriteRet = try
+                              khepri_tx:does_api_comply_with(uniform_write_ret)
+                          catch
+                              error:undef ->
+                                  false
+                          end,
+    case UsesUniformWriteRet of
+        true ->
+            {ok, Deleted} = khepri_tx_adv:delete(khepri_exchange_path(XName)),
+            IndirectDeletions =
+                rabbit_db_binding:node_props_to_deletions_in_khepri_tx(
+                  Deleted, OnlyDurable),
+            {deleted, X, Bindings, Deletions} =
+                rabbit_db_binding:delete_all_for_exchange_in_khepri(
+                  X, OnlyDurable, RemoveBindingsForSource),
+            {deleted, X, Bindings,
+             rabbit_binding:combine_deletions(IndirectDeletions, Deletions)};
+        false ->
+            Ret = rabbit_db_binding:delete_all_for_exchange_in_khepri(
+                    X, OnlyDurable, RemoveBindingsForSource),
+            ok = khepri_tx:delete(khepri_exchange_path(XName)),
+            Ret
+    end.
 
 %% -------------------------------------------------------------------
 %% delete_all().

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -448,8 +448,11 @@ unconditional_delete_in_khepri(X, OnlyDurable) ->
     delete_in_khepri(X, OnlyDurable, true).
 
 delete_in_khepri(X = #exchange{name = XName}, OnlyDurable, RemoveBindingsForSource) ->
+    Ret = rabbit_db_binding:delete_all_for_exchange_in_khepri(
+            X, OnlyDurable, RemoveBindingsForSource),
+    %% See rabbitmq/rabbitmq-server#17255
     ok = khepri_tx:delete(khepri_exchange_path(XName)),
-    rabbit_db_binding:delete_all_for_exchange_in_khepri(X, OnlyDurable, RemoveBindingsForSource).
+    Ret.
 
 %% -------------------------------------------------------------------
 %% delete_all().

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -479,6 +479,9 @@ delete_all(VHostName) ->
 delete_all_in_khepri_tx(VHostName) ->
     Pattern = khepri_exchange_path(VHostName, ?KHEPRI_WILDCARD_STAR),
     {ok, NodeProps} = khepri_tx_adv:delete_many(Pattern),
+    %% See rabbitmq/rabbitmq-server#17255
+    Deletions0 = rabbit_db_binding:node_props_to_deletions_in_khepri_tx(
+                   NodeProps, false),
     Deletions =
     maps:fold(
       fun(Path, Props, Deletions) ->
@@ -495,7 +498,7 @@ delete_all_in_khepri_tx(VHostName) ->
                   {_, _} ->
                       Deletions
               end
-      end, rabbit_binding:new_deletions(), NodeProps),
+      end, Deletions0, NodeProps),
     {ok, Deletions}.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -322,7 +322,7 @@ delete_if(QueueName, Conditions, OnlyDurable) ->
         true ->
             case rabbit_khepri:adv_delete(Pattern) of
                 {ok, #{Path := #{data := _}} = Deleted} ->
-                    rabbit_db_binding:khepri_ret_to_deletions(
+                    rabbit_db_binding:node_props_to_deletions(
                       Deleted, OnlyDurable);
                 {ok, _} ->
                     ok;
@@ -870,9 +870,13 @@ do_delete_transient_queues_in_khepri_tx([{Path, Vsn, QName} | Rest], Acc) ->
                                   false
                           end,
     case khepri_tx_adv:delete(VersionedPath) of
-        {ok, #{Path := #{data := _}}} when UsesUniformWriteRet ->
-            Deletions = rabbit_db_binding:delete_for_destination_in_khepri(
-                          QName, false),
+        {ok, #{Path := #{data := _}} = Deleted} when UsesUniformWriteRet ->
+            %% See rabbitmq/rabbitmq-server#17255
+            Deletions = rabbit_binding:combine_deletions(
+                          rabbit_db_binding:node_props_to_deletions_in_khepri_tx(
+                            Deleted, false),
+                          rabbit_db_binding:delete_for_destination_in_khepri(
+                            QName, false)),
             Acc1 = [{QName, Deletions} | Acc],
             do_delete_transient_queues_in_khepri_tx(Rest, Acc1);
         {ok, #{data := _}} when not UsesUniformWriteRet ->

--- a/deps/rabbit/test/rabbit_db_binding_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_binding_SUITE.erl
@@ -46,7 +46,9 @@
          tie_binding_to_dest_with_keep_while_cond_auto_delete_alternate_exchange/1,
          tie_binding_to_dest_with_keep_while_cond_auto_delete_alternate_exchange1/1,
          tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings/1,
-         tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings1/1
+         tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings1/1,
+         tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding/1,
+         tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding1/1
         ]).
 
 -define(VHOST, <<"/">>).
@@ -70,7 +72,8 @@ groups() ->
        tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission,
        tie_binding_to_dest_with_keep_while_cond_auto_delete_without_bindings,
        tie_binding_to_dest_with_keep_while_cond_auto_delete_alternate_exchange,
-       tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings]}
+       tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings,
+       tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding]}
     ].
 
 all_tests() ->
@@ -742,6 +745,45 @@ tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings1(_Config) ->
                            ?VHOST, WithoutBindingName#resource.name),
     ?assertMatch(#{WithBindingPath := _}, KWCS),
     ?assertNotMatch(#{WithoutBindingPath := _}, KWCS),
+    passed.
+
+tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE,
+               tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding1,
+               [Config]).
+
+tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding1(_Config) ->
+    %% An auto-delete exchange without source bindings is skipped by the
+    %% migration, so its record carries no `keep_while' condition. Creating
+    %% a binding must attach the condition, otherwise the exchange is never
+    %% auto-deleted once its last binding goes away.
+    ?assertNot(
+       rabbit_feature_flags:is_enabled(
+         tie_binding_to_dest_with_keep_while_cond)),
+
+    XName = rabbit_misc:r(?VHOST, exchange, <<"auto-delete-x">>),
+    Exchange = #exchange{name = XName, type = direct,
+                         durable = true, auto_delete = true,
+                         decorators = {[], []}},
+    ?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(Exchange)),
+
+    ?assertEqual(
+       ok,
+       rabbit_feature_flags:enable(
+         tie_binding_to_dest_with_keep_while_cond)),
+
+    QName = rabbit_misc:r(?VHOST, queue, <<"test-queue">>),
+    Queue = amqqueue:new(QName, none, true, false, none, [], ?VHOST, #{}),
+    ?assertMatch({created, Queue}, rabbit_db_queue:create_or_get(Queue)),
+    Binding = #binding{source = XName, key = <<"key">>,
+                       destination = QName, args = #{}},
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+
+    _ = rabbit_db_queue:delete(QName, false),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_exchange:khepri_exchange_path(
+                   ?VHOST, XName#resource.name))),
     passed.
 
 tie_binding_to_dest_with_keep_while_cond_orphan_topic_permission(Config) ->

--- a/deps/rabbit/test/rabbit_db_binding_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_binding_SUITE.erl
@@ -48,7 +48,16 @@
          tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings/1,
          tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings1/1,
          tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding/1,
-         tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding1/1
+         tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding1/1,
+         delete_destination_exchange_auto_delete_source_v1/1,
+         delete_destination_exchange_auto_delete_source_v2/1,
+         delete_destination_exchange_auto_delete_source1/2,
+         delete_destination_exchange_auto_delete_source_chain_v1/1,
+         delete_destination_exchange_auto_delete_source_chain_v2/1,
+         delete_destination_exchange_auto_delete_source_chain1/2,
+         delete_for_destination_auto_delete_source_v1/1,
+         delete_for_destination_auto_delete_source_v2/1,
+         delete_for_destination_auto_delete_source1/2
         ]).
 
 -define(VHOST, <<"/">>).
@@ -73,7 +82,13 @@ groups() ->
        tie_binding_to_dest_with_keep_while_cond_auto_delete_without_bindings,
        tie_binding_to_dest_with_keep_while_cond_auto_delete_alternate_exchange,
        tie_binding_to_dest_with_keep_while_cond_auto_delete_with_bindings,
-       tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding]}
+       tie_binding_to_dest_with_keep_while_cond_auto_delete_late_binding,
+       delete_destination_exchange_auto_delete_source_v1,
+       delete_destination_exchange_auto_delete_source_v2,
+       delete_destination_exchange_auto_delete_source_chain_v1,
+       delete_destination_exchange_auto_delete_source_chain_v2,
+       delete_for_destination_auto_delete_source_v1,
+       delete_for_destination_auto_delete_source_v2]}
     ].
 
 all_tests() ->
@@ -265,6 +280,174 @@ auto_delete1(_Config, Version) ->
     ?assertEqual(
        {error, {resources_missing, [{not_found, XName1}]}},
        rabbit_db_binding:exists(Binding)),
+    passed.
+
+delete_destination_exchange_auto_delete_source_v1(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE,
+               delete_destination_exchange_auto_delete_source1, [Config, v1]).
+
+delete_destination_exchange_auto_delete_source_v2(Config) ->
+    Ret = rabbit_ct_broker_helpers:enable_feature_flag(
+            Config, tie_binding_to_dest_with_keep_while_cond),
+    case Ret of
+        ok ->
+            passed = rabbit_ct_broker_helpers:rpc(
+                       Config, 0, ?MODULE,
+                       delete_destination_exchange_auto_delete_source1,
+                       [Config, v2]);
+        {skip, _} = Skip ->
+            Skip
+    end.
+
+delete_destination_exchange_auto_delete_source1(_Config, Version) ->
+    case Version of
+        v1 ->
+            ?assertNot(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond));
+        v2 ->
+            ?assert(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond))
+    end,
+    %% `SourceName' is an auto-delete exchange whose only source binding
+    %% routes to `DestinationName'. Deleting `DestinationName' must cascade
+    %% into auto-deleting `SourceName' and report the deletion, whether or
+    %% not the `keep_while' condition drove the cascade.
+    SourceName = rabbit_misc:r(?VHOST, exchange, <<"source">>),
+    DestinationName = rabbit_misc:r(?VHOST, exchange, <<"destination">>),
+    Source = #exchange{name = SourceName, durable = true,
+                       auto_delete = true, decorators = {[], []}},
+    Destination = #exchange{name = DestinationName, durable = true,
+                            auto_delete = false, decorators = {[], []}},
+    [?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(X))
+     || X <- [Source, Destination]],
+    Binding = #binding{source = SourceName, key = <<"">>,
+                       destination = DestinationName, args = #{}},
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+
+    {deleted, #exchange{name = DestinationName}, [], Deletions} =
+        rabbit_db_exchange:delete(DestinationName, false),
+    ?assertMatch({#exchange{name = SourceName}, deleted, [Binding]},
+                 rabbit_binding:fetch_deletion(SourceName, Deletions)),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_exchange:khepri_exchange_path(SourceName))),
+    passed.
+
+delete_destination_exchange_auto_delete_source_chain_v1(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE,
+               delete_destination_exchange_auto_delete_source_chain1,
+               [Config, v1]).
+
+delete_destination_exchange_auto_delete_source_chain_v2(Config) ->
+    Ret = rabbit_ct_broker_helpers:enable_feature_flag(
+            Config, tie_binding_to_dest_with_keep_while_cond),
+    case Ret of
+        ok ->
+            passed = rabbit_ct_broker_helpers:rpc(
+                       Config, 0, ?MODULE,
+                       delete_destination_exchange_auto_delete_source_chain1,
+                       [Config, v2]);
+        {skip, _} = Skip ->
+            Skip
+    end.
+
+delete_destination_exchange_auto_delete_source_chain1(_Config, Version) ->
+    case Version of
+        v1 ->
+            ?assertNot(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond));
+        v2 ->
+            ?assert(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond))
+    end,
+    %% `XName1' is only bound to `XName2', which in turn is only bound to
+    %% `XName3'. Deleting `XName3' must transitively auto-delete both
+    %% `XName2' and `XName1'.
+    XName1 = rabbit_misc:r(?VHOST, exchange, <<"x1">>),
+    XName2 = rabbit_misc:r(?VHOST, exchange, <<"x2">>),
+    XName3 = rabbit_misc:r(?VHOST, exchange, <<"x3">>),
+    X1 = #exchange{name = XName1, durable = true,
+                   auto_delete = true, decorators = {[], []}},
+    X2 = #exchange{name = XName2, durable = true,
+                   auto_delete = true, decorators = {[], []}},
+    X3 = #exchange{name = XName3, durable = true,
+                   auto_delete = false, decorators = {[], []}},
+    [?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(X))
+     || X <- [X1, X2, X3]],
+    Binding1To2 = #binding{source = XName1, key = <<"">>,
+                           destination = XName2, args = #{}},
+    Binding2To3 = #binding{source = XName2, key = <<"">>,
+                           destination = XName3, args = #{}},
+    [?assertEqual(ok, rabbit_db_binding:create(B, fun(_, _) -> ok end))
+     || B <- [Binding1To2, Binding2To3]],
+
+    {deleted, #exchange{name = XName3}, [], Deletions} =
+        rabbit_db_exchange:delete(XName3, false),
+    ?assertMatch({#exchange{name = XName2}, deleted, [Binding2To3]},
+                 rabbit_binding:fetch_deletion(XName2, Deletions)),
+    ?assertMatch({#exchange{name = XName1}, deleted, [Binding1To2]},
+                 rabbit_binding:fetch_deletion(XName1, Deletions)),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_exchange:khepri_exchange_path(XName2))),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_exchange:khepri_exchange_path(XName1))),
+    passed.
+
+delete_for_destination_auto_delete_source_v1(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE,
+               delete_for_destination_auto_delete_source1, [Config, v1]).
+
+delete_for_destination_auto_delete_source_v2(Config) ->
+    Ret = rabbit_ct_broker_helpers:enable_feature_flag(
+            Config, tie_binding_to_dest_with_keep_while_cond),
+    case Ret of
+        ok ->
+            passed = rabbit_ct_broker_helpers:rpc(
+                       Config, 0, ?MODULE,
+                       delete_for_destination_auto_delete_source1,
+                       [Config, v2]);
+        {skip, _} = Skip ->
+            Skip
+    end.
+
+delete_for_destination_auto_delete_source1(_Config, Version) ->
+    case Version of
+        v1 ->
+            ?assertNot(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond));
+        v2 ->
+            ?assert(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond))
+    end,
+    %% `rabbit_binding:delete_for_destination/2' runs ahead of quorum queue
+    %% deletion. It must still report the auto-delete of `SourceName' when
+    %% Khepri's own `keep_while' cascade removes it as a side effect of
+    %% this same call.
+    SourceName = rabbit_misc:r(?VHOST, exchange, <<"source">>),
+    QName = rabbit_misc:r(?VHOST, queue, <<"destination-queue">>),
+    Source = #exchange{name = SourceName, durable = true,
+                       auto_delete = true, decorators = {[], []}},
+    Q = amqqueue:new(QName, none, true, false, none, [], ?VHOST, #{},
+                     rabbit_classic_queue),
+    ?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(Source)),
+    ?assertMatch({created, _}, rabbit_db_queue:create_or_get(Q)),
+    Binding = #binding{source = SourceName, key = <<"">>,
+                       destination = QName, args = #{}},
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+
+    Deletions = rabbit_db_binding:delete_for_destination(QName),
+    ?assertMatch({#exchange{name = SourceName}, deleted, [Binding]},
+                 rabbit_binding:fetch_deletion(SourceName, Deletions)),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_exchange:khepri_exchange_path(SourceName))),
     passed.
 
 get_all(Config) ->

--- a/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
@@ -41,6 +41,7 @@ all_tests() ->
      delete,
      delete_destination_exchange,
      delete_if_unused,
+     delete_all,
      exists,
      match,
      recover
@@ -304,6 +305,28 @@ delete_if_unused1(_Config) ->
     ?assertMatch({error, in_use}, rabbit_db_exchange:delete(XName1, true)),
     ?assertMatch({ok, #exchange{name = XName1}}, rabbit_db_exchange:get(XName1)),
     ?assertMatch([#exchange{}, #exchange{}], rabbit_db_exchange:get_all_durable()),
+    passed.
+
+delete_all(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_all1, [Config]).
+
+delete_all1(_Config) ->
+    XName1 = rabbit_misc:r(?VHOST, exchange, <<"test-exchange1">>),
+    XName2 = rabbit_misc:r(?VHOST, exchange, <<"test-exchange2">>),
+    Exchange1 = rabbit_exchange_decorator:set(
+                  #exchange{name = XName1, durable = true, auto_delete = false}),
+    Exchange2 = rabbit_exchange_decorator:set(
+                  #exchange{name = XName2, durable = true, auto_delete = false}),
+    Binding = #binding{source = XName1, key = <<"">>, destination = XName2, args = #{}},
+    create([Exchange1, Exchange2]),
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+    {ok, Deletions} = rabbit_db_exchange:delete_all(?VHOST),
+    ?assertMatch({#exchange{name = XName1}, deleted, [#binding{destination = XName2}]},
+                 rabbit_binding:fetch_deletion(XName1, Deletions)),
+    ?assertMatch({#exchange{name = XName2}, deleted, []},
+                 rabbit_binding:fetch_deletion(XName2, Deletions)),
+    ?assertEqual([], rabbit_db_exchange:get_all(?VHOST)),
+    ?assertEqual([], rabbit_db_binding:get_all_for_source(XName1)),
     passed.
 
 exists(Config) ->

--- a/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
@@ -39,6 +39,7 @@ all_tests() ->
      next_serial,
      delete_serial,
      delete,
+     delete_destination_exchange,
      delete_if_unused,
      exists,
      match,
@@ -264,6 +265,26 @@ delete1(_Config) ->
                  rabbit_db_exchange:delete(XName, false)),
     ?assertEqual({error, not_found}, rabbit_db_exchange:get(XName)),
     ?assertEqual([], rabbit_db_exchange:get_all_durable()),
+    passed.
+
+delete_destination_exchange(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_destination_exchange1, [Config]).
+
+delete_destination_exchange1(_Config) ->
+    XName1 = rabbit_misc:r(?VHOST, exchange, <<"test-exchange1">>),
+    XName2 = rabbit_misc:r(?VHOST, exchange, <<"test-exchange2">>),
+    Exchange1 = rabbit_exchange_decorator:set(
+                  #exchange{name = XName1, durable = true, auto_delete = false}),
+    Exchange2 = rabbit_exchange_decorator:set(
+                  #exchange{name = XName2, durable = true, auto_delete = false}),
+    Binding = #binding{source = XName1, key = <<"">>, destination = XName2, args = #{}},
+    create([Exchange1, Exchange2]),
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+    {deleted, #exchange{name = XName2}, [], Deletions} =
+        rabbit_db_exchange:delete(XName2, false),
+    ?assertMatch({#exchange{name = XName1}, not_deleted, [#binding{destination = XName2}]},
+                 rabbit_binding:fetch_deletion(XName1, Deletions)),
+    ?assertEqual([], rabbit_db_binding:get_all_for_destination(XName2)),
     passed.
 
 delete_if_unused(Config) ->

--- a/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
@@ -40,6 +40,7 @@ all_tests() ->
      delete_serial,
      delete,
      delete_destination_exchange,
+     delete_source_exchange,
      delete_if_unused,
      delete_all,
      exists,
@@ -285,6 +286,33 @@ delete_destination_exchange1(_Config) ->
         rabbit_db_exchange:delete(XName2, false),
     ?assertMatch({#exchange{name = XName1}, not_deleted, [#binding{destination = XName2}]},
                  rabbit_binding:fetch_deletion(XName1, Deletions)),
+    ?assertEqual([], rabbit_db_binding:get_all_for_destination(XName2)),
+    passed.
+
+delete_source_exchange(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_source_exchange1, [Config]).
+
+delete_source_exchange1(_Config) ->
+    XName1 = rabbit_misc:r(?VHOST, exchange, <<"test-exchange1">>),
+    XName2 = rabbit_misc:r(?VHOST, exchange, <<"test-exchange2">>),
+    Exchange1 = rabbit_exchange_decorator:set(
+                  #exchange{name = XName1, durable = true, auto_delete = false}),
+    Exchange2 = rabbit_exchange_decorator:set(
+                  #exchange{name = XName2, durable = true, auto_delete = false}),
+    Binding = #binding{source = XName1, key = <<"">>, destination = XName2, args = #{}},
+    create([Exchange1, Exchange2]),
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+    {deleted, #exchange{name = XName1} = X, Bindings, Deletions0} =
+        rabbit_db_exchange:delete(XName1, false),
+    %% Merge the returned bindings the way `rabbit_exchange:delete/3' does
+    %% before it emits notifications.
+    Deletions = rabbit_binding:add_deletion(
+                  XName1, X, deleted, Bindings, Deletions0),
+    ?assertMatch({#exchange{name = XName1}, deleted,
+                  [#binding{source = XName1, destination = XName2}]},
+                 rabbit_binding:fetch_deletion(XName1, Deletions)),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_exchange:khepri_exchange_path(XName1))),
     ?assertEqual([], rabbit_db_binding:get_all_for_destination(XName2)),
     passed.
 

--- a/deps/rabbit/test/rabbit_db_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_queue_SUITE.erl
@@ -47,7 +47,8 @@
          mark_local_durable_queues_stopped/1,
          mark_local_durable_queues_stopped1/1,
          foreach_durable/1, foreach_durable1/1,
-         internal_delete/1, internal_delete1/1
+         internal_delete/1, internal_delete1/1,
+         delete_transient/1, delete_transient1/1
         ]).
 
 -define(VHOST, <<"/">>).
@@ -89,7 +90,8 @@ all_tests() ->
      update_durable,
      mark_local_durable_queues_stopped,
      foreach_durable,
-     internal_delete
+     internal_delete,
+     delete_transient
     ].
 
 %% -------------------------------------------------------------------
@@ -122,6 +124,8 @@ init_per_testcase(Testcase, Config) ->
 
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, clear, []),
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_exchange, clear, []),
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_binding, clear, []),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% ---------------------------------------------------------------------------
@@ -573,6 +577,31 @@ internal_delete1(_Config) ->
     ?assertEqual({error, not_found}, rabbit_db_queue:get_durable(QName)),
     passed.
 
+delete_transient(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_transient1, [Config]).
+
+delete_transient1(_Config) ->
+    QName = rabbit_misc:r(?VHOST, queue, <<"test-transient-queue">>),
+    Q = new_transient_queue(QName, rabbit_classic_queue),
+    XName = rabbit_misc:r(?VHOST, exchange, <<"test-exchange">>),
+    X = rabbit_exchange_decorator:set(
+          #exchange{name = XName, durable = true, auto_delete = false}),
+    Binding = #binding{source = XName, key = <<"transient">>,
+                       destination = QName, args = #{}},
+    ?assertEqual(ok, rabbit_db_queue:set(Q)),
+    ?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(X)),
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+    {QNames, DeletionsList} = rabbit_db_queue:delete_transient(fun(_) -> true end),
+    ?assertEqual([QName], QNames),
+    Deletions = lists:foldl(
+                  fun rabbit_binding:combine_deletions/2,
+                  rabbit_binding:new_deletions(), DeletionsList),
+    ?assertMatch({#exchange{name = XName}, not_deleted, [#binding{destination = QName}]},
+                 rabbit_binding:fetch_deletion(XName, Deletions)),
+    ?assertEqual({error, not_found}, rabbit_db_queue:get(QName)),
+    ?assertEqual([], rabbit_db_binding:get_all_for_source(XName)),
+    passed.
+
 set_list(Qs) ->
     [?assertEqual(ok, rabbit_db_queue:set(Q)) || Q <- Qs].
 
@@ -584,3 +613,6 @@ new_queue(#resource{virtual_host = VHost} = QName, Type, Pid) ->
 
 new_exclusive_queue(#resource{virtual_host = VHost} = QName, Type, Owner) ->
     amqqueue:new(QName, none, true, false, Owner, [], VHost, #{}, Type).
+
+new_transient_queue(#resource{virtual_host = VHost} = QName, Type) ->
+    amqqueue:new(QName, none, false, false, none, [], VHost, #{}, Type).

--- a/deps/rabbit/test/rabbit_db_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_queue_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("khepri/include/khepri.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include("amqqueue.hrl").
 
@@ -48,19 +49,26 @@
          mark_local_durable_queues_stopped1/1,
          foreach_durable/1, foreach_durable1/1,
          internal_delete/1, internal_delete1/1,
-         delete_transient/1, delete_transient1/1
+         delete_transient/1, delete_transient1/1,
+         delete_transient_auto_delete_source_v1/1,
+         delete_transient_auto_delete_source_v2/1,
+         delete_transient_auto_delete_source1/2
         ]).
 
 -define(VHOST, <<"/">>).
 
 all() ->
     [
-     {group, all_tests}
+     {group, all_tests},
+     {group, feature_flags}
     ].
 
 groups() ->
     [
-     {all_tests, [], all_tests()}
+     {all_tests, [], all_tests()},
+     {feature_flags, [],
+      [delete_transient_auto_delete_source_v1,
+       delete_transient_auto_delete_source_v2]}
     ].
 
 all_tests() ->
@@ -110,7 +118,15 @@ init_per_group(Group, Config) ->
         {rmq_nodename_suffix, Group},
         {rmq_nodes_count, 1}
       ]),
-    rabbit_ct_helpers:run_steps(Config1,
+    Config2 = case Group of
+                  feature_flags ->
+                      rabbit_ct_helpers:merge_app_env(
+                        Config1,
+                        {rabbit, [{forced_feature_flags_on_init, []}]});
+                  _ ->
+                      Config1
+              end,
+    rabbit_ct_helpers:run_steps(Config2,
       rabbit_ct_broker_helpers:setup_steps() ++
       rabbit_ct_client_helpers:setup_steps()).
 
@@ -120,7 +136,16 @@ end_per_group(_Group, Config) ->
       rabbit_ct_broker_helpers:teardown_steps()).
 
 init_per_testcase(Testcase, Config) ->
-    rabbit_ct_helpers:testcase_started(Config, Testcase).
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    case lists:member({name, feature_flags}, ?config(tc_group_properties, Config)) of
+        true ->
+            ok = rabbit_ct_broker_helpers:stop_broker(Config, 0),
+            ok = rabbit_ct_broker_helpers:reset_node(Config, 0),
+            ok = rabbit_ct_broker_helpers:start_broker(Config, 0);
+        false ->
+            ok
+    end,
+    Config.
 
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, clear, []),
@@ -600,6 +625,62 @@ delete_transient1(_Config) ->
                  rabbit_binding:fetch_deletion(XName, Deletions)),
     ?assertEqual({error, not_found}, rabbit_db_queue:get(QName)),
     ?assertEqual([], rabbit_db_binding:get_all_for_source(XName)),
+    passed.
+
+delete_transient_auto_delete_source_v1(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE,
+               delete_transient_auto_delete_source1, [Config, v1]).
+
+delete_transient_auto_delete_source_v2(Config) ->
+    Ret = rabbit_ct_broker_helpers:enable_feature_flag(
+            Config, tie_binding_to_dest_with_keep_while_cond),
+    case Ret of
+        ok ->
+            passed = rabbit_ct_broker_helpers:rpc(
+                       Config, 0, ?MODULE,
+                       delete_transient_auto_delete_source1,
+                       [Config, v2]);
+        {skip, _} = Skip ->
+            Skip
+    end.
+
+delete_transient_auto_delete_source1(_Config, Version) ->
+    case Version of
+        v1 ->
+            ?assertNot(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond));
+        v2 ->
+            ?assert(
+               rabbit_feature_flags:is_enabled(
+                 tie_binding_to_dest_with_keep_while_cond))
+    end,
+    %% `XName' is an auto-delete exchange whose only source binding routes
+    %% to the transient queue. Deleting the queue must cascade into
+    %% auto-deleting `XName' and report it, whether or not the `keep_while'
+    %% condition drove the cascade.
+    QName = rabbit_misc:r(?VHOST, queue, <<"test-transient-queue">>),
+    Q = new_transient_queue(QName, rabbit_classic_queue),
+    XName = rabbit_misc:r(?VHOST, exchange, <<"test-exchange">>),
+    X = rabbit_exchange_decorator:set(
+          #exchange{name = XName, durable = true, auto_delete = true}),
+    Binding = #binding{source = XName, key = <<"transient">>,
+                       destination = QName, args = #{}},
+    ?assertEqual(ok, rabbit_db_queue:set(Q)),
+    ?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(X)),
+    ?assertEqual(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
+    {QNames, DeletionsList} = rabbit_db_queue:delete_transient(fun(_) -> true end),
+    ?assertEqual([QName], QNames),
+    Deletions = lists:foldl(
+                  fun rabbit_binding:combine_deletions/2,
+                  rabbit_binding:new_deletions(), DeletionsList),
+    ?assertMatch({#exchange{name = XName}, deleted, [#binding{destination = QName}]},
+                 rabbit_binding:fetch_deletion(XName, Deletions)),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_queue:khepri_queue_path(QName))),
+    ?assertNot(rabbit_khepri:exists(
+                 rabbit_db_exchange:khepri_exchange_path(XName))),
     passed.
 
 set_list(Qs) ->


### PR DESCRIPTION
These changes started with a fix for what #17255 describes but some deeper digging found a couple of remaining comparable problems.

This should be safe to backport to `v4.3.x` without a feature flag.