### PR TITLE
Test flake chase (Aug 31, 2026) (round 1)

### DIFF
--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -3158,6 +3158,9 @@ recover_from_multiple_failures(Config) ->
     publish(Ch, QQ),
     publish(Ch, QQ),
     publish(Ch, QQ),
+    %% The publishes above are not yet confirmed. They cannot be committed once the
+    %% second node is stopped below.
+    wait_for_messages_ready([Server], RaName, 3),
 
     ok = rabbit_ct_broker_helpers:stop_node(Config, Server2),
     assert_cluster_status({Servers, Servers, [Server]}, [Server]),

--- a/deps/rabbitmq_ct_helpers/src/stream_test_utils.erl
+++ b/deps/rabbitmq_ct_helpers/src/stream_test_utils.erl
@@ -15,6 +15,9 @@
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
 
 -define(RESPONSE_CODE_OK, 1).
+%% The first command against a freshly booted cluster waits for the stream
+%% coordinator to elect a leader.
+-define(RECV_TIMEOUT, 30_000).
 
 connect(Config, Node) ->
     StreamPort = rabbit_ct_broker_helpers:get_node_config(Config, Node, tcp_port_stream),
@@ -190,7 +193,7 @@ receive_stream_commands(_Transport, _Sock, C0, 0) ->
 receive_stream_commands(Transport, Sock, C0, N) ->
     case rabbit_stream_core:next_command(C0) of
         empty ->
-            case Transport:recv(Sock, 0, 5000) of
+            case Transport:recv(Sock, 0, ?RECV_TIMEOUT) of
                 {ok, Data} ->
                     C1 = rabbit_stream_core:incoming_data(Data, C0),
                     receive_stream_commands(Transport, Sock, C1, N - 1);

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -501,6 +501,20 @@ end_per_testcase(T, Config)
     SetupProcess ! stop,
     close_all_connections(Config);
 
+end_per_testcase(T, Config)
+  when T =:= vhost_connection_limit;
+       T =:= vhost_queue_limit ->
+    %% A refused connection kills the linked test case process with an exit
+    %% signal, which runs no cleanup in the test case itself.
+    _ = rabbit_ct_broker_helpers:clear_vhost_limit(Config, 0, <<"/">>),
+    close_all_connections(Config),
+    rabbit_ct_helpers:testcase_finished(Config, T);
+
+end_per_testcase(T = user_connection_limit, Config) ->
+    _ = rabbit_ct_broker_helpers:clear_user_limits(Config, <<"guest">>, max_connections),
+    close_all_connections(Config),
+    rabbit_ct_helpers:testcase_finished(Config, T);
+
 end_per_testcase(Testcase, Config) ->
     close_all_connections(Config),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
@@ -1279,21 +1293,18 @@ vhost_connection_limit(Config) ->
     %% tracking removes registered connections asynchronously.
     ?awaitMatch(0, count_connections_per_vhost(Config), 30000),
     ok = rabbit_ct_broker_helpers:set_vhost_limit(Config, 0, <<"/">>, max_connections, 2),
