### PR TITLE
Force close a stuck TLS connection

### DIFF
--- a/deps/rabbit_common/Makefile
+++ b/deps/rabbit_common/Makefile
@@ -38,6 +38,9 @@ DEPS = ranch recon credentials_obfuscation
 
 -include development.pre.mk
 
+# Appended after the include because development.pre.mk resets TEST_DEPS.
+TEST_DEPS += meck
+
 DEP_EARLY_PLUGINS = $(PROJECT)/mk/rabbitmq-early-plugin.mk
 # We do not depend on rabbit therefore can't run the broker.
 DEP_PLUGINS = $(PROJECT)/mk/rabbitmq-build.mk \

--- a/deps/rabbit_common/src/rabbit_net.erl
+++ b/deps/rabbit_common/src/rabbit_net.erl
@@ -18,6 +18,10 @@
     hostname/0, getifaddrs/0, proxy_ssl_info/2,
     dist_info/0]).
 
+-ifdef(TEST).
+-export([fast_close/2]).
+-endif.
+
 %%---------------------------------------------------------------------------
 
 -export_type([socket/0, proxy_socket/0, ip_port/0, hostname/0]).
@@ -61,6 +65,7 @@
 -spec send(socket(), iodata()) -> ok_or_any_error().
 -spec close(socket()) -> ok_or_any_error().
 -spec fast_close(socket()) -> ok_or_any_error().
+-spec fast_close(socket(), timeout()) -> ok_or_any_error().
 -spec sockname(socket()) ->
           ok_val_or_error({inet:ip_address(), ip_port()} |
                           inet:returned_non_ip_address()).
@@ -178,11 +183,76 @@ send(Sock, Data) when is_port(Sock) -> gen_tcp:send(Sock, Data).
 close(Sock)      when ?IS_SSL(Sock) -> ssl:close(Sock);
 close(Sock)      when is_port(Sock) -> gen_tcp:close(Sock).
 
-fast_close(Sock) when ?IS_SSL(Sock) ->
-    _ = ssl:close(Sock, ?SSL_CLOSE_TIMEOUT),
-    ok;
-fast_close(Sock) when is_port(Sock) ->
+fast_close(Sock) ->
+    fast_close(Sock, ?SSL_CLOSE_TIMEOUT).
+
+%% ssl:close/2 does not bound the caller: internally it is a gen_statem:call/2
+%% with an infinite timeout, so a stuck TLS connection process (for example
+%% stuck in prim_inet:recv0/3 inside tls_gen_connection:close/4 when the peer
+%% never closes the transport) makes it hang forever. Run it in a separate
+%% process and, if it does not finish within Timeout, close the stuck TLS
+%% connection process's transport port, which makes the stuck operation return
+%% and unblocks the close.
+fast_close(Sock, Timeout) when ?IS_SSL(Sock) ->
+    {Pid, MRef} = spawn_monitor(fun () -> _ = ssl:close(Sock, Timeout) end),
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            ok
+    after Timeout ->
+        force_close_stuck_ssl_connections(Pid, MRef, Timeout)
+    end;
+fast_close(Sock, _Timeout) when is_port(Sock) ->
     catch port_close(Sock), ok.
+
+force_close_stuck_ssl_connections(Pid, MRef, Timeout) ->
+    ConnPid = get_ssl_connection_pid(Pid),
+    _ = close_linked_ports(ConnPid),
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            ok
+    after Timeout ->
+        %% Last resort if closing the port did not unblock the ssl:close call.
+        _ = case ConnPid of
+                undefined -> ok;
+                _         -> exit(ConnPid, kill)
+            end,
+        erlang:demonitor(MRef, [flush]),
+        exit(Pid, kill),
+        ok
+    end.
+
+%% The spawned ssl:close/2 above blocks in a single gen_statem:call to the TLS
+%% connection process, so its caller monitors exactly that one process, which
+%% owns the transport socket port. This function avoids retrieving the
+%% connection PID and port from the version-specific sslsocket record.
+get_ssl_connection_pid(Pid) ->
+    case erlang:process_info(Pid, monitors) of
+        {monitors, Monitors} ->
+            case [ConnPid || {process, ConnPid} <- Monitors,
+                             has_linked_port(ConnPid)] of
+                [ConnPid] -> ConnPid;
+                []        -> undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+has_linked_port(Pid) ->
+    case erlang:process_info(Pid, links) of
+        {links, Links} -> lists:any(fun erlang:is_port/1, Links);
+        _              -> false
+    end.
+
+close_linked_ports(undefined) ->
+    ok;
+close_linked_ports(Pid) ->
+    case erlang:process_info(Pid, links) of
+        {links, Links} ->
+            _ = [catch erlang:port_close(P) || P <- Links, is_port(P)],
+            ok;
+        _ ->
+            ok
+    end.
 
 sockname(Sock)   when ?IS_SSL(Sock) -> ssl:sockname(Sock);
 sockname(Sock)   when is_port(Sock) -> inet:sockname(Sock).

