### PR TITLE
Shovel: look up non-built-in modules via `rabbit_registry`

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_definition.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_definition.erl
@@ -55,7 +55,7 @@ extract_source_info(Def0, ShovelVHost) ->
 -spec extract_source_info_for_index(Definition :: list() | map(), ShovelVHost :: vhost:name()) -> source_info().
 extract_source_info_for_index(Def0, ShovelVHost) ->
     Def = rabbit_data_coercion:to_proplist(Def0),
-    Protocol = rabbit_shovel_parameters:src_protocol(Def),
+    Protocol = builtin_src_protocol(Def),
     BaseInfo = #{protocol => Protocol, vhost => ShovelVHost},
     case Protocol of
         amqp10 ->
@@ -69,6 +69,16 @@ extract_source_info_for_index(Def0, ShovelVHost) ->
             end;
         _ ->
             extract_amqp091_local_source(Def, BaseInfo)
+    end.
+
+-spec builtin_src_protocol(list()) -> protocol().
+builtin_src_protocol(Def) ->
+    case pget(<<"src-protocol">>, Def) of
+        <<"amqp10">> -> amqp10;
+        amqp10       -> amqp10;
+        <<"local">>  -> local;
+        local        -> local;
+        _            -> amqp091
     end.
 
 %% Parse AMQP 1.0 address using RabbitMQ address scheme v2.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
@@ -184,11 +184,31 @@ protocols(Def) ->
     Dst = dest_protocol(Def),
     {Src, Dst}.
 
-registered_protocol_to_atom(Protocol) when is_atom(Protocol) -> Protocol;
-registered_protocol_to_atom(<<"amqp091">>)                  -> amqp091;
-registered_protocol_to_atom(<<"amqp10">>)                   -> amqp10;
-registered_protocol_to_atom(<<"local">>)                    -> local;
-registered_protocol_to_atom(_)                              -> amqp091.
+registered_protocol_to_atom(Protocol) when is_atom(Protocol) ->
+    Protocol;
+registered_protocol_to_atom(Protocol) when is_binary(Protocol) ->
+    case lookup_registered_protocol(Protocol) of
+        {ok, Registered}   -> Registered;
+        {error, not_found} -> builtin_protocol_to_atom(Protocol)
+    end;
+registered_protocol_to_atom(_) ->
+    amqp091.
+
+lookup_registered_protocol(Protocol) ->
+    try
+        Atom = binary_to_existing_atom(Protocol),
+        case rabbit_registry:lookup_module(shovel_protocol, Atom) of
+            {ok, _Mod}         -> {ok, Atom};
+            {error, not_found} -> {error, not_found}
+        end
+    catch
+        error:badarg -> {error, not_found}
+    end.
+
+builtin_protocol_to_atom(<<"amqp091">>) -> amqp091;
+builtin_protocol_to_atom(<<"amqp10">>)  -> amqp10;
+builtin_protocol_to_atom(<<"local">>)   -> local;
+builtin_protocol_to_atom(_)             -> amqp091.
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbitmq_shovel/test/dummy_shovel_protocol.erl
+++ b/deps/rabbitmq_shovel/test/dummy_shovel_protocol.erl
@@ -1,0 +1,100 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(dummy_shovel_protocol).
+
+-behaviour(rabbit_shovel_behaviour).
+
+-export([parse/2,
+         parse_source/1,
+         parse_dest/4,
+         validate_src/1,
+         validate_dest/1,
+         validate_src_funs/2,
+         validate_dest_funs/2,
+         connect_source/1,
+         connect_dest/1,
+         init_source/1,
+         init_dest/1,
+         source_uri/1,
+         dest_uri/1,
+         source_protocol/1,
+         dest_protocol/1,
+         source_endpoint/1,
+         dest_endpoint/1,
+         close_source/1,
+         close_dest/1,
+         handle_source/2,
+         handle_dest/2,
+         ack/3,
+         nack/3,
+         forward/3,
+         status/1,
+         pending_count/1]).
+
+parse(_Name, {_Part, Conf}) ->
+    maps:from_list([{module, ?MODULE}, {uris, []} | Conf]).
+
+parse_source(Def) ->
+    {#{module => ?MODULE,
+       uris => [],
+       dummy_target => rabbit_misc:pget(<<"src-dummy-target">>, Def)}, []}.
+
+parse_dest(_Name, _ClusterName, Def, _SourceHeaders) ->
+    #{module => ?MODULE,
+      uris => [],
+      dummy_target => rabbit_misc:pget(<<"dest-dummy-target">>, Def)}.
+
+validate_src(_Def) ->
+    [ok].
+
+validate_dest(_Def) ->
+    [ok].
+
+validate_src_funs(_Def, _User) ->
+    [{<<"src-dummy-target">>, fun rabbit_parameter_validation:binary/2, mandatory}].
+
+validate_dest_funs(_Def, _User) ->
+    [{<<"dest-dummy-target">>, fun rabbit_parameter_validation:binary/2, mandatory}].
+
+connect_source(State) -> State.
+
+connect_dest(State) -> State.
+
+init_source(State) -> State.
+
+init_dest(State) -> State.
+
+source_uri(_State) -> <<"dummy://">>.
+
+dest_uri(_State) -> <<"dummy://">>.
+
+source_protocol(_State) -> dummy.
+
+dest_protocol(_State) -> dummy.
+
+source_endpoint(_State) -> [].
+
+dest_endpoint(_State) -> [].
+
+close_source(_State) -> ok.
+
+close_dest(_State) -> ok.
+
+handle_source(_Msg, _State) -> not_handled.
+
+handle_dest(_Msg, _State) -> not_handled.
+
+ack(_Tag, _Multi, State) -> State.
+
+nack(_Tag, _Multi, State) -> State.
+
+forward(_Tag, _Msg, State) -> State.
+
+status(_State) -> running.
+
+pending_count(_State) -> 0.