-    try
-        {ok, C1} = connect_anonymous(Config, <<"client1">>),
-        {ok, _} = emqtt:connect(C1),
-        {ok, C2} = connect_anonymous(Config, <<"client2">>),
-        {ok, _} = emqtt:connect(C2),
-        ?awaitMatch(2, count_connections_per_vhost(Config), 30000),
-        {ok, C3} = connect_anonymous(Config, <<"client3">>),
-        ExpectedError = expected_connection_limit_error(Config),
-        unlink(C3),
-        ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C3)),
-        ok = emqtt:disconnect(C1),
-        ok = emqtt:disconnect(C2)
-    after
-        ok = rabbit_ct_broker_helpers:clear_vhost_limit(Config, 0, <<"/">>)
-    end.
+    {ok, C1} = connect_anonymous(Config, <<"client1">>),
+    {ok, _} = emqtt:connect(C1),
+    {ok, C2} = connect_anonymous(Config, <<"client2">>),
+    {ok, _} = emqtt:connect(C2),
+    ?awaitMatch(2, count_connections_per_vhost(Config), 30000),
+    {ok, C3} = connect_anonymous(Config, <<"client3">>),
+    ExpectedError = expected_connection_limit_error(Config),
+    unlink(C3),
+    ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C3)),
+    ok = emqtt:disconnect(C1),
+    ok = emqtt:disconnect(C2),
+    ok = rabbit_ct_broker_helpers:clear_vhost_limit(Config, 0, <<"/">>).
 
 count_connections_per_vhost(Config)  ->
     rabbit_ct_broker_helpers:rpc(
@@ -1317,6 +1328,9 @@ vhost_queue_limit(Config) ->
     ok = rabbit_ct_broker_helpers:clear_vhost_limit(Config, 0, <<"/">>).
 
 user_connection_limit(Config) ->
+    %% Every client in this suite authenticates as guest, and tracking removes
+    %% registered connections asynchronously.
+    ?awaitMatch(0, count_connections_per_vhost(Config), 30000),
     DefaultUser = <<"guest">>,
     ok = rabbit_ct_broker_helpers:set_user_limits(Config, DefaultUser, #{max_connections => 1}),
     {ok, C1} = connect_anonymous(Config, <<"client1">>),

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -1275,19 +1275,25 @@ expect_authentication_failure(ConnectFun, Config) ->
     ok.
 
 vhost_connection_limit(Config) ->
+    %% The limit counts connections across all protocols in the virtual host, and
+    %% tracking removes registered connections asynchronously.
+    ?awaitMatch(0, count_connections_per_vhost(Config), 30000),
     ok = rabbit_ct_broker_helpers:set_vhost_limit(Config, 0, <<"/">>, max_connections, 2),
-    {ok, C1} = connect_anonymous(Config, <<"client1">>),
-    {ok, _} = emqtt:connect(C1),
-    {ok, C2} = connect_anonymous(Config, <<"client2">>),
-    {ok, _} = emqtt:connect(C2),
-    ?awaitMatch(2, count_connections_per_vhost(Config), 30000),
-    {ok, C3} = connect_anonymous(Config, <<"client3">>),
-    ExpectedError = expected_connection_limit_error(Config),
-    unlink(C3),
-    ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C3)),
-    ok = emqtt:disconnect(C1),
-    ok = emqtt:disconnect(C2),
-    ok = rabbit_ct_broker_helpers:clear_vhost_limit(Config, 0, <<"/">>).
+    try
+        {ok, C1} = connect_anonymous(Config, <<"client1">>),
+        {ok, _} = emqtt:connect(C1),
+        {ok, C2} = connect_anonymous(Config, <<"client2">>),
+        {ok, _} = emqtt:connect(C2),
+        ?awaitMatch(2, count_connections_per_vhost(Config), 30000),
+        {ok, C3} = connect_anonymous(Config, <<"client3">>),
+        ExpectedError = expected_connection_limit_error(Config),
+        unlink(C3),
+        ?assertMatch({error, {ExpectedError, _}}, emqtt:connect(C3)),
+        ok = emqtt:disconnect(C1),
+        ok = emqtt:disconnect(C2)
+    after
+        ok = rabbit_ct_broker_helpers:clear_vhost_limit(Config, 0, <<"/">>)
+    end.
 
 count_connections_per_vhost(Config)  ->
     rabbit_ct_broker_helpers:rpc(

--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -42,7 +42,7 @@
          get_global_counters/3, get_global_counters/4,
          expect_publishes/3,
          connect/2, connect/3, connect/4,
-         get_events/1, assert_event_type/2, assert_event_prop/2,
+         get_events/1, await_events/2, assert_event_type/2, assert_event_prop/2,
          await_exit/1, await_exit/2,
          publish_qos1_timeout/4,
          non_clean_sess_opts/0]).
@@ -606,7 +606,7 @@ events(Config) ->
     ClientId = atom_to_binary(?FUNCTION_NAME),
     C = connect(ClientId, Config),
 
