### PR TITLE
Report a Mnesia partition that has no other visible symptom

### DIFF
--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -22,7 +22,7 @@
          write_cluster_status/1, read_cluster_status/0,
          update_cluster_status/0, reset_cluster_status/0]).
 -export([notify_node_up/0, notify_joined_cluster/0, notify_left_cluster/1]).
--export([partitions/0, partitions/1, status/1, subscribe/1]).
+-export([partitions/0, partitions/1, mnesia_split/0, status/1, subscribe/1]).
 -export([pause_partition_guard/0]).
 -export([global_sync/0]).
 
@@ -40,8 +40,14 @@
 -define(RABBIT_DOWN_PING_INTERVAL, 1000).
 -define(NODE_DISCONNECTION_TIMEOUT, 1000).
 
+%% How often a Mnesia partition is repeated in the log while it lasts. The
+%% condition has no other symptom, so an operator arriving long after it
+%% started still needs to find it.
+-define(MNESIA_SPLIT_LOG_INTERVAL, 600000).
+
 -record(state, {monitors, partitions, subscribers, down_ping_timer,
-                keepalive_timer, autoheal, guid, node_guids}).
+                keepalive_timer, autoheal, guid, node_guids,
+                mnesia_split = [], mnesia_split_logged_at}).
 
 %%----------------------------------------------------------------------------
 %% Start
@@ -202,6 +208,15 @@ partitions() ->
 partitions(Nodes) ->
     {Replies, _} = gen_server:multi_call(Nodes, ?SERVER, partitions, ?NODE_REPLY_TIMEOUT),
     Replies.