--- a/deps/rabbit_common/test/rabbit_net_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_net_SUITE.erl
@@ -1,0 +1,196 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_net_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+all() ->
+    [
+     fast_close_plain_port,
+     fast_close_healthy_tls,
+     fast_close_bounds_stuck_close,
+     fast_close_recovers_from_stuck_recv
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    PrivDir = ?config(priv_dir, Config),
+    CertFile = filename:join(PrivDir, "cert.pem"),
+    KeyFile = filename:join(PrivDir, "key.pem"),
+    Cmd = lists:flatten(
+            io_lib:format(
+              "openssl req -x509 -newkey rsa:2048 -keyout ~ts -out ~ts "
+              "-days 1 -nodes -subj /CN=localhost 2>/dev/null",
+              [KeyFile, CertFile])),
+    _ = os:cmd(Cmd),
+    case filelib:is_file(CertFile) andalso filelib:is_file(KeyFile) of
+        true  -> [{certfile, CertFile}, {keyfile, KeyFile} | Config];
+        false -> {skip, "openssl is required to generate test certificates"}
+    end.
+
+end_per_suite(Config) ->
+    Config.
+
+%% -------------------------------------------------------------------
+%% Test cases.
+%% -------------------------------------------------------------------
+
+%% A plain TCP socket is closed immediately.
+fast_close_plain_port(_Config) ->
+    {ok, L} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    {ok, Port} = inet:port(L),
+    {ok, _C} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 5000),
+    {ok, S} = gen_tcp:accept(L, 5000),
+    ?assertEqual(ok, rabbit_net:fast_close(S)),
+    ?assertEqual(undefined, erlang:port_info(S)),
+    ok = gen_tcp:close(L).
+
+%% A healthy TLS socket is closed promptly, without paying the timeout.
+fast_close_healthy_tls(Config) ->
+    {S, Client, _ConnPid} = new_tls_pair(Config, []),
+    T0 = erlang:monotonic_time(millisecond),
+    ?assertEqual(ok, rabbit_net:fast_close(S)),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    ?assert(Elapsed < 1000),
+    stop_client(Client),
+    ok.
+
+%% When the peer stops reading, ssl:close/2 parks (waiting on the stuck
+%% transport). This exercises the real ssl:close/2 path, without mocks:
+%% fast_close/2 must force the transport port closed and return within its bound,
+%% well under the several seconds ssl:close/2 would otherwise take.
+fast_close_bounds_stuck_close(Config) ->
+    SmallBuffers = [{sndbuf, 4096}, {recbuf, 4096}, {buffer, 4096},
+                    {high_watermark, 2048}, {low_watermark, 1024}],
+    {S, Client, _ConnPid} = new_tls_pair(Config, SmallBuffers),
+    %% The peer never reads; fill the pipe so the server's close will park.
+    FloodPid = spawn(fun () -> flood(S) end),
+    await_backpressure(FloodPid),
+    Timeout = 300,
+    T0 = erlang:monotonic_time(millisecond),
+    ?assertEqual(ok, rabbit_net:fast_close(S, Timeout)),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    ?assert(Elapsed >= Timeout - 100),
+    ?assert(Elapsed < 3000),
+    %% Kill the flood process in case it is still blocked in ssl:send, so it does
+    %% not leak into later test cases.
+    exit(FloodPid, kill),
+    stop_client(Client),
+    ok.
+
+%% Reproduce the "stuck port" Erlang VM bug: the recv in
+%% tls_gen_connection:close/4 never returns on its own (its timeout does not
+%% fire), and only returns once the transport port is closed. fast_close/2 must
+%% detect the stuck connection process, close its port, and return.
+fast_close_recovers_from_stuck_recv(Config) ->
+    {S, Client, ConnPid} = new_tls_pair(Config, []),
+    TransportPort = transport_port(ConnPid),
+    ok = meck:new(gen_tcp, [unstick, passthrough]),
+    try
+        %% close/4 calls Transport:recv(Socket, 0, Timeout); make that recv hang
+        %% until the port terminates (mimicking the stuck transport port).
+        ok = meck:expect(
+               gen_tcp, recv,
+               fun (Sock, 0, _Timeout) when Sock =:= TransportPort ->
+                       Ref = erlang:monitor(port, Sock),
+                       receive {'DOWN', Ref, port, Sock, _} -> {error, closed} end;
+                   (Sock, Length, Timeout) ->
+                       meck:passthrough([Sock, Length, Timeout])
+               end),
+        Timeout = 300,
+        T0 = erlang:monotonic_time(millisecond),
+        ?assertEqual(ok, rabbit_net:fast_close(S, Timeout)),
+        Elapsed = erlang:monotonic_time(millisecond) - T0,
+        %% The recv genuinely hung, so the forced path was taken (>= Timeout) and
+        %% it was bounded (< several seconds).
+        ?assert(Elapsed >= Timeout - 100),
+        ?assert(Elapsed < 3000),
+        %% The stuck recv was actually reached and intercepted.
+        ?assert(meck:num_calls(gen_tcp, recv, [TransportPort, 0, '_']) >= 1),
+        ?assertNot(erlang:is_process_alive(ConnPid))
+    after
+        meck:unload(gen_tcp)
+    end,
+    stop_client(Client),
+    ok.
+
+%% -------------------------------------------------------------------
+%% Helpers.
+%% -------------------------------------------------------------------
+
+new_tls_pair(Config, ExtraOpts) ->
+    CertFile = ?config(certfile, Config),
+    KeyFile = ?config(keyfile, Config),
+    {ok, L} = ssl:listen(0, [{certfile, CertFile}, {keyfile, KeyFile}, binary,
+                             {active, false}, {reuseaddr, true} | ExtraOpts]),
+    {ok, {_, Port}} = ssl:sockname(L),
+    Before = tls_server_connections(),
+    Parent = self(),
+    Client = spawn(fun () ->
+                           {ok, C} = ssl:connect(
+                                       "localhost", Port,
+                                       [binary, {active, false},
+                                        {verify, verify_none} | ExtraOpts], 5000),
+                           Parent ! {client_ready, self()},
+                           receive stop -> ssl:close(C) end
+                   end),
+    {ok, T} = ssl:transport_accept(L, 5000),
+    ok = ssl:close(L),
+    {ok, S} = ssl:handshake(T, 5000),
+    receive {client_ready, _} -> ok
+    after 5000 -> ct:fail(tls_client_did_not_connect)
+    end,
+    [ConnPid] = tls_server_connections() -- Before,
+    {S, Client, ConnPid}.
+
+stop_client(Client) ->
+    Client ! stop,
+    ok.
+
+flood(S) ->
+    case ssl:send(S, binary:copy(<<0>>, 4096)) of
+        ok     -> flood(S);
+        _Error -> ok
+    end.
+
+%% Wait until the flooding process stops making progress, i.e. it is blocked in
+%% ssl:send because the peer is not reading. Only then is the send actually
+%% stuck and the server's close will park.
+await_backpressure(Pid) ->
+    await_backpressure(Pid, reductions(Pid), 200).
+
+await_backpressure(_Pid, _Reds, 0) ->
+    ct:fail(backpressure_not_established);
+await_backpressure(Pid, Reds, N) ->
+    timer:sleep(20),
+    case reductions(Pid) of
+        Reds  -> ok;
+        Reds2 -> await_backpressure(Pid, Reds2, N - 1)
+    end.
+
+reductions(Pid) ->
+    case erlang:process_info(Pid, reductions) of
+        {reductions, R} -> R;
+        undefined       -> 0
+    end.
+
+tls_server_connections() ->
+    [P || P <- erlang:processes(),
+          case proc_lib:get_label(P) of
+              {tls, server, _}    -> true;
+              {tls, server, _, _} -> true;
+              _                   -> false
+          end].
+
+transport_port(ConnPid) ->
+    {links, Links} = erlang:process_info(ConnPid, links),
+    hd([P || P <- Links, is_port(P)]).


