### PR TITLE
QQ: park delayed messages on the untracked enqueue path

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -2273,6 +2273,10 @@ maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg,
                                          },
                     {ok, State, Effects0};
                 DeliveryTime ->
+                    %% A deferral token is never registered on first enqueue:
+                    %% tokens are established only by a consumer parking a
+                    %% message via the MODIFIED outcome, so an
+                    %% x-opt-deferral-token set at publish time is ignored here.
                     Delayed = delayed_in(DeliveryTime, RaftIdx,
                                          Msg, undefined,
                                          State0#?STATE.delayed),

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -2209,16 +2209,25 @@ maybe_enqueue(RaftIdx, Ts, undefined, undefined, RawMsg,
               Effects, #?STATE{msg_bytes_enqueue = Enqueue,
                                messages = Messages,
                                messages_total = Total} = State0) ->
-    % direct enqueue without tracking
+    %% Direct enqueue without tracking.
     Size = MetaSize + BodySize,
     Header0 = maybe_set_msg_ttl(RawMsg, Ts, Size, State0),
     Header = maybe_set_msg_delivery_count(RawMsg, Header0),
     Msg = make_msg(RaftIdx, Header),
-    Priority = msg_priority(RawMsg),
-    State = State0#?STATE{msg_bytes_enqueue = Enqueue + Size,
-                          messages_total = Total + 1,
-                          messages = rabbit_fifo_pq:in(Priority, Msg, Messages)
-                         },
+    State = case get_delivery_time(Ts, RawMsg) of
+                undefined ->
+                    Priority = msg_priority(RawMsg),
+                    State0#?STATE{msg_bytes_enqueue = Enqueue + Size,
+                                  messages_total = Total + 1,
+                                  messages = rabbit_fifo_pq:in(Priority, Msg,
+                                                               Messages)};
+                DeliveryTime ->
+                    Delayed = delayed_in(DeliveryTime, RaftIdx, Msg, undefined,
+                                         State0#?STATE.delayed),
+                    State0#?STATE{msg_bytes_enqueue = Enqueue + Size,
+                                  messages_total = Total + 1,
+                                  delayed = Delayed}
+            end,
     {ok, State, Effects};
 maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg,
               {MetaSize, BodySize} = MsgSize,

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -3586,6 +3586,37 @@ delivery_time_on_enqueue_past_test(Config) ->
                    num_delayed_messages := 0}, rabbit_fifo:overview(State1)),
     ok.
 
+delivery_time_on_untracked_enqueue_test(Config) ->
+    %% An untracked (stateless) enqueue - the path taken by dead-lettering and
+    %% other stateless deliveries - must honour a future `dt` annotation just
+    %% like the tracked enqueue path, parking the message instead of making it
+    %% immediately deliverable.
+    Conf = #{name => ?FUNCTION_NAME,
+             queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B)},
+    State0 = init(Conf),
+    Msg = mc:set_annotation(dt, 5000, mk_mc(<<"m1">>)),
+    {State1, _, _} = apply(meta(Config, 1, 100),
+                           rabbit_fifo:make_enqueue(undefined, undefined, Msg),
+                           State0),
+    ?assertMatch(#{num_ready_messages := 0,
+                   num_delayed_messages := 1,
+                   next_delayed_at := 5000}, rabbit_fifo:overview(State1)),
+    ok.
+
+delivery_time_on_untracked_enqueue_past_test(Config) ->
+    %% A `dt` annotation that has already elapsed by enqueue time should not
+    %% delay an untracked enqueue either.
+    Conf = #{name => ?FUNCTION_NAME,
+             queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B)},
+    State0 = init(Conf),
+    Msg = mc:set_annotation(dt, 50, mk_mc(<<"m1">>)),
+    {State1, _, _} = apply(meta(Config, 1, 100),
+                           rabbit_fifo:make_enqueue(undefined, undefined, Msg),
+                           State0),
+    ?assertMatch(#{num_ready_messages := 1,
+                   num_delayed_messages := 0}, rabbit_fifo:overview(State1)),
+    ok.
+
 delayed_retry_counts_towards_limit_test(Config) ->
     %% Delayed messages should count towards max_length limit.
     %% The limit check uses messages_ready + delayed (not checked_out).


### PR DESCRIPTION
> [!NOTE]
> This pull request description was drafted by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who provided significant guidance throughout and reviewed the change before opening it. The fix and its tests were verified against the quorum-queue test suite.

## What

Two changes against the `qq-vNext` (rabbit_fifo v9) branch, found while reviewing the deferred-message and message-delay work.

### Fix: park delayed messages on the untracked enqueue path

v9 added delivery-time parking only to the tracked enqueuer clause of `rabbit_fifo:maybe_enqueue/8`. The untracked clause, used by stateless deliveries such as at-most-once dead-lettering, enqueued straight into the ready queue and ignored the `dt` annotation.

`rabbit_quorum_queue:deliver/3` stamps the `dt` annotation on every message, including `{Q, stateless}` targets, and `rabbit_dead_letter:publish/5` preserves `x-opt-delivery-time`. A future-dated message dead-lettered into a quorum queue therefore became immediately deliverable instead of being parked until its delivery time.

The untracked clause now routes through `get_delivery_time/2` as well, so a future delivery time parks the message via `delayed_in/5` and a past or absent one keeps the current ready-queue behaviour. Covered by two new `rabbit_fifo_SUITE` cases mirroring the existing tracked-enqueue tests.

### Docs: document that first enqueue never registers a deferral token

Both enqueue clauses of `maybe_enqueue/8` pass `undefined` as the deferral token to `delayed_in/5`, so an `x-opt-deferral-token` supplied at publish time is ignored; only `should_delay/5` on the return/modified path reads the token. Added a comment recording that this is intentional, since deferral tokens are established solely by a consumer parking a message via the MODIFIED outcome.

## Testing

`gmake -C deps/rabbit ct-rabbit_fifo` passes (169 cases, including the two new ones).