+
+-spec mnesia_split() -> [node()].
+%% @doc Returns the cluster members this node's Mnesia is partitioned from.
+%%
+%% A member appears here while it is reachable and running the `rabbit'
+%% application, but Mnesia leaves it out of its running nodes.
+
+mnesia_split() ->
+    gen_server:call(?SERVER, mnesia_split, infinity).
 
 -spec status([node()]) -> {[{node(), [node()]}], [node()]}.
 
@@ -422,6 +437,9 @@ init([]) ->
 
 handle_call(partitions, _From, State = #state{partitions = Partitions}) ->
     {reply, Partitions, State};
+
+handle_call(mnesia_split, _From, State = #state{mnesia_split = Split}) ->
+    {reply, Split, State};
 
 handle_call(status, _From, State = #state{partitions = Partitions}) ->
     {reply, [{partitions, Partitions},
@@ -711,7 +729,20 @@ handle_info(ping_up_nodes, State) ->
     %% In this case we need to ensure that we ping "quickly" -
     %% i.e. only nodes that we know to be up.
     [cast(N, keepalive) || N <- alive_nodes() -- [node()]],
-    {noreply, ensure_keepalive_timer(State#state{keepalive_timer = undefined})};
+    %% The timer is re-armed before anything else below, so that slow work
+    %% cannot stretch the keepalive interval.
+    State1 = ensure_keepalive_timer(State#state{keepalive_timer = undefined}),
+    %% get_feature_state/0 rather than is_enabled/0: the latter blocks while
+    %% Khepri is being enabled and Mnesia tables are migrated, and this runs on
+    %% a timer.
+    _ = case rabbit_khepri:get_feature_state() of
+            enabled -> ok;
+            _       -> request_mnesia_split_check()
+        end,
+    {noreply, State1};
+
+handle_info({mnesia_split, Split}, State) ->
+    {noreply, report_mnesia_split(Split, State)};
 
 handle_info({'EXIT', _, _} = Info, State = #state{autoheal = AState0}) ->
     AState = rabbit_autoheal:process_down(Info, AState0),
@@ -877,6 +908,65 @@ handle_dead_rabbit(Node, State) ->
                  false -> on_node_down_using_mnesia(Node, State)
              end,
     ensure_ping_timer(State1).
+
+%% Mnesia never re-merges a partition it has detected. With
+%% cluster_partition_handling set to 'ignore' nothing re-merges it either, and
+%% 'pause_minority' only recovers when it engages, which it does not when the
+%% outage is shorter than its detection window. What is left is a node whose
+%% Mnesia excludes a peer that is reachable and running the 'rabbit'
+%% application: no partition event, no alarm, and nothing in the log pointing
+%% at the metadata store.
+%%
+%% This reports that state and nothing more. In particular it does not touch
+%% #state.partitions, which the partition handling strategies act on.
+request_mnesia_split_check() ->
+    Self = self(),
+    %% possibly_partitioned_nodes/0 pings the members and makes an RPC to each
+    %% one, so as always we must not run it in the node monitor itself.
+    _ = spawn_link(
+          fun () ->
+                  %% The subtraction guards the case where Mnesia is down
+                  %% locally: cluster_nodes(running) then comes from the
+                  %% cluster status file with the local node stripped, while
+                  %% this node remains a member of itself.
+                  Split = lists:sort(possibly_partitioned_nodes() -- [node()]),
+                  Self ! {mnesia_split, Split}
+          end),
+    ok.
+
+report_mnesia_split(Split, State = #state{mnesia_split = Split,
+                                          mnesia_split_logged_at = LoggedAt})
+  when Split =/= [] ->
+    Now = erlang:monotonic_time(millisecond),
+    case Now - LoggedAt >= ?MNESIA_SPLIT_LOG_INTERVAL of
+        true  -> log_mnesia_split(Split),
+                 State#state{mnesia_split_logged_at = Now};
+        false -> State
+    end;
+report_mnesia_split(Split, State = #state{mnesia_split = Split}) ->
+    State;
+report_mnesia_split([], State = #state{mnesia_split = Reported}) ->
+    %% Logged at the same level as the warning below on purpose: with
+    %% log.default.level set to warning, a lower level would show an operator
+    %% the split and never its resolution.
+    ?LOG_WARNING("Mnesia is no longer partitioned from ~tp", [Reported]),
+    State#state{mnesia_split = [], mnesia_split_logged_at = undefined};
+report_mnesia_split(Split, State) ->
+    log_mnesia_split(Split),
+    State#state{mnesia_split = Split,
+                mnesia_split_logged_at = erlang:monotonic_time(millisecond)}.
+
+log_mnesia_split(Split) ->
+    ?LOG_WARNING(
+      "Mnesia is partitioned from ~tp.~n"
+      "Those nodes are reachable and the 'rabbit' application is running on "
+      "them, but Mnesia excludes them from its running nodes, so this node's "
+      "view of the metadata store is incomplete. Mnesia does not re-merge on "
+      "its own. Restarting the 'rabbit' application on one side, with "
+      "`rabbitmqctl stop_app` followed by `rabbitmqctl start_app`, re-merges "
+      "the cluster; the side that is restarted loses any metadata changes it "
+      "accepted while partitioned.",
+      [Split]).
 
 on_node_down_using_mnesia(Node, State = #state{partitions = Partitions,
                                                autoheal   = Autoheal}) ->

--- a/deps/rabbit/test/clustering_recovery_SUITE.erl
+++ b/deps/rabbit/test/clustering_recovery_SUITE.erl
@@ -1140,6 +1140,16 @@ temporary_queue_after_node_loss(Config, QueueDeclare) ->
 %% report that state for as long as it lasts, and stop reporting it once Mnesia
 %% has merged again.
 mnesia_split_is_reported_and_cleared(Config) ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            %% The assertions call rabbit_node_monitor:mnesia_split/0, which
+            %% the older nodes of a mixed-version cluster do not export.
+            {skip, "Requires rabbit_node_monitor:mnesia_split/0 on all nodes"};
+        false ->
+            mnesia_split_is_reported_and_cleared1(Config)
+    end.
+
+mnesia_split_is_reported_and_cleared1(Config) ->
     [Node1, Node2, Node3] = rabbit_ct_broker_helpers:get_node_configs(
                               Config, nodename),
     Peers = lists:sort([Node1, Node3]),

--- a/deps/rabbit/test/clustering_recovery_SUITE.erl
+++ b/deps/rabbit/test/clustering_recovery_SUITE.erl
@@ -41,7 +41,8 @@ groups() ->
                                                  exclusive_transient_queue_after_partition_recovery_1,
                                                  exclusive_durable_queue_after_partition_recovery_1,
                                                  exclusive_transient_queue_after_node_loss,
-                                                 exclusive_durable_queue_after_node_loss
+                                                 exclusive_durable_queue_after_node_loss,
+                                                 mnesia_split_is_reported_and_cleared
                                                 ]}
                           ]}
                         ]},
@@ -149,6 +150,17 @@ init_per_testcase(Testcase, Config) ->
                         Config1,
                         {rabbit,
                          [{cluster_partition_handling, pause_minority}]});
+                  mnesia_split_is_reported_and_cleared ->
+                      %% 'ignore' keeps the split in place: no node pauses, so
+                      %% nothing restarts Mnesia and re-merges it behind the
+                      %% test's back. The short keepalive interval is what the
+                      %% detection runs on, so it bounds how long the test
+                      %% waits for a report.
+                      rabbit_ct_helpers:merge_app_env(
+                        Config1,
+                        {rabbit,
+                         [{cluster_partition_handling, ignore},
+                          {cluster_keepalive_interval, 1000}]});
                   _ ->
                       Config1
               end,
@@ -1120,9 +1132,66 @@ temporary_queue_after_node_loss(Config, QueueDeclare) ->
             ok
     end.
 
+%% Mnesia never re-merges a partition it has detected, and with
+%% cluster_partition_handling = ignore nothing restarts the node either, so the
+%% metadata store stays split long after the network recovered. While it is
+%% split, distribution is up and the 'rabbit' application runs everywhere,
+%% which leaves an operator with nothing to go on. The node monitor should
+%% report that state for as long as it lasts, and stop reporting it once Mnesia
+%% has merged again.
+mnesia_split_is_reported_and_cleared(Config) ->
+    [Node1, Node2, Node3] = rabbit_ct_broker_helpers:get_node_configs(
+                              Config, nodename),
+    Peers = lists:sort([Node1, Node3]),
+    AllNodes = lists:sort([Node1, Node2, Node3]),
+    Timeout = 60000,
+
+    ?assertEqual(AllNodes, running_db_nodes(Config, Node2)),
+    ?assertEqual([], mnesia_split(Config, Node2)),
+
+    %% net_ticktime is 5s under CT, so Mnesia sees both peers go down a few
+    %% seconds after the block. Neither side stops, which is what leaves both
+    %% of them holding a mnesia_down for the other.
+    [rabbit_ct_broker_helpers:block_traffic_between(Node2, Peer)
+     || Peer <- Peers],
+    ?awaitMatch([Node2], running_db_nodes(Config, Node2), Timeout),
+
+    %% Distribution recovers. Mnesia does not.
+    [rabbit_ct_broker_helpers:allow_traffic_between(Node2, Peer)
+     || Peer <- Peers],
+    [?awaitMatch(pong,
+                 rabbit_ct_broker_helpers:rpc(
+                   Config, Node2, net_adm, ping, [Peer]),
+                 Timeout)
+     || Peer <- Peers],
+    ?assertEqual([Node2], running_db_nodes(Config, Node2)),
+
+    %% So the split is reported, and keeps being reported.
+    ?awaitMatch(Peers, mnesia_split(Config, Node2), Timeout),
+
+    %% Re-merge without restarting the node, so the report has to clear itself
+    %% rather than being reset by a fresh node monitor process.
+    ?assertMatch({ok, _},
+                 rabbit_ct_broker_helpers:rpc(
+                   Config, Node2, mnesia, change_config,
+                   [extra_db_nodes, Peers])),
+    ?awaitMatch(AllNodes, running_db_nodes(Config, Node2), Timeout),
+    ?awaitMatch([], mnesia_split(Config, Node2), Timeout),
+    ok.
+
 %% -------------------------------------------------------------------
 %% Internal utils
 %% -------------------------------------------------------------------
+mnesia_split(Config, Node) ->
+    lists:sort(
+      rabbit_ct_broker_helpers:rpc(
+        Config, Node, rabbit_node_monitor, mnesia_split, [])).
+
+running_db_nodes(Config, Node) ->
+    lists:sort(
+      rabbit_ct_broker_helpers:rpc(
+        Config, Node, mnesia, system_info, [running_db_nodes])).
+
 declare_and_publish_to_queue(Config, Node, QName, Args) ->
     {Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, Node),
     declare(Ch, QName, Args),


### PR DESCRIPTION
> [!NOTE]
> This description was written by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who reviewed it before opening the PR. The reproduction and the test run described below were carried out at his direction.

Closes #17319, or at least gives it a signal to work with.

## The problem

Mnesia never re-merges a partition it has detected. With `cluster_partition_handling = ignore` nothing else re-merges it either, and `pause_minority` only recovers when it engages, which it does not when the outage is shorter than its detection window. A blip of a few milliseconds is enough to strand a cluster: the two `mnesia_monitor` processes are linked, so a peer leaves `running_db_nodes` the instant the distribution connection breaks, with no tick timeout involved.

The resulting state has almost no symptoms. Distribution is up, the `rabbit` application runs on every node, quorum queues are unaffected, and the only trace is that Mnesia excludes the peer from its running nodes. The reporter in #17319 sat in it for eight days: their only clue was `"running": false` in `GET /api/nodes`, with nothing pointing at the metadata store.

I reproduced it on a 3-node 4.2.9 cluster (Erlang 27, Mnesia metadata store, three 3-replica quorum queues under load) with a **4 ms** outage, twice. For contrast, a 90 second outage heals itself, because it trips `net_tick_timeout` and `pause_minority` restarts the node. The short fault is the dangerous one.

## What this changes

One thing: on each `ping_up_nodes` keepalive tick, a node compares the members it can reach whose `rabbit` application is running against Mnesia's running nodes, and warns when a peer is in the first set and not the second.

```
[warning] Mnesia is partitioned from [rabbit@node1,rabbit@node2].
Those nodes are reachable and the 'rabbit' application is running on them, but
Mnesia excludes them from its running nodes, so this node's view of the metadata
store is incomplete. Mnesia does not re-merge on its own. Restarting the 'rabbit'
application on one side, with `rabbitmqctl stop_app` followed by
`rabbitmqctl start_app`, re-merges the cluster; the side that is restarted loses
any metadata changes it accepted while partitioned.
```

Details that matter:

- The check runs in a spawned process that messages the result back, following the pattern already used for `check_partial_partition` and `ping_down_nodes`, so the `gen_server` callback does not block. `rabbit_nodes:filter_running/1` can take up to `?FILTER_RPC_TIMEOUT` (10s), which is also the default `cluster_keepalive_interval`.
- It reuses the existing `possibly_partitioned_nodes/0` rather than recomputing the set. That helper pings the members first, so a split peer whose distribution connection has since lapsed is still seen.
- The keepalive timer is re-armed before the check starts, so slow work cannot stretch the interval.
- The Khepri gate uses `get_feature_state/0`, not `is_enabled/0`, which blocks while Mnesia tables are migrated and would be a poor thing to call from a timer.
- The warning repeats every 10 minutes while the split lasts rather than only on transition, because the condition has no other symptom and an operator may arrive hours later. The resolution is logged at the same level, so it stays visible where `log.default.level = warning`.

## What this deliberately does not change

**No partition-handling behaviour.** The change does not touch `#state.partitions`, so `pause_minority`, `pause_if_all_down` and `autoheal` all behave exactly as before. Feeding the detected split into that field would make `cluster_status`, `/api/nodes` and `node_health_check` report it too, which is tempting, but it is also what `autoheal` gates on, so autoheal would begin acting on splits it previously never saw. That is a behaviour change, not an observability fix, and it does not belong in a patch release.