### PR DESCRIPTION
## Proposed Changes

There is an Erlang VM bug [1] whereby a TLS socket (actually the underlying port representing the TCP socket) can get stuck, causing `ssl:close/2` and the underlying `gen_tcp:recv/3` to block indefinitely, ignoring the provided timeouts. When this happens while an AMQP 0-9-1 over TLS connection is terminating, the `rabbit_reader` process gets stuck (calling `rabbit_net:fast_close` -> `ssl:close`). Meanwhile the heartbeat process keeps sending heartbeat Erlang messages to the reader process, slowly growing its message queue. This can slowly, over weeks or months, lead to high memory usage and a potential OOM.

This commit reintroduces an old workaround that was removed in RabbitMQ 4.2.0 (da8f4299). The workaround was there to implement a timeout as back in the days there was no `ssl:close` variant with a timeout. The workaround was rightfully removed as there is now an `ssl:close` variant with a timeout. However removing that workaround uncovered the Erlang VM bug which was probably present in older Erlang versions as well (seen at least with OTP 26) but the workaround coincidentally worked it around.

We've seen the stuck terminating AMQPS connections happen on a few dozens of servers over a couple of months on various patch versions of RabbitMQ 4.2.x and OTP 28.x.

[1] https://github.com/erlang/otp/issues/10791

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
