### PR TITLE
Fix badfun in stream metadata endpoint collection

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream.erl
@@ -22,7 +22,10 @@
          host/0,
          tls_host/0,
          port/0,
-         tls_port/0]).
+         tls_port/0,
+         advertised_endpoint/1,
+         advertised_host/1,
+         advertised_port/1]).
 -export([stop/1]).
 -export([emit_connection_info_local/3,
          emit_connection_info_all/4,
@@ -46,6 +49,21 @@ start(_Type, _Args) ->
     rabbit_global_counters:init(#{protocol => stream,
                                   queue_type => ?STREAM_QUEUE_TYPE}),
     rabbit_stream_sup:start_link().
+
+%% Called on peer nodes to assemble metadata responses. host/0, tls_host/0,
+%% port/0 and tls_port/0 are called the same way by peers that predate this
+%% function, so they have to stay as they are.
+-spec advertised_endpoint(tcp | ssl) -> {Host, Port} when
+      Host :: binary(),
+      Port :: integer() | {error, term()}.
+advertised_endpoint(Transport) ->
+    {advertised_host(Transport), advertised_port(Transport)}.
+
+advertised_host(tcp) -> host();
+advertised_host(ssl) -> tls_host().
+
+advertised_port(tcp) -> port();
+advertised_port(ssl) -> tls_port().
 
 tls_host() ->
     case application:get_env(rabbitmq_stream, ?K_AD_TLS_HOST,

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -83,7 +83,6 @@
          peer_cert_validity]).
 -define(UNKNOWN_FIELD, unknown_field).
 -define(SILENT_CLOSE_DELAY, 3_000).
--define(METADATA_TIMEOUT, 10_000).
 -define(SAC_MOD, rabbit_stream_sac_coordinator).
 %% publisher_id and subscription_id are encoded as a single byte on the wire.
 -define(MAX_PUBLISHERS_PER_CONNECTION, 256).
@@ -1627,8 +1626,8 @@ handle_frame_pre_auth(Transport,
             ok ?= check_user_connection_limit(Username),
             ok ?= check_vhost_access(User, VirtualHost, S),
 
-            AdHost = advertised_host(TransportLayer),
-            AdPort = rabbit_data_coercion:to_binary(advertised_port(TransportLayer)),
+            AdHost = rabbit_stream:advertised_host(TransportLayer),
+            AdPort = rabbit_data_coercion:to_binary(rabbit_stream:advertised_port(TransportLayer)),
             ConnProps = #{<<"advertised_host">> => AdHost,
                           <<"advertised_port">> => AdPort},
 
@@ -2589,28 +2588,7 @@ handle_frame_post_auth(Transport,
                              =:= false
                      end,
                      Nodes0),
-        HostFun = advertised_host_fun(TransportLayer),
-        PortFun = advertised_port_fun(TransportLayer),
-
-        FetchFun = fun() -> {rabbit_stream:HostFun(), rabbit_stream:PortFun()} end,
-        Results = erpc:multicall(Nodes, FetchFun, ?METADATA_TIMEOUT),
-        NodeEndpoints =
-        lists:foldl(
-          fun({Node, {ok, {Host, Port}}}, Acc) when is_binary(Host), is_integer(Port) ->
-                  %% Happy path: Node responded in time with valid data
-                  Acc#{Node => {Host, Port}};
-             ({Node, {ok, {Host, Port}}}, Acc) ->
-                  %% Node responded, but data was malformed
-                  ?LOG_WARNING("Error when retrieving broker '~tp' metadata: ~tp ~tp",
-                               [Node, Host, Port]),
-                  Acc;
-             ({Node, Error}, Acc) ->
-                  %% Node timed out, was unreachable, or threw an exception
-                  ?LOG_WARNING("Error/Timeout when retrieving broker '~tp' metadata: ~tp",
-                               [Node, Error]),
-                  Acc
-          end,
-          #{}, lists:zip(Nodes, Results)),
+        NodeEndpoints = rabbit_stream_utils:node_endpoints(Nodes, TransportLayer),
 
         Metadata =
         lists:foldl(fun(Stream, Acc) ->
@@ -4441,24 +4419,6 @@ retry_sac_call(Call, N) ->
         R ->
             R
     end.
-
-advertised_host(Transport) ->
-    F = advertised_host_fun(Transport),
-    rabbit_stream:F().
-
-advertised_port(Transport) ->
-    F = advertised_port_fun(Transport),
-    rabbit_stream:F().
-
-advertised_host_fun(tcp) ->
-    host;
-advertised_host_fun(ssl) ->
-    tls_host.
-
-advertised_port_fun(tcp) ->
-    port;
-advertised_port_fun(ssl) ->
-    tls_port.
 
 check_node_connection_limit(undefined) ->
     ok;

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -18,6 +18,8 @@
 
 -define(MAX_SUPER_STREAM_PARTITIONS, 1000).
 
+-define(ENDPOINT_TIMEOUT, 10_000).
+
 %% Sub-entry compression types 0-4 are assigned (none, gzip, snappy, lz4, zstd);
 %% 5-7 are not, and a batch declaring one of them can never be decoded by a consumer.
 -define(MAX_KNOWN_COMPRESSION_TYPE, 4).
@@ -44,7 +46,8 @@
          offset_lag/4,
          consumer_offset/3,
          validate_super_stream_max_partitions/1,
-         max_super_stream_partitions/0]).
+         max_super_stream_partitions/0,
+         node_endpoints/2]).
 
 %% super stream partition helpers
 -export([streams_from_partitions/2,
@@ -53,7 +56,10 @@
          routing_keys/1]).
 
 %% for tests
