### PR TITLE
[management] /init endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ gmake stop-cluster NODES=3
 
 ### Running JavaScript Tests
 
-Plugins with a JavaScript-based Web UI can run JavaScript tests alongside Erlang tests when executing `gmake test`.
+Plugins with a JavaScript-based Web UI can run JavaScript tests alongside Erlang tests when executing `gmake tests`.
 
 To enable JavaScript tests for a plugin:
 

--- a/deps/rabbit_common/mk/rabbitmq-npm-tests.mk
+++ b/deps/rabbit_common/mk/rabbitmq-npm-tests.mk
@@ -1,7 +1,5 @@
-# JavaScript/Node tests: any plugin that ships a package.json at its root
-# opts in automatically, with no changes needed to the plugin's own Makefile.
-# Skipped silently if npm isn't installed, since not every developer works
-# with the JavaScript side.
+# Any plugin with a package.json at its root runs its JavaScript tests as
+# part of `tests`. Skipped if npm is not installed.
 ifneq ($(wildcard $(CURDIR)/package.json),)
 .PHONY: npm-test
 npm-test:

--- a/deps/rabbitmq_federation_management/test/federation.test.js
+++ b/deps/rabbitmq_federation_management/test/federation.test.js
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/deps/rabbitmq_management/priv/www/js/dispatcher.js
+++ b/deps/rabbitmq_management/priv/www/js/dispatcher.js
@@ -29,7 +29,9 @@ dispatcher_add(function(sammy) {
     path('#/cluster-name', {'cluster_name': '/cluster-name'}, 'cluster-name');
     sammy.put('#/cluster-name', function() {
             if (sync_put(this, '/cluster-name')) {
-                setup_global_vars();
+                var new_name = this.params['name'];
+                window.app_settings.cluster_name = new_name;
+                update_cluster_name_ui(new_name);
                 update();
             }
             return false;

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -772,7 +772,7 @@ function DisplayControl() {
 function update_cluster_name_ui(new_name) {
     cluster_name = fmt_escape_html(new_name);
     var nav_link = user_administrator ? '<a href="#/cluster-name">' + cluster_name + '</a>' : cluster_name;
-    
+
     // If the element exists, update it, otherwise create it (initial boot)
     var $li = $('#logout').prev('li');
     if ($li.length > 0 && $li.text().startsWith('Cluster')) {

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -768,12 +768,10 @@ function DisplayControl() {
 }
 
 
-// Set up the above vars
 function update_cluster_name_ui(new_name) {
     cluster_name = fmt_escape_html(new_name);
     var nav_link = user_administrator ? '<a href="#/cluster-name">' + cluster_name + '</a>' : cluster_name;
 
-    // If the element exists, update it, otherwise create it (initial boot)
     var $li = $('#logout').prev('li');
     if ($li.length > 0 && $li.text().startsWith('Cluster')) {
         $li.html('Cluster ' + nav_link);

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -769,39 +769,49 @@ function DisplayControl() {
 
 
 // Set up the above vars
-function setup_global_vars(overview) {
-    rates_mode = overview.rates_mode;
-    is_op_policy_updating_enabled = overview.is_op_policy_updating_enabled;
+function update_cluster_name_ui(new_name) {
+    cluster_name = fmt_escape_html(new_name);
+    var nav_link = user_administrator ? '<a href="#/cluster-name">' + cluster_name + '</a>' : cluster_name;
+    
+    // If the element exists, update it, otherwise create it (initial boot)
+    var $li = $('#logout').prev('li');
+    if ($li.length > 0 && $li.text().startsWith('Cluster')) {
+        $li.html('Cluster ' + nav_link);
+    } else {
+        $('#logout').before('<li>Cluster ' + nav_link + '</li>');
+    }
+}
+
+// Set up the above vars
+function setup_global_vars(settings) {
+    rates_mode = settings.rates_mode;
+    is_op_policy_updating_enabled = settings.is_op_policy_updating_enabled;
     user_tags = expand_user_tags(user.tags);
     user_administrator = jQuery.inArray("administrator", user_tags) != -1;
     is_user_policymaker = jQuery.inArray("policymaker", user_tags) != -1;
     user_monitor = jQuery.inArray("monitoring", user_tags) != -1;
-    exchange_types = overview.exchange_types.map(function(xt) { return fmt_escape_html_one_line(xt.name); });
+    exchange_types = settings.exchange_types.map(function(xt) { return fmt_escape_html_one_line(xt.name); });
 
-    cluster_name = fmt_escape_html(overview.cluster_name);
-    $('#logout').before(
-      '<li>Cluster ' + (user_administrator ?  '<a href="#/cluster-name">' + cluster_name + '</a>' : cluster_name) + '</li>'
-    );
+    update_cluster_name_ui(settings.cluster_name);
 
     user_name = fmt_escape_html(user.name);
     $('#header #logout').prepend(
       'User ' + (user_administrator && user.is_internal_user ?  '<a href="#/users/' + user_name + '">' + user_name + '</a>' : user_name)
     );
 
-    var product = overview.rabbitmq_version;
-    if (overview.product_name && overview.product_version) {
-        product = overview.product_name + ' ' + overview.product_version;
+    var product = settings.product_info.rabbitmq_version;
+    if (settings.product_info.product_name && settings.product_info.product_version) {
+        product = settings.product_info.product_name + ' ' + settings.product_info.product_version;
     }
 
     $('#versions').html(
       '<abbr title="Available exchange types: ' + exchange_types.join(", ") + '">' + fmt_escape_html(product) + '</abbr>' +
-      '<abbr title="' + fmt_escape_html(overview.erlang_full_version) + '">Erlang ' + fmt_escape_html(overview.erlang_version) + '</abbr>'
+      '<abbr title="' + fmt_escape_html(settings.product_info.erlang_full_version) + '">Erlang ' + fmt_escape_html(settings.product_info.erlang_version) + '</abbr>'
     );
     nodes_interesting = false;
     rabbit_versions_interesting = false;
     if (user_monitor) {
-        var nodes = JSON.parse(sync_get('/nodes'));
-        if (nodes.length > 1) {
+        if (ui_data_model.nodes && ui_data_model.nodes.length > 1) {
             nodes_interesting = true;
             var v = '';
             for (var i = 0; i < ui_data_model.nodes.length; i++) {
@@ -817,13 +827,13 @@ function setup_global_vars(overview) {
 
     queue_type = "default";
     current_vhost = get_pref('vhost');
-    exchange_types = overview.exchange_types;
+    exchange_types = settings.exchange_types;
 
-    disable_stats = overview.disable_stats;
-    enable_queue_totals = overview.enable_queue_totals;
+    disable_stats = settings.disable_stats;
+    enable_queue_totals = settings.enable_queue_totals;
     COLUMNS = disable_stats?DISABLED_STATS_COLUMNS:ALL_COLUMNS;
 
-    setup_chart_ranges(overview.sample_retention_policies);
+    setup_chart_ranges(settings.sample_retention_policies);
 }
 
 function setup_chart_ranges(srp) {

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -136,19 +136,25 @@ function check_login () {
     return false;
   }
 
-  // Fetch initialization data synchronously (which sends Authorization header)
-  var rawInitData = sync_get('/init');
-  if (rawInitData) {
-      var initData = JSON.parse(rawInitData);
-      window.app_settings = initData.settings;
-      window.app_vhosts = initData.vhosts;
-      if (initData.nodes) {
-          window.app_nodes = initData.nodes;
-      }
-  } else {
-      console.error("Failed to load /api/init");
-  }
+  load_init_data();
   load_ui(user);
+  return true;
+}
+
+// Sent with the Authorization header, so it must run after the credentials
+// have been set.
+function load_init_data() {
+  var raw = sync_get('/init');
+  if (!raw) {
+      console.error("Failed to load /api/init");
+      return false;
+  }
+  var data = JSON.parse(raw);
+  window.app_settings = data.settings;
+  window.app_vhosts = data.vhosts;
+  if (data.nodes) {
+      window.app_nodes = data.nodes;
+  }
   return true;
 }
 
@@ -182,18 +188,7 @@ function login(username, password) {
   var scheme = result.token.type === 'bearer' ? 'Bearer' : 'Basic';
   set_auth(scheme, result.token.value);
 
-  // Fetch initialization data synchronously
-  var rawInitData = sync_get('/init');
-  if (rawInitData) {
-      var initData = JSON.parse(rawInitData);
-      window.app_settings = initData.settings;
-      window.app_vhosts = initData.vhosts;
-      if (initData.nodes) {
-          window.app_nodes = initData.nodes;
-      }
-  } else {
-      console.error("Failed to load /api/init");
-  }
+  load_init_data();
   load_ui(user);
 
   return true;

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -136,11 +136,7 @@ function check_login () {
     return false;
   }
 
-  if (!load_init_data()) {
-    return false;
-  }
-  load_ui(user);
-  return true;
+  return load_init_data_and_ui(user);
 }
 
 // Sent with the Authorization header, so it must run after the credentials
@@ -193,11 +189,14 @@ function login(username, password) {
   var scheme = result.token.type === 'bearer' ? 'Bearer' : 'Basic';
   set_auth(scheme, result.token.value);
 
+  return load_init_data_and_ui(user);
+}
+
+function load_init_data_and_ui(user) {
   if (!load_init_data()) {
     return false;
   }
   load_ui(user);
-
   return true;
 }
 
@@ -208,7 +207,7 @@ function load_ui(user) {
 
   var settings = window.app_settings;
 
-  replace_content('outer', format('layout', {disable_stats: settings.disable_stats}));
+  replace_content('outer', format('layout', {}));
 
   ui_data_model.vhosts = window.app_vhosts;
   ac.update(user, ui_data_model);

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -135,6 +135,19 @@ function check_login () {
     }
     return false;
   }
+
+  // Fetch initialization data synchronously (which sends Authorization header)
+  var rawInitData = sync_get('/init');
+  if (rawInitData) {
+      var initData = JSON.parse(rawInitData);
+      window.app_settings = initData.settings;
+      window.app_vhosts = initData.vhosts;
+      if (initData.nodes) {
+          window.app_nodes = initData.nodes;
+      }
+  } else {
+      console.error("Failed to load /api/init");
+  }
   load_ui(user);
   return true;
 }
@@ -168,8 +181,21 @@ function login(username, password) {
   clear_local_pref(SESSION_EXPIRY);
   var scheme = result.token.type === 'bearer' ? 'Bearer' : 'Basic';
   set_auth(scheme, result.token.value);
-  
+
+  // Fetch initialization data synchronously
+  var rawInitData = sync_get('/init');
+  if (rawInitData) {
+      var initData = JSON.parse(rawInitData);
+      window.app_settings = initData.settings;
+      window.app_vhosts = initData.vhosts;
+      if (initData.nodes) {
+          window.app_nodes = initData.nodes;
+      }
+  } else {
+      console.error("Failed to load /api/init");
+  }
   load_ui(user);
+
   return true;
 }
 
@@ -177,18 +203,24 @@ function load_ui(user) {
   set_session_expiry_if_required(user.login_session_timeout);
   check_version();
   hide_popup_warn();
-  replace_content('outer', format('layout', {}));
 
-  ui_data_model.vhosts = JSON.parse(sync_get('/vhosts'));
+  var settings = window.app_settings;
+
+  replace_content('outer', format('layout', {disable_stats: settings.disable_stats}));
+
+  ui_data_model.vhosts = window.app_vhosts;
   ac.update(user, ui_data_model);
-  if (ac.isMonitoringUser()) {
-    ui_data_model.nodes = JSON.parse(sync_get('/nodes'));
+
+  if (window.app_nodes !== undefined) {
+      ui_data_model.nodes = window.app_nodes;
   }
-  var overview = JSON.parse(sync_get('/overview'));
 
-  display.update(overview, ui_data_model);
+  // Update EJS templates to use settings
+  ui_data_model.settings = settings;
 
-  setup_global_vars(overview);
+  display.update(settings, ui_data_model);
+
+  setup_global_vars(settings);
 
   setup_constant_events();
   update_vhosts();
@@ -1468,6 +1500,8 @@ function format(template, json) {
     try {
         var fn = COMPILED_TEMPLATES[template];
         if (!fn) throw new Error('Template not found: ' + template);
+        // Inject settings object
+        json.settings = window.app_settings;
         return fn.call(json, json, json);
     } catch (err) {
         clearInterval(timer);

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1499,7 +1499,6 @@ function format(template, json) {
     try {
         var fn = COMPILED_TEMPLATES[template];
         if (!fn) throw new Error('Template not found: ' + template);
-        // Inject settings object
         json.settings = window.app_settings;
         return fn.call(json, json, json);
     } catch (err) {

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -136,7 +136,9 @@ function check_login () {
     return false;
   }
 
-  load_init_data();
+  if (!load_init_data()) {
+    return false;
+  }
   load_ui(user);
   return true;
 }
@@ -147,14 +149,17 @@ function load_init_data() {
   var raw = sync_get('/init');
   if (!raw) {
       console.error("Failed to load /api/init");
+      if (oauth.enabled) {
+          renderWarningMessageInLoginStatus(oauth, 'Could not load the management UI');
+      } else {
+          replace_content('login-status', '<p>Could not load the management UI</p>');
+      }
       return false;
   }
   var data = JSON.parse(raw);
   window.app_settings = data.settings;
   window.app_vhosts = data.vhosts;
-  if (data.nodes) {
-      window.app_nodes = data.nodes;
-  }
+  window.app_nodes = data.nodes || undefined;
   return true;
 }
 
@@ -188,7 +193,9 @@ function login(username, password) {
   var scheme = result.token.type === 'bearer' ? 'Bearer' : 'Basic';
   set_auth(scheme, result.token.value);
 
-  load_init_data();
+  if (!load_init_data()) {
+    return false;
+  }
   load_ui(user);
 
   return true;
@@ -209,9 +216,6 @@ function load_ui(user) {
   if (window.app_nodes !== undefined) {
       ui_data_model.nodes = window.app_nodes;
   }
-
-  // Update EJS templates to use settings
-  ui_data_model.settings = settings;
 
   display.update(settings, ui_data_model);
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
@@ -3,7 +3,7 @@
     <li id="interval">
       <label for="update-every" id="status"></label>
       <select id="update-every">
-        <% if(disable_stats) { %>
+        <% if(settings.disable_stats) { %>
          <option value="">Do not refresh</option>
          <option value="5000">Refresh every 5 seconds</option>
         <% } else { %>
@@ -11,7 +11,7 @@
         <% } %>
         <option value="10000">Refresh every 10 seconds</option>
         <option value="30000">Refresh every 30 seconds</option>
-        <% if(!disable_stats) { %>
+        <% if(!settings.disable_stats) { %>
          <option value="">Do not refresh</option>
         <% } %>
       </select>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
@@ -347,7 +347,7 @@
         <td>
           <p>
             <label>Definitions file:</label><br/>
-            <input type="file" name="file"<% if (overview.require_definition_json_extension) { %> accept=".json"<% } %>/>
+            <input type="file" name="file"<% if (settings.definitions && settings.definitions.require_definition_json_extension) { %> accept=".json"<% } %>/>
           </p>
         </td>
         <td>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -224,6 +224,7 @@ dispatcher() ->
      {"/auth/attempts/:node",                                  rabbit_mgmt_wm_auth_attempts, [all]},
      {"/auth/attempts/:node/source",                           rabbit_mgmt_wm_auth_attempts, [by_source]},
      {"/login",                                                rabbit_mgmt_wm_login, []},
+     {"/init",                                                 rabbit_mgmt_wm_init, []},
      {"/config/effective",                                     rabbit_mgmt_wm_environment, []},
      {"/auth/hash_password/:password",                         rabbit_mgmt_wm_hash_password, []},
      {"/version",                                              rabbit_mgmt_wm_version, []}

--- a/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
@@ -10,7 +10,9 @@
 -export([is_op_policy_updating_disabled/0,
          is_qq_replica_operations_disabled/0,
          are_stats_enabled/0,
-         is_definition_json_extension_required/0]).
+         get_definitions_settings/0,
+         get_settings/1,
+         get_product_info/0]).
 
 is_qq_replica_operations_disabled() ->
     get_restriction([quorum_queue_replica_operations, disabled]).
@@ -29,11 +31,117 @@ are_stats_enabled() ->
         _    -> rabbit_mgmt_agent_config:is_metrics_collector_permitted()
     end.
 
-is_definition_json_extension_required() ->
-    application:get_env(rabbitmq_management, require_definition_json_extension, false).
+get_definitions_settings() ->
+    [
+        {require_definition_json_extension,
+         application:get_env(rabbitmq_management, require_definition_json_extension, false)}
+    ].
+
+get_settings(ReqData) ->
+    RatesMode = rabbit_mgmt_agent_config:get_env(rates_mode),
+    SRP = get_sample_retention_policies(),
+    ExchangeTypes = lists:sort(
+        fun(ET1, ET2) ->
+            proplists:get_value(name, ET1, none)
+            =<
+            proplists:get_value(name, ET2, none)
+        end,
+        rabbit_mgmt_external_stats:list_registry_plugins(exchange)),
+    [
+        {rates_mode,                RatesMode},
+        {sample_retention_policies, SRP},
+        {exchange_types,            ExchangeTypes},
+        {cluster_tags,              cluster_tags()},
+        {node_tags,                 node_tags()},
+        {disable_stats,             rabbit_mgmt_util:disable_stats(ReqData)},
+        {default_queue_type,        rabbit_queue_type:default_alias()},
+        {is_op_policy_updating_enabled, not is_op_policy_updating_disabled()},
+        {enable_queue_totals,       rabbit_mgmt_util:enable_queue_totals(ReqData)},
+        {definitions,               get_definitions_settings()}
+    ].
+
+get_product_info() ->
+    [
+        {product_name,        list_to_binary(rabbit:product_name())},
+        {product_version,     list_to_binary(rabbit:product_version())},
+        {rabbitmq_version,    list_to_binary(rabbit:base_product_version())},
+        {management_version,  version(rabbitmq_management)},
+        {erlang_version,      erlang_version()},
+        {erlang_full_version, erlang_full_version()}
+    ].
 
 %% Private
 
 get_restriction(Path) ->
     Restrictions = application:get_env(rabbitmq_management,  restrictions, []),
     rabbit_misc:deep_pget(Path, Restrictions, false).
+
+version(App) ->
+    {ok, V} = application:get_key(App, vsn),
+    list_to_binary(V).
+
+erlang_version() -> list_to_binary(rabbit_misc:otp_release()).
+
+erlang_full_version() ->
+    list_to_binary(rabbit_misc:otp_system_version()).
+
+get_sample_retention_policies() ->
+    P = rabbit_mgmt_agent_config:get_env(sample_retention_policies),
+    get_sample_retention_policies(P).
+
+get_sample_retention_policies(undefined) ->
+    [{global, []}, {basic, []}, {detailed, []}];
+get_sample_retention_policies(Policies) ->
+    [transform_retention_policy(Pol, Policies) || Pol <- [global, basic, detailed]].
+
+transform_retention_policy(Pol, Policies) ->
+    case proplists:lookup(Pol, Policies) of
+        none ->
+            {Pol, []};
+        {Pol, Intervals} ->
+            {Pol, transform_retention_intervals(Intervals, [])}
+    end.
+
+transform_retention_intervals([], Acc) ->
+    lists:sort(Acc);
+transform_retention_intervals([{MaxAgeInSeconds, _}|Rest], Acc) ->
+    %
+    % Seconds | Interval
+    % 60      | last minute
+    % 600     | last 10 minutes
+    % 3600    | last hour
+    % 28800   | last 8 hours
+    % 86400   | last day
+    %
+    % rabbitmq/rabbitmq-management#635
+    %
+    % We check for the max age in seconds to be within 10% of the value above.
+    % The reason being that the default values are "bit higher" to accommodate
+    % edge cases (see deps/rabbitmq_management_agent/Makefile)
+    AccVal = if
+                 MaxAgeInSeconds >= 0 andalso MaxAgeInSeconds =< 66 ->
+                     60;
+                 MaxAgeInSeconds >= 540 andalso MaxAgeInSeconds =< 660 ->
+                     600;
+                 MaxAgeInSeconds >= 3240 andalso MaxAgeInSeconds =< 3960 ->
+                     3600;
+                 MaxAgeInSeconds >= 25920 andalso MaxAgeInSeconds =< 31681 ->
+                     28800;
+                 MaxAgeInSeconds >= 77760 andalso MaxAgeInSeconds =< 95041 ->
+                     86400;
+                 true ->
+                     0
+             end,
+    transform_retention_intervals(Rest, [AccVal|Acc]).
+
+cluster_tags() ->
+    Val = case rabbit_runtime_parameters:value_global(cluster_tags) of
+        not_found ->
+            [];
+        Tags -> Tags
+    end,
+    rabbit_data_coercion:to_map(Val).
+
+node_tags() ->
+    Val = application:get_env(rabbit, node_tags, []),
+    rabbit_data_coercion:to_map(Val).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
@@ -48,6 +48,7 @@ get_settings(ReqData) ->
         end,
         rabbit_mgmt_external_stats:list_registry_plugins(exchange)),
     [
+        {cluster_name,              rabbit_nodes:cluster_name()},
         {rates_mode,                RatesMode},
         {sample_retention_policies, SRP},
         {exchange_types,            ExchangeTypes},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -421,7 +421,8 @@ get_all_parts(Req0, BodySize0, BodySizeLimit, Acc, FileFilename) ->
     end.
 
 is_acceptable_filename(Filename) ->
-    not rabbit_mgmt_features:is_definition_json_extension_required()
+    Settings = rabbit_mgmt_features:get_definitions_settings(),
+    not proplists:get_value(require_definition_json_extension, Settings, false)
         orelse has_json_extension(Filename).
 
 has_json_extension(unknown) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -43,9 +43,18 @@ get_settings_json(ReqData, _Context) ->
 
     rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(Settings0)).
 
-get_vhosts_json(_ReqData, Context) ->
-    VHosts = rabbit_mgmt_util:list_visible_vhosts(Context#context.user),
-    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(VHosts)).
+get_vhosts_json(ReqData, Context) ->
+    %% Must be the same shape /vhosts returns, which is what the UI used to
+    %% fetch: the virtual host selector reads .name off each entry. Note
+    %% that rabbit_mgmt_util:list_visible_vhosts/1 returns names, not vhost
+    %% records, so it is not enough on its own.
+    VHosts = rabbit_queue_type:vhosts_with_dqt(
+               rabbit_mgmt_wm_vhosts:augmented(ReqData, Context)),
+    %% list_names/0 does an unordered ets:select, and /vhosts sorts by name.
+    Sorted = lists:sort(
+               fun(A, B) -> maps:get(name, A, <<>>) =< maps:get(name, B, <<>>) end,
+               VHosts),
+    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(Sorted)).
 
 get_nodes_json(ReqData, _Context) ->
     Nodes = rabbit_mgmt_wm_nodes:all_nodes(ReqData),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -50,7 +50,6 @@ to_json(ReqData, Context) ->
 
 settings(ReqData) ->
     [
-        {management_version,        proplists:get_value(management_version, rabbit_mgmt_features:get_product_info())},
         {product_info,              rabbit_mgmt_features:get_product_info()},
         {cluster_name,              rabbit_nodes:cluster_name()}
     ] ++ rabbit_mgmt_features:get_settings(ReqData).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -40,7 +40,7 @@ to_json(ReqData, Context) ->
             {nodes,    Nodes}
         ],
         %% `reply/3` replaces the `cache-control` header set in `init/2`, so
-        %% we have re-inject the value we want
+        %% we have to re-inject the value we want
         case rabbit_mgmt_util:reply(Payload, ReqData, Context) of
             {stop, _, _} = Stop ->
                 Stop;

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -1,6 +1,7 @@
 -module(rabbit_mgmt_wm_init).
 -export([init/2]).
 -export([content_types_provided/2, is_authorized/2, to_json/2]).
+-export([variances/2]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
@@ -10,6 +11,9 @@ init(Req0, _State) ->
     Req2 = rabbit_mgmt_headers:set_no_cache_headers(Req1, ?MODULE),
     {cowboy_rest, Req2, #context{}}.
 
+variances(Req, Context) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
+
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).
 
@@ -18,37 +22,40 @@ content_types_provided(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     try
-        SettingsJSON = get_settings_json(ReqData, Context),
-        VhostsJSON = get_vhosts_json(ReqData, Context),
-
         UserTags = (Context#context.user)#user.tags,
-        NodesJSON = case rabbit_mgmt_util:is_monitor(UserTags) of
-            true -> get_nodes_json(ReqData, Context);
-            false -> <<"null">>
+        Nodes = case rabbit_mgmt_util:is_monitor(UserTags) of
+            true -> rabbit_mgmt_wm_nodes:all_nodes(ReqData);
+            false -> null
         end,
-
-        JSONContent = [
-            "{\"settings\": ", SettingsJSON, ",\n",
-            " \"vhosts\": ", VhostsJSON, ",\n",
-            " \"nodes\": ", NodesJSON, "\n",
-            "}\n"
+        Payload = [
+            {settings, settings(ReqData)},
+            {vhosts,   vhosts(ReqData, Context)},
+            {nodes,    Nodes}
         ],
-        {iolist_to_binary(JSONContent), ReqData, Context}
+        %% content_types_provided/2 advertises application/bert alongside
+        %% application/json, the same way rabbit_mgmt_util:reply/3 does for
+        %% every other endpoint.
+        case maps:get(media_type, ReqData, undefined) of
+            {<<"application">>, <<"bert">>, _} ->
+                {term_to_binary(Payload), ReqData, Context};
+            _ ->
+                {rabbit_json:encode(
+                   rabbit_mgmt_format:prepare_for_encoding(Payload)),
+                 ReqData, Context}
+        end
     catch
         {error, invalid_range_parameters, Reason} ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
     end.
 
-get_settings_json(ReqData, _Context) ->
-    Settings0 = [
+settings(ReqData) ->
+    [
         {management_version,        proplists:get_value(management_version, rabbit_mgmt_features:get_product_info())},
         {product_info,              rabbit_mgmt_features:get_product_info()},
         {cluster_name,              rabbit_nodes:cluster_name()}
-    ] ++ rabbit_mgmt_features:get_settings(ReqData),
+    ] ++ rabbit_mgmt_features:get_settings(ReqData).
 
-    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(Settings0)).
-
-get_vhosts_json(ReqData, Context) ->
+vhosts(ReqData, Context) ->
     %% Must be the same shape /vhosts returns, which is what the UI used to
     %% fetch: the virtual host selector reads .name off each entry. Note
     %% that rabbit_mgmt_util:list_visible_vhosts/1 returns names, not vhost
@@ -56,11 +63,6 @@ get_vhosts_json(ReqData, Context) ->
     VHosts = rabbit_queue_type:vhosts_with_dqt(
                rabbit_mgmt_wm_vhosts:augmented(ReqData, Context)),
     %% list_names/0 does an unordered ets:select, and /vhosts sorts by name.
-    Sorted = lists:sort(
-               fun(A, B) -> maps:get(name, A, <<>>) =< maps:get(name, B, <<>>) end,
-               VHosts),
-    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(Sorted)).
-
-get_nodes_json(ReqData, _Context) ->
-    Nodes = rabbit_mgmt_wm_nodes:all_nodes(ReqData),
-    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(Nodes)).
+    lists:sort(
+      fun(A, B) -> maps:get(name, A, <<>>) =< maps:get(name, B, <<>>) end,
+      VHosts).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -39,16 +39,13 @@ to_json(ReqData, Context) ->
             {vhosts,   vhosts(ReqData, Context)},
             {nodes,    Nodes}
         ],
-        %% content_types_provided/2 advertises application/bert alongside
-        %% application/json, the same way rabbit_mgmt_util:reply/3 does for
-        %% every other endpoint.
-        case maps:get(media_type, ReqData, undefined) of
-            {<<"application">>, <<"bert">>, _} ->
-                {term_to_binary(Payload), ReqData, Context};
-            _ ->
-                {rabbit_json:encode(
-                   rabbit_mgmt_format:prepare_for_encoding(Payload)),
-                 ReqData, Context}
+        %% `reply/3` replaces the `cache-control` header set in `init/2`, so
+        %% we have re-inject the value we want
+        case rabbit_mgmt_util:reply(Payload, ReqData, Context) of
+            {stop, _, _} = Stop ->
+                Stop;
+            {Body, ReqData1, Context1} ->
+                {Body, rabbit_mgmt_headers:set_no_cache_headers(ReqData1, ?MODULE), Context1}
         end
     catch
         {error, invalid_range_parameters, Reason} ->
@@ -57,8 +54,7 @@ to_json(ReqData, Context) ->
 
 settings(ReqData) ->
     [
-        {product_info,              rabbit_mgmt_features:get_product_info()},
-        {cluster_name,              rabbit_nodes:cluster_name()}
+        {product_info, rabbit_mgmt_features:get_product_info()}
     ] ++ rabbit_mgmt_features:get_settings(ReqData).
 
 vhosts(ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -58,13 +58,9 @@ settings(ReqData) ->
     ] ++ rabbit_mgmt_features:get_settings(ReqData).
 
 vhosts(ReqData, Context) ->
-    %% Must be the same shape /vhosts returns, which is what the UI used to
-    %% fetch: the virtual host selector reads .name off each entry. Note
-    %% that rabbit_mgmt_util:list_visible_vhosts/1 returns names, not vhost
-    %% records, so it is not enough on its own.
+    %% Same shape and order as `GET /vhosts`, which the UI used to fetch.
     VHosts = rabbit_queue_type:vhosts_with_dqt(
                rabbit_mgmt_wm_vhosts:augmented(ReqData, Context)),
-    %% list_names/0 does an unordered ets:select, and /vhosts sorts by name.
     lists:sort(
       fun(A, B) -> maps:get(name, A, <<>>) =< maps:get(name, B, <<>>) end,
       VHosts).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -1,0 +1,52 @@
+-module(rabbit_mgmt_wm_init).
+-export([init/2]).
+-export([content_types_provided/2, is_authorized/2, to_json/2]).
+
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+init(Req0, _State) ->
+    Req1 = rabbit_mgmt_headers:set_common_permission_headers(Req0, ?MODULE),
+    Req2 = rabbit_mgmt_headers:set_no_cache_headers(Req1, ?MODULE),
+    {cowboy_rest, Req2, #context{}}.
+
+is_authorized(ReqData, Context) ->
+    rabbit_mgmt_util:is_authorized(ReqData, Context).
+
+content_types_provided(ReqData, Context) ->
+    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+
+to_json(ReqData, Context) ->
+    SettingsJSON = get_settings_json(ReqData, Context),
+    VhostsJSON = get_vhosts_json(ReqData, Context),
+    
+    UserTags = (Context#context.user)#user.tags,
+    NodesJSON = case rabbit_mgmt_util:is_monitor(UserTags) of
+        true -> get_nodes_json(ReqData, Context);
+        false -> <<"null">>
+    end,
+    
+    JSONContent = [
+        "{\"settings\": ", SettingsJSON, ",\n",
+        " \"vhosts\": ", VhostsJSON, ",\n",
+        " \"nodes\": ", NodesJSON, "\n",
+        "}\n"
+    ],
+    {iolist_to_binary(JSONContent), ReqData, Context}.
+
+get_settings_json(ReqData, _Context) ->
+    Settings0 = [
+        {management_version,        proplists:get_value(management_version, rabbit_mgmt_features:get_product_info())},
+        {product_info,              rabbit_mgmt_features:get_product_info()},
+        {cluster_name,              rabbit_nodes:cluster_name()}
+    ] ++ rabbit_mgmt_features:get_settings(ReqData),
+
+    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(Settings0)).
+
+get_vhosts_json(_ReqData, Context) ->
+    VHosts = rabbit_mgmt_util:list_visible_vhosts(Context#context.user),
+    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(VHosts)).
+
+get_nodes_json(ReqData, _Context) ->
+    Nodes = rabbit_mgmt_wm_nodes:all_nodes(ReqData),
+    rabbit_json:encode(rabbit_mgmt_format:prepare_for_encoding(Nodes)).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -1,3 +1,10 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
 -module(rabbit_mgmt_wm_init).
 -export([init/2]).
 -export([content_types_provided/2, is_authorized/2, to_json/2]).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_init.erl
@@ -17,22 +17,27 @@ content_types_provided(ReqData, Context) ->
     {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    SettingsJSON = get_settings_json(ReqData, Context),
-    VhostsJSON = get_vhosts_json(ReqData, Context),
-    
-    UserTags = (Context#context.user)#user.tags,
-    NodesJSON = case rabbit_mgmt_util:is_monitor(UserTags) of
-        true -> get_nodes_json(ReqData, Context);
-        false -> <<"null">>
-    end,
-    
-    JSONContent = [
-        "{\"settings\": ", SettingsJSON, ",\n",
-        " \"vhosts\": ", VhostsJSON, ",\n",
-        " \"nodes\": ", NodesJSON, "\n",
-        "}\n"
-    ],
-    {iolist_to_binary(JSONContent), ReqData, Context}.
+    try
+        SettingsJSON = get_settings_json(ReqData, Context),
+        VhostsJSON = get_vhosts_json(ReqData, Context),
+
+        UserTags = (Context#context.user)#user.tags,
+        NodesJSON = case rabbit_mgmt_util:is_monitor(UserTags) of
+            true -> get_nodes_json(ReqData, Context);
+            false -> <<"null">>
+        end,
+
+        JSONContent = [
+            "{\"settings\": ", SettingsJSON, ",\n",
+            " \"vhosts\": ", VhostsJSON, ",\n",
+            " \"nodes\": ", NodesJSON, "\n",
+            "}\n"
+        ],
+        {iolist_to_binary(JSONContent), ReqData, Context}
+    catch
+        {error, invalid_range_parameters, Reason} ->
+            rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)
+    end.
 
 get_settings_json(ReqData, _Context) ->
     Settings0 = [

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -32,7 +32,9 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {cluster_name,              rabbit_nodes:cluster_name()},
                  {crypto_lib_version,        rabbit_runtime:crypto_lib_version()}
                  ] ++ rabbit_mgmt_features:get_product_info()
-                   ++ rabbit_mgmt_features:get_settings(ReqData),
+                   ++ rabbit_mgmt_features:get_settings(ReqData)
+                   %% The top level key is added for backwards compatibility with earlier `4.3.x` releases.
+                   ++ rabbit_mgmt_features:get_definitions_settings(),
     try
         case rabbit_mgmt_util:disable_stats(ReqData) of
             false ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -31,7 +31,7 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
     Overview0 = [
                  {cluster_name,              rabbit_nodes:cluster_name()},
                  {crypto_lib_version,        rabbit_runtime:crypto_lib_version()}
-                 ] ++ rabbit_mgmt_features:get_product_info() 
+                 ] ++ rabbit_mgmt_features:get_product_info()
                    ++ rabbit_mgmt_features:get_settings(ReqData),
     try
         case rabbit_mgmt_util:disable_stats(ReqData) of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -28,36 +28,11 @@ content_types_provided(ReqData, Context) ->
    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
-    RatesMode = rabbit_mgmt_agent_config:get_env(rates_mode),
-    SRP = get_sample_retention_policies(),
-    %% NB: this duplicates what's in /nodes but we want a global idea
-    %% of this. And /nodes is not accessible to non-monitor users.
-    ExchangeTypes = lists:sort(
-        fun(ET1, ET2) ->
-            proplists:get_value(name, ET1, none)
-            =<
-            proplists:get_value(name, ET2, none)
-        end,
-        rabbit_mgmt_external_stats:list_registry_plugins(exchange)),
-    Overview0 = [{management_version,        version(rabbitmq_management)},
-                 {rates_mode,                RatesMode},
-                 {sample_retention_policies, SRP},
-                 {exchange_types,            ExchangeTypes},
-                 {product_version,           list_to_binary(rabbit:product_version())},
-                 {product_name,              list_to_binary(rabbit:product_name())},
-                 {rabbitmq_version,          list_to_binary(rabbit:base_product_version())},
+    Overview0 = [
                  {cluster_name,              rabbit_nodes:cluster_name()},
-                 {cluster_tags,              cluster_tags()},
-                 {node_tags,                 node_tags()},
-                 {erlang_version,            erlang_version()},
-                 {erlang_full_version,       erlang_full_version()},
-                 {crypto_lib_version,        rabbit_runtime:crypto_lib_version()},
-                 {disable_stats,                 rabbit_mgmt_util:disable_stats(ReqData)},
-                 {default_queue_type,            rabbit_queue_type:default_alias()},
-                 {is_op_policy_updating_enabled, not rabbit_mgmt_features:is_op_policy_updating_disabled()},
-                 {enable_queue_totals,           rabbit_mgmt_util:enable_queue_totals(ReqData)},
-                 {require_definition_json_extension,
-                  rabbit_mgmt_features:is_definition_json_extension_required()}],
+                 {crypto_lib_version,        rabbit_runtime:crypto_lib_version()}
+                 ] ++ rabbit_mgmt_features:get_product_info() 
+                   ++ rabbit_mgmt_features:get_settings(ReqData),
     try
         case rabbit_mgmt_util:disable_stats(ReqData) of
             false ->
@@ -107,10 +82,6 @@ is_authorized(ReqData, Context) ->
 
 %%--------------------------------------------------------------------
 
-version(App) ->
-    {ok, V} = application:get_key(App, vsn),
-    list_to_binary(V).
-
 listeners() ->
     rabbit_mgmt_util:sort_list(
       [rabbit_mgmt_format:listener(L)
@@ -133,69 +104,3 @@ fmt_contexts(Node) ->
 
 fmt_context(Node, C) ->
   rabbit_mgmt_format:web_context([{node, pget(name, Node)} | C]).
-
-erlang_version() -> list_to_binary(rabbit_misc:otp_release()).
-
-erlang_full_version() ->
-    list_to_binary(rabbit_misc:otp_system_version()).
-
-get_sample_retention_policies() ->
-    P = rabbit_mgmt_agent_config:get_env(sample_retention_policies),
-    get_sample_retention_policies(P).
-
-get_sample_retention_policies(undefined) ->
-    [{global, []}, {basic, []}, {detailed, []}];
-get_sample_retention_policies(Policies) ->
-    [transform_retention_policy(Pol, Policies) || Pol <- [global, basic, detailed]].
-
-transform_retention_policy(Pol, Policies) ->
-    case proplists:lookup(Pol, Policies) of
-        none ->
-            {Pol, []};
-        {Pol, Intervals} ->
-            {Pol, transform_retention_intervals(Intervals, [])}
-    end.
-
-transform_retention_intervals([], Acc) ->
-    lists:sort(Acc);
-transform_retention_intervals([{MaxAgeInSeconds, _}|Rest], Acc) ->
-    %
-    % Seconds | Interval
-    % 60      | last minute
-    % 600     | last 10 minutes
-    % 3600    | last hour
-    % 28800   | last 8 hours
-    % 86400   | last day
-    %
-    % rabbitmq/rabbitmq-management#635
-    %
-    % We check for the max age in seconds to be within 10% of the value above.
-    % The reason being that the default values are "bit higher" to accommodate
-    % edge cases (see deps/rabbitmq_management_agent/Makefile)
-    AccVal = if
-                 MaxAgeInSeconds >= 0 andalso MaxAgeInSeconds =< 66 ->
-                     60;
-                 MaxAgeInSeconds >= 540 andalso MaxAgeInSeconds =< 660 ->
-                     600;
-                 MaxAgeInSeconds >= 3240 andalso MaxAgeInSeconds =< 3960 ->
-                     3600;
-                 MaxAgeInSeconds >= 25920 andalso MaxAgeInSeconds =< 31681 ->
-                     28800;
-                 MaxAgeInSeconds >= 77760 andalso MaxAgeInSeconds =< 95041 ->
-                     86400;
-                 true ->
-                     0
-             end,
-    transform_retention_intervals(Rest, [AccVal|Acc]).
-
-cluster_tags() ->
-    Val = case rabbit_runtime_parameters:value_global(cluster_tags) of
-        not_found ->
-            [];
-        Tags -> Tags
-    end,
-    rabbit_data_coercion:to_map(Val).
-
-node_tags() ->
-    Val = application:get_env(rabbit, node_tags, []),
-    rabbit_data_coercion:to_map(Val).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -29,7 +29,6 @@ content_types_provided(ReqData, Context) ->
 
 to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
     Overview0 = [
-                 {cluster_name,              rabbit_nodes:cluster_name()},
                  {crypto_lib_version,        rabbit_runtime:crypto_lib_version()}
                  ] ++ rabbit_mgmt_features:get_product_info()
                    ++ rabbit_mgmt_features:get_settings(ReqData)

--- a/deps/rabbitmq_management/test/formatters.test.js
+++ b/deps/rabbitmq_management/test/formatters.test.js
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/deps/rabbitmq_management/test/oidc-oauth/helper.test.js
+++ b/deps/rabbitmq_management/test/oidc-oauth/helper.test.js
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -3654,7 +3654,8 @@ definitions_multipart_non_json_extension_allowed_when_not_enforced_test(Config) 
 require_definition_json_extension_defaults_to_false_in_overview_test(Config) ->
     %% By default, require_definition_json_extension is false and must be reflected in the overview.
     Overview = http_get(Config, "/overview"),
-    ?assertEqual(false, maps:get(require_definition_json_extension, Overview)),
+    Definitions = maps:get(definitions, Overview),
+    ?assertEqual(false, maps:get(require_definition_json_extension, Definitions)),
     passed.
 
 require_definition_json_extension_enabled_in_overview_test(Config) ->
@@ -3663,7 +3664,8 @@ require_definition_json_extension_enabled_in_overview_test(Config) ->
         [rabbitmq_management, require_definition_json_extension, true]),
     try
         Overview = http_get(Config, "/overview"),
-        ?assertEqual(true, maps:get(require_definition_json_extension, Overview)),
+        Definitions = maps:get(definitions, Overview),
+        ?assertEqual(true, maps:get(require_definition_json_extension, Definitions)),
         passed
     after
         rpc(Config, application, unset_env,

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -3656,6 +3656,7 @@ require_definition_json_extension_defaults_to_false_in_overview_test(Config) ->
     Overview = http_get(Config, "/overview"),
     Definitions = maps:get(definitions, Overview),
     ?assertEqual(false, maps:get(require_definition_json_extension, Definitions)),
+    ?assertEqual(false, maps:get(require_definition_json_extension, Overview)),
     passed.
 
 require_definition_json_extension_enabled_in_overview_test(Config) ->
@@ -3666,6 +3667,7 @@ require_definition_json_extension_enabled_in_overview_test(Config) ->
         Overview = http_get(Config, "/overview"),
         Definitions = maps:get(definitions, Overview),
         ?assertEqual(true, maps:get(require_definition_json_extension, Definitions)),
+        ?assertEqual(true, maps:get(require_definition_json_extension, Overview)),
         passed
     after
         rpc(Config, application, unset_env,

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
@@ -1,3 +1,10 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
 -module(rabbit_mgmt_http_init_SUITE).
 
 -include_lib("common_test/include/ct.hrl").

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
@@ -11,7 +11,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -import(rabbit_ct_broker_helpers, [rpc/4]).
--import(rabbit_mgmt_test_util, [http_get/2, http_put/4, http_delete/3]).
+-import(rabbit_mgmt_test_util, [http_get/2, http_get/5, http_put/4, http_delete/3]).
 
 -compile([export_all, nowarn_export_all]).
 
@@ -20,7 +20,8 @@ all() ->
         unauthorized_test,
         init_settings_test,
         init_monitor_nodes_test,
-        init_monitor_vhosts_test
+        init_monitor_vhosts_test,
+        invalid_range_test
     ].
 
 init_per_suite(Config) ->
@@ -112,4 +113,8 @@ init_monitor_vhosts_test(Config) ->
     ?assertNotEqual([], Vhosts),
     [?assertMatch(#{<<"name">> := _}, V) || V <- Vhosts],
     ?assert(lists:any(fun(V) -> maps:get(<<"name">>, V) =:= <<"/">> end, Vhosts)),
+    passed.
+
+invalid_range_test(Config) ->
+    http_get(Config, "/init?msg_rates_age=60&msg_rates_incr=0", "test_user", "test_user", 400),
     passed.

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
@@ -48,8 +48,6 @@ end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 unauthorized_test(Config) ->
-    %% Call endpoint with an unauthorized user (no management tag)
-    %% Guest without valid password or totally unknown user will return 401
     Headers = [rabbit_mgmt_test_util:auth_header("unknown_user", "bad_password")],
     {ok, {{_Version, 401, Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
     ?assertEqual("Unauthorized", Reason),
@@ -60,15 +58,12 @@ unauthorized_test(Config) ->
     passed.
 
 init_settings_test(Config) ->
-    %% Call the raw endpoint as a management user
     Headers = [rabbit_mgmt_test_util:auth_header("test_user", "test_user")],
     {ok, {{_Version, 200, _Reason}, ResponseHeaders, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
 
-    %% Check that the content type is json
     ContentType = proplists:get_value("content-type", ResponseHeaders),
     ?assertEqual("application/json", [C || C <- ContentType, C =/= $\s]),
 
-    %% Verify headers correctly specify no-cache
     CacheControl = proplists:get_value("cache-control", ResponseHeaders),
     ?assertMatch({match, _}, re:run(list_to_binary(CacheControl), <<"no-cache">>)),
     ?assertMatch({match, _}, re:run(list_to_binary(CacheControl), <<"no-store">>)),
@@ -79,47 +74,35 @@ init_settings_test(Config) ->
     Expires = proplists:get_value("expires", ResponseHeaders),
     ?assertEqual("0", Expires),
 
-    %% Decode the JSON body
     JsonBody = rabbit_json:decode(Body),
 
-    %% Check that the settings are present
     Settings = maps:get(<<"settings">>, JsonBody),
     ?assertMatch(#{<<"cluster_name">> := _}, Settings),
 
-    %% Verify the settings include the nested groups
     ?assertMatch(#{<<"product_info">> := _}, Settings),
     ?assertMatch(#{<<"definitions">> := _}, Settings),
 
-    %% test_user has the management tag and no permissions on any virtual
-    %% host, so it is expected to see none. The shape of the entries is
-    %% asserted by init_monitor_vhosts_test, which uses a user that does
-    %% see them.
+    %% test_user has no permissions on any virtual host, so the list is empty.
     Vhosts = maps:get(<<"vhosts">>, JsonBody),
     ?assert(is_list(Vhosts)),
 
-    %% Check that nodes are not present for a non-monitor user
     Nodes = maps:get(<<"nodes">>, JsonBody),
     ?assertEqual(null, Nodes),
     passed.
 
 init_monitor_nodes_test(Config) ->
-    %% Call the raw endpoint as a monitoring user
     Headers = [rabbit_mgmt_test_util:auth_header("test_monitor", "test_monitor")],
     {ok, {{_Version, 200, _Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
 
     JsonBody = rabbit_json:decode(Body),
 
-    %% Verify the json contains the nodes variable since user has monitoring tag
     Nodes = maps:get(<<"nodes">>, JsonBody),
     ?assert(is_list(Nodes)),
     passed.
 
 init_monitor_vhosts_test(Config) ->
-    %% A user with the monitoring tag can see every virtual host even
-    %% without permissions on any of them, and the UI's virtual host
-    %% selector reads .name off each entry - so asserting that the payload
-    %% is a list is not enough. A list of bare names satisfies that and
-    %% still leaves the selector empty.
+    %% The UI's virtual host selector reads .name off each entry, so a list
+    %% of bare names would not do.
     Headers = [rabbit_mgmt_test_util:auth_header("test_monitor", "test_monitor")],
     {ok, {{_Version, 200, _Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
@@ -13,8 +13,7 @@ all() ->
         unauthorized_test,
         init_settings_test,
         init_monitor_nodes_test,
-        init_monitor_vhosts_test,
-        init_no_monitor_no_nodes_test
+        init_monitor_vhosts_test
     ].
 
 init_per_suite(Config) ->
@@ -47,7 +46,7 @@ unauthorized_test(Config) ->
     Headers = [rabbit_mgmt_test_util:auth_header("unknown_user", "bad_password")],
     {ok, {{_Version, 401, Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
     ?assertEqual("Unauthorized", Reason),
-    
+
     Decoded = rabbit_json:decode(Body),
     ?assertEqual(<<"not_authorized">>, maps:get(<<"error">>, Decoded)),
     ?assertEqual(<<"Not_Authorized">>, maps:get(<<"reason">>, Decoded)),
@@ -57,40 +56,40 @@ init_settings_test(Config) ->
     %% Call the raw endpoint as a management user
     Headers = [rabbit_mgmt_test_util:auth_header("test_user", "test_user")],
     {ok, {{_Version, 200, _Reason}, ResponseHeaders, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
-        
+
     %% Check that the content type is json
     ContentType = proplists:get_value("content-type", ResponseHeaders),
     ?assertEqual("application/json", [C || C <- ContentType, C =/= $\s]),
-    
+
     %% Verify headers correctly specify no-cache
     CacheControl = proplists:get_value("cache-control", ResponseHeaders),
     ?assertMatch({match, _}, re:run(list_to_binary(CacheControl), <<"no-cache">>)),
     ?assertMatch({match, _}, re:run(list_to_binary(CacheControl), <<"no-store">>)),
-    
+
     Pragma = proplists:get_value("pragma", ResponseHeaders),
     ?assertEqual("no-cache", Pragma),
-    
+
     Expires = proplists:get_value("expires", ResponseHeaders),
     ?assertEqual("0", Expires),
-    
+
     %% Decode the JSON body
     JsonBody = rabbit_json:decode(Body),
-    
+
     %% Check that the settings are present
     Settings = maps:get(<<"settings">>, JsonBody),
     ?assertMatch(#{<<"cluster_name">> := _}, Settings),
-    
+
     %% Verify the settings include the nested groups
     ?assertMatch(#{<<"product_info">> := _}, Settings),
     ?assertMatch(#{<<"definitions">> := _}, Settings),
-    
+
     %% test_user has the management tag and no permissions on any virtual
     %% host, so it is expected to see none. The shape of the entries is
     %% asserted by init_monitor_vhosts_test, which uses a user that does
     %% see them.
     Vhosts = maps:get(<<"vhosts">>, JsonBody),
     ?assert(is_list(Vhosts)),
-    
+
     %% Check that nodes are not present for a non-monitor user
     Nodes = maps:get(<<"nodes">>, JsonBody),
     ?assertEqual(null, Nodes),
@@ -100,9 +99,9 @@ init_monitor_nodes_test(Config) ->
     %% Call the raw endpoint as a monitoring user
     Headers = [rabbit_mgmt_test_util:auth_header("test_monitor", "test_monitor")],
     {ok, {{_Version, 200, _Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
-        
+
     JsonBody = rabbit_json:decode(Body),
-    
+
     %% Verify the json contains the nodes variable since user has monitoring tag
     Nodes = maps:get(<<"nodes">>, JsonBody),
     ?assert(is_list(Nodes)),
@@ -123,16 +122,4 @@ init_monitor_vhosts_test(Config) ->
     ?assertNotEqual([], Vhosts),
     [?assertMatch(#{<<"name">> := _}, V) || V <- Vhosts],
     ?assert(lists:any(fun(V) -> maps:get(<<"name">>, V) =:= <<"/">> end, Vhosts)),
-    passed.
-
-init_no_monitor_no_nodes_test(Config) ->
-    %% Call the raw endpoint as a normal management user
-    Headers = [rabbit_mgmt_test_util:auth_header("test_user", "test_user")],
-    {ok, {{_Version, 200, _Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
-        
-    JsonBody = rabbit_json:decode(Body),
-    
-    %% Verify the json DOES NOT contain the nodes variable
-    Nodes = maps:get(<<"nodes">>, JsonBody),
-    ?assertEqual(null, Nodes),
     passed.

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
@@ -1,0 +1,117 @@
+-module(rabbit_mgmt_http_init_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-import(rabbit_ct_broker_helpers, [rpc/4]).
+-import(rabbit_mgmt_test_util, [http_get/2, http_put/4, http_delete/3]).
+
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [
+        unauthorized_test,
+        init_settings_test,
+        init_monitor_nodes_test,
+        init_no_monitor_no_nodes_test
+    ].
+
+init_per_suite(Config) ->
+    inets:start(),
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, ?MODULE},
+        {rmq_nodes_count, 1}
+    ]),
+    rabbit_ct_helpers:run_setup_steps(Config1,
+        rabbit_ct_broker_helpers:setup_steps() ++
+        rabbit_ct_client_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config, rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    http_put(Config, "/users/test_user", [{password, <<"test_user">>}, {tags, <<"management">>}], {group, '2xx'}),
+    http_put(Config, "/users/test_monitor", [{password, <<"test_monitor">>}, {tags, <<"monitoring">>}], {group, '2xx'}),
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    http_delete(Config, "/users/test_user", {group, '2xx'}),
+    http_delete(Config, "/users/test_monitor", {group, '2xx'}),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+unauthorized_test(Config) ->
+    %% Call endpoint with an unauthorized user (no management tag)
+    %% Guest without valid password or totally unknown user will return 401
+    Headers = [rabbit_mgmt_test_util:auth_header("unknown_user", "bad_password")],
+    {ok, {{_Version, 401, Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
+    ?assertEqual("Unauthorized", Reason),
+    
+    Decoded = rabbit_json:decode(Body),
+    ?assertEqual(<<"not_authorized">>, maps:get(<<"error">>, Decoded)),
+    ?assertEqual(<<"Not_Authorized">>, maps:get(<<"reason">>, Decoded)),
+    passed.
+
+init_settings_test(Config) ->
+    %% Call the raw endpoint as a management user
+    Headers = [rabbit_mgmt_test_util:auth_header("test_user", "test_user")],
+    {ok, {{_Version, 200, _Reason}, ResponseHeaders, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
+        
+    %% Check that the content type is json
+    ContentType = proplists:get_value("content-type", ResponseHeaders),
+    ?assertEqual("application/json", [C || C <- ContentType, C =/= $\s]),
+    
+    %% Verify headers correctly specify no-cache
+    CacheControl = proplists:get_value("cache-control", ResponseHeaders),
+    ?assertMatch({match, _}, re:run(list_to_binary(CacheControl), <<"no-cache">>)),
+    ?assertMatch({match, _}, re:run(list_to_binary(CacheControl), <<"no-store">>)),
+    
+    Pragma = proplists:get_value("pragma", ResponseHeaders),
+    ?assertEqual("no-cache", Pragma),
+    
+    Expires = proplists:get_value("expires", ResponseHeaders),
+    ?assertEqual("0", Expires),
+    
+    %% Decode the JSON body
+    JsonBody = rabbit_json:decode(Body),
+    
+    %% Check that the settings are present
+    Settings = maps:get(<<"settings">>, JsonBody),
+    ?assertMatch(#{<<"cluster_name">> := _}, Settings),
+    
+    %% Verify the settings include the nested groups
+    ?assertMatch(#{<<"product_info">> := _}, Settings),
+    ?assertMatch(#{<<"definitions">> := _}, Settings),
+    
+    %% Check that the vhosts are present
+    Vhosts = maps:get(<<"vhosts">>, JsonBody),
+    ?assert(is_list(Vhosts)),
+    
+    %% Check that nodes are not present for a non-monitor user
+    Nodes = maps:get(<<"nodes">>, JsonBody),
+    ?assertEqual(null, Nodes),
+    passed.
+
+init_monitor_nodes_test(Config) ->
+    %% Call the raw endpoint as a monitoring user
+    Headers = [rabbit_mgmt_test_util:auth_header("test_monitor", "test_monitor")],
+    {ok, {{_Version, 200, _Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
+        
+    JsonBody = rabbit_json:decode(Body),
+    
+    %% Verify the json contains the nodes variable since user has monitoring tag
+    Nodes = maps:get(<<"nodes">>, JsonBody),
+    ?assert(is_list(Nodes)),
+    passed.
+
+init_no_monitor_no_nodes_test(Config) ->
+    %% Call the raw endpoint as a normal management user
+    Headers = [rabbit_mgmt_test_util:auth_header("test_user", "test_user")],
+    {ok, {{_Version, 200, _Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
+        
+    JsonBody = rabbit_json:decode(Body),
+    
+    %% Verify the json DOES NOT contain the nodes variable
+    Nodes = maps:get(<<"nodes">>, JsonBody),
+    ?assertEqual(null, Nodes),
+    passed.

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_init_SUITE.erl
@@ -13,6 +13,7 @@ all() ->
         unauthorized_test,
         init_settings_test,
         init_monitor_nodes_test,
+        init_monitor_vhosts_test,
         init_no_monitor_no_nodes_test
     ].
 
@@ -83,7 +84,10 @@ init_settings_test(Config) ->
     ?assertMatch(#{<<"product_info">> := _}, Settings),
     ?assertMatch(#{<<"definitions">> := _}, Settings),
     
-    %% Check that the vhosts are present
+    %% test_user has the management tag and no permissions on any virtual
+    %% host, so it is expected to see none. The shape of the entries is
+    %% asserted by init_monitor_vhosts_test, which uses a user that does
+    %% see them.
     Vhosts = maps:get(<<"vhosts">>, JsonBody),
     ?assert(is_list(Vhosts)),
     
@@ -102,6 +106,23 @@ init_monitor_nodes_test(Config) ->
     %% Verify the json contains the nodes variable since user has monitoring tag
     Nodes = maps:get(<<"nodes">>, JsonBody),
     ?assert(is_list(Nodes)),
+    passed.
+
+init_monitor_vhosts_test(Config) ->
+    %% A user with the monitoring tag can see every virtual host even
+    %% without permissions on any of them, and the UI's virtual host
+    %% selector reads .name off each entry - so asserting that the payload
+    %% is a list is not enough. A list of bare names satisfies that and
+    %% still leaves the selector empty.
+    Headers = [rabbit_mgmt_test_util:auth_header("test_monitor", "test_monitor")],
+    {ok, {{_Version, 200, _Reason}, _Headers, Body}} = rabbit_mgmt_test_util:req(Config, 0, get, "/init", Headers),
+
+    JsonBody = rabbit_json:decode(Body),
+    Vhosts = maps:get(<<"vhosts">>, JsonBody),
+
+    ?assertNotEqual([], Vhosts),
+    [?assertMatch(#{<<"name">> := _}, V) || V <- Vhosts],
+    ?assert(lists:any(fun(V) -> maps:get(<<"name">>, V) =:= <<"/">> end, Vhosts)),
     passed.
 
 init_no_monitor_no_nodes_test(Config) ->

--- a/deps/rabbitmq_shovel_management/test/shovel.test.js
+++ b/deps/rabbitmq_shovel_management/test/shovel.test.js
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/deps/rabbitmq_stream_management/test/stream.test.js
+++ b/deps/rabbitmq_stream_management/test/stream.test.js
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';

--- a/selenium/test/pageobjects/QueuesAndStreamsPage.js
+++ b/selenium/test/pageobjects/QueuesAndStreamsPage.js
@@ -59,16 +59,9 @@ module.exports = class QueuesAndStreamsPage extends BasePage {
   async fillInAddNewQueue(queueDetails) {
     await this.selectQueueType(queueDetails.type)
 
-    // Changing the queue type fires select_queue_type(), which calls the
-    // full-page update(). That re-renders and replaces this form, and the
-    // name input is rendered without a value attribute, so anything typed
-    // into it is lost. update() is asynchronous, so the re-render can land
-    // between typing the name and clicking submit, in which case the form
-    // is submitted with an empty name and no queue is created - which then
-    // shows up as the queue never appearing in the table.
-    //
-    // So: type the name, confirm it survived, and only then submit,
-    // retrying the whole fill if the form was replaced underneath us.
+    // Changing the queue type triggers an asynchronous page update that
+    // re-renders this form and drops the typed name. Type, verify, then
+    // submit, and retry if the form was replaced in between.
     return doUntil(
       async () => {
         const input = await this.waitForDisplayed(FORM_QUEUE_NAME)


### PR DESCRIPTION
## Proposed Changes

Consolidates all the settings required by the management ui into a single /init endpoint, replacing the four separate blocking requests the login flow used to make. Not only that, the /overview endpoint have been used to provide settings required by the ui. We cannot remove them because they are somewhat part of the public api. However, a very recent setting `require_definition_json_extension` has been removed.

Base branch: this PR is based on another [PR](https://github.com/rabbitmq/rabbitmq-server/pull/17286).

Split from [rabbitmq/rabbitmq-server#17109](https://github.com/rabbitmq/rabbitmq-server/pull/17109) to keep that PR focused.

What change:

- New GET /init (rabbit_mgmt_wm_init.erl) returns {settings, vhosts, nodes} in one response. nodes is omitted server-side for non-monitor users, replacing the old client-side ac.isMonitoringUser() check.
- Login used to make four requests before rendering the app: /overview, /vhosts, /nodes, plus a second, redundant /nodes fetch buried inside setup_global_vars. All four collapse into the one /init call.
- Settings computation moved out of /overview into rabbit_mgmt_features:get_settings/1 and get_product_info/0, so /init and /overview share one implementation instead of /overview duplicating it. rabbit_mgmt_wm_overview.erl shrinks from 
- Client side: check_login()/login() fetch /init once into window.app_settings/app_vhosts/app_nodes; load_ui()/setup_global_vars() read from there instead of issuing their own requests. format() now injects settings into every template's render context.
- Fixed a live bug along the way: the #/cluster-name route handler called setup_global_vars() with no argument, which dereferences settings fields with nothing to read them from - throws on main today. It now updates window.app_settings.cluster_name directly and repaints via a new update_cluster_name_ui() helper (carved out of setup_global_vars for this purpose).

Breaking change

- /overview no longer has a top-level `require_definition_json_extension` field - it now lives under a nested definitions object (rabbit_mgmt_features:get_definitions_settings/0), alongside the other settings /init and /overview now share.
