### PR TITLE
DO NOT MERGE CQ shared store: Fix crash on concurrent message removal

### DIFF
--- a/deps/rabbit/include/rabbit_msg_store.hrl
+++ b/deps/rabbit/include/rabbit_msg_store.hrl
@@ -1,0 +1,14 @@
+-record(msg_location, {msg_id, ref_count, file, offset, total_size}).
+
+-record(client_msstate,
+        { server,
+          client_ref,
+          reader,
+          index_ets,
+          dir,
+          file_handles_ets,
+          cur_file_cache_ets,
+          flying_ets,
+          credit_disc_bound,
+          last_v1_file
+        }).

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -16,6 +16,7 @@
          write/4, write_flow/4, read/2, read_many/2, contains/2, remove/2]).
 
 -export([compact_file/2, truncate_file/4, delete_file/2]). %% internal
+-export([client_read3/2]). %% internal, exposed for tests
 
 -export([scan_file_for_valid_messages/1, scan_file_for_valid_messages/2]). %% salvage tool
 
@@ -659,7 +660,18 @@ client_read3(#msg_location { msg_id = MsgId, file = File },
         #msg_location { file = File, ref_count = RefCount } = MsgLocation when RefCount > 0 ->
             {Msg, CState1} = read_from_disk(MsgLocation, CState),
             mark_handle_closed(FileHandlesEts, File, Ref),
-            {{ok, Msg}, CState1}
+            {{ok, Msg}, CState1};
+        _ ->
+            %% The message is no longer readable from the file we just
+            %% pinned: either it was removed entirely (e.g. a different
+            %% queue acking the same fanned-out message) or its index entry
+            %% was deleted and later rewritten under a different file, both
+            %% racing between our caller's snapshot read and this second
+            %% lookup. Close the handle we just opened instead of leaving
+            %% it stuck in FileHandlesEts, which would otherwise defer this
+            %% file's truncation/deletion forever.
+            mark_handle_closed(FileHandlesEts, File, Ref),
+            {not_found, CState}
     end.
 
 read_from_disk(#msg_location { msg_id = MsgId, file = File, offset = Offset,

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -665,7 +665,9 @@ client_write(MsgRef, MsgId, Msg, Flow,
 %% stale content instead of not_found for a message that is really gone.
 %%
 %% Bounds retries for a MsgId that keeps getting rewritten across every
-%% attempt -- vanishingly unlikely, but a loop must still be bounded.
+%% attempt. Exhausting them means the message is alive in a file we never
+%% managed to confirm, which is raised rather than reported as not_found
+%% because the latter would silently drop a readable message.
 -define(CLIENT_READ3_MAX_RETRIES, 3).
 
 client_read3(Location, CState) ->
@@ -687,18 +689,26 @@ client_read3(#msg_location { msg_id = MsgId, file = File },
             {Msg, CState1} = read_from_cache_or_disk(MsgId, MsgLocation, CState, CurFileCacheEts),
             mark_handle_closed(FileHandlesEts, File, Ref),
             {{ok, Msg}, CState1};
-        #msg_location { ref_count = RefCount } = Fresh
-          when RefCount > 0, RetriesLeft > 0 ->
+        #msg_location { ref_count = RefCount } = Fresh when RefCount > 0 ->
             %% Still alive, but under a different file than the one our
             %% caller's snapshot saw and this handle was just opened for.
             %% Retry against the fresh location, which opens and confirms
-            %% that file in turn.
+            %% that file in turn. Reading it here instead would risk a
+            %% stale offset: only a handle opened before the confirming
+            %% lookup defers truncation.
             mark_handle_closed(FileHandlesEts, File, Ref),
-            client_read3(Fresh, CState, RetriesLeft - 1);
+            case read_from_cache(CurFileCacheEts, MsgId) of
+                {ok, Msg} ->
+                    {{ok, Msg}, CState};
+                not_found when RetriesLeft > 0 ->
+                    client_read3(Fresh, CState, RetriesLeft - 1);
+                not_found ->
+                    error({rabbit_msg_store_read, relocation_retries_exhausted,
+                           Fresh#msg_location.file, MsgId})
+            end;
         _ ->
-            %% Either genuinely gone (e.g. a different queue acking the
-            %% last reference to a fanned-out message) or still being
-            %% rewritten after every retry. Close the handle we just
+            %% Genuinely gone, e.g. a different queue acking the last
+            %% reference to a fanned-out message. Close the handle we just
             %% opened instead of leaving it stuck in FileHandlesEts, which
             %% would otherwise defer this file's truncation/deletion
             %% forever.
@@ -707,9 +717,15 @@ client_read3(#msg_location { msg_id = MsgId, file = File },
     end.
 
 read_from_cache_or_disk(MsgId, MsgLocation, CState, CurFileCacheEts) ->
+    case read_from_cache(CurFileCacheEts, MsgId) of
+        {ok, Msg} -> {Msg, CState};
+        not_found -> read_from_disk(MsgLocation, CState)
+    end.
+
+read_from_cache(CurFileCacheEts, MsgId) ->
     case ets:lookup(CurFileCacheEts, MsgId) of
-        [{MsgId, Msg, _CacheRefCount}] -> {Msg, CState};
-        [] -> read_from_disk(MsgLocation, CState)
+        [{MsgId, Msg, _CacheRefCount}] -> {ok, Msg};
+        [] -> not_found
     end.
 
 read_from_disk(#msg_location { msg_id = MsgId, file = File, offset = Offset,

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -28,10 +28,9 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include("rabbit_msg_store.hrl").
 
 -type(msg() :: any()).
-
--record(msg_location, {msg_id, ref_count, file, offset, total_size}).
 
 %% We flush to disk at an interval to make sure we don't keep
 %% the data in memory too long. Confirms are sent after the
@@ -124,19 +123,6 @@
           credit_disc_bound,
           %% Highest-numbered v1 (.rdq) file, or 'none' if the store has
           %% no v1 files at all.
-          last_v1_file
-        }).
-
--record(client_msstate,
-        { server,
-          client_ref,
-          reader,
-          index_ets,
-          dir,
-          file_handles_ets,
-          cur_file_cache_ets,
-          flying_ets,
-          credit_disc_bound,
           last_v1_file
         }).
 
@@ -650,14 +636,15 @@ client_write(MsgRef, MsgId, Msg, Flow,
 %% Compaction only ever rewrites a live message's offset, never its file
 %% (index_update_offset_if_unchanged/5 always keeps the same File). So the
 %% only way the confirming lookup below can see a different file for a
-%% still-positive ref count is a full removal followed by a brand new
-%% write/4 that reuses the same MsgId (e.g. republishing identical
-%% content). That fresh copy can land in the store's current file, whose
+%% still-positive ref count is a full removal followed by another write of
+%% the same MsgId: with fan-out, one queue can drop its last reference
+%% before another queue's write of the same message is processed.
+%% That fresh copy can land in the store's current file, whose
 %% bytes may still be sitting in the write buffer rather than on disk
 %% (writer_append/3, flushed later by writer_flush/1) -- reading it
 %% straight from disk before that flush would misread garbage. Once a
 %% lookup below confirms the message is still alive, check the cache
-%% before the disk, exactly like client_read2/2 does before ever calling
+%% before the disk, exactly like read/2 does before ever calling
 %% here, since it's kept live for anything still in the current file.
 %% The cache is not consulted ahead of that liveness check: a removed
 %% message's cache row is deliberately not cleared (in case a write for

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -647,10 +647,36 @@ client_write(MsgRef, MsgId, Msg, Flow,
 %% index information points to the file we are expecting we are good.
 %% And the file only gets deleted after all data was copied, index
 %% was updated and file handles got closed.
+%% Compaction only ever rewrites a live message's offset, never its file
+%% (index_update_offset_if_unchanged/5 always keeps the same File). So the
+%% only way the confirming lookup below can see a different file for a
+%% still-positive ref count is a full removal followed by a brand new
+%% write/4 that reuses the same MsgId (e.g. republishing identical
+%% content). That fresh copy can land in the store's current file, whose
+%% bytes may still be sitting in the write buffer rather than on disk
+%% (writer_append/3, flushed later by writer_flush/1) -- reading it
+%% straight from disk before that flush would misread garbage. Once a
+%% lookup below confirms the message is still alive, check the cache
+%% before the disk, exactly like client_read2/2 does before ever calling
+%% here, since it's kept live for anything still in the current file.
+%% The cache is not consulted ahead of that liveness check: a removed
+%% message's cache row is deliberately not cleared (in case a write for
+%% the same MsgId is still in flight), so checking it first would return
+%% stale content instead of not_found for a message that is really gone.
+%%
+%% Bounds retries for a MsgId that keeps getting rewritten across every
+%% attempt -- vanishingly unlikely, but a loop must still be bounded.
+-define(CLIENT_READ3_MAX_RETRIES, 3).
+
+client_read3(Location, CState) ->
+    client_read3(Location, CState, ?CLIENT_READ3_MAX_RETRIES).
+
 client_read3(#msg_location { msg_id = MsgId, file = File },
-             CState = #client_msstate { index_ets        = IndexEts,
-                                        file_handles_ets = FileHandlesEts,
-                                        client_ref       = Ref }) ->
+             CState = #client_msstate { index_ets          = IndexEts,
+                                        file_handles_ets   = FileHandlesEts,
+                                        cur_file_cache_ets = CurFileCacheEts,
+                                        client_ref         = Ref },
+             RetriesLeft) ->
     %% We immediately mark the handle open so that we don't get the
     %% file truncated while we are reading from it. The file may still
     %% be truncated past that point but that's OK because we do a second
@@ -658,20 +684,32 @@ client_read3(#msg_location { msg_id = MsgId, file = File },
     mark_handle_open(FileHandlesEts, File, Ref),
     case index_lookup(IndexEts, MsgId) of
         #msg_location { file = File, ref_count = RefCount } = MsgLocation when RefCount > 0 ->
-            {Msg, CState1} = read_from_disk(MsgLocation, CState),
+            {Msg, CState1} = read_from_cache_or_disk(MsgId, MsgLocation, CState, CurFileCacheEts),
             mark_handle_closed(FileHandlesEts, File, Ref),
             {{ok, Msg}, CState1};
+        #msg_location { ref_count = RefCount } = Fresh
+          when RefCount > 0, RetriesLeft > 0 ->
+            %% Still alive, but under a different file than the one our
+            %% caller's snapshot saw and this handle was just opened for.
+            %% Retry against the fresh location, which opens and confirms
+            %% that file in turn.
+            mark_handle_closed(FileHandlesEts, File, Ref),
+            client_read3(Fresh, CState, RetriesLeft - 1);
         _ ->
-            %% The message is no longer readable from the file we just
-            %% pinned: either it was removed entirely (e.g. a different
-            %% queue acking the same fanned-out message) or its index entry
-            %% was deleted and later rewritten under a different file, both
-            %% racing between our caller's snapshot read and this second
-            %% lookup. Close the handle we just opened instead of leaving
-            %% it stuck in FileHandlesEts, which would otherwise defer this
-            %% file's truncation/deletion forever.
+            %% Either genuinely gone (e.g. a different queue acking the
+            %% last reference to a fanned-out message) or still being
+            %% rewritten after every retry. Close the handle we just
+            %% opened instead of leaving it stuck in FileHandlesEts, which
+            %% would otherwise defer this file's truncation/deletion
+            %% forever.
             mark_handle_closed(FileHandlesEts, File, Ref),
             {not_found, CState}
+    end.
+
+read_from_cache_or_disk(MsgId, MsgLocation, CState, CurFileCacheEts) ->
+    case ets:lookup(CurFileCacheEts, MsgId) of
+        [{MsgId, Msg, _CacheRefCount}] -> {Msg, CState};
+        [] -> read_from_disk(MsgLocation, CState)
     end.
 
 read_from_disk(#msg_location { msg_id = MsgId, file = File, offset = Offset,

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1158,10 +1158,13 @@ read_msg(SeqId, _, _, MsgLocation, State = #vqstate{ store_state = StoreState0 }
     {Msg, State#vqstate{ store_state = StoreState }};
 read_msg(_, MsgId, IsPersistent, rabbit_msg_store, State = #vqstate{msg_store_clients = MSCState,
                                                                     disk_read_count   = Count}) ->
-    {{ok, Msg}, MSCState1} =
-        msg_store_read(MSCState, IsPersistent, MsgId),
-    {Msg, State #vqstate {msg_store_clients = MSCState1,
-                          disk_read_count   = Count + 1}}.
+    case msg_store_read(MSCState, IsPersistent, MsgId) of
+        {{ok, Msg}, MSCState1} ->
+            {Msg, State #vqstate {msg_store_clients = MSCState1,
+                                  disk_read_count   = Count + 1}};
+        {not_found, _MSCState1} ->
+            error({msg_store_read_not_found, MsgId})
+    end.
 
 %% Helper macros to make the code as obvious as possible.
 %% It's OK to call msg_size/1 for Inc because it gets inlined.

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -64,6 +64,7 @@ groups() ->
      {backing_queue_tests, [], [
           msg_store,
           msg_store_read_many_fanout,
+          msg_store_read_after_concurrent_remove_returns_not_found,
           msg_store_compaction_v2,
           msg_store_compaction_v2_exact_fit,
           msg_store_compaction_v2_scannable_before_truncate,
@@ -403,6 +404,78 @@ msg_store_read_many_fanout1(_Config) ->
                    MSCStateN
            end),
     passed.
+
+%% A message fanned out to two queues has ref_count = 2. If one queue's
+%% consumer acks the message (dropping the reference to 0) between another
+%% reader's snapshot lookup and client_read3/2's own, second, confirming
+%% lookup, the second lookup used to have no fallback clause and crashed
+%% with case_clause -- and left the file handle it had just marked open
+%% stuck open forever, which blocks that file's reclamation. The fix
+%% turns that crash into a clean not_found and closes the handle; it does
+%% not change what the sole production caller, rabbit_variable_queue,
+%% does with a not_found result, which already hard-matches {ok, _} on
+%% the pre-existing first-lookup not_found path.
+msg_store_read_after_concurrent_remove_returns_not_found(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_read_after_concurrent_remove_returns_not_found1, [Config]).
+
+msg_store_read_after_concurrent_remove_returns_not_found1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    CState0 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+    MsgRef = rabbit_guid:gen(),
+    MsgId = msg_id_bin(MsgRef),
+    ok = rabbit_msg_store:write(MsgRef, MsgId, MsgId, CState0),
+    %% ensure the write above has been processed by the server: same-priority
+    %% casts and calls are handled in FIFO order by this gen_server2
+    true = rabbit_msg_store:contains(MsgId, CState0),
+
+    %% capture the location the way read/2's own snapshot check would,
+    %% while the message still has a positive ref count
+    StaleLocation = stale_location(MsgId, CState0),
+    true = StaleLocation =/= not_found,
+    File = location_file(StaleLocation),
+
+    %% remove the only reference -- simulating a different queue's consumer
+    %% acking the same fanned-out message concurrently -- and sync again
+    {ok, []} = rabbit_msg_store:remove([{MsgRef, MsgId}], CState0),
+    false = rabbit_msg_store:contains(MsgId, CState0),
+
+    %% call the function under test directly with the now-stale location:
+    %% its own second, index-based lookup will find ref_count = 0, which
+    %% must return not_found instead of crashing with case_clause
+    {Result, CState1} = rabbit_msg_store:client_read3(StaleLocation, CState0),
+    not_found = Result,
+
+    %% the handle marked open for File just before the second lookup must
+    %% not be left open, or File's reclamation is blocked forever
+    false = handle_open(File, CState1),
+
+    ok = rabbit_msg_store:client_terminate(CState1),
+    passed.
+
+%% Exposes the same snapshot lookup read/2 does before calling
+%% client_read3/2, so a test can hold onto it and call client_read3/2
+%% with it after the index has since changed underneath it.
+stale_location(MsgId, CState) ->
+    IndexEts = element(5, CState),
+    case ets:lookup(IndexEts, MsgId) of
+        [MsgLocation] when element(3, MsgLocation) > 0 ->
+            MsgLocation;
+        _ ->
+            not_found
+    end.
+
+location_file(MsgLocation) ->
+    element(4, MsgLocation).
+
+%% Whether a handle is still marked open for File, so a test can
+%% confirm client_read3/2's not_found fallback actually closes the
+%% handle it just opened rather than leaking it.
+handle_open(File, CState) ->
+    FileHandlesEts = element(7, CState),
+    ClientRef = element(3, CState),
+    ets:member(FileHandlesEts, {ClientRef, File}).
 
 %% Compaction of a v2 (.sqs) segment file is the one path that isn't
 %% adequately covered by scanning hand-built files (msg_store_file_scan_v2):

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -65,6 +65,8 @@ groups() ->
           msg_store,
           msg_store_read_many_fanout,
           msg_store_read_after_concurrent_remove_returns_not_found,
+          msg_store_read_after_relocation_retries,
+          msg_store_read_after_relocation_finds_unflushed_current_file,
           msg_store_compaction_v2,
           msg_store_compaction_v2_exact_fit,
           msg_store_compaction_v2_scannable_before_truncate,
@@ -447,6 +449,111 @@ msg_store_read_after_concurrent_remove_returns_not_found1(_Config) ->
     ok = rabbit_msg_store:client_terminate(CState1),
     passed.
 
+%% If a message is fully removed and then rewritten under the same MsgId
+%% (e.g. republishing identical content) between a reader's snapshot and
+%% client_read3/2's confirming lookup, the message is still alive, just
+%% under a different file than the snapshot said. client_read3/2 must
+%% retry against the fresh location instead of reporting not_found.
+msg_store_read_after_relocation_retries(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_read_after_relocation_retries1, [Config]).
+
+msg_store_read_after_relocation_retries1(_Config) ->
+    {ok, DefaultFileSizeLimit} = application:get_env(rabbit, msg_store_file_size_limit),
+    %% Small enough that the padding write below rolls file 0 over to
+    %% file 1, so MsgId and OtherContent end up in different files.
+    %% Restored in the `after` clause regardless of outcome.
+    ok = application:set_env(rabbit, msg_store_file_size_limit, 100),
+    try
+        msg_store_read_after_relocation_retries2()
+    after
+        ok = application:set_env(rabbit, msg_store_file_size_limit, DefaultFileSizeLimit)
+    end.
+
+msg_store_read_after_relocation_retries2() ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    {Cap, CState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref),
+
+    MsgRef = rabbit_guid:gen(),
+    MsgId = msg_id_bin(MsgRef),
+    ok = rabbit_msg_store:write(MsgRef, MsgId, MsgId, CState0),
+    %% pushes file 0 past the 100-byte limit, rolling to file 1 as part
+    %% of its own write -- so it lands in file 0 too, but the next write
+    %% won't
+    PaddingRef = rabbit_guid:gen(),
+    PaddingId = msg_id_bin(PaddingRef),
+    ok = rabbit_msg_store:write(PaddingRef, PaddingId,
+                                crypto:strong_rand_bytes(200), CState0),
+    ok = on_disk_await(Cap, [{MsgRef, MsgId}, {PaddingRef, PaddingId}]),
+    StaleLocation = stale_location(MsgId, CState0),
+    true = StaleLocation =/= not_found,
+
+    %% write a second, unrelated message -- now into file 1 -- then
+    %% splice the index so that MsgId resolves to its (real, readable)
+    %% location instead, simulating MsgId having been fully removed and
+    %% rewritten into file 1, while StaleLocation still points at file 0
+    OtherRef = rabbit_guid:gen(),
+    OtherContent = msg_id_bin(rabbit_guid:gen()),
+    ok = rabbit_msg_store:write(OtherRef, OtherContent, OtherContent, CState0),
+    ok = on_disk_await(Cap, [{OtherRef, OtherContent}]),
+    OtherLocation = stale_location(OtherContent, CState0),
+    true = OtherLocation =/= not_found,
+    true = location_file(OtherLocation) =/= location_file(StaleLocation),
+    true = ets:insert(element(5, CState0), set_msg_id(OtherLocation, MsgId)),
+
+    {Result, CState1} = rabbit_msg_store:client_read3(StaleLocation, CState0),
+    {ok, OtherContent} = Result,
+
+    ok = on_disk_stop(Cap),
+    ok = rabbit_msg_store:client_terminate(CState1),
+    passed.
+
+%% Same rewritten-under-the-same-MsgId race, but the fresh copy lands in
+%% the store's *current* file, still sitting in the write buffer rather
+%% than on disk. client_read3/2 must find it via cur_file_cache_ets
+%% instead of reading the file directly, which would misread it.
+msg_store_read_after_relocation_finds_unflushed_current_file(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_read_after_relocation_finds_unflushed_current_file1,
+      [Config]).
+
+msg_store_read_after_relocation_finds_unflushed_current_file1(_Config) ->
+    restart_msg_store_empty(),
+    Ref = rabbit_guid:gen(),
+    %% Plain client (no on-disk confirmation callback): the store only
+    %% ever schedules its periodic flush timer once a client has pending
+    %% confirmations to fulfil (record_pending_confirm/3), so this keeps
+    %% both writes below in the write buffer indefinitely, deterministically,
+    %% rather than racing a 200ms timer that a capture client would arm.
+    CState0 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+
+    MsgRef = rabbit_guid:gen(),
+    MsgId = msg_id_bin(MsgRef),
+    ok = rabbit_msg_store:write(MsgRef, MsgId, MsgId, CState0),
+    true = rabbit_msg_store:contains(MsgId, CState0),
+    StaleLocation = stale_location(MsgId, CState0),
+    true = StaleLocation =/= not_found,
+
+    {ok, []} = rabbit_msg_store:remove([{MsgRef, MsgId}], CState0),
+    false = rabbit_msg_store:contains(MsgId, CState0),
+
+    %% Rewrite MsgId (content must be identical: MsgIds are
+    %% content-addressed, so a reused MsgId is always the same bytes --
+    %% update_msg_cache/3 relies on this and only bumps a pending-write
+    %% counter on a cache hit, it never overwrites the cached content).
+    %% Still in the write buffer, not yet flushed, when client_read3/2
+    %% is called below.
+    NewRef = rabbit_guid:gen(),
+    ok = rabbit_msg_store:write(NewRef, MsgId, MsgId, CState0),
+    true = rabbit_msg_store:contains(MsgId, CState0),
+
+    {Result, CState1} = rabbit_msg_store:client_read3(StaleLocation, CState0),
+    {ok, MsgId} = Result,
+
+    ok = rabbit_msg_store:client_terminate(CState1),
+    passed.
+
 %% Exposes the same snapshot lookup read/2 does before calling
 %% client_read3/2, so a test can hold onto it and call client_read3/2
 %% with it after the index has since changed underneath it.
@@ -461,6 +568,9 @@ stale_location(MsgId, CState) ->
 
 location_file(MsgLocation) ->
     element(4, MsgLocation).
+
+set_msg_id(MsgLocation, MsgId) ->
+    setelement(2, MsgLocation, MsgId).
 
 %% Whether a handle is still marked open for File, so a test can
 %% confirm client_read3/2's not_found fallback actually closes the

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -405,16 +405,9 @@ msg_store_read_many_fanout1(_Config) ->
            end),
     passed.
 
-%% A message fanned out to two queues has ref_count = 2. If one queue's
-%% consumer acks the message (dropping the reference to 0) between another
-%% reader's snapshot lookup and client_read3/2's own, second, confirming
-%% lookup, the second lookup used to have no fallback clause and crashed
-%% with case_clause -- and left the file handle it had just marked open
-%% stuck open forever, which blocks that file's reclamation. The fix
-%% turns that crash into a clean not_found and closes the handle; it does
-%% not change what the sole production caller, rabbit_variable_queue,
-%% does with a not_found result, which already hard-matches {ok, _} on
-%% the pre-existing first-lookup not_found path.
+%% A reader can retain a positive-ref-count snapshot while another operation
+%% removes the message's final reference before client_read3/2 performs its
+%% own confirming lookup.
 msg_store_read_after_concurrent_remove_returns_not_found(Config) ->
     passed = rabbit_ct_broker_helpers:rpc(Config, 0,
       ?MODULE, msg_store_read_after_concurrent_remove_returns_not_found1, [Config]).

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include("amqqueue.hrl").
+-include("rabbit_msg_store.hrl").
 
 -compile(nowarn_export_all).
 -compile(export_all).
@@ -429,7 +430,7 @@ msg_store_read_after_concurrent_remove_returns_not_found1(_Config) ->
     %% while the message still has a positive ref count
     StaleLocation = stale_location(MsgId, CState0),
     true = StaleLocation =/= not_found,
-    File = location_file(StaleLocation),
+    File = StaleLocation#msg_location.file,
 
     %% remove the only reference -- simulating a different queue's consumer
     %% acking the same fanned-out message concurrently -- and sync again
@@ -499,8 +500,9 @@ msg_store_read_after_relocation_retries2() ->
     ok = on_disk_await(Cap, [{OtherRef, OtherContent}]),
     OtherLocation = stale_location(OtherContent, CState0),
     true = OtherLocation =/= not_found,
-    true = location_file(OtherLocation) =/= location_file(StaleLocation),
-    true = ets:insert(element(5, CState0), set_msg_id(OtherLocation, MsgId)),
+    true = OtherLocation#msg_location.file =/= StaleLocation#msg_location.file,
+    true = ets:insert(CState0#client_msstate.index_ets,
+                      OtherLocation#msg_location{ msg_id = MsgId }),
 
     {Result, CState1} = rabbit_msg_store:client_read3(StaleLocation, CState0),
     {ok, OtherContent} = Result,
@@ -558,27 +560,19 @@ msg_store_read_after_relocation_finds_unflushed_current_file1(_Config) ->
 %% client_read3/2, so a test can hold onto it and call client_read3/2
 %% with it after the index has since changed underneath it.
 stale_location(MsgId, CState) ->
-    IndexEts = element(5, CState),
-    case ets:lookup(IndexEts, MsgId) of
-        [MsgLocation] when element(3, MsgLocation) > 0 ->
+    case ets:lookup(CState#client_msstate.index_ets, MsgId) of
+        [MsgLocation = #msg_location{ ref_count = RefCount }] when RefCount > 0 ->
             MsgLocation;
         _ ->
             not_found
     end.
 
-location_file(MsgLocation) ->
-    element(4, MsgLocation).
-
-set_msg_id(MsgLocation, MsgId) ->
-    setelement(2, MsgLocation, MsgId).
-
 %% Whether a handle is still marked open for File, so a test can
 %% confirm client_read3/2's not_found fallback actually closes the
 %% handle it just opened rather than leaking it.
 handle_open(File, CState) ->
-    FileHandlesEts = element(7, CState),
-    ClientRef = element(3, CState),
-    ets:member(FileHandlesEts, {ClientRef, File}).
+    ets:member(CState#client_msstate.file_handles_ets,
+               {CState#client_msstate.client_ref, File}).
 
 %% Compaction of a v2 (.sqs) segment file is the one path that isn't
 %% adequately covered by scanning hand-built files (msg_store_file_scan_v2):


### PR DESCRIPTION
client_read3/2's confirming index lookup had no fallback clause: if a fanned-out message's ref count dropped to 0 (or its index entry moved to another file) between a reader's snapshot lookup and this second lookup, it raised case_clause and left the file handle it had just marked open stuck in file_handles_ets.
