### PR TITLE
CQ: Count each recovered shared message store reference once

### DIFF
--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -2189,12 +2189,14 @@ count_msg_refs(Gen, Seed, State = #msstate{ index_ets = IndexEts }) ->
         %% It can be removed once we no longer support converting from v1 data.
         {MsgId, 1, Next} ->
             index_update_ref_counter(IndexEts, MsgId, +1,
-                #msg_location{msg_id=MsgId, file=undefined, ref_count=1}),
+                #msg_location{msg_id=MsgId, file=undefined, ref_count=0}),
             count_msg_refs(Gen, Next, State);
         {MsgIds, Next} ->
+            %% ets:update_counter/4 applies the increment to a freshly
+            %% inserted default, so the default must start at 0.
             lists:foreach(fun(MsgId) ->
                 index_update_ref_counter(IndexEts, MsgId, +1,
-                    #msg_location{msg_id=MsgId, file=undefined, ref_count=1})
+                    #msg_location{msg_id=MsgId, file=undefined, ref_count=0})
             end, MsgIds),
             count_msg_refs(Gen, Next, State)
     end.

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -75,6 +75,7 @@ groups() ->
           msg_store_recovers_from_truncated_file_summary_dump,
           msg_store_recovers_from_truncated_index_dump,
           msg_store_dirty_recovery_dispatch_failure_does_not_hang,
+          msg_store_dirty_recovery_counts_each_reference_once,
           msg_store_recovers_torn_current_file,
           msg_store_recovers_from_corrupted_file,
           msg_store_recovers_from_corrupted_file_no_fd_leak,
@@ -1108,11 +1109,6 @@ msg_store_v1_compat1(_Config) ->
     GCPid = rabbit_msg_store:gc_pid(StorePid),
     Path = msg_store_file_path(?VHOST, ?PERSISTENT_MSG_STORE, "0.rdq"),
     SizeBeforeCompact = filelib:file_size(Path),
-    %% count_msg_refs registers refs via ets:update_counter/4, whose
-    %% Default already carries ref_count=1; on a fresh key the Increment
-    %% is added on top of that, so a message recovered this way starts
-    %% at ref_count=2 and needs two removes to be fully dereferenced.
-    {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId1}], MSCState7),
     {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId1}], MSCState7),
     timer:sleep(200),
     ok = rabbit_msg_store_gc:compact(GCPid, 0),
@@ -1129,7 +1125,6 @@ msg_store_v1_compat1(_Config) ->
 
     %% Removing the last legacy message empties the v1 file, which goes
     %% through delete_file's v1 dispatch and disappears entirely.
-    {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId2}], MSCState8),
     {ok, _} = rabbit_msg_store:remove([{make_ref(), MsgId2}], MSCState8),
     timer:sleep(500),
     {ok, Files2} = file:list_dir(Dir),
@@ -2025,6 +2020,54 @@ msg_store_v1_scan_failure_crashes_recovery1(_Config) ->
     false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
     MSCState0 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
     {{ok, LegacyMsg}, MSCState1} = rabbit_msg_store:read(MsgId, MSCState0),
+    ok = rabbit_msg_store:client_terminate(MSCState1),
+
+    restart_msg_store_empty(),
+    passed.
+
+%% Dirty recovery rebuilds ref_count from the queue indexes. A message
+%% referenced by N queues must come back with exactly N references, so
+%% that N removes bring it to zero and its file can be reclaimed; one
+%% reference too many leaks the message on disk for good.
+msg_store_dirty_recovery_counts_each_reference_once(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, msg_store_dirty_recovery_counts_each_reference_once1, [Config]).
+
+msg_store_dirty_recovery_counts_each_reference_once1(_Config) ->
+    restart_msg_store_empty(),
+    Ref0 = rabbit_guid:gen(),
+    {Cap0, MSCState0} = msg_store_client_init_capture(?PERSISTENT_MSG_STORE, Ref0),
+    MsgIdOnce = msg_id_bin(refcount_once),
+    MsgIdTwice = msg_id_bin(refcount_twice),
+    ok = rabbit_msg_store:write(1, MsgIdOnce, {payload, <<"referenced by one queue">>}, MSCState0),
+    ok = rabbit_msg_store:write(2, MsgIdTwice, {payload, <<"referenced by two queues">>}, MSCState0),
+    ok = on_disk_await(Cap0, [{1, MsgIdOnce}, {2, MsgIdTwice}]),
+    ok = rabbit_msg_store:client_terminate(MSCState0),
+    ok = on_disk_stop(Cap0),
+
+    ok = rabbit_variable_queue:stop_msg_store(?VHOST),
+    Dir = filename:join([rabbit_vhost:msg_store_dir_path(?VHOST), atom_to_list(?PERSISTENT_MSG_STORE)]),
+    ok = file:delete(filename:join(Dir, "clean.dot")),
+
+    %% The generator yields one msg_id per queue index entry, the way
+    %% rabbit_classic_queue_index_v2:queue_index_walker/1 does.
+    Ref = rabbit_guid:gen(),
+    Gen = fun
+        ([])  -> finished;
+        (Ids) -> {Ids, []}
+    end,
+    ok = rabbit_variable_queue:start_msg_store(?VHOST, [Ref],
+           {Gen, [MsgIdOnce, MsgIdTwice, MsgIdTwice]}),
+    false = rabbit_vhost_msg_store:successfully_recovered_state(?VHOST, ?PERSISTENT_MSG_STORE),
+
+    MSCState1 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
+    true = rabbit_msg_store:contains(MsgIdOnce, MSCState1),
+    true = rabbit_msg_store:contains(MsgIdTwice, MSCState1),
+    {ok, []} = rabbit_msg_store:remove([{1, MsgIdOnce}, {2, MsgIdTwice}], MSCState1),
+    false = rabbit_msg_store:contains(MsgIdOnce, MSCState1),
+    true = rabbit_msg_store:contains(MsgIdTwice, MSCState1),
+    {ok, []} = rabbit_msg_store:remove([{3, MsgIdTwice}], MSCState1),
+    false = rabbit_msg_store:contains(MsgIdTwice, MSCState1),
     ok = rabbit_msg_store:client_terminate(MSCState1),
 
     restart_msg_store_empty(),


### PR DESCRIPTION
## Proposed Changes

There was a bug in the CQ shared message store, the recovery process after an unclean shutdown counted every live message one too many, when it goes through every per-queue index to look for shared messages that are still referenced by any queue.

Bug introduced in commit 18acc01a47 included in 4.0.0

Details: `rabbit_msg_store:count_msg_refs/3` registers references with `ets:update_counter/4` and a default object carrying ref_count=1. The increment is applied to a freshly inserted default as well, so every message came out of dirty recovery with one reference too many. That reference was never released: after a crash, every message that was in the store at the time stayed on disk for good, with its index entry, once all queues had consumed it. Fan-out messages were affected the same way (N queues gave N+1 references).

Start the default at 0. Add a regression test, and make msg_store_v1_compat remove each message once, as its second remove of a zero-reference entry now crashes the store the way it would in production.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
