### PR TITLE
Fail the build on end_per_testcase/end_per_suite failures, not just testcase failures

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -237,16 +237,19 @@ define ct_master.erl
 	peer:call(Pid2, persistent_term, put, [rabbit_ct_tcp_port_base, 20000]),
 	peer:call(Pid3, persistent_term, put, [rabbit_ct_tcp_port_base, 24000]),
 	peer:call(Pid4, persistent_term, put, [rabbit_ct_tcp_port_base, 28000]),
-	[{[_], {ok, Results}}] = ct_master_fork:run("$1"),
+	[{[_], {ok, Results, EventFailed}}] = ct_master_fork:run("$1"),
 	peer:stop(Pid4),
 	peer:stop(Pid3),
 	peer:stop(Pid2),
 	peer:stop(Pid1),
-	lists:foldl(fun
-		({_, {_, 0, {_, 0}}}, Err) -> Err + 1;
-		(What, Peer) -> halt(Peer)
-	end, 1, Results),
-	halt(0)
+	NodeFailed = lists:any(fun
+		({_, {_, 0, {_, 0}}}) -> false;
+		(_) -> true
+	end, Results),
+	case NodeFailed orelse EventFailed =/= [] of
+		true -> halt(1);
+		false -> halt(0)
+	end
 endef
 
 PARALLEL_CT_SET_1_A = unit_definitions_import_https unit_rabbit_ssl unit_networking_ssl_options_overrides unit_cluster_formation_locking_mocks unit_cluster_formation_sort_nodes unit_collections unit_config_value_encryption unit_connection_tracking unit_amqp_reader unit_queue_decorator unit_stream_arg_validation unix_domain_socket vhost_tracing vhost_tracing_prop

--- a/deps/rabbit_common/mk/rabbitmq-early-plugin.mk
+++ b/deps/rabbit_common/mk/rabbitmq-early-plugin.mk
@@ -39,8 +39,23 @@ endif
 TEST_DEPS += cth_styledout
 dep_cth_styledout = git https://github.com/rabbitmq/cth_styledout.git master
 
+# Fails the build on an end_per_testcase/end_per_group/end_per_suite crash.
+CT_HOOKS += cth_fail_on_teardown_crash
+
 ifneq ($(strip $(CT_HOOKS)),)
-CT_OPTS += -ct_hooks $(CT_HOOKS)
+# `ct_run' expects multiple hooks as `Hook1 and Hook2', not `Hook1 Hook2':
+# the latter is parsed as `Hook1' with `Hook2' as its own init argument.
+CT_OPTS += -ct_hooks $(subst $(space),$(space)and$(space),$(strip $(CT_HOOKS)))
+endif
+
+ifeq ($(PROJECT),rabbit_common)
+# A normal TEST_DEPS entry would rebuild rabbit_common plainly (dropping
+# its -ifdef(TEST) exports), since rabbitmq_ct_helpers depends on it.
+# Compiled directly instead, just for rabbit_common.
+CTH_FAIL_ON_TEARDOWN_CRASH_DIR = $(DEPS_DIR)/rabbitmq_ct_helpers
+test-build::
+	$(verbose) mkdir -p $(CTH_FAIL_ON_TEARDOWN_CRASH_DIR)/ebin
+	$(verbose) cd $(CTH_FAIL_ON_TEARDOWN_CRASH_DIR)/src && erlc -o ../ebin cth_fail_on_teardown_crash.erl
 endif
 
 # We fetch a SECONDARY_DIST if SECONDARY_DIST_VSN is set and

--- a/deps/rabbitmq_ct_helpers/src/ct_master_fork.erl
+++ b/deps/rabbitmq_ct_helpers/src/ct_master_fork.erl
@@ -44,6 +44,11 @@
 %-doc "Filename of test spec to be executed.".
 -type test_spec() :: file:name_all().
 
+%-doc "Per-node run results, plus the test cases whose `tc_done' event
+%carried `{failed, Reason}'; unlike the per-node results, this covers cases
+%whose body passed but whose `end_per_testcase' failed.".
+-type run_result() :: {'ok', Finished :: [term()], Failed :: [term()]}.
+
 -record(state, {node_ctrl_pids=[],
 		logdirs=[],
 		results=[],
@@ -51,7 +56,7 @@
 		blocked=[]
 		}).
 
--export_type([test_spec/0]).
+-export_type([test_spec/0, run_result/0]).
 
 %-doc """
 %Tests are spawned on `Node` using `ct:run_test/1`
@@ -156,7 +161,7 @@ run_test(NodeOptsList) when is_list(NodeOptsList) ->
 %the nodes in `InclNodes`. Nodes in the `ExclNodes` list are excluded from the
 %test.
 %""".