-    [E0, E1] = get_events(Server),
+    [E0, E1] = await_events(Server, 2),
     assert_event_type(user_authentication_success, E0),
     assert_event_prop([{name, <<"guest">>},
                        {connection_type, network}],
@@ -637,7 +637,7 @@ events(Config) ->
 
     QueueNameBin = <<"mqtt-subscription-", ClientId/binary, "qos0">>,
     QueueName = {resource, <<"/">>, queue, QueueNameBin},
-    [E2, E3] = get_events(Server),
+    [E2, E3] = await_events(Server, 2),
     assert_event_type(queue_created, E2),
     assert_event_prop([{name, QueueName},
                        {durable, true},
@@ -666,12 +666,12 @@ events(Config) ->
 
     {ok, _, _} = emqtt:unsubscribe(C, MqttTopic),
 
-    [E4] = get_events(Server),
+    [E4] = await_events(Server, 1),
     assert_event_type(binding_deleted, E4),
 
     ok = emqtt:disconnect(C),
 
-    [E5, E6] = get_events(Server),
+    [E5, E6] = await_events(Server, 2),
     assert_event_type(connection_closed, E5),
     ?assertEqual(E1#event.props, E5#event.props,
                  "connection_closed event props should match connection_created event props. "

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -245,7 +245,7 @@ event_authentication_failure(Config) ->
 
     ?assertMatch({error, _}, emqtt:connect(C)),
 
-    [E | _] = util:get_events(Server, user_authentication_failure),
+    [E | _] = util:await_events(Server, user_authentication_failure, 1),
     util:assert_event_type(user_authentication_failure, E),
     util:assert_event_prop([{name, <<"Trudy">>},
                             {connection_type, network}],

--- a/deps/rabbitmq_mqtt/test/retainer_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/retainer_SUITE.erl
@@ -199,10 +199,12 @@ recover_with_message_expiry_interval(Config) ->
     C1 = connect(ClientId, Config),
     {ok, _} = emqtt:publish(C1, <<"topic/1">>,
                             <<"m1">>, [{retain, true}, {qos, 1}]),
-    %% Stay close to the timestamp the retainer records for the next publish.
-    Start = os:system_time(second),
     {ok, _} = emqtt:publish(C1, <<"topic/2">>, #{'Message-Expiry-Interval' => 100},
                             <<"m2">>, [{retain, true}, {qos, 1}]),
+    %% A value close to the timestamp the retainer records for the publish
+    %% above. The retainer handles the retain cast after the PUBACK, so a
+    %% reading taken before the publish can be a full round trip too early.
+    Start = os:system_time(second),
     {ok, _} = emqtt:publish(C1, <<"topic/3">>, #{'Message-Expiry-Interval' => 3},
                             <<"m3">>, [{retain, true}, {qos, 1}]),
     {ok, _} = emqtt:publish(C1, <<"topic/4">>, #{'Message-Expiry-Interval' => 15},

--- a/deps/rabbitmq_mqtt/test/retainer_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/retainer_SUITE.erl
@@ -197,9 +197,10 @@ recover(Config) ->
 recover_with_message_expiry_interval(Config) ->
     ClientId = atom_to_binary(?FUNCTION_NAME),
     C1 = connect(ClientId, Config),
-    Start = os:system_time(second),
     {ok, _} = emqtt:publish(C1, <<"topic/1">>,
                             <<"m1">>, [{retain, true}, {qos, 1}]),
+    %% Stay close to the timestamp the retainer records for the next publish.
+    Start = os:system_time(second),
     {ok, _} = emqtt:publish(C1, <<"topic/2">>, #{'Message-Expiry-Interval' => 100},
                             <<"m2">>, [{retain, true}, {qos, 1}]),
     {ok, _} = emqtt:publish(C1, <<"topic/3">>, #{'Message-Expiry-Interval' => 3},
@@ -219,7 +220,6 @@ recover_with_message_expiry_interval(Config) ->
     ct:pal("Sleeping for ~b ms", [SleepMs]),
     timer:sleep(SleepMs),
 
-    ElapsedSeconds2 = os:system_time(second) - Start,
     {ok, _, [1,1,1,1]} = emqtt:subscribe(C2, [{<<"topic/1">>, qos1},
                                               {<<"topic/2">>, qos1},
                                               {<<"topic/3">>, qos1},
@@ -238,6 +238,8 @@ recover_with_message_expiry_interval(Config) ->
                         topic := <<"topic/2">>,
                         payload := <<"m2">>,
                         properties :=  #{'Message-Expiry-Interval' := MEI}}} ->
+                %% The broker computes the interval at lookup time.
+                ElapsedSeconds2 = os:system_time(second) - Start,
                 assert_message_expiry_interval(100 - ElapsedSeconds2, MEI)
     after 30_000 -> ct:fail("did not topic/2")
     end,

--- a/deps/rabbitmq_mqtt/test/util.erl
+++ b/deps/rabbitmq_mqtt/test/util.erl
@@ -5,6 +5,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(AWAIT_EVENTS_TIMEOUT, 30_000).
+
 -export([all_connection_pids/1,
          publish_qos1_timeout/4,
          sync_publish_result/3,
@@ -19,6 +21,8 @@
          start_client/4,
          get_events/1,
          get_events/2,
+         await_events/2,
+         await_events/3,
          assert_event_type/2,
          assert_event_prop/2,
          assert_message_expiry_interval/2,
@@ -91,14 +95,40 @@ get_global_counters(Config, Proto, Node, Labels) ->
 
 get_events(Node) ->
     timer:sleep(500), %% events are sent and processed asynchronously
+    take_events(Node).
+
+get_events(Node, Type) ->
+    filter_events(Type, get_events(Node)).
+
+await_events(Node, N) ->
+    await_events(Node, N, ?AWAIT_EVENTS_TIMEOUT, [], fun(Events) -> Events end).
+
+await_events(Node, Type, N) ->
+    await_events(Node, N, ?AWAIT_EVENTS_TIMEOUT, [],
+                 fun(Events) -> filter_events(Type, Events) end).
+
+%% `take_state/1` drains the recorder, therefore we need to accumulate
+%% the values across ticks/calls
+await_events(Node, N, Timeout, Acc0, Filter) ->
+    case Acc0 ++ Filter(take_events(Node)) of
+        Acc when length(Acc) >= N ->
+            Acc;
+        Acc when Timeout =< 0 ->
+            ct:fail({not_enough_events, Node, N, Acc});
+        Acc ->
+            timer:sleep(100),
+            await_events(Node, N, Timeout - 100, Acc, Filter)
+    end.
+
+take_events(Node) ->
     Result = gen_event:call({rabbit_event, Node}, event_recorder, take_state),
     ?assert(is_list(Result)),
     Result.
 
-get_events(Node, Type) ->
+filter_events(Type, Events) ->
     lists:filter(fun(#event{type = T}) ->
-                         T == Type
-                 end, get_events(Node)).
+                         T =:= Type
+                 end, Events).
 
 assert_event_type(ExpectedType, #event{type = ActualType}) ->
     ?assertEqual(ExpectedType, ActualType).

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -361,6 +361,8 @@ message_expiry_retained_message(Config) ->
                             <<"m2">>, [{retain, true}, {qos, 1}]),
     {ok, _} = emqtt:publish(Pub, <<"topic3">>, #{'Message-Expiry-Interval' => 100},
                             <<"m3.1">>, [{retain, true}, {qos, 1}]),
+    %% A value close to the timestamp the retainer records for the next publish.
+    Start = os:system_time(second),
     {ok, _} = emqtt:publish(Pub, <<"topic4">>, #{'Message-Expiry-Interval' => 100},
                             <<"m4">>, [{retain, true}, {qos, 1}]),
 
@@ -370,9 +372,11 @@ message_expiry_retained_message(Config) ->
                             <<>>, [{retain, true}, {qos, 1}]),
     {ok, _} = emqtt:publish(Pub, <<"topic3">>, #{},
                             <<"m3.2">>, [{retain, true}, {qos, 1}]),
-    timer:sleep(2001),
+    %% The retainer starts the expiry timer when it processes the retain cast,
+    %% which lands after the PUBACK the publisher waits for.
+    timer:sleep(timer:seconds(4)),
     %% Expectations:
-    %% topic1 expired because 2 seconds elapsed
+    %% topic1 expired because more than 2 seconds elapsed
     %% topic2 is not retained because it got deleted
     %% topic3 is retained because its new message does not have an Expiry-Interval set
     %% topic4 is retained because 100 seconds have not elapsed
@@ -395,7 +399,8 @@ message_expiry_retained_message(Config) ->
                         topic := <<"topic4">>,
                         payload := <<"m4">>,
                         properties := #{'Message-Expiry-Interval' := MEI}}} ->
-                assert_message_expiry_interval(100 - 2, MEI)
+                ElapsedSeconds = os:system_time(second) - Start,
+                assert_message_expiry_interval(100 - ElapsedSeconds, MEI)
     after ?TIMEOUT -> ct:fail("did not receive topic4")
     end,
     assert_nothing_received(),

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -361,10 +361,12 @@ message_expiry_retained_message(Config) ->
                             <<"m2">>, [{retain, true}, {qos, 1}]),
     {ok, _} = emqtt:publish(Pub, <<"topic3">>, #{'Message-Expiry-Interval' => 100},
                             <<"m3.1">>, [{retain, true}, {qos, 1}]),
-    %% A value close to the timestamp the retainer records for the next publish.
-    Start = os:system_time(second),
     {ok, _} = emqtt:publish(Pub, <<"topic4">>, #{'Message-Expiry-Interval' => 100},
                             <<"m4">>, [{retain, true}, {qos, 1}]),
+    %% A value close to the timestamp the retainer records for the publish
+    %% above. The retainer handles the retain cast after the PUBACK, so a
+    %% reading taken before the publish can be a full round trip too early.
+    Start = os:system_time(second),
 
     {ok, _} = emqtt:publish(Pub, <<"topic1">>, #{'Message-Expiry-Interval' => 2},
                             <<"m1.2">>, [{retain, true}, {qos, 1}]),


### PR DESCRIPTION
Originally discovered opn `v4.3.x` as part of chasing https://github.com/rabbitmq/rabbitmq-server/pull/17279 CI failures.

The backport should be largely a no-op but let's keep the same discipline we apply to `main` to `v4.3.x` backports.