--export([validate_super_stream_max_partitions/2]).
+-export([validate_super_stream_max_partitions/2,
+         node_endpoints/3,
+         classify_endpoint/3,
+         transient_endpoint_error/1]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbitmq_stream_common/include/rabbit_stream.hrl").
@@ -509,3 +515,125 @@ binding_keys(BindingKeysBin) ->
     [Trimmed || K <- Keys,
                 Trimmed <- [string:trim(K)],
                 Trimmed =/= <<>>].
+
+-spec node_endpoints([node()], tcp | ssl) -> #{node() => {binary(), integer()}}.
+node_endpoints(Nodes, Transport) ->
+    node_endpoints(Nodes, Transport, advertised_endpoint).
+
+node_endpoints([], _Transport, _Fun) ->
+    #{};
+node_endpoints(Nodes, Transport, Fun) ->
+    %% Absolute deadline, so that both phases and the receive loop of the
+    %% fallback share one budget.
+    Deadline = {abs, erlang:monotonic_time(millisecond) + ?ENDPOINT_TIMEOUT},
+    Results = erpc:multicall(Nodes, rabbit_stream, Fun, [Transport], Deadline),
+    Classify = fun(NodeResult, Acc) ->
+                       classify_endpoint(Fun, NodeResult, Acc)
+               end,
+    {Endpoints, Legacy} = lists:foldl(Classify, {#{}, []},
+                                      lists:zip(Nodes, Results)),
+    case Legacy of
+        [] ->
+            Endpoints;
+        _ ->
+            ?LOG_DEBUG("Nodes ~tp do not export rabbit_stream:~ts/1, "
+                       "retrieving host and port separately", [Legacy, Fun]),
+            Fallback = legacy_node_endpoints(Legacy, Transport, Deadline),
+            maps:merge(Endpoints, Fallback)
+    end.
+
+classify_endpoint(_Fun, {Node, {ok, {Host, Port}}}, {Endpoints, Legacy})
+  when is_binary(Host), is_integer(Port) ->
+    {Endpoints#{Node => {Host, Port}}, Legacy};
+%% The peer predates advertised_endpoint/1, or the stream plugin is not
+%% running there.
+classify_endpoint(Fun,
+                  {Node,
+                   {error, {exception, undef, [{rabbit_stream, Fun, _, _} | _]}}},
+                  {Endpoints, Legacy}) ->
+    {Endpoints, [Node | Legacy]};
+classify_endpoint(_Fun, {Node, Result}, {Endpoints, Legacy}) ->
+    log_unusable_endpoint(Node, Result),
+    {Endpoints, Legacy}.
+
+log_unusable_endpoint(Node, {ok, {Host, Port}}) ->
+    ?LOG_WARNING("Invalid stream endpoint reported by node '~ts': ~tp ~tp",
+                 [Node, Host, Port]);
+log_unusable_endpoint(Node, Result) ->
+    Level = case transient_endpoint_error(Result) of
+                true -> debug;
+                false -> warning
+            end,
+    ?LOG(Level, "Could not retrieve the endpoint of node '~ts': ~tp",
+         [Node, Result]).
+
+transient_endpoint_error({error, {erpc, timeout}}) ->
+    true;
+transient_endpoint_error({error, {erpc, noconnection}}) ->
+    true;
+%% The stream plugin is not running on that node.
+transient_endpoint_error({error, {exception, undef,
+                                  [{rabbit_stream, _, _, _} | _]}}) ->
+    true;
+transient_endpoint_error(_) ->
+    false.
+
+%% For peers that do not export rabbit_stream:advertised_endpoint/1. It can go
+%% away once every version an upgrade can start from exports it.
+%%
+%% Both requests of a node are sent before any of them is collected, so that a
+%% slow node does not use up the budget of the others.
+legacy_node_endpoints(Nodes, Transport, Deadline) ->
+    HostFun = legacy_host_fun(Transport),
+    PortFun = legacy_port_fun(Transport),
+    ReqIds = lists:foldl(
+               fun(Node, Acc0) ->
+                       Acc1 = erpc:send_request(Node, rabbit_stream, HostFun,
+                                                [], {Node, host}, Acc0),
+                       erpc:send_request(Node, rabbit_stream, PortFun,
+                                         [], {Node, port}, Acc1)
+               end, erpc:reqids_new(), Nodes),
+    Parts = receive_endpoint_parts(ReqIds, Deadline, #{}),
+    Endpoints = maps:filtermap(
+                  fun(_Node, #{host := H, port := P})
+                        when is_binary(H), is_integer(P) ->
+                          {true, {H, P}};
+                     (_Node, _Part) ->
+                          false
+                  end, Parts),
+    case Nodes -- maps:keys(Endpoints) of
+        [] ->
+            ok;
+        Missing ->
+            ?LOG_DEBUG("Could not retrieve the endpoint of nodes ~tp: ~tp",
+                       [Missing, maps:with(Missing, Parts)])
+    end,
+    Endpoints.
+
+receive_endpoint_parts(ReqIds, Deadline, Acc) ->
+    try erpc:receive_response(ReqIds, Deadline, true) of
+        no_request ->
+            Acc;
+        {Value, {Node, Key}, ReqIds1} ->
+            Acc1 = add_endpoint_part(Node, Key, Value, Acc),
+            receive_endpoint_parts(ReqIds1, Deadline, Acc1)
+    catch
+        error:{erpc, timeout} ->
+            %% receive_response/3 abandons the outstanding requests.
+            Acc;
+        _Class:{Reason, {Node, Key}, ReqIds1} ->
+            Acc1 = add_endpoint_part(Node, Key, {error, Reason}, Acc),
+            receive_endpoint_parts(ReqIds1, Deadline, Acc1)
+    end.
+
+add_endpoint_part(Node, Key, Value, Acc) ->
+    Part = maps:get(Node, Acc, #{}),
+    Acc#{Node => Part#{Key => Value}}.
+
+%% Only functions old peers export, hence not advertised_host/1 and
+%% advertised_port/1.
+legacy_host_fun(tcp) -> host;
+legacy_host_fun(ssl) -> tls_host.
+
+legacy_port_fun(tcp) -> port;
+legacy_port_fun(ssl) -> tls_port.

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -99,6 +99,7 @@ groups() ->
        sac_subscription_with_partition_index_conflict_should_return_error,
        test_metadata_with_advertised_hints,
        test_connection_properties_with_advertised_hints,
+       test_advertised_endpoint,
        test_resolve_offset_spec
       ]},
      %% Run `test_global_counters` on its own so the global metrics are
@@ -107,7 +108,7 @@ groups() ->
      {single_node_initial_frame_max, [],
       [oversized_frame_rejected_pre_auth_custom_initial_frame_max]},
      {cluster, [], [test_stream, test_stream_tls, test_metadata, java,
-                    test_resolve_offset_spec]}].
+                    test_resolve_offset_spec, node_endpoints_fallback]}].
 
 init_per_suite(Config) ->
     case rabbit_ct_helpers:is_mixed_versions() of
