### PR TITLE
Make management property lookup resilient to duplicate keys and scalar values (Fixes #11886)

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -663,10 +663,14 @@ get_dotted_value0([Key | Keys], Item) ->
 pget_bin(Key, Map, Default) when is_map(Map) ->
     maps:get(Key, Map, Default);
 pget_bin(Key, List, Default) when is_list(List) ->
-    case lists:partition(fun ({K, _V}) -> a2b(K) =:= Key end, List) of
-        {[{_K, V}], _} -> V;
-        {[],        _} -> Default
-    end.
+    case lists:search(fun ({K, _V}) -> a2b(K) =:= Key;
+                          (_)       -> false
+                      end, List) of
+        {value, {_K, V}} -> V;
+        false            -> Default
+    end;
+pget_bin(_Key, _Other, Default) ->
+    Default.
 maybe_pagination(Item, false, ReqData) ->
     extract_column_items(Item, columns(ReqData));
 maybe_pagination([{items, Item} | T], true, ReqData) ->

--- a/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
@@ -25,7 +25,8 @@ groups() ->
                                    default_restrictions,
                                    path_prefix_test,
                                    regex_dos_test,
-                                   has_json_extension_test
+                                   has_json_extension_test,
+                                   sort_list_test
                                   ]},
      {sequential_tests, [], [
                               referrer_policy_header_set_when_configured,
@@ -183,3 +184,19 @@ fake_req() ->
         scheme       => <<"http">>,
         port         => 15672
     }.
+
+sort_list_test(_Config) ->
+    %% Duplicate keys in proplists (issue #11886)
+    Item1 = [{name, <<"b">>}, {consumers, 1}, {consumers, 10}],
+    Item2 = [{name, <<"a">>}, {consumers, 2}, {consumers, 20}],
+    ?assertEqual([Item1, Item2], rabbit_mgmt_util:sort_list([Item1, Item2], ["consumers"])),
+    %% First occurrence precedence matches JSON serialization
+    Item3 = [{name, <<"c">>}, {consumers, 0}, {consumers, 99}],
+    ?assertEqual([Item3, Item1, Item2], rabbit_mgmt_util:sort_list([Item1, Item2, Item3], ["consumers"])),
+    %% Dotted traversal into scalar values
+    ItemScalar = [{name, <<"d">>}, {messages, 10}],
+    ?assertEqual([ItemScalar], rabbit_mgmt_util:sort_list([ItemScalar], ["messages.rate"])),
+    %% Dotted traversal into lists of non-2-tuples
+    ItemList = [{name, <<"e">>}, {tags, [<<"tag1">>, <<"tag2">>]}],
+    ?assertEqual([ItemList], rabbit_mgmt_util:sort_list([ItemList], ["tags.foo"])),
+    ok.


### PR DESCRIPTION
### Problem

When querying the RabbitMQ Management HTTP API with sorting or pagination parameters (e.g. `/api/queues?sort=consumers`), Cowboy request handler processes could crash with an unhandled `{case_clause, ...}` exception, resulting in an HTTP 500 error (#11886).

The crash occurred in `rabbit_mgmt_util:pget_bin/3`:
```erlang
pget_bin(Key, List, Default) when is_list(List) ->
    case lists:partition(fun ({K, _V}) -> a2b(K) =:= Key end, List) of
        {[{_K, V}], _} -> V;
        {[],        _} -> Default
    end.
```
`lists:partition/2` strictly matched `{[{_K, V}], _}`. If an item'\''s property list contained duplicate keys (produced during node maintenance or stats aggregation across nodes), `lists:partition/2` returned multiple matches, failing the pattern match.

Additionally:
- Dotted sort keys traversing into scalar/primitive values (e.g. `?sort=messages.rate` where `messages` is an integer) crashed with `function_clause` in `pget_bin/3`.
- Dotted sort keys traversing into lists of non-2-tuples (e.g. `?sort=tags.foo` where `tags` is a list of binaries) crashed the predicate with `function_clause`.

### Solution

1. **Use `lists:search/2` in `pget_bin/3`**:
   - Stops immediately at the first matching key, eliminating unnecessary list allocations.
   - Preserves standard Erlang `proplists:get_value/3` precedence (first occurrence wins), matching `rabbit_mgmt_format:dedup_keys/1` behavior during JSON serialization.
2. **Defensive predicate**: Added `(_) -> false` to ignore non-2-tuple elements in lists.
3. **Fallback clause**: Added `pget_bin(_Key, _Other, Default) -> Default.` to gracefully return the default value when attempting to navigate into scalar values.
4. **Unit test coverage**: Added `sort_list_test/1` in `rabbit_mgmt_test_unit_SUITE` covering duplicate keys, first-occurrence precedence, scalar values, and non-tuple list elements.

Fixes #11886