### PR TITLE
Redact TLS/PSK secrets from ssl_opts in management API responses

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
@@ -343,14 +343,60 @@ format_mochiweb_option_list(C) ->
     [{K, format_mochiweb_option(K, V)} || {K, V} <- C].
 
 format_mochiweb_option(ssl_opts, V) ->
-    format_mochiweb_option_list(V);
+    format_mochiweb_option_list(redact_ssl_opts(V));
+format_mochiweb_option(_K, '...') ->
+    <<"...">>;
 format_mochiweb_option(_K, V) ->
     case io_lib:printable_unicode_list(V) of
         true  -> rabbit_data_coercion:to_utf8_binary(V);
         false -> rabbit_data_coercion:to_utf8_binary(rabbit_misc:format("~w", [V]))
     end.
 
+redact_ssl_opts([{K, _V} | Rest]) when K =:= cert;
+                                       K =:= certs_keys;
+                                       K =:= cacerts;
+                                       K =:= key;
+                                       K =:= password;
+                                       K =:= sni_hosts;
+                                       K =:= stateless_tickets_seed;
+                                       K =:= verify_fun;
+                                       K =:= user_lookup_fun ->
+    [{K, '...'} | redact_ssl_opts(Rest)];
+redact_ssl_opts([Opt | Rest]) ->
+    [Opt | redact_ssl_opts(Rest)];
+redact_ssl_opts([]) ->
+    [].
+
 %%--------------------------------------------------------------------
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+format_context_redacts_ssl_opts_secrets_test() ->
+    Context = {"/some/path", "some description",
+               [{port, 15671},
+                {ssl_opts, [{verify, verify_peer},
+                            {password, "hunter2"},
+                            {key, {'RSAPrivateKey', <<1, 2, 3>>}},
+                            {cert, <<4, 5, 6>>},
+                            {cacerts, [<<7, 8, 9>>]},
+                            {certs_keys, [#{}]},
+                            {sni_hosts, [{"other.example.com",
+                                          [{key, {'RSAPrivateKey', <<1, 2, 3>>}},
+                                           {cert, <<4, 5, 6>>}]}]},
+                            {stateless_tickets_seed, <<10, 11, 12>>},
+                            {verify_fun, {fun(_,_,_) -> {valid, ok} end,
+                                          <<"secretstate">>}},
+                            {user_lookup_fun, {fun(_,_,_) -> ok end,
+                                              #{<<"client1">> => <<"supersecretpsk">>}}}]}]},
+    Formatted = format_context(Context),
+    {ssl_opts, SslOpts} = lists:keyfind(ssl_opts, 1, Formatted),
+    ?assertEqual(<<"verify_peer">>, proplists:get_value(verify, SslOpts)),
+    [?assertEqual(<<"...">>, proplists:get_value(K, SslOpts))
+     || K <- [password, key, cert, cacerts, certs_keys, sni_hosts,
+              stateless_tickets_seed, verify_fun, user_lookup_fun]].
+
+-endif.
 
 init([]) ->
     {ok, Interval}   = application:get_env(rabbit, collect_statistics_interval),

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -341,6 +341,15 @@ format_socket_opts([{certs_keys, CertsKeys} | Tail], Acc) when is_list(CertsKeys
     CertsKeysMsg = rabbit_data_coercion:to_utf8_binary(
         io_lib:format("(~b certs_keys entries)", [length(CertsKeys)])),
     format_socket_opts(Tail, [{certs_keys, CertsKeysMsg} | Acc]);
+%% hide sensitive information
+format_socket_opts([{cert, _Value} | Tail], Acc) ->
+    format_socket_opts(Tail, [{cert, '...'} | Acc]);
+format_socket_opts([{key, _Value} | Tail], Acc) ->
+    format_socket_opts(Tail, [{key, '...'} | Acc]);
+format_socket_opts([{password, _Value} | Tail], Acc) ->
+    format_socket_opts(Tail, [{password, '...'} | Acc]);
+format_socket_opts([{stateless_tickets_seed, _Value} | Tail], Acc) ->
+    format_socket_opts(Tail, [{stateless_tickets_seed, '...'} | Acc]);
 %% we do not report SNI host details in the UI,
 %% so skip this option and avoid some recursive formatting
 %% complexity
@@ -663,3 +672,31 @@ parse_bool(V)           -> throw({error, {not_boolean, V}}).
 
 args_hash(Args) ->
     list_to_binary(rabbit_misc:base64url(<<(erlang:phash2(Args, 1 bsl 32)):32>>)).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+listener_redacts_ssl_opts_secrets_test() ->
+    Listener = #listener{node = node(), protocol = 'https',
+                         ip_address = {0,0,0,0}, port = 15671,
+                         opts = [{ssl_opts, [{verify, verify_peer},
+                                             {password, "hunter2"},
+                                             {key, {'RSAPrivateKey', <<1, 2, 3>>}},
+                                             {cert, <<4, 5, 6>>},
+                                             {sni_hosts, [{"other.example.com",
+                                                           [{key, {'RSAPrivateKey', <<1, 2, 3>>}}]}]},
+                                             {stateless_tickets_seed, <<10, 11, 12>>},
+                                             {verify_fun, {fun(_,_,_) -> {valid, ok} end,
+                                                           <<"secretstate">>}},
+                                             {user_lookup_fun, {fun(_,_,_) -> ok end,
+                                                               #{<<"client1">> => <<"supersecretpsk">>}}}]}]},
+    Formatted = listener(Listener),
+    {socket_opts, SocketOpts} = lists:keyfind(socket_opts, 1, Formatted),
+    {ssl_opts, SslOpts} = lists:keyfind(ssl_opts, 1, SocketOpts),
+    ?assertEqual(verify_peer, proplists:get_value(verify, SslOpts)),
+    [?assertEqual('...', proplists:get_value(K, SslOpts))
+     || K <- [password, key, cert, stateless_tickets_seed]],
+    [?assertEqual(undefined, proplists:get_value(K, SslOpts))
+     || K <- [sni_hosts, verify_fun, user_lookup_fun]].
+
+-endif.


### PR DESCRIPTION
Redact cert, key, cacerts, certs_keys, password, sni_hosts, stateless_tickets_seed, verify_fun and user_lookup_fun to the atom '...' before formatting, keeping the key so operators can still see that the option is configured. Mirrors the approach already used by ranch_acceptors_sup:hide_socket_opts/1 for the same class of option.