@@ -323,7 +324,8 @@ end_per_testcase(unauthorized_vhost_access_should_close_with_delay = TestCase, C
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(TestCase, Config)
   when TestCase =:= test_metadata_with_advertised_hints orelse
-       TestCase =:= test_connection_properties_with_advertised_hints ->
+       TestCase =:= test_connection_properties_with_advertised_hints orelse
+       TestCase =:= test_advertised_endpoint ->
     lists:foreach(fun(K) ->
                           ok = rpc(Config, 0,
                                    application,
@@ -831,6 +833,30 @@ test_metadata(Config) ->
               closed = wait_for_socket_close(Transport, S, 10)
       end, Transports),
 
+    ok.
+
+%% Forces the fallback path of rabbit_stream_utils:node_endpoints/3 by
+%% passing a function name no peer exports, so every node answers `undef`
+%% and is resolved through host/0, tls_host/0, port/0 and tls_port/0. This
+%% stands in for talking to a peer that predates advertised_endpoint/1,
+%% without needing a mixed-version cluster.
+node_endpoints_fallback(Config) ->
+    Nodes = [get_node_name(Config, N) || N <- lists:seq(0, 2)],
+    lists:foreach(
+      fun(Transport) ->
+              Endpoints = rpc(Config, 0, rabbit_stream_utils, node_endpoints,
+                              [Nodes, Transport]),
+              FallbackEndpoints = rpc(Config, 0, rabbit_stream_utils,
+                                      node_endpoints,
+                                      [Nodes, Transport,
+                                       no_such_endpoint_function]),
+              ?assertEqual(Endpoints, FallbackEndpoints),
+              ?assertEqual(lists:sort(Nodes), lists:sort(maps:keys(Endpoints))),
+              maps:foreach(fun(_Node, {Host, Port}) ->
+                                   ?assert(is_binary(Host)),
+                                   ?assert(is_integer(Port))
+                           end, Endpoints)
+      end, [tcp, ssl]),
     ok.
 
 test_gc_consumers(Config) ->
@@ -1986,6 +2012,38 @@ test_metadata_with_advertised_hints(Config) ->
               _ = test_close(Transport, S, C5),
               closed = wait_for_socket_close(Transport, S, 10)
       end, Transports),
+    ok.
+
+test_advertised_endpoint(Config) ->
+    lists:foreach(
+      fun(Transport) ->
+              {ExpectedHostFun, ExpectedPortFun, KH, KP} =
+                  case Transport of
+                      tcp -> {host, port, ?K_AD_HOST, ?K_AD_PORT};
+                      ssl -> {tls_host, tls_port, ?K_AD_TLS_HOST, ?K_AD_TLS_PORT}
+                  end,
+              AssertAgreement =
+                  fun() ->
+                          ExpectedHost = rpc(Config, 0, rabbit_stream,
+                                             ExpectedHostFun, []),
+                          ExpectedPort = rpc(Config, 0, rabbit_stream,
+                                             ExpectedPortFun, []),
+                          ?assertEqual({ExpectedHost, ExpectedPort},
+                                       rpc(Config, 0, rabbit_stream,
+                                          advertised_endpoint, [Transport]))
+                  end,
+
+              AssertAgreement(),
+
+              AdHost = rand:bytes(20),
+              AdPort = rand:uniform(65535),
+              rpc(Config, 0, application, set_env, [rabbitmq_stream, KH, AdHost]),
+              rpc(Config, 0, application, set_env, [rabbitmq_stream, KP, AdPort]),
+              AssertAgreement(),
+
+              rpc(Config, 0, application, set_env, [rabbitmq_stream, KH, undefined]),
+              rpc(Config, 0, application, set_env, [rabbitmq_stream, KP, undefined])
+      end, [tcp, ssl]),
     ok.
 
 test_connection_properties_with_advertised_hints(Config) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
@@ -36,7 +36,13 @@ groups() ->
        write_messages_sub_batch_unknown_compression_type_rejected,
        write_messages_sub_batch_empty_batch_with_compression_rejected,
        write_messages_sub_batch_high_compression_ratio_accepted,
-       write_messages_fail_fast_after_first_invalid_sub_batch]}].
+       write_messages_fail_fast_after_first_invalid_sub_batch,
+       classify_endpoint_valid_result,
+       classify_endpoint_invalid_result,
+       classify_endpoint_legacy_peer,
+       classify_endpoint_foreign_undef,
+       classify_endpoint_other_error,
+       transient_endpoint_error_classification]}].
 
 init_per_suite(Config) ->
     Config.
