### PR TITLE
Pin dsaltares/fetch-gh-release-asset to a tagged release

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -56,7 +56,7 @@ jobs:
           https://cdn.jsdelivr.net/hex
 
     - name: MIXED CLUSTERS - FETCH SIGNING KEYS
-      uses: dsaltares/fetch-gh-release-asset@master
+      uses: dsaltares/fetch-gh-release-asset@1.1.2
       if: inputs.mixed_clusters
       with:
         repo: rabbitmq/signing-keys
@@ -64,7 +64,7 @@ jobs:
 
     - name: MIXED CLUSTERS - FETCH PREVIOUS VERSION
       id: fetch_secondary_dist
-      uses: dsaltares/fetch-gh-release-asset@master
+      uses: dsaltares/fetch-gh-release-asset@1.1.2
       if: inputs.mixed_clusters
       with:
         version: ${{ inputs.previous_version }}

--- a/.github/workflows/test-upgrades.yaml
+++ b/.github/workflows/test-upgrades.yaml
@@ -129,7 +129,7 @@ jobs:
             https://cdn.jsdelivr.net/hex
 
       - name: Download omq(1)
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@1.1.2
         with:
           repo: 'rabbitmq/omq'
           regex: true


### PR DESCRIPTION
## Summary
- `dsaltares/fetch-gh-release-asset` was referenced via the mutable `@master` branch ref in `test-make-target.yaml` and `test-upgrades.yaml`, letting the action's behavior change without review (TNZGOV-18215)
- Pin all three usages to the tagged release `1.1.2`
- Dependabot already tracks the `github-actions` ecosystem on `main` (`.github/dependabot.yaml`), so it will automatically pick up and open PRs to bump this pinned tag going forward — no dependabot config change was needed

## Test plan
- [ ] CI runs for `test-make-target.yaml` and `test-upgrades.yaml` workflows pass with the pinned action version