### PR TITLE
Handle error tuples and RFC 5280 UTCTime in certificate expiration health check

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
@@ -205,6 +205,10 @@ defmodule RabbitMQ.CLI.Core.Listeners do
     nil
   end
 
+  def cert_validity({:error, _} = err) do
+    err
+  end
+
   def cert_validity(cert) do
     dsa_entries = :public_key.pem_decode(cert)
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
@@ -217,27 +217,63 @@ defmodule RabbitMQ.CLI.Core.Listeners do
 
         Enum.map(dsa_entries, fn
           {:Certificate, _, _} = dsa_entry ->
-            certificate(tbsCertificate: tbs_certificate) = :public_key.pem_entry_decode(dsa_entry)
-            tbscertificate(validity: validity) = tbs_certificate
-            validity(notAfter: not_after, notBefore: not_before) = validity
-            start = :pubkey_cert.time_str_2_gregorian_sec(not_before)
+            try do
+              certificate(tbsCertificate: tbs_certificate) = :public_key.pem_entry_decode(dsa_entry)
+              tbscertificate(validity: validity) = tbs_certificate
+              validity(notAfter: not_after, notBefore: not_before) = validity
 
-            case start > now do
-              true ->
-                {:ok, naive} =
-                  NaiveDateTime.from_erl(:calendar.gregorian_seconds_to_datetime(start))
+              case parse_time(not_before) do
+                {:error, _} = err ->
+                  err
 
-                startdate = NaiveDateTime.to_string(naive)
-                {:error, "Certificate is not yet valid. It starts on #{startdate}"}
+                start when start > now ->
+                  {:ok, naive} =
+                    NaiveDateTime.from_erl(:calendar.gregorian_seconds_to_datetime(start))
 
-              false ->
-                :pubkey_cert.time_str_2_gregorian_sec(not_after)
+                  startdate = NaiveDateTime.to_string(naive)
+                  {:error, "Certificate is not yet valid. It starts on #{startdate}"}
+
+                _start ->
+                  parse_time(not_after)
+              end
+            rescue
+              _ ->
+                {:error, "Malformed certificate entry"}
             end
 
           {type, _, _} ->
             {:error, "The certificate file provided contains a #{type} entry."}
         end)
     end
+  end
+
+  defp parse_time(time) do
+    try do
+      time_str_2_gregorian_sec(time)
+    rescue
+      _ ->
+        {:error, "Invalid date format in certificate"}
+    end
+  end
+
+  # RFC 5280 Section 4.1.2.5.1: YY >= 50 is interpreted as 19YY, YY < 50 as 20YY.
+  defp time_str_2_gregorian_sec({:utcTime, [y1, y2, m1, m2, d1, d2, h1, h2, min1, min2, s1, s2, ?Z]}) do
+    yy = List.to_integer([y1, y2])
+    year = if yy >= 50, do: 1900 + yy, else: 2000 + yy
+    month = List.to_integer([m1, m2])
+    day = List.to_integer([d1, d2])
+    hour = List.to_integer([h1, h2])
+    min = List.to_integer([min1, min2])
+    sec = List.to_integer([s1, s2])
+    :calendar.datetime_to_gregorian_seconds({{year, month, day}, {hour, min, sec}})
+  end
+
+  defp time_str_2_gregorian_sec({:utcTime, [y1, y2, m1, m2, d1, d2, h1, h2, min1, min2, ?Z]}) do
+    time_str_2_gregorian_sec({:utcTime, [y1, y2, m1, m2, d1, d2, h1, h2, min1, min2, ?0, ?0, ?Z]})
+  end
+
+  defp time_str_2_gregorian_sec(time) do
+    :pubkey_cert.time_str_2_gregorian_sec(time)
   end
 
   def listener_rows(listeners) do

--- a/deps/rabbitmq_cli/test/core/listeners_test.exs
+++ b/deps/rabbitmq_cli/test/core/listeners_test.exs
@@ -73,4 +73,10 @@ defmodule CoreListenersTest do
     assert not listener_expiring_within(listener, 86400 * (validityInDays - 5))
     assert listener_expiring_within(listener, 86400 * (validityInDays + 5))
   end
