### PR TITLE
Quorum queue CMR: correctly compare member (replica) count with the limit

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
@@ -13,6 +13,10 @@
 
 -export([start_link/0]).
 
+-ifdef(TEST).
+-export([get_target_size/2]).
+-endif.
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
@@ -222,10 +226,10 @@ get_target_size(Q) ->
                   end,
     Arguments = amqqueue:get_arguments(Q),
     case rabbit_misc:table_lookup(Arguments, <<"x-quorum-target-group-size">>) of
-        undefined ->
-            PolicyValue;
-        ArgN ->
-            max(ArgN, PolicyValue)
+        {_Type, ArgN} when is_integer(ArgN) ->
+            max(ArgN, PolicyValue);
+        _ ->
+            PolicyValue
     end.
 
 remove_members(_Q, []) ->

--- a/deps/rabbit/test/unit_quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/unit_quorum_queue_SUITE.erl
@@ -10,7 +10,8 @@ all() ->
      all_replica_states_includes_alive_nonvoters,
      filter_nonvoters,
      filter_quorum_critical_accounts_nonvoters,
-     ra_machine_conf_delivery_limit
+     ra_machine_conf_delivery_limit,
+     periodic_membership_reconciliation_target_group_size
     ].
 
 ra_machine_conf_delivery_limit(_Config) ->
@@ -120,6 +121,17 @@ all_replica_states_includes_alive_nonvoters(_Config) ->
 
     true = ets:delete(ra_state),
     _ = stop_qprocs(QPids),
+    ok.
+
+periodic_membership_reconciliation_target_group_size(_Config) ->
+    Q0 = amqqueue:new(rabbit_misc:r(<<"/">>, queue, <<"q1">>),
+                      {q1, test@leader},
+                      false, false, none, [], undefined, #{}),
+    Q = amqqueue:set_arguments(
+          Q0, [{<<"x-quorum-target-group-size">>, long, 3}]),
+    ?assertEqual(
+       3, rabbit_quorum_queue_periodic_membership_reconciliation:get_target_size(
+            Q, undefined)),
     ok.
 
 make_ra_machine_conf(Q0, Arg, Pol, OpPol) ->


### PR DESCRIPTION
Yes, that's a tuple-to-integer comparison bug caught in the wild.

See #17310 for context.

Closes #17310.
