### PR TITLE
Fix spurious connection_created events on failed STOMP logins

### DIFF
--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -444,10 +444,20 @@ process_connect(Implicit, Frame,
                             State)
               end,
               case {Res1, Implicit} of
+                  %% Success (Implicit)
+                  %% Update state without sending a CONNECTED frame
                   {{ok, _, StateN2}, implicit} ->
-                      self() ! connection_created, ok(StateN2);
-                  _ ->
-                      self() ! connection_created, Res1
+                      self() ! connection_created,
+                      ok(StateN2);
+                  %% Success (Explicit)
+                  %% Return the CONNECTED frame and update state
+                  {{ok, _, _}, _} ->
+                      self() ! connection_created,
+                      Res1;
+                  %% Failure (Authentication, quotas, etc.)
+                  %% Do NOT emit connection_created
+                  {ErrorRes, _} ->
+                      ErrorRes
               end
       end,
       State).

--- a/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
@@ -67,7 +67,14 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config)
   when Testcase == proxy_protocol_v1 orelse Testcase == proxy_protocol_v1_tls ->
     %% Restore default loopback restrictions
-    ok = set_loopback_users(Config, [<<"guest">>]);
+    ok = set_loopback_users(Config, [<<"guest">>]),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
+end_per_testcase(Testcase, Config)
+  when Testcase == loopback_user_via_non_loopback_proxy_is_rejected
+       orelse Testcase == loopback_user_via_local_proxy_is_accepted ->
+    %% Survives a linked exit, which would skip a `try ... after` in the test.
+    ok = set_loopback_users(Config, []),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
@@ -132,39 +139,54 @@ connection_name(Retries) ->
             connection_name(Retries - 1)
     end.
 
+connection_names() ->
+    [Name || {_Key, Values} <- ets:tab2list(connection_created),
+             {conn_name, Name} <- [lists:keyfind(conn_name, 1, Values)]].
+
+%% Regression guard: a rejected login must never register a
+%% `connection_created` entry.
+assert_no_connection_created(Config, Pattern) ->
+    rabbit_ct_helpers:consistently(
+      ?_assertNot(
+         lists:any(
+           fun(Name) -> match =:= re:run(Name, Pattern, [{capture, none}]) end,
+           rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, connection_names, []))),
+      200, 5).
+
 %% A loopback-only user must be evaluated against the PROXY source, not the
 %% immediate peer (the proxy connection itself).
 loopback_user_via_non_loopback_proxy_is_rejected(Config) ->
     ok = set_loopback_users(Config, [<<"guest">>]),
-    try
-        Command = connect_response_command(
-            Config, "PROXY TCP4 192.168.1.1 192.168.1.2 80 81\r\n"),
-        ?assertEqual(<<"ERROR">>, Command)
-    after
-        ok = set_loopback_users(Config, [])
-    end.
+    {Socket, Command} = connect_response(
+        Config, "PROXY TCP4 10.10.10.10 10.10.10.11 8080 8081\r\n"),
+    ?assertEqual(<<"ERROR">>, Command),
+    %% The socket stays open: closing it deletes any `connection_created`
+    %% entry, hiding the event this asserts the absence of.
+    ok = assert_no_connection_created(
+           Config, <<"^10.10.10.10:8080 -> 10.10.10.11:8081$">>),
+    gen_tcp:close(Socket).
 
 %% A LOCAL v2 header keeps the real (loopback) ends, so guest is accepted.
 loopback_user_via_local_proxy_is_accepted(Config) ->
     ok = set_loopback_users(Config, [<<"guest">>]),
