### PR TITLE
Bound LIKE filter subject length independent of the message-size cap

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_filter_sql.erl
+++ b/deps/rabbit/src/rabbit_amqp_filter_sql.erl
@@ -26,6 +26,17 @@
 
 -define(DEFAULT_MSG_PRIORITY, 4).
 
+%% A LIKE pattern with several %-wildcards compiles to a regex.
+%% rabbit_re:run/2 already bounds backtracking via match_limit and
+%% match_limit_recursion (surfacing as a plain nomatch, not an error, so
+%% it doesn't by itself risk a wrong answer becoming a crash) -- but the
+%% residual cost of scanning the subject at all is still roughly linear
+%% in its length, and this filter runs once per candidate message inside
+%% the target queue's own process. Bound the subject independently of
+%% the overall message-size cap, which allows it to be far larger than
+%% reasonable for a single filtered field.
+-define(MAX_LIKE_SUBJECT_LENGTH, 4096).
+
 -spec parse(tuple()) ->
     {ok, parsed_expression()} | error.
 parse({described, Descriptor, {utf8, SQL}}) ->
@@ -255,12 +266,20 @@ like(Subject,{{prefix, PrefixSize, _} = Prefix,
     like(Subject, Suffix);
 like(Subject, CompiledRe)
   when element(1, CompiledRe) =:= re_pattern ->
-    case rabbit_re:run(Subject, CompiledRe) of
-        match           -> true;
-        nomatch         -> false;
-        %% Subject is not a UTF-8 string.
-        {error, badarg} -> undefined;
-        {error, _}      -> false
+    case byte_size(Subject) > ?MAX_LIKE_SUBJECT_LENGTH of
+        true ->
+            %% "Comparison or arithmetic with an unknown value always
+            %% yields an unknown value" -- treat an oversized subject the
+            %% same as the is_binary(Subject) =:= false case above.
+            undefined;
+        false ->
+            case rabbit_re:run(Subject, CompiledRe) of
+                match           -> true;
+                nomatch         -> false;
+                %% Subject is not a UTF-8 string.
+                {error, badarg} -> undefined;
+                {error, _}      -> false
+            end
     end.
 
 get_field_value(priority, Msg) ->

--- a/deps/rabbit/src/rabbit_amqp_filter_sql.erl
+++ b/deps/rabbit/src/rabbit_amqp_filter_sql.erl
@@ -264,11 +264,11 @@ like(Subject, CompiledRe)
             undefined;
         false ->
             case rabbit_re:run(Subject, CompiledRe) of
-                match           -> true;
-                nomatch         -> false;
-                %% Subject is not a UTF-8 string.
-                {error, badarg} -> undefined;
-                {error, _}      -> false
+                match      -> true;
+                nomatch    -> false;
+                %% The subject is not a UTF-8 string, or the match limit
+                %% was exhausted before a verdict was reached.
+                {error, _} -> undefined
             end
     end.
 

--- a/deps/rabbit/src/rabbit_amqp_filter_sql.erl
+++ b/deps/rabbit/src/rabbit_amqp_filter_sql.erl
@@ -22,20 +22,10 @@
 %% [Filter-Expressions-v1.0 7.1]
 %% https://docs.oasis-open.org/amqp/filtex/v1.0/csd01/filtex-v1.0-csd01.html#_Toc67929316
 -define(MAX_EXPRESSION_LENGTH, 4096).
+-define(MAX_LIKE_SUBJECT_LENGTH, 4096).
 -define(MAX_TOKENS, 200).
 
 -define(DEFAULT_MSG_PRIORITY, 4).
-
-%% A LIKE pattern with several %-wildcards compiles to a regex.
-%% rabbit_re:run/2 already bounds backtracking via match_limit and
-%% match_limit_recursion (surfacing as a plain nomatch, not an error, so
-%% it doesn't by itself risk a wrong answer becoming a crash) -- but the
-%% residual cost of scanning the subject at all is still roughly linear
-%% in its length, and this filter runs once per candidate message inside
-%% the target queue's own process. Bound the subject independently of
-%% the overall message-size cap, which allows it to be far larger than
-%% reasonable for a single filtered field.
--define(MAX_LIKE_SUBJECT_LENGTH, 4096).
 
 -spec parse(tuple()) ->
     {ok, parsed_expression()} | error.

--- a/deps/rabbit/test/amqp_filter_sql_unit_SUITE.erl
+++ b/deps/rabbit/test/amqp_filter_sql_unit_SUITE.erl
@@ -505,7 +505,24 @@ like_operator(_Config) ->
     false = match("k LIKE '%%X'",      [{{utf8, <<"k">>}, {utf8, <<"abc">>}}]),
     true  = match("k LIKE '%%X'",      [{{utf8, <<"k">>}, {utf8, <<"abcX">>}}]),
     true  = match("k LIKE '%%a%%b%%'", [{{utf8, <<"k">>}, {utf8, <<"xaxbx">>}}]),
-    false = match("k LIKE '%%a%%b%%'", [{{utf8, <<"k">>}, {utf8, <<"xbxax">>}}]).
+    false = match("k LIKE '%%a%%b%%'", [{{utf8, <<"k">>}, {utf8, <<"xbxax">>}}]),
+
+    %% A LIKE pattern with several %-wildcards compiles to a regex; its
+    %% subject is bounded independently of the message-size limit since
+    %% matching runs inside the target queue's own process. A subject
+    %% that would otherwise match must stop matching once it exceeds the
+    %% cap, and one within the cap must still match normally.
+    WithinCap = binary:copy(<<"a">>, 10),
+    true = match("k LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, WithinCap}}]),
+    Oversized = binary:copy(<<"a">>, 5000),
+    false = match("k LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, Oversized}}]),
+
+    %% An oversized subject evaluates to unknown, not false, matching the
+    %% "identifier is NULL" convention already used for LIKE elsewhere in
+    %% this suite -- this is only observable through NOT LIKE: unknown
+    %% still doesn't match (unlike a hard false, which NOT would flip to
+    %% a match).
+    false = match("k NOT LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, Oversized}}]).
 
 in_operator(_Config) ->
     AppPropsUtf8 = [{{utf8, <<"country">>}, {utf8, <<"🇬🇧"/utf8>>}}],

--- a/deps/rabbit/test/amqp_filter_sql_unit_SUITE.erl
+++ b/deps/rabbit/test/amqp_filter_sql_unit_SUITE.erl
@@ -512,9 +512,9 @@ like_operator(_Config) ->
     %% matching runs inside the target queue's own process. A subject
     %% that would otherwise match must stop matching once it exceeds the
     %% cap, and one within the cap must still match normally.
-    WithinCap = binary:copy(<<"a">>, 10),
-    true = match("k LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, WithinCap}}]),
-    Oversized = binary:copy(<<"a">>, 5000),
+    AtCap = binary:copy(<<"a">>, 4096),
+    true = match("k LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, AtCap}}]),
+    Oversized = binary:copy(<<"a">>, 4097),
     false = match("k LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, Oversized}}]),
 
     %% An oversized subject evaluates to unknown, not false, matching the

--- a/deps/rabbit/test/amqp_filter_sql_unit_SUITE.erl
+++ b/deps/rabbit/test/amqp_filter_sql_unit_SUITE.erl
@@ -507,21 +507,15 @@ like_operator(_Config) ->
     true  = match("k LIKE '%%a%%b%%'", [{{utf8, <<"k">>}, {utf8, <<"xaxbx">>}}]),
     false = match("k LIKE '%%a%%b%%'", [{{utf8, <<"k">>}, {utf8, <<"xbxax">>}}]),
 
-    %% A LIKE pattern with several %-wildcards compiles to a regex; its
-    %% subject is bounded independently of the message-size limit since
-    %% matching runs inside the target queue's own process. A subject
-    %% that would otherwise match must stop matching once it exceeds the
-    %% cap, and one within the cap must still match normally.
+    %% A LIKE pattern with several %-wildcards compiles to a regex whose
+    %% subject is bounded independently of the message-size limit.
     AtCap = binary:copy(<<"a">>, 4096),
     true = match("k LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, AtCap}}]),
     Oversized = binary:copy(<<"a">>, 4097),
     false = match("k LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, Oversized}}]),
 
-    %% An oversized subject evaluates to unknown, not false, matching the
-    %% "identifier is NULL" convention already used for LIKE elsewhere in
-    %% this suite -- this is only observable through NOT LIKE: unknown
-    %% still doesn't match (unlike a hard false, which NOT would flip to
-    %% a match).
+    %% An oversized subject evaluates to unknown rather than false, so
+    %% NOT LIKE does not match either.
     false = match("k NOT LIKE '%a%a%'", [{{utf8, <<"k">>}, {utf8, Oversized}}]).
 
 in_operator(_Config) ->


### PR DESCRIPTION
Cap the subject considered by a compiled multi-wildcard LIKE pattern at 4096 bytes, matching the existing ?MAX_EXPRESSION_LENGTH scale already used for the filter's own source. An oversized subject evaluates to unknown (matching the "identifier is NULL" convention already used elsewhere in this module) rather than a hard false.
