### PR TITLE
Fix stream x-max-age equivalence checks (Fixes #8509)

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -881,12 +881,28 @@ with_exclusive_access_or_die(Name, ReaderPid, F) ->
                         F(Q)
                 end).
 
-assert_args_equivalence(Q, NewArgs) ->
-    ExistingArgs = amqqueue:get_arguments(Q),
+assert_args_equivalence(Q, NewArgs0) ->
+    ExistingArgs = normalize_max_age(amqqueue:get_arguments(Q)),
+    NewArgs = normalize_max_age(NewArgs0),
     QueueName = amqqueue:get_name(Q),
     Type = amqqueue:get_type(Q),
     QueueTypeArgs = rabbit_queue_type:arguments(queue_arguments, Type),
     rabbit_misc:assert_args_equivalence(ExistingArgs, NewArgs, QueueName, QueueTypeArgs).
+
+%% Stream 'x-max-age' values can be equivalent but syntactically different (e.g. "1D" vs "24h").
+%% This normalizes valid max-age strings into their exact millisecond string representations
+%% so that the generic equivalence check can safely compare them.
+normalize_max_age(Args) ->
+    case rabbit_misc:table_lookup(Args, <<"x-max-age">>) of
+        {longstr, Val} ->
+            case check_max_age(Val) of
+                {error, _} -> Args;
+                Ms when is_integer(Ms) ->
+                    rabbit_misc:set_table_value(Args, <<"x-max-age">>, longstr, integer_to_binary(Ms))
+            end;
+        _ ->
+            Args
+    end.
 
 -spec maybe_inject_default_queue_type_shortcut_into_args(
     rabbit_framing:amqp_table(), rabbit_queue_type:queue_type()) -> rabbit_framing:amqp_table().


### PR DESCRIPTION
Fixes #8509

When clients redeclare a stream with equivalent `x-max-age` values (e.g., `"1D"` vs `"24h"`), the broker throws a `PRECONDITION_FAILED` equivalence exception because it performs a strict string comparison.

This normalizes both `x-max-age` values into their millisecond equivalents before asserting args equivalence, avoiding spurious exceptions.

### Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvements (corrections, new content, etc)

### Checklist

- [x] Mandatory: I have signed the CA (see [https://github.com/rabbitmq/cla](https://github.com/rabbitmq/cla))
- [x] I have read the [CONTRIBUTING.md](https://github.com/rabbitmq/rabbitmq-server/blob/main/CONTRIBUTING.md) document
