### PR TITLE
Fix incomplete case clause in SAC coordinator state_enter/2

### DIFF
--- a/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
@@ -1206,7 +1206,9 @@ state_enter(leader, #?MODULE{groups = Groups,
                     %% 10 seconds is arbitrary, nothing specific about the value
                     10_000;
              T when T > DisTimeout ->
-                 DisTimeout
+                 DisTimeout;
+             T ->
+                 T
          end,
          node_disconnected_timer_effect(P, Time)
      end || P := Ts <- maps:iterator(DisConns, ordered)];

--- a/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
@@ -2052,6 +2052,24 @@ state_enter_disconnected_timer_between_bounds_test(_) ->
     ?assert(Time >= 10_000 andalso Time =< 60_000),
     ok.
 
+state_enter_disconnected_timer_over_timeout_test(_) ->
+    N0 = node(),
+    P0 = new_process(N0),
+    P1 = new_process(N0),
+
+    Id0 = group_id(<<"sO">>),
+
+    DisconnectedTs = erlang:system_time(millisecond) - 90_000,
+    DisconnectedCsr = (csr(P1, {disconnected, waiting}))#consumer{ts = DisconnectedTs},
+
+    [MonNode, MonP0, MonP1, {timer, {sac, node_disconnected, #{connection_pid := P1}}, Time}] =
+        state_enter_leader(#{Id0 => grp([csr(P0), DisconnectedCsr])}),
+
+    ?assertEqual(mon_node_eff(N0), MonNode),
+    ?assertEqual(mon_proc_eff([P0, P1]), [MonP0, MonP1]),
+    ?assertEqual(60_000, Time),
+    ok.
+
 mon_node_eff(Nodes) when is_list(Nodes) ->
     lists:sort([mon_node_eff(N) || N <- Nodes]);
 mon_node_eff(N) ->

--- a/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
@@ -2030,6 +2030,28 @@ state_enter_test(_) ->
     stop_node(N2Pid),
     ok.
 
+%% a disconnected consumer that has been disconnected for longer than 10s
+%% but less than the disconnected timeout used to crash the case
+%% expression in state_enter/2 with a case_clause error
+state_enter_disconnected_timer_between_bounds_test(_) ->
+    N0 = node(),
+    P0 = new_process(N0),
+    P1 = new_process(N0),
+
+    Id0 = group_id(<<"sO">>),
+
+    Elapsed = 30_000,
+    DisconnectedTs = erlang:system_time(millisecond) - Elapsed,
+    DisconnectedCsr = (csr(P1, {disconnected, waiting}))#consumer{ts = DisconnectedTs},
+
+    [MonNode, MonP0, MonP1, {timer, {sac, node_disconnected, #{connection_pid := P1}}, Time}] =
+        state_enter_leader(#{Id0 => grp([csr(P0), DisconnectedCsr])}),
+
+    ?assertEqual(mon_node_eff(N0), MonNode),
+    ?assertEqual(mon_proc_eff([P0, P1]), [MonP0, MonP1]),
+    ?assert(Time >= 10_000 andalso Time =< 60_000),
+    ok.
+
 mon_node_eff(Nodes) when is_list(Nodes) ->
     lists:sort([mon_node_eff(N) || N <- Nodes]);
 mon_node_eff(N) ->


### PR DESCRIPTION
A disconnected consumer's elapsed disconnection time between 10 and 60 seconds (the default disconnected timeout) had no matching case clause, crashing the Ra state machine whenever a node became the new leader while such a consumer was present.