@@ -283,6 +289,78 @@ flush_one() ->
     after 100 ->
         no_message
     end.
+
+%%%===================================================================
+%%% node_endpoints/3 helpers
+%%%===================================================================
+
+classify_endpoint_valid_result(_Config) ->
+    ?assertEqual({#{node1 => {<<"host1">>, 5552}}, []},
+                 rabbit_stream_utils:classify_endpoint(
+                   advertised_endpoint,
+                   {node1, {ok, {<<"host1">>, 5552}}},
+                   {#{}, []})),
+    ok.
+
+classify_endpoint_invalid_result(_Config) ->
+    %% a malformed reply is neither added to the endpoints nor treated as a
+    %% legacy peer: it is only logged.
+    ?assertEqual({#{}, []},
+                 rabbit_stream_utils:classify_endpoint(
+                   advertised_endpoint,
+                   {node1, {ok, {<<"host1">>, {error, no_listener}}}},
+                   {#{}, []})),
+    ?assertEqual({#{}, []},
+                 rabbit_stream_utils:classify_endpoint(
+                   advertised_endpoint,
+                   {node1, {ok, {not_a_binary, 5552}}},
+                   {#{}, []})),
+    ok.
+
+classify_endpoint_legacy_peer(_Config) ->
+    Result = {error, {exception, undef,
+                      [{rabbit_stream, advertised_endpoint, [tcp], []}]}},
+    ?assertEqual({#{}, [node1]},
+                 rabbit_stream_utils:classify_endpoint(
+                   advertised_endpoint, {node1, Result}, {#{}, []})),
+    ok.
+
+classify_endpoint_foreign_undef(_Config) ->
+    %% undef raised deeper in the call, not at rabbit_stream:Fun/1 itself,
+    %% must not be mistaken for an old peer.
+    Result = {error, {exception, undef,
+                      [{some_other_module, some_fun, [], []}]}},
+    ?assertEqual({#{}, []},
+                 rabbit_stream_utils:classify_endpoint(
+                   advertised_endpoint, {node1, Result}, {#{}, []})),
+    Result2 = {error, {exception, undef,
+                       [{rabbit_stream, some_other_fun, [], []}]}},
+    ?assertEqual({#{}, []},
+                 rabbit_stream_utils:classify_endpoint(
+                   advertised_endpoint, {node1, Result2}, {#{}, []})),
+    ok.
+
+classify_endpoint_other_error(_Config) ->
+    [?assertEqual({#{}, []},
+                  rabbit_stream_utils:classify_endpoint(
+                    advertised_endpoint, {node1, Result}, {#{}, []}))
+     || Result <- [{error, {erpc, timeout}},
+                   {error, {erpc, noconnection}},
+                   {error, {exception, some_error, []}}]],
+    ok.
+
+transient_endpoint_error_classification(_Config) ->
+    [?assertEqual(true, rabbit_stream_utils:transient_endpoint_error(Result))
+     || Result <- [{error, {erpc, timeout}},
+                   {error, {erpc, noconnection}},
+                   {error, {exception, undef,
+                           [{rabbit_stream, advertised_endpoint, [tcp], []}]}}]],
+    [?assertEqual(false, rabbit_stream_utils:transient_endpoint_error(Result))
+     || Result <- [{error, {exception, error, []}},
+                   {error, {exception, undef,
+                           [{some_other_module, foo, [], []}]}},
+                   {error, some_other_reason}]],
+    ok.
 
 binding(Destination, Order) ->
     #binding{destination = #resource{name = Destination},


### PR DESCRIPTION
rabbit_stream_reader sent a local closure to peer nodes via erpc:multicall/3 to fetch each node's advertised host and port. A local closure is resolved against the peer's own copy of the defining module, so any difference introduced by a rolling upgrade makes the lookup fail with badfun, dropping the node from the metadata response.

Add rabbit_stream:advertised_endpoint/1, an MFA-safe replacement, and move the endpoint collection into rabbit_stream_utils:node_endpoints/2, with a fallback onto host/0, tls_host/0, port/0 and tls_port/0 for peers that predate the new function. Nodes that answer undef are retried through the fallback in a single wave; the erpc undef reply doubles as the capability probe, so no feature flag or version check is needed.