-    try
-        Header = ranch_proxy_header:header(#{command => local, version => 2}),
-        Command = connect_response_command(Config, Header),
-        ?assertEqual(<<"CONNECTED">>, Command)
-    after
-        ok = set_loopback_users(Config, [])
-    end.
+    Header = ranch_proxy_header:header(#{command => local, version => 2}),
+    Command = connect_response_command(Config, Header),
+    ?assertEqual(<<"CONNECTED">>, Command).
 
 connect_response_command(Config, ProxyHeader) ->
+    {Socket, Command} = connect_response(Config, ProxyHeader),
+    gen_tcp:close(Socket),
+    Command.
+
+connect_response(Config, ProxyHeader) ->
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
     ok = inet:send(Socket, ProxyHeader),
     ok = inet:send(Socket, <<"CONNECT\nlogin:guest\npasscode:guest\n\n", 0>>),
     {ok, Response} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
-    gen_tcp:close(Socket),
     %% The reply is a single STOMP frame; its command is the leading line.
-    hd(binary:split(Response, <<"\n">>)).
+    {Socket, hd(binary:split(Response, <<"\n">>))}.
 
 set_loopback_users(Config, Users) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,

--- a/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
@@ -56,22 +56,32 @@ end_per_suite(Config) ->
 init_per_group(_, Config) -> Config.
 end_per_group(_, Config) -> Config.
 
+init_per_testcase(Testcase, Config)
+  when Testcase == proxy_protocol_v1 orelse Testcase == proxy_protocol_v1_tls ->
+    %% Allow guest from the spoofed 192.168.1.1 IP
+    ok = set_loopback_users(Config, []),
+    rabbit_ct_helpers:testcase_started(Config, Testcase);
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
+end_per_testcase(Testcase, Config)
+  when Testcase == proxy_protocol_v1 orelse Testcase == proxy_protocol_v1_tls ->
+    %% Restore default loopback restrictions
+    ok = set_loopback_users(Config, [<<"guest">>]);
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 proxy_protocol_v1(Config) ->
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
-        [binary, {active, false}, {packet, raw}]),
+                                   [binary, {active, false}, {packet, raw}]),
     ok = inet:send(Socket, "PROXY TCP4 192.168.1.1 192.168.1.2 80 81\r\n"),
     ok = inet:send(Socket, stomp_connect_frame()),
     {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
-        ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+                                                  ?MODULE, connection_name, []),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>,
+                   [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -341,8 +341,6 @@ websocket_info(login_timeout, State = #state{proc_state = ProcState}) ->
         _ ->
             {ok, State}
     end;
-websocket_info(login_timeout, State) ->
-    {ok, State};
 
 websocket_info(Msg, State) ->
     ?LOG_INFO("Web STOMP: unexpected message ~tp",

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -333,10 +333,14 @@ websocket_info(increase_max_frame_size, State) ->
         rabbitmq_stomp, max_frame_size, ?DEFAULT_MAX_FRAME_SIZE) + 4096,
     {[{set_options, #{max_frame_size => MaxFrameSize}}], State};
 
-websocket_info(login_timeout, State = #state{connection = C})
-  when C =:= none; C =:= undefined ->
-    ?LOG_ERROR("Web STOMP: closing connection (login timeout)"),
-    stop(State);
+websocket_info(login_timeout, State = #state{proc_state = ProcState}) ->
+    case rabbit_stomp_processor:info(user, ProcState) of
+        undefined ->
+            ?LOG_ERROR("Web STOMP: closing connection (login timeout)"),
+            stop(State);
+        _ ->
+            {ok, State}
+    end;
 websocket_info(login_timeout, State) ->
     {ok, State};
 

--- a/deps/rabbitmq_web_stomp/test/login_timeout_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/login_timeout_SUITE.erl
@@ -16,7 +16,8 @@ suite() ->
 
 all() ->
     [unauthenticated_connection_is_closed,
-     authenticated_connection_survives_timeout].
+     authenticated_connection_survives_timeout,
+     failed_login_connection_is_closed_by_timeout].
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
@@ -64,6 +65,17 @@ authenticated_connection_survives_timeout(Config) ->
     timer:sleep(600),
     ok = raw_send(WS, "DISCONNECT", []),
     {close, {1000, _}} = rfc6455_client:recv(WS),
+    ok.
+
+%% Bad credentials must not count as authenticated: the timeout still fires.
+failed_login_connection_is_closed_by_timeout(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    WS = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws", self()),
+    {ok, _} = rfc6455_client:open(WS),
+    ok = raw_send(WS, "CONNECT",
+                  [{"login", "guest"}, {"passcode", "wrong-passcode"}]),
+    {ok, _ErrorFrame} = rfc6455_client:recv(WS),
+    {close, _} = rfc6455_client:recv(WS, 5000),
     ok.
 
 raw_send(WS, Command, Headers) ->


### PR DESCRIPTION
Previously, `rabbit_stomp_processor:process_connect/3` unconditionally fired a `connection_created` event, even if the connection attempt was refused (e.g., due to invalid credentials, vhost limits, or loopback restrictions).

This caused two issues:
1. It bypassed the `login_timeout` guard in Web STOMP, as the handler prematurely assumed a fully established connection.
2. It polluted operator-visible connection metrics with unauthenticated clients.

This patch updates the processor to only emit the `connection_created` event when authentication succeeds and the CONNECTED state is actually reached.

Additionally, this updates `proxy_protocol_SUITE`. The `proxy_protocol_v1` and `proxy_protocol_v1_tls` tests were inadvertently relying on this bug: they attempted to log in as `guest` from a spoofed non-loopback IP, which fails auth but historically still emitted the event the tests were waiting for. These tests now explicitly temporarily clear loopback restrictions before running.