--- a/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
@@ -21,7 +21,8 @@
 
 all() ->
     [
-      {group, tests}
+      {group, tests},
+      {group, registry}
     ].
 
 groups() ->
@@ -45,6 +46,9 @@ groups() ->
           test_protocols_explicit,
           test_protocols_mixed,
           test_protocols_with_maps
+        ]},
+      {registry, [], [
+          custom_registered_protocol
         ]}
     ].
 
@@ -410,6 +414,44 @@ validate_amqp10_with_a_map_0() ->
                                                 "my-shovel", Params, none),
         [] = validate_ok(Res),
         ok.
+
+custom_registered_protocol(Config) ->
+    rabbit_ct_broker_helpers:add_code_path_to_all_nodes(
+      Config, dummy_shovel_protocol),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, rabbit_registry, register,
+           [shovel_protocol, <<"dummy">>, dummy_shovel_protocol]),
+    try
+        ok = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE, custom_registered_protocol0, [])
+    after
+        ok = rabbit_ct_broker_helpers:rpc(
+               Config, 0, rabbit_registry, unregister,
+               [shovel_protocol, <<"dummy">>])
+    end.
+
+custom_registered_protocol0() ->
+    Params = [{<<"src-protocol">>, <<"dummy">>},
+              {<<"src-dummy-target">>, <<"a-src-target">>},
+              {<<"dest-protocol">>, <<"dummy">>},
+              {<<"dest-dummy-target">>, <<"a-dest-target">>}],
+
+    ?assertEqual(dummy, rabbit_shovel_parameters:src_protocol(Params)),
+    ?assertEqual(dummy, rabbit_shovel_parameters:dest_protocol(Params)),
+    ?assertEqual({dummy, dummy}, rabbit_shovel_parameters:protocols(Params)),
+
+    Res = rabbit_shovel_parameters:validate(<<"my-vhost">>, <<"shovel">>,
+                                            <<"my-shovel">>, Params, none),
+    [] = validate_ok(Res),
+
+    {ok, Parsed} = rabbit_shovel_parameters:parse({<<"my-vhost">>, <<"my-shovel">>},
+                                                  my_cluster, Params),
+    ?assertMatch(#{source := #{module := dummy_shovel_protocol,
+                               dummy_target := <<"a-src-target">>},
+                   dest := #{module := dummy_shovel_protocol,
+                             dummy_target := <<"a-dest-target">>}},
+                 Parsed),
+    ok.
 
 validate_ok([ok | T]) ->
     validate_ok(T);


### PR DESCRIPTION
But fall back to AMQP 0-9-1 for unknown [to the runtime, the atom table] atoms.

For shovel types provided by plugins this means "for modules that were not loaded".

Closes #17341.