The cost of that decision is stated plainly for anyone reading later: this warning goes to the log only, and the partition-visible surfaces still depend on Mnesia's `inconsistent_database` event, which I observed is not emitted for every split pair.

**No automatic re-merge.** Calling `mnesia_controller:connect_nodes/1` on detection does work mechanically, and `mnesia:change_config(extra_db_nodes, Peers)` re-merges a split cluster in the field. But either silently picks a winner for metadata written on both sides of the split, which is the decision `autoheal` makes explicitly by restarting the loser. Reporting the condition and leaving the choice to an operator is the safe half.

## Test

`clustering_recovery_SUITE:mnesia_split_is_reported_and_cleared`, added to the existing `mnesia_store` group. It blocks one node from both peers, waits for Mnesia to drop them, unblocks, asserts distribution is back while `running_db_nodes` is still split, waits for the report, then re-merges with `mnesia:change_config/2` and waits for the report to clear. Runs in about 26 seconds.

Two notes on its shape. It runs under `ignore`, because `inet_tcp_proxy_dist` blocking does not tear down an established connection, so the outage is bounded by CT's `net_ticktime 5` rather than being sub-second, and a multi-second outage under `pause_minority` deterministically pauses the isolated node and self-heals, leaving nothing to detect. And it remediates with `change_config` rather than `stop_app`/`start_app`, so the report has to clear itself instead of being reset by a fresh monitor process.

I checked it fails when it should: with the detection mutated to always compute `[]`, it fails at the report assertion with `{value,[]}`, and returns to green when the module is restored.

## About the target branch

This is against `v4.2.x` because it is Mnesia-specific and 4.3 removed Mnesia entirely, so there is nothing to fix on `main`. 4.2 left community support on 31 July 2026, so I understand if you would rather not take this. Filing it so the analysis and the reproduction are on record; happy for it to be closed if the series is done.
