### PR TITLE
With contributions from @Vishal-770: improve `x-max-age` equivalence check ergonomics (usability)

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -889,9 +889,9 @@ assert_args_equivalence(Q, NewArgs0) ->
     QueueTypeArgs = rabbit_queue_type:arguments(queue_arguments, Type),
     rabbit_misc:assert_args_equivalence(ExistingArgs, NewArgs, QueueName, QueueTypeArgs).
 
-%% Stream 'x-max-age' values can be equivalent but syntactically different (e.g. "1D" vs "24h").
-%% This normalizes valid max-age strings into their exact millisecond string representations
-%% so that the generic equivalence check can safely compare them.
+%% Stream 'x-max-age' values can be equivalent in ms but different strings (e.g. "1D" vs "24h").
+%% Equivalence checks really should be performed on millisecond values, not the client-provided
+%% strings.
 normalize_max_age(Args) ->
     case rabbit_misc:table_lookup(Args, <<"x-max-age">>) of
         {longstr, Val} ->

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -881,12 +881,28 @@ with_exclusive_access_or_die(Name, ReaderPid, F) ->
                         F(Q)
                 end).
 
-assert_args_equivalence(Q, NewArgs) ->
-    ExistingArgs = amqqueue:get_arguments(Q),
+assert_args_equivalence(Q, NewArgs0) ->
+    ExistingArgs = normalize_max_age(amqqueue:get_arguments(Q)),
+    NewArgs = normalize_max_age(NewArgs0),
     QueueName = amqqueue:get_name(Q),
     Type = amqqueue:get_type(Q),
     QueueTypeArgs = rabbit_queue_type:arguments(queue_arguments, Type),
     rabbit_misc:assert_args_equivalence(ExistingArgs, NewArgs, QueueName, QueueTypeArgs).
+
+%% Stream 'x-max-age' values can be equivalent but syntactically different (e.g. "1D" vs "24h").
+%% This normalizes valid max-age strings into their exact millisecond string representations
+%% so that the generic equivalence check can safely compare them.
+normalize_max_age(Args) ->
+    case rabbit_misc:table_lookup(Args, <<"x-max-age">>) of
+        {longstr, Val} ->
+            case check_max_age(Val) of
+                {error, _} -> Args;
+                Ms when is_integer(Ms) ->
+                    rabbit_misc:set_table_value(Args, <<"x-max-age">>, longstr, integer_to_binary(Ms))
+            end;
+        _ ->
+            Args
+    end.
 
 -spec maybe_inject_default_queue_type_shortcut_into_args(
     rabbit_framing:amqp_table(), rabbit_queue_type:queue_type()) -> rabbit_framing:amqp_table().

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -108,6 +108,7 @@ all_tests_1() ->
     [
      declare_args,
      declare_max_age,
+     declare_max_age_equivalence,
      declare_invalid_properties,
      declare_server_named,
      declare_invalid_arg,
@@ -354,6 +355,39 @@ declare_max_age(Config) ->
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
                  declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                              {<<"x-max-age">>, longstr, <<"1Y">>}])),
+    assert_queue_type(Server, Q, rabbit_stream_queue),
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
+
+declare_max_age_equivalence(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Q = ?config(queue_name, Config),
+
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-age">>, longstr, <<"1D">>}])),
+
+    %% "24h" is the same duration as "1D"; see rabbitmq/rabbitmq-server#8509
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-age">>, longstr, <<"24h">>}])),
+
+    %% a genuinely different duration should still be rejected
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                   {<<"x-max-age">>, longstr, <<"2D">>}])),
+
+    assert_queue_type(Server, Q, rabbit_stream_queue),
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]),
+
+    %% cover "1Y" and "365D" to introduce some assertion variation
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-age">>, longstr, <<"1Y">>}])),
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-age">>, longstr, <<"365D">>}])),
+
     assert_queue_type(Server, Q, rabbit_stream_queue),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 


### PR DESCRIPTION
This PR was started in https://github.com/rabbitmq/rabbitmq-server/pull/17258 by @Vishal-770 and finished by me.

The `x-max-age` optional argument values are now compared just like they are stored, as values in milliseconds. This means that redeclaration where one client uses `1D` and another uses `24h` won't fail with a non-equivalent argument exception (`PRECONDITION_FAILED`).

Fixes #8509.