--spec run(TestSpecs, AllowUserTerms, InclNodes, ExclNodes) -> [{Specs, 'ok'} | {'error', Reason}]
+-spec run(TestSpecs, AllowUserTerms, InclNodes, ExclNodes) -> [{Specs, run_result()} | {'error', Reason}]
               when TestSpecs :: TestSpec | [TestSpec] | [[TestSpec]],
                    TestSpec :: test_spec(),
                    AllowUserTerms :: boolean(),
@@ -201,7 +206,7 @@ run(TS,AllowUserTerms,InclNodes,ExclNodes) when is_list(InclNodes),
     run([TS],AllowUserTerms,InclNodes,ExclNodes).
 
 %-doc(#{equiv => run(TestSpecs, false, InclNodes, ExclNodes)}).
--spec run(TestSpecs, InclNodes, ExclNodes) -> [{Specs, 'ok'} | {'error', Reason}]
+-spec run(TestSpecs, InclNodes, ExclNodes) -> [{Specs, run_result()} | {'error', Reason}]
               when TestSpecs :: TestSpec | [TestSpec] | [[TestSpec]],
                    TestSpec :: test_spec(),
                    InclNodes :: [node()],
@@ -220,7 +225,7 @@ run(TestSpecs,InclNodes,ExclNodes) ->
 %Equivalent to [`run([TS], false, [], [])`](`run/4`) if
 %called with TS being string.
 %""".
--spec run(TestSpecs) -> [{Specs, 'ok'} | {'error', Reason}]
+-spec run(TestSpecs) -> [{Specs, run_result()} | {'error', Reason}]
               when TestSpecs :: TestSpec | [TestSpec] | [[TestSpec]],
                    TestSpec :: test_spec(),
                    Specs :: [file:filename_all()],
@@ -603,11 +608,13 @@ master_loop(#state{node_ctrl_pids=[],
     log(all,"Info","Updating log files",[]),
 
     %% Print the failed and auto skipped tests.
-    master_print_summary(),
+    #{failed := Failed} = master_print_summary(),
 
     ct_master_event_fork:stop(),
     ct_master_logs_fork:stop(),
-    {ok, Finished};
+    %% Teardown failures are not reflected in the per-node counters, so
+    %% callers must also check this list.
+    {ok, Finished, Failed};
 
 master_loop(State=#state{node_ctrl_pids=NodeCtrlPids,
 			 results=Results,
@@ -723,13 +730,13 @@ master_loop(State=#state{node_ctrl_pids=NodeCtrlPids,
     end.
 
 master_print_summary() ->
-    #{
+    Results = #{
         auto_skipped := AutoSkipped,
         failed := Failed
     } = ct_master_event_fork:get_results(),
     master_print_summary_for("Auto skipped test cases", AutoSkipped),
     master_print_summary_for("Failed test cases", Failed),
-    ok.
+    Results.
 
 master_print_summary_for(Title,List) ->
     _ = case List of

--- a/deps/rabbitmq_ct_helpers/src/cth_fail_on_teardown_crash.erl
+++ b/deps/rabbitmq_ct_helpers/src/cth_fail_on_teardown_crash.erl
@@ -1,0 +1,60 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% A Common Test hook. A crash in `end_per_testcase'/`end_per_group'/
+%% `end_per_suite' normally only shows up as a warning; the run is still
+%% reported as a pass.
+-module(cth_fail_on_teardown_crash).
+-moduledoc false.
+
+-export([id/1, init/2, terminate/1]).
+-export([post_end_per_testcase/4, post_end_per_group/4, post_end_per_suite/4]).
+
+id(_Opts) ->
+    ?MODULE.
+
+init(_Id, _Opts) ->
+    {ok, false}.
+
+%% A passing test case returns `ok' (or its `Config'); a crash in
+%% `end_per_testcase' comes back as `{failed, {_, end_per_testcase, _}}'.
+%% Returning `{fail, Return}' makes Common Test count the test case as
+%% failed.
+post_end_per_testcase(_TestcaseName, _Config, {failed, {_, end_per_testcase, _}} = Return, State) ->
+    {{fail, Return}, State};
+post_end_per_testcase(_TestcaseName, _Config, Return, State) ->
+    {Return, State}.
+
+%% `end_per_group'/`end_per_suite' are configuration functions, not test
+%% cases: unlike above, returning `{fail, Reason}' here does not affect
+%% `ct_run''s exit status. `terminate/1' is what fails the build for
+%% these two; this just records whether either one crashed.
+%%
+%% `Return' is only `{error, _}' here if `end_per_group' itself crashed.
+post_end_per_group(_GroupName, _Config, {error, _} = Return, _State) ->
+    {{fail, Return}, true};
+post_end_per_group(_GroupName, _Config, Return, State) ->
+    {Return, State}.
+
+post_end_per_suite(_SuiteName, _Config, {error, _} = Return, _State) ->
+    {{fail, Return}, true};
+post_end_per_suite(_SuiteName, _Config, Return, State) ->
+    {Return, State}.
+
+%% Runs once, after every suite's own `post_end_per_group'/
+%% `post_end_per_suite' above, but before Common Test regenerates the
+%% cross-run logs/index.html and logs/all_runs.html. Halting here leaves
+%% this run's own reports intact, at the cost of those two files not
+%% being updated with this run.
+terminate(false) ->
+    ok;
+terminate(true) ->
+    io:format(user,
+              "~nlogs/index.html and logs/all_runs.html will not be "
+              "updated with this run~n",
+              []),
+    halt(1).

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -94,16 +94,19 @@ define ct_master.erl
 	peer:call(Pid2, persistent_term, put, [rabbit_ct_tcp_port_base, 25000]),
 	peer:call(Pid3, persistent_term, put, [rabbit_ct_tcp_port_base, 27000]),
 	peer:call(Pid4, persistent_term, put, [rabbit_ct_tcp_port_base, 29000]),
-	[{[_], {ok, Results}}] = ct_master_fork:run("$1"),
+	[{[_], {ok, Results, EventFailed}}] = ct_master_fork:run("$1"),
 	peer:stop(Pid4),
 	peer:stop(Pid3),
 	peer:stop(Pid2),
 	peer:stop(Pid1),
-	lists:foldl(fun
-		({_, {_, 0, {_, 0}}}, Err) -> Err + 1;
-		(What, Peer) -> halt(Peer)
-	end, 1, Results),
-	halt(0)
+	NodeFailed = lists:any(fun
+		({_, {_, 0, {_, 0}}}) -> false;
+		(_) -> true
+	end, Results),
+	case NodeFailed orelse EventFailed =/= [] of
+		true -> halt(1);
+		false -> halt(0)
+	end
 endef
 
 PARALLEL_CT_SET_1_A = auth retainer federation disconnect_on_unauthorized

--- a/deps/rabbitmq_prelaunch/Makefile
+++ b/deps/rabbitmq_prelaunch/Makefile
@@ -4,9 +4,11 @@ PROJECT_VERSION = 4.0.0
 PROJECT_MOD = rabbit_prelaunch_app
 
 DEPS = rabbit_common cuttlefish osiris systemd
+TEST_DEPS = rabbitmq_ct_helpers
 
 PLT_APPS += runtime_tools eunit
 
+DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk
 
 include ../../rabbitmq-components.mk

--- a/deps/rabbitmq_top/Makefile
+++ b/deps/rabbitmq_top/Makefile
@@ -7,6 +7,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 DEPS = rabbit_common rabbit amqp_client rabbitmq_management
+TEST_DEPS = rabbitmq_ct_helpers
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk \


### PR DESCRIPTION
## Summary

Common Test reports a test case as passed if its body passed, even when `end_per_testcase`/`end_per_group`/`end_per_suite` subsequently crashes; that failure only shows up as a warning, and `ct_run`'s own exit status stays 0. Both the plain `ct-<suite>` targets and the parallel "master" runs (`ct_master_fork`, used by `deps/rabbit/Makefile` and `deps/rabbitmq_mqtt/Makefile` to fan suites out across peer nodes) have this gap, so a teardown crash can go unnoticed and the build still reports success.

- A new Common Test hook, `cth_fail_on_teardown_crash`:
  - `post_end_per_testcase/4`: a crash in `end_per_testcase` comes back as `Return = {failed, {_, end_per_testcase, _}}`; returning `{fail, Return}` makes Common Test count the test case itself as failed, which on its own fails the build via `ct_run`'s normal exit status.
  - `post_end_per_group/4` / `post_end_per_suite/4`: unlike test cases, returning `{fail, Reason}` here does *not* get reflected in `ct_run`'s exit status. So these two just record whether either one crashed.
  - `terminate/1`: called once, after every suite's own `post_end_per_group`/`post_end_per_suite` above but before Common Test regenerates the cross-run `logs/index.html`/`logs/all_runs.html`. If a crash was recorded, halts with a non-zero status here. The only cost is that those two cross-run index files won't be updated with this run — logged to the console when that happens.
  - Wired in via `CT_HOOKS`/`CT_OPTS` in `deps/rabbit_common/mk/rabbitmq-early-plugin.mk`, applying on CI too. Compiled directly with `erlc`.
- Parallel master runs (`ct_master_fork.erl`): `master_loop/1` returns the list of teardown-only failures collected from the event stream (previously computed but discarded after being printed), and the `ct_master.erl` snippets in `deps/rabbit/Makefile` and `deps/rabbitmq_mqtt/Makefile` fail the run if that list is non-empty, in addition to the existing per-node pass/fail counters.
- Crashes found during `end_per_suite`/`end_per_testcase` teardown should not be silently ignored: if a specific crash is known and acceptable, it should be added to the ignored-crashes list (e.g. via `rabbit_ct_broker_helpers`'s crash-matching), not left to slip through unnoticed because the build didn't fail.