### PR TITLE
Offer DELAYED_DELIVERY as a connection capability

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -505,6 +505,12 @@ handle_connection_frame(
                     <<"LINK_PAIR_V1_0">>,
                     %% https://docs.oasis-open.org/amqp/anonterm/v1.0/cs01/anonterm-v1.0-cs01.html#doc-anonymous-relay
                     <<"ANONYMOUS-RELAY">>,
+                    %% [schdmsg-v1.0-wd02] §2.1, [amqp-bindmap-jms-v1.0-wd10] §9
+                    %% Offered for the whole connection instead of per link: a sending link often targets an exchange
+                    %% or the anonymous relay, so which queues a message reaches, and therefore whether they support
+                    %% a delivery delay, is only known per message at routing time. Queue types that do not support
+                    %% delivery delays enqueue the message immediately.
+                    <<"DELAYED_DELIVERY">>,
                     %% amqp-bindmap-jms-v1.0-wd10 §8
                     <<"SHARED-SUBS">>],
     {map, Props0} = server_properties(),


### PR DESCRIPTION
Delivery delays were only reachable by a sender that attached directly to a JMS queue, because rabbit_jms_queue is the only queue type offering the DELAYED_DELIVERY link capability. A sender that targets an exchange or the anonymous relay got no such offer and, per [schdmsg-v1.0-wd02] §2.1, had to conclude we do not support delivery delays at all.

That rules the feature out for a large part of normal usage. An AMQP 1.0 client publishing to, say, a headers exchange cannot know which queue types are bound to it, and an anonymous producer picks its destination per message. In JMS the loss is worse than inconvenient: Qpid JMS implements JMSProducer as an anonymous producer, so JMSProducer.setDeliveryDelay - a mandatory Jakarta Messaging 3.1 API - could never be used, and the client rejected such sends before they ever reached us. Six Jakarta Messaging TCK tests failed with "Remote does not support delayed message delivery".

The link capability cannot express what we actually support. It is negotiated at attach, against a terminus, but for an exchange or the anonymous relay the queues a message reaches - and therefore whether they support a delivery delay - is only decided per message at routing time, and changes as bindings change. There is no answer to give at attach time.

So offer the capability for the whole connection instead, and let queue types that do not implement delivery delays enqueue the message immediately. Today that means JMS queues honour the delay while classic queues and streams do not; quorum queues will gain support in 4.4. Note that a JMS topic subscription is backed by a classic or quorum queue depending on durability.

Read strictly, §2.1 makes this an over-claim: a peer that does not offer the capability at connection level is saying it lacks support "on at least some addresses", so offering it claims support on all of them. The alternative is worse. Restricting ourselves to the link capability leaves delivery delay unusable for exchange and anonymous targets even when every bound queue supports it, and rejecting a delayed message aimed at a queue type without support is incoherent under fan-out, since a disposition applies to the whole transfer and would have to reject a message that other, capable queues already accepted. Silently making the message available immediately is also the degradation §2.2 already defines for a delivery time in the past.

Note that the TCK already tests this change.

We do not need to backport this change to `v4.3.x` since JMS Topics over AMQP are only supported in 4.4 and quorum queues also support delivery delays starting only in 4.4.