+
+  test "cert_validity handles file read errors and empty PEM" do
+    assert cert_validity(nil) == nil
+    assert cert_validity({:error, :enoent}) == {:error, :enoent}
+    assert cert_validity("") == {:error, "The certificate file provided does not contain any PEM entry."}
+  end
 end

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_certificate_expiration.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_certificate_expiration.erl
@@ -120,7 +120,7 @@ listener_expiring_within(#listener{node = Node, protocol = Protocol, ip_address 
     end.
 
 expires_on_list({error, Reason}) ->
-    #{error => format_error_reason(Reason)};
+    [#{error => format_error_reason(Reason)}];
 expires_on_list(ExpiresOn) when is_list(ExpiresOn) ->
     [case S of
          {error, Reason} ->
@@ -129,6 +129,8 @@ expires_on_list(ExpiresOn) when is_list(ExpiresOn) ->
              seconds_to_bin(Seconds)
      end || S <- ExpiresOn].
 
+format_error_reason(Reason) when is_atom(Reason) ->
+    atom_to_binary(Reason, utf8);
 format_error_reason(Reason) when is_binary(Reason) ->
     Reason;
 format_error_reason(Reason) ->
@@ -159,21 +161,26 @@ cert_validity(Cert) ->
             Now = calendar:datetime_to_gregorian_seconds(calendar:universal_time()),
             lists:map(
               fun({'Certificate', _, _} = DsaEntry) ->
-                      #'Certificate'{tbsCertificate = TBSCertificate} = public_key:pem_entry_decode(DsaEntry),
-                      #'TBSCertificate'{validity = Validity} = TBSCertificate,
-                      #'Validity'{notAfter = NotAfter, notBefore = NotBefore} = Validity,
-                      case parse_time(NotBefore) of
-                          {error, _} = Err ->
-                              Err;
-                          Start when Start > Now ->
-                              {error, "Certificate is not yet valid"};
-                          _Start ->
-                              case parse_time(NotAfter) of
+                      try public_key:pem_entry_decode(DsaEntry) of
+                          #'Certificate'{tbsCertificate = TBSCertificate} ->
+                              #'TBSCertificate'{validity = Validity} = TBSCertificate,
+                              #'Validity'{notAfter = NotAfter, notBefore = NotBefore} = Validity,
+                              case parse_time(NotBefore) of
                                   {error, _} = Err ->
                                       Err;
-                                  End ->
-                                      End
+                                  Start when Start > Now ->
+                                      {error, "Certificate is not yet valid"};
+                                  _Start ->
+                                      case parse_time(NotAfter) of
+                                          {error, _} = Err ->
+                                              Err;
+                                          End ->
+                                              End
+                                      end
                               end
+                      catch
+                          _:_ ->
+                              {error, "Malformed certificate entry"}
                       end;
                  ({Type, _, _}) ->
                       {error, io_lib:format("The certificate file provided contains a ~tp entry",
@@ -226,13 +233,30 @@ seconds_to_bin(Seconds) ->
 -include_lib("eunit/include/eunit.hrl").
 
 rfc5280_utctime_test() ->
+    Sec1950 = time_str_2_gregorian_sec({utcTime, "500101000000Z"}),
+    ?assertEqual({{1950, 1, 1}, {0, 0, 0}}, calendar:gregorian_seconds_to_datetime(Sec1950)),
     Sec1970 = time_str_2_gregorian_sec({utcTime, "700101000000Z"}),
     ?assertEqual({{1970, 1, 1}, {0, 0, 0}}, calendar:gregorian_seconds_to_datetime(Sec1970)),
+    Sec1970NoSec = time_str_2_gregorian_sec({utcTime, "7001010000Z"}),
+    ?assertEqual({{1970, 1, 1}, {0, 0, 0}}, calendar:gregorian_seconds_to_datetime(Sec1970NoSec)),
+    Sec2000 = time_str_2_gregorian_sec({utcTime, "000101000000Z"}),
+    ?assertEqual({{2000, 1, 1}, {0, 0, 0}}, calendar:gregorian_seconds_to_datetime(Sec2000)),
     Sec2049 = time_str_2_gregorian_sec({utcTime, "491231235959Z"}),
     ?assertEqual({{2049, 12, 31}, {23, 59, 59}}, calendar:gregorian_seconds_to_datetime(Sec2049)).
 
-expires_on_list_error_tuple_test() ->
-    Error = {error, "Certificate is not yet valid"},
-    ?assertEqual([#{error => <<"Certificate is not yet valid">>}], expires_on_list([Error])).
+format_error_reason_test() ->
+    ?assertEqual(<<"enoent">>, format_error_reason(enoent)),
+    ?assertEqual(<<"custom error">>, format_error_reason("custom error")),
+    ?assertEqual(<<"binary error">>, format_error_reason(<<"binary error">>)).
+
+expires_on_list_error_test() ->
+    ErrorStr = {error, "Certificate is not yet valid"},
+    ?assertEqual([#{error => <<"Certificate is not yet valid">>}], expires_on_list([ErrorStr])),
+    ErrorAtom = {error, enoent},
+    ?assertEqual([#{error => <<"enoent">>}], expires_on_list(ErrorAtom)),
+    ?assertEqual([#{error => <<"enoent">>}], expires_on_list([ErrorAtom])).
+
+parse_time_error_test() ->
+    ?assertEqual({error, "Invalid date format in certificate"}, parse_time({utcTime, "bad-date"})).
 
 -endif.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_certificate_expiration.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_certificate_expiration.erl
@@ -120,9 +120,19 @@ listener_expiring_within(#listener{node = Node, protocol = Protocol, ip_address 
     end.
 
 expires_on_list({error, Reason}) ->
-    {error, list_to_binary(Reason)};
-expires_on_list(ExpiresOn) ->
-    [seconds_to_bin(S) || S <- ExpiresOn].
+    #{error => format_error_reason(Reason)};
+expires_on_list(ExpiresOn) when is_list(ExpiresOn) ->
+    [case S of
+         {error, Reason} ->
+             #{error => format_error_reason(Reason)};
+         Seconds when is_integer(Seconds) ->
+             seconds_to_bin(Seconds)
+     end || S <- ExpiresOn].
+
+format_error_reason(Reason) when is_binary(Reason) ->
+    Reason;
+format_error_reason(Reason) ->
+    iolist_to_binary(Reason).
 
 read_cert(undefined) ->
     undefined;
@@ -138,6 +148,8 @@ read_cert(Path) ->
 
 cert_validity(undefined) ->
     undefined;
+cert_validity({error, _} = Err) ->
+    Err;
 cert_validity(Cert) ->
     DsaEntries = public_key:pem_decode(Cert),
     case DsaEntries of
@@ -150,18 +162,49 @@ cert_validity(Cert) ->
                       #'Certificate'{tbsCertificate = TBSCertificate} = public_key:pem_entry_decode(DsaEntry),
                       #'TBSCertificate'{validity = Validity} = TBSCertificate,
                       #'Validity'{notAfter = NotAfter, notBefore = NotBefore} = Validity,
-                      Start = pubkey_cert:time_str_2_gregorian_sec(NotBefore),
-                      case Start > Now of
-                          true ->
+                      case parse_time(NotBefore) of
+                          {error, _} = Err ->
+                              Err;
+                          Start when Start > Now ->
                               {error, "Certificate is not yet valid"};
-                          false ->
-                              pubkey_cert:time_str_2_gregorian_sec(NotAfter)
+                          _Start ->
+                              case parse_time(NotAfter) of
+                                  {error, _} = Err ->
+                                      Err;
+                                  End ->
+                                      End
+                              end
                       end;
                  ({Type, _, _}) ->
                       {error, io_lib:format("The certificate file provided contains a ~tp entry",
                                             [Type])}
               end, DsaEntries)
     end.
+
+parse_time(Time) ->
+    try
+        time_str_2_gregorian_sec(Time)
+    catch
+        _:_ ->
+            {error, "Invalid date format in certificate"}
+    end.
+
+%% RFC 5280 Section 4.1.2.5.1: YY >= 50 is interpreted as 19YY, YY < 50 as 20YY.
+time_str_2_gregorian_sec({utcTime, [Y1, Y2, M1, M2, D1, D2, H1, H2, M3, M4, S1, S2, $Z]}) ->
+    YY = list_to_integer([Y1, Y2]),
+    Year = if YY >= 50 -> 1900 + YY;
+              true     -> 2000 + YY
+           end,
+    Month = list_to_integer([M1, M2]),
+    Day = list_to_integer([D1, D2]),
+    Hour = list_to_integer([H1, H2]),
+    Min = list_to_integer([M3, M4]),
+    Sec = list_to_integer([S1, S2]),
+    calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {Hour, Min, Sec}});
+time_str_2_gregorian_sec({utcTime, [Y1, Y2, M1, M2, D1, D2, H1, H2, M3, M4, $Z]}) ->
+    time_str_2_gregorian_sec({utcTime, [Y1, Y2, M1, M2, D1, D2, H1, H2, M3, M4, $0, $0, $Z]});
+time_str_2_gregorian_sec(Time) ->
+    pubkey_cert:time_str_2_gregorian_sec(Time).
 
 expired(undefined, _ExpiryDate) ->
     [];
@@ -178,3 +221,18 @@ seconds_to_bin(Seconds) ->
     {{Y, M, D}, {H, Min, S}} = calendar:gregorian_seconds_to_datetime(Seconds),
     list_to_binary(lists:flatten(io_lib:format("~w-~2.2.0w-~2.2.0w ~w:~2.2.0w:~2.2.0w",
                                                [Y, M, D, H, Min, S]))).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+rfc5280_utctime_test() ->
+    Sec1970 = time_str_2_gregorian_sec({utcTime, "700101000000Z"}),
+    ?assertEqual({{1970, 1, 1}, {0, 0, 0}}, calendar:gregorian_seconds_to_datetime(Sec1970)),
+    Sec2049 = time_str_2_gregorian_sec({utcTime, "491231235959Z"}),
+    ?assertEqual({{2049, 12, 31}, {23, 59, 59}}, calendar:gregorian_seconds_to_datetime(Sec2049)).
+
+expires_on_list_error_tuple_test() ->
+    Error = {error, "Certificate is not yet valid"},
+    ?assertEqual([#{error => <<"Certificate is not yet valid">>}], expires_on_list([Error])).
+
+-endif.


### PR DESCRIPTION
## Description

Fixes #12464

When checking certificate expiration via `/api/health/checks/certificate-expiration/...`, if a certificate validity parsing returns an error tuple (e.g. invalid date format, non-certificate PEM entry, or `{error, "Certificate is not yet valid"}`), `rabbit_mgmt_wm_health_check_certificate_expiration` passed the `{error, Reason}` tuple inside `ExpiresOn` to `seconds_to_bin/1` and `calendar:gregorian_seconds_to_datetime/1`. This resulted in a `badarith` exception (`div 86400`) in Cowboy, returning HTTP 500 without a body.

Additionally, certificates starting in 1970 using 2-digit `UTCTime` (e.g. `"700101000000Z"`) were misinterpreted by `pubkey_cert:time_str_2_gregorian_sec` due to its 100-year sliding window (`CurrentYear - 50` to `CurrentYear + 49`), reading `"70"` as 2070 and falsely flagging valid 1970 certificates as `"Certificate is not yet valid"`.

## Changes

- Updated `expires_on_list/1` to handle `{error, Reason}` tuples within the expiration list and format them into maps (`#{error => format_error_reason(Reason)}`), matching the expected response structure.
- Implemented RFC 5280 Section 4.1.2.5.1 UTCTime parsing (`YY >= 50` is 19YY, `YY < 50` is 20YY) in `time_str_2_gregorian_sec/1`.
- Wrapped date parsing with safe handling for malformed certificate dates.
- Added EUnit tests for RFC 5280 UTCTime decoding and error list formatting.