### PR TITLE
Reject malformed urn:uuid: correlation/message IDs instead of crashing

### DIFF
--- a/deps/rabbit/src/mc_util.erl
+++ b/deps/rabbit/src/mc_util.erl
@@ -51,8 +51,12 @@ uuid_to_urn_string(<<TL:4/binary, TM:2/binary, THV:2/binary,
 -spec urn_string_to_uuid(binary()) ->
     {ok, binary()} | {error, not_urn_string}.
 urn_string_to_uuid(<<"urn:uuid:", UuidStr:36/binary>>) ->
-    Parts = binary:split(UuidStr, <<"-">>, [global]),
-    {ok, iolist_to_binary([binary:decode_hex(Part) || Part <- Parts])};
+    try
+        Parts = binary:split(UuidStr, <<"-">>, [global]),
+        {ok, iolist_to_binary([binary:decode_hex(Part) || Part <- Parts])}
+    catch error:badarg ->
+        {error, not_urn_string}
+    end;
 urn_string_to_uuid(_) ->
     {error, not_urn_string}.
 

--- a/deps/rabbit/src/mc_util.erl
+++ b/deps/rabbit/src/mc_util.erl
@@ -50,10 +50,12 @@ uuid_to_urn_string(<<TL:4/binary, TM:2/binary, THV:2/binary,
 
 -spec urn_string_to_uuid(binary()) ->
     {ok, binary()} | {error, not_urn_string}.
-urn_string_to_uuid(<<"urn:uuid:", UuidStr:36/binary>>) ->
+urn_string_to_uuid(<<"urn:uuid:",
+                     TL:8/binary, "-", TM:4/binary, "-", THV:4/binary, "-",
+                     CS:4/binary, "-", N:12/binary>>) ->
     try
-        Parts = binary:split(UuidStr, <<"-">>, [global]),
-        {ok, iolist_to_binary([binary:decode_hex(Part) || Part <- Parts])}
+        {ok, binary:decode_hex(<<TL/binary, TM/binary, THV/binary,
+                                 CS/binary, N/binary>>)}
     catch error:badarg ->
         {error, not_urn_string}
     end;

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -26,6 +26,7 @@ all_tests() ->
     [
      mc_util_uuid_to_urn_roundtrip,
      mc_util_urn_string_to_uuid_rejects_non_hex_body,
+     mc_util_urn_string_to_uuid_rejects_wrong_dash_placement,
      amqpl_defaults,
      amqpl_compat,
      amqpl_table_x_header,
@@ -514,6 +515,29 @@ mc_util_urn_string_to_uuid_rejects_non_hex_body(_Config) ->
     ?assertEqual(36, byte_size(OddSegmentBody)),
     ?assertEqual({error, not_urn_string},
                  mc_util:urn_string_to_uuid(<<"urn:uuid:", OddSegmentBody/binary>>)),
+    ok.
+
+%% binary:decode_hex/1 only rejects non-hex characters or an odd count of
+%% them; it doesn't care where the dashes are. A 36-byte body with dashes
+%% misplaced (or missing) decodes to a wrong-sized binary that is still
+%% tagged {ok, _} and later handed to the AMQP 1.0 encoder as a uuid,
+%% which requires exactly 16 bytes and crashes on anything else.
+mc_util_urn_string_to_uuid_rejects_wrong_dash_placement(_Config) ->
+    %% 36 hex characters, no dashes: decodes to 18 bytes, not 16
+    NoDashes = binary:copy(<<"a">>, 36),
+    ?assertEqual({error, not_urn_string},
+                 mc_util:urn_string_to_uuid(<<"urn:uuid:", NoDashes/binary>>)),
+    %% 36 dashes: matches the shape, but "-" isn't hex
+    AllDashes = binary:copy(<<"-">>, 36),
+    ?assertEqual({error, not_urn_string},
+                 mc_util:urn_string_to_uuid(<<"urn:uuid:", AllDashes/binary>>)),
+    %% right character counts (32 hex, 4 dashes), wrong grouping: dashes
+    %% clustered in the middle instead of at the canonical 8-4-4-4-12 spots
+    HexHalf = binary:copy(<<"a">>, 16),
+    ClusteredDashes = <<HexHalf/binary, "----", HexHalf/binary>>,
+    ?assertEqual(36, byte_size(ClusteredDashes)),
+    ?assertEqual({error, not_urn_string},
+                 mc_util:urn_string_to_uuid(<<"urn:uuid:", ClusteredDashes/binary>>)),
     ok.
 
 do_n(0, _) ->

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -498,41 +498,38 @@ mc_util_uuid_to_urn_roundtrip(_Config) ->
     S = mc_util:uuid_to_urn_string(UUID),
     ?assertEqual(<<"urn:uuid:58b867b0-8151-1f56-1bd4-73229807fd60">>, S),
     ?assertEqual({ok, UUID}, mc_util:urn_string_to_uuid(S)),
+    %% RFC 4122 requires readers to accept upper case hex
+    ?assertEqual({ok, UUID},
+                 mc_util:urn_string_to_uuid(
+                   <<"urn:uuid:58B867B0-8151-1F56-1BD4-73229807FD60">>)),
     ok.
 
-%% Only the "urn:uuid:" prefix and the 36-byte body length were checked;
-%% the body was never validated as actual hex-and-dashes before being
-%% passed to binary:decode_hex/1, which raises badarg on non-hex input.
+%% Only the `urn:uuid:` prefix and the 36-byte body length were checked, so
+%% a non-hex body reached `binary:decode_hex/1`, which raises badarg.
 mc_util_urn_string_to_uuid_rejects_non_hex_body(_Config) ->
-    %% right length (36 bytes total, dashes in the right places), body not hex
     NotHexBody = <<"zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz">>,
     ?assertEqual(36, byte_size(NotHexBody)),
     ?assertEqual({error, not_urn_string},
                  mc_util:urn_string_to_uuid(<<"urn:uuid:", NotHexBody/binary>>)),
-    %% right total length, but one segment has an odd number of hex
-    %% characters, which decode_hex/1 also rejects with badarg
+    %% dashes in the wrong places, leaving segments `binary:decode_hex/1` rejects
     OddSegmentBody = <<"abcdefg-1234-5678-9abc-def0123456789">>,
     ?assertEqual(36, byte_size(OddSegmentBody)),
     ?assertEqual({error, not_urn_string},
                  mc_util:urn_string_to_uuid(<<"urn:uuid:", OddSegmentBody/binary>>)),
     ok.
 
-%% binary:decode_hex/1 only rejects non-hex characters or an odd count of
-%% them; it doesn't care where the dashes are. A 36-byte body with dashes
-%% misplaced (or missing) decodes to a wrong-sized binary that is still
-%% tagged {ok, _} and later handed to the AMQP 1.0 encoder as a uuid,
-%% which requires exactly 16 bytes and crashes on anything else.
+%% `binary:decode_hex/1` doesn't care where the dashes are, so a 36-byte body
+%% with misplaced dashes used to decode to a wrong-sized binary and reach the
+%% AMQP 1.0 encoder, which requires a uuid to be exactly 16 bytes.
 mc_util_urn_string_to_uuid_rejects_wrong_dash_placement(_Config) ->
-    %% 36 hex characters, no dashes: decodes to 18 bytes, not 16
+    %% no dashes at all: decodes to 18 bytes
     NoDashes = binary:copy(<<"a">>, 36),
     ?assertEqual({error, not_urn_string},
                  mc_util:urn_string_to_uuid(<<"urn:uuid:", NoDashes/binary>>)),
-    %% 36 dashes: matches the shape, but "-" isn't hex
     AllDashes = binary:copy(<<"-">>, 36),
     ?assertEqual({error, not_urn_string},
                  mc_util:urn_string_to_uuid(<<"urn:uuid:", AllDashes/binary>>)),
-    %% right character counts (32 hex, 4 dashes), wrong grouping: dashes
-    %% clustered in the middle instead of at the canonical 8-4-4-4-12 spots
+    %% 32 hex characters and 4 dashes, but grouped 16-4-16
     HexHalf = binary:copy(<<"a">>, 16),
     ClusteredDashes = <<HexHalf/binary, "----", HexHalf/binary>>,
     ?assertEqual(36, byte_size(ClusteredDashes)),

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -25,6 +25,7 @@ groups() ->
 all_tests() ->
     [
      mc_util_uuid_to_urn_roundtrip,
+     mc_util_urn_string_to_uuid_rejects_non_hex_body,
      amqpl_defaults,
      amqpl_compat,
      amqpl_table_x_header,
@@ -496,6 +497,23 @@ mc_util_uuid_to_urn_roundtrip(_Config) ->
     S = mc_util:uuid_to_urn_string(UUID),
     ?assertEqual(<<"urn:uuid:58b867b0-8151-1f56-1bd4-73229807fd60">>, S),
     ?assertEqual({ok, UUID}, mc_util:urn_string_to_uuid(S)),
+    ok.
+
+%% Only the "urn:uuid:" prefix and the 36-byte body length were checked;
+%% the body was never validated as actual hex-and-dashes before being
+%% passed to binary:decode_hex/1, which raises badarg on non-hex input.
+mc_util_urn_string_to_uuid_rejects_non_hex_body(_Config) ->
+    %% right length (36 bytes total, dashes in the right places), body not hex
+    NotHexBody = <<"zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz">>,
+    ?assertEqual(36, byte_size(NotHexBody)),
+    ?assertEqual({error, not_urn_string},
+                 mc_util:urn_string_to_uuid(<<"urn:uuid:", NotHexBody/binary>>)),
+    %% right total length, but one segment has an odd number of hex
+    %% characters, which decode_hex/1 also rejects with badarg
+    OddSegmentBody = <<"abcdefg-1234-5678-9abc-def0123456789">>,
+    ?assertEqual(36, byte_size(OddSegmentBody)),
+    ?assertEqual({error, not_urn_string},
+                 mc_util:urn_string_to_uuid(<<"urn:uuid:", OddSegmentBody/binary>>)),
     ok.
 
 do_n(0, _) ->


### PR DESCRIPTION
A non-hex byte, or a segment with an odd number of hex characters, crashed the AMQP format conversion for the message.

Catch badarg and return {error, not_urn_string}, the same value already returned for anything that doesn't match the expected shape.
