### PR TITLE
`mc_amqpl`: remove parsing of <= 3.13 AMQP 1.0 compatibility headers

### DIFF
--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -251,18 +251,12 @@ routing_headers(Msg, Opts) ->
     List = application_properties_as_simple_map(Msg, X),
     maps:from_list(List).
 
-get_property(durable, #msg_body_encoded{header = Header} = Msg) ->
+get_property(durable, #msg_body_encoded{header = Header}) ->
     case Header of
         #'v1_0.header'{durable = D} when is_boolean(D) ->
             D;
         _ ->
-            %% fallback in case the source protocol was old AMQP 0.9.1
-            case message_annotation(<<"x-basic-delivery-mode">>, Msg, undefined) of
-                {ubyte, 2} ->
-                    true;
-                _ ->
-                    false
-            end
+            false
     end;
 get_property(timestamp, #msg_body_encoded{properties = Properties}) ->
     case Properties of
@@ -271,32 +265,19 @@ get_property(timestamp, #msg_body_encoded{properties = Properties}) ->
         _ ->
             undefined
     end;
-get_property(ttl, #msg_body_encoded{header = Header} = Msg) ->
+get_property(ttl, #msg_body_encoded{header = Header}) ->
     case Header of
         #'v1_0.header'{ttl = {uint, Ttl}} ->
             Ttl;
         _ ->
-            %% fallback in case the source protocol was AMQP 0.9.1
-            case message_annotation(<<"x-basic-expiration">>, Msg, undefined) of
-                {utf8, Expiration}  ->
-                    {ok, Ttl} = rabbit_basic:parse_expiration(Expiration),
-                    Ttl;
-                _ ->
-                    undefined
-            end
+            undefined
     end;
-get_property(priority, #msg_body_encoded{header = Header} = Msg) ->
+get_property(priority, #msg_body_encoded{header = Header}) ->
     case Header of
         #'v1_0.header'{priority = {ubyte, Priority}} ->
             Priority;
         _ ->
-            %% fallback in case the source protocol was AMQP 0.9.1
-            case message_annotation(<<"x-basic-priority">>, Msg, undefined) of
-                {_, Priority}  ->
-                    Priority;
-                _ ->
-                    undefined
-            end
+            undefined
     end.
 
 %% protocol_state/2 serialises the protocol state outputting an AMQP encoded message.

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -313,7 +313,6 @@ convert_to(?MODULE, Content, _Env) ->
 convert_to(mc_amqp, #content{payload_fragments_rev = PFR} = Content, Env) ->
     #content{properties = Props} = prepare(read, Content),
     #'P_basic'{message_id = MsgId0,
-               expiration = Expiration,
                delivery_mode = DelMode,
                headers = Headers0,
                user_id = UserId,
@@ -331,21 +330,19 @@ convert_to(mc_amqp, #content{payload_fragments_rev = PFR} = Content, Env) ->
                       _ ->
                           Timestamp * 1000
                   end,
-
     Headers = case Headers0 of
                   undefined -> [];
                   _ -> Headers0
               end,
+
+    Ttl = case rabbit_basic:parse_expiration(Props) of
+              {ok, Val} ->
+                  Val;
+              {error, _} ->
+                  undefined
+          end,
     %% TODO: only add header section if at least one of the fields
     %% needs to be set
-    Ttl = case Expiration of
-              undefined ->
-                  undefined;
-              _ ->
-                  %% Channel already checked for valid integer.
-                  binary_to_integer(Expiration)
-          end,
-
     H = #'v1_0.header'{durable = DelMode =:= 2,
                        ttl = wrap(uint, Ttl),
                        %% TODO: check Priority is a ubyte?

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -790,7 +790,14 @@ essential_properties(#content{} = C) ->
                priority = Priority,
                timestamp = TimestampRaw,
                headers = Headers} = Props = C#content.properties,
-    {ok, MsgTTL} = rabbit_basic:parse_expiration(Props),
+    %% Not every publisher goes through the AMQP 0.9.1 channel, which rejects an
+    %% invalid expiration at publish time.
+    MsgTTL = case rabbit_basic:parse_expiration(Props) of
+                 {ok, Ttl} ->
+                     Ttl;
+                 {error, _} ->
+                     undefined
+             end,
     Timestamp = case TimestampRaw of
                     undefined ->
                         undefined;

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -37,10 +37,6 @@
 
 -define(HEADER_GUESS_SIZE, 100). %% see determine_persist_to/2
 -define(AMQP10_TYPE, <<"amqp-1.0">>).
--define(AMQP10_PROPERTIES_HEADER, <<"x-amqp-1.0-properties">>).
--define(AMQP10_APP_PROPERTIES_HEADER, <<"x-amqp-1.0-app-properties">>).
--define(AMQP10_MESSAGE_ANNOTATIONS_HEADER, <<"x-amqp-1.0-message-annotations">>).
--define(AMQP10_FOOTER, <<"x-amqp-1.0-footer">>).
 -define(CLASS_ID, 60).
 -define(IS_BODY_SECTION(S),
         is_record(S, 'v1_0.data') orelse
@@ -133,18 +129,17 @@ convert_from(mc_amqp, Sections, _Env) ->
     DelMode = case H of
                   #'v1_0.header'{durable = true} -> 2;
                   #'v1_0.header'{durable = false} -> 1;
-                  _ -> amqp10_map_get(symbol(<<"x-basic-delivery-mode">>), MA)
+                  _ -> undefined
               end,
     Priority = case H of
                    #'v1_0.header'{priority = {_, P}} -> P;
-                   _ -> amqp10_map_get(symbol(<<"x-basic-priority">>), MA)
+                   _ -> undefined
                end,
-    %% check amqp header first for priority, ttl
     Expiration = case H of
                      #'v1_0.header'{ttl = {_, T}} ->
                          integer_to_binary(T);
                      _ ->
-                         amqp10_map_get(symbol(<<"x-basic-expiration">>), MA)
+                         undefined
                  end,
     Type = case Type0 of
                undefined ->
@@ -374,73 +369,53 @@ convert_to(mc_amqp, #content{payload_fragments_rev = PFR} = Content, Env) ->
                 _ ->
                     wrap(utf8, MsgId0)
             end,
-    P = case amqp10_section_header(?AMQP10_PROPERTIES_HEADER, Headers) of
-            undefined ->
-                #'v1_0.properties'{message_id = MsgId,
-                                   user_id = wrap(binary, UserId),
-                                   to = undefined,
-                                   % subject = wrap(utf8, RKey),
-                                   reply_to = ReplyTo,
-                                   correlation_id = CorrId,
-                                   content_type = wrap(symbol, ContentType),
-                                   content_encoding = wrap(symbol, ContentEncoding),
-                                   creation_time = wrap(timestamp, ConvertedTs),
-                                   %% this is semantically not the best idea but you
-                                   %% could imagine these having similar behaviour
-                                   group_id = wrap(utf8, AppId)
-                                  };
-            V10Prop ->
-                V10Prop
-        end,
+    P = #'v1_0.properties'{message_id = MsgId,
+                           user_id = wrap(binary, UserId),
+                           to = undefined,
+                           % subject = wrap(utf8, RKey),
+                           reply_to = ReplyTo,
+                           correlation_id = CorrId,
+                           content_type = wrap(symbol, ContentType),
+                           content_encoding = wrap(symbol, ContentEncoding),
+                           creation_time = wrap(timestamp, ConvertedTs),
+                           %% this is semantically not the best idea but you
+                           %% could imagine these having similar behaviour
+                           group_id = wrap(utf8, AppId)
+                          },
 
-    AP = case amqp10_section_header(?AMQP10_APP_PROPERTIES_HEADER, Headers) of
-             undefined ->
-                 %% non x- headers are stored as application properties when the type allows
-                 APC = [{wrap(utf8, K), from_091(T, V)}
-                        || {K, T, V} <- Headers,
-                           supported_header_value_type(T),
-                           not mc_util:is_x_header(K)],
-                 #'v1_0.application_properties'{content = APC};
-             A ->
-                 A
-         end,
+    %% non x- headers are stored as application properties when the type allows
+    APC = [{wrap(utf8, K), from_091(T, V)}
+           || {K, T, V} <- Headers,
+              supported_header_value_type(T),
+              not mc_util:is_x_header(K)],
+    AP = #'v1_0.application_properties'{content = APC},
 
     %% x- headers are stored as message annotations
-    MA = case amqp10_section_header(?AMQP10_MESSAGE_ANNOTATIONS_HEADER, Headers) of
-             undefined ->
-                 MAC0 = lists:filtermap(
-                          fun({<<"x-", _/binary>> = K, T, V}) ->
-                                  %% All message annotation keys need to be either a symbol or ulong
-                                  %% but 0.9.1 field-table names are always strings.
-                                  {true, {{symbol, K}, from_091(T, V)}};
-                             ({<<"CC">>, T = array, V}) ->
-                                  %% Special case the 0.9.1 CC header into 1.0 message annotations because
-                                  %% 1.0 application properties must not contain list or array values.
-                                  {true, {{symbol, <<"x-cc">>}, from_091(T, V)}};
-                             (_) ->
-                                  false
-                          end, Headers),
-                 %% `type' doesn't have a direct equivalent so adding as
-                 %% a message annotation here
-                 MAC = map_add(symbol, <<"x-basic-type">>, utf8, Type, MAC0),
-                 #'v1_0.message_annotations'{content = MAC};
-             Section ->
-                 Section
-         end,
+    MAC0 = lists:filtermap(
+             fun({<<"x-", _/binary>> = K, T, V}) ->
+                     %% All message annotation keys need to be either a symbol or ulong
+                     %% but 0.9.1 field-table names are always strings.
+                     {true, {{symbol, K}, from_091(T, V)}};
+                ({<<"CC">>, T = array, V}) ->
+                     %% Special case the 0.9.1 CC header into 1.0 message annotations because
+                     %% 1.0 application properties must not contain list or array values.
+                     {true, {{symbol, <<"x-cc">>}, from_091(T, V)}};
+                (_) ->
+                     false
+             end, Headers),
+    %% `type' doesn't have a direct equivalent so adding as
+    %% a message annotation here
+    MAC = map_add(symbol, <<"x-basic-type">>, utf8, Type, MAC0),
+    MA = #'v1_0.message_annotations'{content = MAC},
+
     BodySections = case Type of
                        ?AMQP10_TYPE ->
                            amqp10_body_sections(lists:reverse(PFR));
                        _ ->
                            [#'v1_0.data'{content = lists:reverse(PFR)}]
                    end,
-    Tail = case amqp10_section_header(?AMQP10_FOOTER, Headers) of
-               undefined ->
-                   BodySections;
-               #'v1_0.footer'{} = Footer ->
-                   BodySections ++ [Footer]
-           end,
 
-    Sections = [H, MA, P, AP | Tail],
+    Sections = [H, MA, P, AP | BodySections],
     mc_amqp:convert_from(mc_amqp, Sections, Env);
 convert_to(_TargetProto, _Content, _Env) ->
     not_implemented.
@@ -891,15 +866,6 @@ is_body_sections_tail([#'v1_0.footer'{}]) ->
     true;
 is_body_sections_tail(Sections) ->
     is_body_sections(Sections).
-
-amqp10_section_header(Header, Headers) ->
-    case lists:keyfind(Header, 1, Headers) of
-        {_, _, Data} when is_binary(Data) ->
-            [Section] = amqp10_framing:decode_bin(Data),
-            Section ;
-        _ ->
-            undefined
-    end.
 
 amqp_encoded_binary(Section) ->
     iolist_to_binary(amqp10_framing:encode_bin(Section)).

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -42,6 +42,10 @@
 -define(AMQP10_MESSAGE_ANNOTATIONS_HEADER, <<"x-amqp-1.0-message-annotations">>).
 -define(AMQP10_FOOTER, <<"x-amqp-1.0-footer">>).
 -define(CLASS_ID, 60).
+-define(IS_BODY_SECTION(S),
+        is_record(S, 'v1_0.data') orelse
+        is_record(S, 'v1_0.amqp_sequence') orelse
+        is_record(S, 'v1_0.amqp_value')).
 
 -opaque state() :: #content{}.
 
@@ -71,9 +75,7 @@ convert_from(mc_amqp, Sections, _Env) ->
          (#'v1_0.application_properties'{} = S, Acc) ->
               setelement(4, Acc, S);
          (BodySect, Acc)
-           when is_record(BodySect, 'v1_0.data') orelse
-                is_record(BodySect, 'v1_0.amqp_sequence') orelse
-                is_record(BodySect, 'v1_0.amqp_value') ->
+           when ?IS_BODY_SECTION(BodySect) ->
               Body = element(5, Acc),
               setelement(5, Acc, [BodySect | Body]);
          (Body = {amqp_encoded_body_and_footer, _}, Acc) ->
@@ -427,8 +429,7 @@ convert_to(mc_amqp, #content{payload_fragments_rev = PFR} = Content, Env) ->
          end,
     BodySections = case Type of
                        ?AMQP10_TYPE ->
-                           amqp10_framing:decode_bin(
-                             iolist_to_binary(lists:reverse(PFR)));
+                           amqp10_body_sections(lists:reverse(PFR));
                        _ ->
                            [#'v1_0.data'{content = lists:reverse(PFR)}]
                    end,
@@ -852,6 +853,44 @@ is_internal_header(<<"x-death">>) ->
     true;
 is_internal_header(_) ->
     false.
+
+%% `type' is an ordinary AMQP 0.9.1 property that any publisher can set, so a
+%% payload claiming to be AMQP 1.0 encoded may be neither well formed nor a
+%% message body. Treat the type as a hint and fall back to an opaque data
+%% section, which is what the payload would have become had the type not
+%% claimed otherwise.
+amqp10_body_sections(Payload) ->
+    Fallback = [#'v1_0.data'{content = Payload}],
+    try amqp10_framing:decode_bin(iolist_to_binary(Payload)) of
+        Sections ->
+            case is_body_sections(Sections) of
+                true ->
+                    Sections;
+                false ->
+                    Fallback
+            end
+    catch throw:_ ->
+              Fallback;
+          error:_ ->
+              Fallback
+    end.
+
+%% A body consists of one or more data, one or more amqp-sequence, or a single
+%% amqp-value section, optionally followed by a footer [§3.2]. RabbitMQ 3.13 and
+%% earlier allowed any number of each kind in any permutation, so the order and
+%% cardinality within the body itself are not validated here.
+is_body_sections([Section | Rest])
+  when ?IS_BODY_SECTION(Section) ->
+    is_body_sections_tail(Rest);
+is_body_sections(_) ->
+    false.
+
+is_body_sections_tail([]) ->
+    true;
+is_body_sections_tail([#'v1_0.footer'{}]) ->
+    true;
+is_body_sections_tail(Sections) ->
+    is_body_sections(Sections).
 
 amqp10_section_header(Header, Headers) ->
     case lists:keyfind(Header, 1, Headers) of

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -350,6 +350,25 @@ convert_to(mc_amqp, #content{payload_fragments_rev = PFR} = Content, Env) ->
                        ttl = wrap(uint, Ttl),
                        %% TODO: check Priority is a ubyte?
                        priority = wrap(ubyte, Priority)},
+
+    %% x- headers are stored as message annotations
+    MAC0 = lists:filtermap(
+             fun({<<"x-", _/binary>> = K, T, V}) ->
+                     %% All message annotation keys need to be either a symbol or ulong
+                     %% but 0.9.1 field-table names are always strings.
+                     {true, {{symbol, K}, from_091(T, V)}};
+                ({<<"CC">>, T = array, V}) ->
+                     %% Special case the 0.9.1 CC header into 1.0 message annotations because
+                     %% 1.0 application properties must not contain list or array values.
+                     {true, {{symbol, <<"x-cc">>}, from_091(T, V)}};
+                (_) ->
+                     false
+             end, Headers),
+    %% `type' doesn't have a direct equivalent so adding as
+    %% a message annotation here
+    MAC = map_add(symbol, <<"x-basic-type">>, utf8, Type, MAC0),
+    MA = #'v1_0.message_annotations'{content = MAC},
+
     ReplyTo = case ReplyTo0 of
                   undefined ->
                       undefined;
@@ -372,7 +391,6 @@ convert_to(mc_amqp, #content{payload_fragments_rev = PFR} = Content, Env) ->
     P = #'v1_0.properties'{message_id = MsgId,
                            user_id = wrap(binary, UserId),
                            to = undefined,
-                           % subject = wrap(utf8, RKey),
                            reply_to = ReplyTo,
                            correlation_id = CorrId,
                            content_type = wrap(symbol, ContentType),
@@ -380,39 +398,20 @@ convert_to(mc_amqp, #content{payload_fragments_rev = PFR} = Content, Env) ->
                            creation_time = wrap(timestamp, ConvertedTs),
                            %% this is semantically not the best idea but you
                            %% could imagine these having similar behaviour
-                           group_id = wrap(utf8, AppId)
-                          },
+                           group_id = wrap(utf8, AppId)},
 
     %% non x- headers are stored as application properties when the type allows
-    APC = [{wrap(utf8, K), from_091(T, V)}
-           || {K, T, V} <- Headers,
-              supported_header_value_type(T),
-              not mc_util:is_x_header(K)],
+    APC = [{wrap(utf8, K), from_091(T, V)} || {K, T, V} <- Headers,
+                                              supported_header_value_type(T),
+                                              not mc_util:is_x_header(K)],
     AP = #'v1_0.application_properties'{content = APC},
 
-    %% x- headers are stored as message annotations
-    MAC0 = lists:filtermap(
-             fun({<<"x-", _/binary>> = K, T, V}) ->
-                     %% All message annotation keys need to be either a symbol or ulong
-                     %% but 0.9.1 field-table names are always strings.
-                     {true, {{symbol, K}, from_091(T, V)}};
-                ({<<"CC">>, T = array, V}) ->
-                     %% Special case the 0.9.1 CC header into 1.0 message annotations because
-                     %% 1.0 application properties must not contain list or array values.
-                     {true, {{symbol, <<"x-cc">>}, from_091(T, V)}};
-                (_) ->
-                     false
-             end, Headers),
-    %% `type' doesn't have a direct equivalent so adding as
-    %% a message annotation here
-    MAC = map_add(symbol, <<"x-basic-type">>, utf8, Type, MAC0),
-    MA = #'v1_0.message_annotations'{content = MAC},
-
+    PayloadFragments = lists:reverse(PFR),
     BodySections = case Type of
                        ?AMQP10_TYPE ->
-                           amqp10_body_sections(lists:reverse(PFR));
+                           amqp10_body_sections(PayloadFragments);
                        _ ->
-                           [#'v1_0.data'{content = lists:reverse(PFR)}]
+                           [#'v1_0.data'{content = PayloadFragments}]
                    end,
 
     Sections = [H, MA, P, AP | BodySections],
@@ -790,14 +789,12 @@ essential_properties(#content{} = C) ->
                priority = Priority,
                timestamp = TimestampRaw,
                headers = Headers} = Props = C#content.properties,
-    %% Not every publisher goes through the AMQP 0.9.1 channel, which rejects an
-    %% invalid expiration at publish time.
-    MsgTTL = case rabbit_basic:parse_expiration(Props) of
-                 {ok, Ttl} ->
-                     Ttl;
-                 {error, _} ->
-                     undefined
-             end,
+    TTL = case rabbit_basic:parse_expiration(Props) of
+              {ok, Exp} ->
+                  Exp;
+              {error, _} ->
+                  undefined
+          end,
     Timestamp = case TimestampRaw of
                     undefined ->
                         undefined;
@@ -815,7 +812,7 @@ essential_properties(#content{} = C) ->
     maps_put_truthy(
       ?ANN_PRIORITY, Priority,
       maps_put_truthy(
-        ttl, MsgTTL,
+        ttl, TTL,
         maps_put_truthy(
           ?ANN_TIMESTAMP, Timestamp,
           maps_put_falsy(
@@ -836,33 +833,20 @@ is_internal_header(<<"x-death">>) ->
 is_internal_header(_) ->
     false.
 
-%% `type' is an ordinary AMQP 0.9.1 property that any publisher can set, so a
-%% payload claiming to be AMQP 1.0 encoded may be neither well formed nor a
-%% message body. Treat the type as a hint and fall back to an opaque data
-%% section, which is what the payload would have become had the type not
-%% claimed otherwise.
 amqp10_body_sections(Payload) ->
-    Fallback = [#'v1_0.data'{content = Payload}],
     try amqp10_framing:decode_bin(iolist_to_binary(Payload)) of
         Sections ->
             case is_body_sections(Sections) of
                 true ->
                     Sections;
                 false ->
-                    Fallback
+                    [#'v1_0.data'{content = Payload}]
             end
-    catch throw:_ ->
-              Fallback;
-          error:_ ->
-              Fallback
+    catch _:_ ->
+              [#'v1_0.data'{content = Payload}]
     end.
 
-%% A body consists of one or more data, one or more amqp-sequence, or a single
-%% amqp-value section, optionally followed by a footer [§3.2]. RabbitMQ 3.13 and
-%% earlier allowed any number of each kind in any permutation, so the order and
-%% cardinality within the body itself are not validated here.
-is_body_sections([Section | Rest])
-  when ?IS_BODY_SECTION(Section) ->
+is_body_sections([Section | Rest]) when ?IS_BODY_SECTION(Section) ->
     is_body_sections_tail(Rest);
 is_body_sections(_) ->
     false.

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -45,6 +45,7 @@ all_tests() ->
      amqpl_amqp_type_body_shapes,
      amqpl_amqp_type_invalid_payload,
      amqpl_invalid_expiration,
+     amqpl_to_amqp_invalid_expiration,
      amqp_x_headers,
      amqpl_x_headers
     ].
@@ -828,6 +829,26 @@ amqpl_invalid_expiration(_Config) ->
            end,
     ?assertEqual(60_000, Init(<<"60000">>)),
     [?assertEqual(undefined, Init(Expiration))
+     || Expiration <- [<<"abc">>, <<"10x">>, <<"-1">>, <<>>,
+                       <<"99999999999999999999999">>]],
+    ok.
+
+%% mc_amqpl:convert_to/3 must not assume that expiration was already
+%% validated either, for the same reason as amqpl_invalid_expiration.
+amqpl_to_amqp_invalid_expiration(_Config) ->
+    Ttl = fun(Expiration) ->
+                  Content = #content{class_id = 60,
+                                     properties = #'P_basic'{expiration = Expiration},
+                                     properties_bin = none,
+                                     payload_fragments_rev = [<<"data">>]},
+                  Msg = mc:init(mc_amqpl, Content, annotations()),
+                  [HeaderBin | _] = mc:protocol_state(mc:convert(mc_amqp, Msg)),
+                  [#'v1_0.header'{ttl = Wrapped}] =
+                      amqp10_framing:decode_bin(iolist_to_binary(HeaderBin)),
+                  Wrapped
+          end,
+    ?assertEqual({uint, 60_000}, Ttl(<<"60000">>)),
+    [?assertEqual(undefined, Ttl(Expiration))
      || Expiration <- [<<"abc">>, <<"10x">>, <<"-1">>, <<>>,
                        <<"99999999999999999999999">>]],
     ok.

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -42,8 +42,8 @@ all_tests() ->
      amqp_amqpl_unsupported_values_not_converted,
      amqp_to_amqpl_data_body,
      amqp_amqpl_amqp_bodies,
-     amqpl_amqp10_type_body_shapes,
-     amqpl_amqp10_type_invalid_payload,
+     amqpl_amqp_type_body_shapes,
+     amqpl_amqp_type_invalid_payload,
      amqpl_invalid_expiration,
      amqp_x_headers,
      amqpl_x_headers
@@ -773,9 +773,7 @@ amqp_amqpl_amqp_bodies(_Config) ->
      end || Body <- Bodies],
     ok.
 
-%% A body is one or more data, one or more amqp-sequence, or a single amqp-value
-%% section, optionally followed by a footer.
-amqpl_amqp10_type_body_shapes(_Config) ->
+amqpl_amqp_type_body_shapes(_Config) ->
     Data = #'v1_0.data'{content = <<"hello">>},
     Seq = #'v1_0.amqp_sequence'{content = [{utf8, <<"one">>}]},
     Value = #'v1_0.amqp_value'{content = {utf8, <<"hello">>}},
@@ -786,51 +784,40 @@ amqpl_amqp10_type_body_shapes(_Config) ->
               [Seq, Footer],
               [Data, Data],
               [Data, Footer]],
-    [?assertEqual(Body, amqp10_type_body_sections(serialize_sections(Body)))
-     || Body <- Bodies],
-
-    %% RabbitMQ 3.13 and earlier allowed any number of each kind in any
-    %% permutation. Such a body is still parsed as a body rather than delivered
-    %% as opaque data, even though mc_amqp keeps a single body section for it.
-    ?assertEqual([Value],
-                 amqp10_type_body_sections(serialize_sections([Data, Seq, Value]))),
-    ok.
+    [?assertEqual(Body, amqp_type_body_sections(serialize_sections(Body)))
+     || Body <- Bodies].
 
 %% `type' is an ordinary AMQP 0.9.1 property that any publisher can set, so a
 %% payload claiming to be AMQP 1.0 encoded may be neither well formed nor a
-%% message body. Such a payload must be delivered as an opaque data section
-%% rather than crash the conversion.
-amqpl_amqp10_type_invalid_payload(_Config) ->
+%% message body. Such a payload is delivered as an opaque data section.
+amqpl_amqp_type_invalid_payload(_Config) ->
     Payloads = [
-                %% not AMQP 1.0 encoded at all
                 <<>>,
                 <<"hello world">>,
                 <<0, 0>>,
-                %% a data section header without its content
+                %% a data section descriptor without its value
                 <<0, 16#53, 16#75>>,
-                %% well formed sections that do not belong in a body
                 serialize_sections([#'v1_0.header'{durable = true}]),
                 serialize_sections([#'v1_0.properties'{subject = {utf8, <<"s">>}}]),
                 serialize_sections([#'v1_0.application_properties'{content = []}]),
                 serialize_sections(
                   [#'v1_0.message_annotations'{
                       content = [{{symbol, <<"x-a">>}, {utf8, <<"v">>}}]}]),
-                %% a footer without a body
                 serialize_sections([#'v1_0.footer'{content = []}]),
-                %% a footer that is not the last section
                 serialize_sections([#'v1_0.amqp_value'{content = {utf8, <<"a">>}},
                                     #'v1_0.footer'{content = []},
                                     #'v1_0.amqp_value'{content = {utf8, <<"b">>}}])
                ],
     [?assertEqual([#'v1_0.data'{content = Payload}],
-                  amqp10_type_body_sections(Payload))
-     || Payload <- Payloads],
-    ok.
+                  amqp_type_body_sections(Payload))
+     || Payload <- Payloads].
 
 %% The AMQP 0.9.1 channel rejects an invalid expiration at publish time, but
 %% other protocols build a #content{} and initialise it directly.
 amqpl_invalid_expiration(_Config) ->
-    Ex = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"ex">>},
+    Ex = #resource{virtual_host = <<"/">>,
+                   kind = exchange,
+                   name = <<"ex">>},
     Init = fun(Expiration) ->
                    Content = #content{class_id = 60,
                                       properties = #'P_basic'{expiration = Expiration},
@@ -839,7 +826,7 @@ amqpl_invalid_expiration(_Config) ->
                    {ok, Msg} = mc_amqpl:message(Ex, <<"rkey">>, Content, #{}),
                    mc:ttl(Msg)
            end,
-    ?assertEqual(60000, Init(<<"60000">>)),
+    ?assertEqual(60_000, Init(<<"60000">>)),
     [?assertEqual(undefined, Init(Expiration))
      || Expiration <- [<<"abc">>, <<"10x">>, <<"-1">>, <<>>,
                        <<"99999999999999999999999">>]],
@@ -895,7 +882,7 @@ amqpl_x_headers(_Config) ->
 
 %% Converts an AMQP 0.9.1 message whose `type' is <<"amqp-1.0">> and returns the
 %% body sections the conversion produced.
-amqp10_type_body_sections(Payload) ->
+amqp_type_body_sections(Payload) ->
     Content = #content{class_id = 60,
                        properties = #'P_basic'{type = <<"amqp-1.0">>},
                        properties_bin = none,

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -44,6 +44,7 @@ all_tests() ->
      amqp_amqpl_amqp_bodies,
      amqpl_amqp10_type_body_shapes,
      amqpl_amqp10_type_invalid_payload,
+     amqpl_invalid_expiration,
      amqp_x_headers,
      amqpl_x_headers
     ].
@@ -824,6 +825,24 @@ amqpl_amqp10_type_invalid_payload(_Config) ->
     [?assertEqual([#'v1_0.data'{content = Payload}],
                   amqp10_type_body_sections(Payload))
      || Payload <- Payloads],
+    ok.
+
+%% The AMQP 0.9.1 channel rejects an invalid expiration at publish time, but
+%% other protocols build a #content{} and initialise it directly.
+amqpl_invalid_expiration(_Config) ->
+    Ex = #resource{virtual_host = <<"/">>, kind = exchange, name = <<"ex">>},
+    Init = fun(Expiration) ->
+                   Content = #content{class_id = 60,
+                                      properties = #'P_basic'{expiration = Expiration},
+                                      properties_bin = none,
+                                      payload_fragments_rev = [<<"data">>]},
+                   {ok, Msg} = mc_amqpl:message(Ex, <<"rkey">>, Content, #{}),
+                   mc:ttl(Msg)
+           end,
+    ?assertEqual(60000, Init(<<"60000">>)),
+    [?assertEqual(undefined, Init(Expiration))
+     || Expiration <- [<<"abc">>, <<"10x">>, <<"-1">>, <<>>,
+                       <<"99999999999999999999999">>]],
     ok.
 
 amqp_x_headers(_Config) ->

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -42,6 +42,8 @@ all_tests() ->
      amqp_amqpl_unsupported_values_not_converted,
      amqp_to_amqpl_data_body,
      amqp_amqpl_amqp_bodies,
+     amqpl_amqp10_type_body_shapes,
+     amqpl_amqp10_type_invalid_payload,
      amqp_x_headers,
      amqpl_x_headers
     ].
@@ -770,6 +772,60 @@ amqp_amqpl_amqp_bodies(_Config) ->
      end || Body <- Bodies],
     ok.
 
+%% A body is one or more data, one or more amqp-sequence, or a single amqp-value
+%% section, optionally followed by a footer.
+amqpl_amqp10_type_body_shapes(_Config) ->
+    Data = #'v1_0.data'{content = <<"hello">>},
+    Seq = #'v1_0.amqp_sequence'{content = [{utf8, <<"one">>}]},
+    Value = #'v1_0.amqp_value'{content = {utf8, <<"hello">>}},
+    Footer = #'v1_0.footer'{content = [{{symbol, <<"x-crc">>}, {uint, 1}}]},
+    Bodies = [[Value],
+              [Value, Footer],
+              [Seq, Seq],
+              [Seq, Footer],
+              [Data, Data],
+              [Data, Footer]],
+    [?assertEqual(Body, amqp10_type_body_sections(serialize_sections(Body)))
+     || Body <- Bodies],
+
+    %% RabbitMQ 3.13 and earlier allowed any number of each kind in any
+    %% permutation. Such a body is still parsed as a body rather than delivered
+    %% as opaque data, even though mc_amqp keeps a single body section for it.
+    ?assertEqual([Value],
+                 amqp10_type_body_sections(serialize_sections([Data, Seq, Value]))),
+    ok.
+
+%% `type' is an ordinary AMQP 0.9.1 property that any publisher can set, so a
+%% payload claiming to be AMQP 1.0 encoded may be neither well formed nor a
+%% message body. Such a payload must be delivered as an opaque data section
+%% rather than crash the conversion.
+amqpl_amqp10_type_invalid_payload(_Config) ->
+    Payloads = [
+                %% not AMQP 1.0 encoded at all
+                <<>>,
+                <<"hello world">>,
+                <<0, 0>>,
+                %% a data section header without its content
+                <<0, 16#53, 16#75>>,
+                %% well formed sections that do not belong in a body
+                serialize_sections([#'v1_0.header'{durable = true}]),
+                serialize_sections([#'v1_0.properties'{subject = {utf8, <<"s">>}}]),
+                serialize_sections([#'v1_0.application_properties'{content = []}]),
+                serialize_sections(
+                  [#'v1_0.message_annotations'{
+                      content = [{{symbol, <<"x-a">>}, {utf8, <<"v">>}}]}]),
+                %% a footer without a body
+                serialize_sections([#'v1_0.footer'{content = []}]),
+                %% a footer that is not the last section
+                serialize_sections([#'v1_0.amqp_value'{content = {utf8, <<"a">>}},
+                                    #'v1_0.footer'{content = []},
+                                    #'v1_0.amqp_value'{content = {utf8, <<"b">>}}])
+               ],
+    [?assertEqual([#'v1_0.data'{content = Payload}],
+                  amqp10_type_body_sections(Payload))
+     || Payload <- Payloads],
+    ok.
+
 amqp_x_headers(_Config) ->
     MAC = [
            {{symbol, <<"x-stream-filter">>}, {utf8, <<"apple">>}},
@@ -817,6 +873,18 @@ amqpl_x_headers(_Config) ->
                  mc:x_headers(BasicMsg)).
 
 %% Utility
+
+%% Converts an AMQP 0.9.1 message whose `type' is <<"amqp-1.0">> and returns the
+%% body sections the conversion produced.
+amqp10_type_body_sections(Payload) ->
+    Content = #content{class_id = 60,
+                       properties = #'P_basic'{type = <<"amqp-1.0">>},
+                       properties_bin = none,
+                       payload_fragments_rev = [Payload]},
+    Msg = mc:init(mc_amqpl, Content, annotations()),
+    [_Header, _MessageAnnotations | BodySections] =
+        mc:protocol_state(mc:convert(mc_amqp, Msg)),
+    amqp10_framing:decode_bin(iolist_to_binary(BodySections)).
 
 amqp10_encode_bin(L) when is_list(L) ->
     [iolist_to_binary(amqp10_framing:encode_bin(X)) || X <- L];

--- a/release-notes/4.4.0.md
+++ b/release-notes/4.4.0.md
@@ -2,6 +2,28 @@
 
 RabbitMQ `4.4.0` is a new feature release.
 
+## Breaking Changes and Compatibility Notes
+
+ * The following AMQP 0-9-1 headers are no longer parsed:
+
+   ```
+   x-amqp-1.0-properties
+   x-amqp-1.0-app-properties
+   x-amqp-1.0-message-annotations
+   x-amqp-1.0-footer
+   ```
+
+   RabbitMQ 3.13 and earlier used them to carry the AMQP 1.0 sections of a
+   message received over AMQP 1.0. Nothing has written them since 4.0, so only
+   a message stored by a 3.13 or earlier node and not read since carries them.
+   Such a message is still delivered, with these headers converted like any
+   other `x-` header rather than restored as AMQP 1.0 sections.
+
+ * Likewise, the `x-basic-delivery-mode`, `x-basic-priority` and
+   `x-basic-expiration` message annotations are no longer parsed. They were
+   written before 4.0 when an AMQP 0-9-1 message was encoded as AMQP 1.0 for a
+   stream, so only a stream entry written by a 3.13 or earlier node carries
+   them, and reading it no longer restores those three properties.
 
 ## Changes Worth Mentioning
 
@@ -36,7 +58,6 @@ RabbitMQ `4.4.0` is a new feature release.
    without a writer and no event to trigger recovery, a stale `start` action
    could survive a re-election, and a replica could stay disconnected instead
    of resuming on `nodeup`.
-
 
 ### Dependency Changes
 


### PR DESCRIPTION
Follows through on the decision in https://github.com/rabbitmq/rabbitmq-server/pull/16077#issuecomment-4260962184 to remove parsing of the AMQP 1.0
compatibility headers in 4.4 rather than harden their validation.

RabbitMQ 3.13 and earlier stored a message received over AMQP 1.0 as an
AMQP 0-9-1 `#content{}`, keeping the sections that do not map to AMQP 0-9-1 in
four headers:

```
x-amqp-1.0-properties
x-amqp-1.0-app-properties
x-amqp-1.0-message-annotations
x-amqp-1.0-footer
```

The module that wrote them was replaced in 4.0, so the only messages that carry
them are ones a 3.13 or earlier node stored and no consumer has read since.
`mc_amqpl` still looked all four up on every conversion to AMQP 1.0. Such a
message is still delivered, with these headers now converted like any other
`x-` header, which is what an AMQP 0-9-1 consumer of one has always seen.

Three message annotations have the same history in the other direction:
`x-basic-delivery-mode`, `x-basic-priority` and `x-basic-expiration`.
`rabbit_msg_record` wrote them when it encoded an AMQP 0-9-1 message as AMQP 1.0
for a stream, and it was deleted before 4.0, so only a stream entry written by a
3.13 or earlier node carries them. `x-basic-type` stays, because
`basic.properties.type` has no AMQP 1.0 equivalent.

Two smaller changes to the same conversion code:

* `basic.properties.type` is a free-form AMQP 0-9-1 property, but `convert_to/3`
  took a value of `amqp-1.0` to mean the payload holds AMQP 1.0 encoded body
  sections. It now checks that the payload is well formed and that the sections
  it decodes to belong in a message body, and falls back to a single data
  section otherwise.

* `essential_properties/1` matched `{ok, TTL}` on
  `rabbit_basic:parse_expiration/1`. `rabbit_channel` checks `expiration` before
  building the message, but producers that build a `#content{}` themselves do
  not go through that check, so an expiration that does not parse is now
  ignored. This changes nothing for AMQP 0-9-1.