### PR TITLE
#17313 by @gomoripeti: Force close a stuck TLS connection

### DIFF
--- a/deps/rabbit_common/Makefile
+++ b/deps/rabbit_common/Makefile
@@ -38,6 +38,9 @@ DEPS = ranch recon credentials_obfuscation
 
 -include development.pre.mk
 
+# Appended after the include because development.pre.mk resets TEST_DEPS.
+TEST_DEPS += meck
+
 DEP_EARLY_PLUGINS = $(PROJECT)/mk/rabbitmq-early-plugin.mk
 # We do not depend on rabbit therefore can't run the broker.
 DEP_PLUGINS = $(PROJECT)/mk/rabbitmq-build.mk \

--- a/deps/rabbit_common/Makefile
+++ b/deps/rabbit_common/Makefile
@@ -38,7 +38,7 @@ DEPS = ranch recon credentials_obfuscation
 
 -include development.pre.mk
 
-# Appended after the include because development.pre.mk resets TEST_DEPS.
+# Appended after the include because `development.pre.mk` resets `TEST_DEPS`.
 TEST_DEPS += meck
 
 DEP_EARLY_PLUGINS = $(PROJECT)/mk/rabbitmq-early-plugin.mk

--- a/deps/rabbit_common/src/rabbit_net.erl
+++ b/deps/rabbit_common/src/rabbit_net.erl
@@ -18,6 +18,10 @@
     hostname/0, getifaddrs/0, proxy_ssl_info/2,
     dist_info/0]).
 
+-ifdef(TEST).
+-export([fast_close/2]).
+-endif.
+
 %%---------------------------------------------------------------------------
 
 -export_type([socket/0, proxy_socket/0, ip_port/0, hostname/0]).
@@ -61,6 +65,7 @@
 -spec send(socket(), iodata()) -> ok_or_any_error().
 -spec close(socket()) -> ok_or_any_error().
 -spec fast_close(socket()) -> ok_or_any_error().
+-spec fast_close(socket(), timeout()) -> ok_or_any_error().
 -spec sockname(socket()) ->
           ok_val_or_error({inet:ip_address(), ip_port()} |
                           inet:returned_non_ip_address()).
@@ -178,12 +183,78 @@ send(Sock, Data) when is_port(Sock) -> gen_tcp:send(Sock, Data).
 close(Sock)      when ?IS_SSL(Sock) -> ssl:close(Sock);
 close(Sock)      when is_port(Sock) -> gen_tcp:close(Sock).
 
-fast_close(Sock) when ?IS_SSL(Sock) ->
-    _ = ssl:close(Sock, ?SSL_CLOSE_TIMEOUT),
-    ok;
-fast_close(Sock) when is_port(Sock) ->
+fast_close(Sock) ->
+    fast_close(Sock, ?SSL_CLOSE_TIMEOUT).
+
+%% ssl:close/2 does not bound the caller: internally it is a gen_statem:call/2
+%% with an infinite timeout, so a stuck TLS connection process (for example
+%% stuck in prim_inet:recv0/3 inside tls_gen_connection:close/4 when the peer
+%% never closes the transport) makes it hang forever. Run it in a separate
+%% process and, if it does not finish within Timeout, close the stuck TLS
+%% connection process's transport port, which makes the stuck operation return
+%% and unblocks the close.
+fast_close(Sock, Timeout) when ?IS_SSL(Sock) ->
+    {Pid, MRef} = spawn_monitor(fun () -> _ = ssl:close(Sock, Timeout) end),
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            ok
+    after Timeout ->
+        force_close_stuck_ssl_connections(Pid, MRef, Timeout)
+    end;
+fast_close(Sock, _Timeout) when is_port(Sock) ->
     try port_close(Sock) catch _:_ -> ok end,
     ok.
+
+force_close_stuck_ssl_connections(Pid, MRef, Timeout) ->
+    ConnPid = get_ssl_connection_pid(Pid),
+    _ = close_linked_ports(ConnPid),
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            ok
+    after Timeout ->
+        %% Last resort if closing the port did not unblock the ssl:close call.
+        _ = case ConnPid of
+                undefined -> ok;
+                _         -> exit(ConnPid, kill)
+            end,
+        erlang:demonitor(MRef, [flush]),
+        exit(Pid, kill),
+        ok
+    end.
+
+%% The spawned ssl:close/2 above blocks in a single gen_statem:call to the TLS
+%% connection process, so its caller monitors exactly that one process, which
+%% owns the transport socket port. This function avoids retrieving the
+%% connection PID and port from the version-specific sslsocket record.
+get_ssl_connection_pid(Pid) ->
+    case erlang:process_info(Pid, monitors) of
+        {monitors, Monitors} ->
+            case [ConnPid || {process, ConnPid} <- Monitors,
+                             has_linked_port(ConnPid)] of
+                [ConnPid] -> ConnPid;
+                []        -> undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+has_linked_port(Pid) ->
+    case erlang:process_info(Pid, links) of
+        {links, Links} -> lists:any(fun erlang:is_port/1, Links);
+        _              -> false
+    end.
+
+close_linked_ports(undefined) ->
+    ok;
+close_linked_ports(Pid) ->
+    case erlang:process_info(Pid, links) of
+        {links, Links} ->
+            _ = [try erlang:port_close(P) catch _:_ -> ok end
+                 || P <- Links, is_port(P)],
+            ok;
+        _ ->
+            ok
+    end.
 
 sockname(Sock)   when ?IS_SSL(Sock) -> ssl:sockname(Sock);
 sockname(Sock)   when is_port(Sock) -> inet:sockname(Sock).

--- a/deps/rabbit_common/src/rabbit_net.erl
+++ b/deps/rabbit_common/src/rabbit_net.erl
@@ -191,7 +191,10 @@ fast_close(Sock) ->
 %% Run it in a separate process; if it does not finish within `Timeout`, close
 %% the transport port, which makes the stuck `recv` return.
 fast_close(Sock, Timeout) when ?IS_SSL(Sock) ->
-    {Pid, MRef} = spawn_monitor(fun () -> _ = ssl:close(Sock, Timeout) end),
+    {Pid, MRef} = spawn_monitor(
+                    fun () ->
+                            try ssl:close(Sock, Timeout) catch exit:_ -> ok end
+                    end),
     receive
         {'DOWN', MRef, process, Pid, _} ->
             ok

--- a/deps/rabbit_common/src/rabbit_net.erl
+++ b/deps/rabbit_common/src/rabbit_net.erl
@@ -186,13 +186,10 @@ close(Sock)      when is_port(Sock) -> gen_tcp:close(Sock).
 fast_close(Sock) ->
     fast_close(Sock, ?SSL_CLOSE_TIMEOUT).
 
-%% ssl:close/2 does not bound the caller: internally it is a gen_statem:call/2
-%% with an infinite timeout, so a stuck TLS connection process (for example
-%% stuck in prim_inet:recv0/3 inside tls_gen_connection:close/4 when the peer
-%% never closes the transport) makes it hang forever. Run it in a separate
-%% process and, if it does not finish within Timeout, close the stuck TLS
-%% connection process's transport port, which makes the stuck operation return
-%% and unblocks the close.
+%% `ssl:close/2` calls the TLS connection process with an infinite timeout, so
+%% a connection stuck in `tls_gen_connection:close/4` hangs the caller forever.
+%% Run it in a separate process; if it does not finish within `Timeout`, close
+%% the transport port, which makes the stuck `recv` return.
 fast_close(Sock, Timeout) when ?IS_SSL(Sock) ->
     {Pid, MRef} = spawn_monitor(fun () -> _ = ssl:close(Sock, Timeout) end),
     receive
@@ -212,7 +209,7 @@ force_close_stuck_ssl_connections(Pid, MRef, Timeout) ->
         {'DOWN', MRef, process, Pid, _} ->
             ok
     after Timeout ->
-        %% Last resort if closing the port did not unblock the ssl:close call.
+        %% Last resort if closing the port did not unblock `ssl:close/2`.
         _ = case ConnPid of
                 undefined -> ok;
                 _         -> exit(ConnPid, kill)
@@ -222,10 +219,9 @@ force_close_stuck_ssl_connections(Pid, MRef, Timeout) ->
         ok
     end.
 
-%% The spawned ssl:close/2 above blocks in a single gen_statem:call to the TLS
-%% connection process, so its caller monitors exactly that one process, which
-%% owns the transport socket port. This function avoids retrieving the
-%% connection PID and port from the version-specific sslsocket record.
+%% The closer process blocks in one `gen_statem:call`, so it monitors exactly
+%% the TLS connection process, which owns the transport port. This avoids
+%% reading the version-specific `#sslsocket{}` record.
 get_ssl_connection_pid(Pid) ->
     case erlang:process_info(Pid, monitors) of
         {monitors, Monitors} ->

--- a/deps/rabbit_common/test/rabbit_net_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_net_SUITE.erl
@@ -1,0 +1,196 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_net_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+all() ->
+    [
+     fast_close_plain_port,
+     fast_close_healthy_tls,
+     fast_close_bounds_stuck_close,
+     fast_close_recovers_from_stuck_recv
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    PrivDir = ?config(priv_dir, Config),
+    CertFile = filename:join(PrivDir, "cert.pem"),
+    KeyFile = filename:join(PrivDir, "key.pem"),
+    Cmd = lists:flatten(
+            io_lib:format(
+              "openssl req -x509 -newkey rsa:2048 -keyout ~ts -out ~ts "
+              "-days 1 -nodes -subj /CN=localhost 2>/dev/null",
+              [KeyFile, CertFile])),
+    _ = os:cmd(Cmd),
+    case filelib:is_file(CertFile) andalso filelib:is_file(KeyFile) of
+        true  -> [{certfile, CertFile}, {keyfile, KeyFile} | Config];
+        false -> {skip, "openssl is required to generate test certificates"}
+    end.
+
+end_per_suite(Config) ->
+    Config.
+
+%% -------------------------------------------------------------------
+%% Test cases.
+%% -------------------------------------------------------------------
+
+%% A plain TCP socket is closed immediately.
+fast_close_plain_port(_Config) ->
+    {ok, L} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    {ok, Port} = inet:port(L),
+    {ok, _C} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 5000),
+    {ok, S} = gen_tcp:accept(L, 5000),
+    ?assertEqual(ok, rabbit_net:fast_close(S)),
+    ?assertEqual(undefined, erlang:port_info(S)),
+    ok = gen_tcp:close(L).
+
+%% A healthy TLS socket is closed promptly, without paying the timeout.
+fast_close_healthy_tls(Config) ->
+    {S, Client, _ConnPid} = new_tls_pair(Config, []),
+    T0 = erlang:monotonic_time(millisecond),
+    ?assertEqual(ok, rabbit_net:fast_close(S)),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    ?assert(Elapsed < 1000),
+    stop_client(Client),
+    ok.
+
+%% When the peer stops reading, ssl:close/2 parks (waiting on the stuck
+%% transport). This exercises the real ssl:close/2 path, without mocks:
+%% fast_close/2 must force the transport port closed and return within its bound,
+%% well under the several seconds ssl:close/2 would otherwise take.
+fast_close_bounds_stuck_close(Config) ->
+    SmallBuffers = [{sndbuf, 4096}, {recbuf, 4096}, {buffer, 4096},
+                    {high_watermark, 2048}, {low_watermark, 1024}],
+    {S, Client, _ConnPid} = new_tls_pair(Config, SmallBuffers),
+    %% The peer never reads; fill the pipe so the server's close will park.
+    FloodPid = spawn(fun () -> flood(S) end),
+    await_backpressure(FloodPid),
+    Timeout = 300,
+    T0 = erlang:monotonic_time(millisecond),
+    ?assertEqual(ok, rabbit_net:fast_close(S, Timeout)),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    ?assert(Elapsed >= Timeout - 100),
+    ?assert(Elapsed < 3000),
+    %% Kill the flood process in case it is still blocked in ssl:send, so it does
+    %% not leak into later test cases.
+    exit(FloodPid, kill),
+    stop_client(Client),
+    ok.
+
+%% Reproduce the "stuck port" Erlang VM bug: the recv in
+%% tls_gen_connection:close/4 never returns on its own (its timeout does not
+%% fire), and only returns once the transport port is closed. fast_close/2 must
+%% detect the stuck connection process, close its port, and return.
+fast_close_recovers_from_stuck_recv(Config) ->
+    {S, Client, ConnPid} = new_tls_pair(Config, []),
+    TransportPort = transport_port(ConnPid),
+    ok = meck:new(gen_tcp, [unstick, passthrough]),
+    try
+        %% close/4 calls Transport:recv(Socket, 0, Timeout); make that recv hang
+        %% until the port terminates (mimicking the stuck transport port).
+        ok = meck:expect(
+               gen_tcp, recv,
+               fun (Sock, 0, _Timeout) when Sock =:= TransportPort ->
+                       Ref = erlang:monitor(port, Sock),
+                       receive {'DOWN', Ref, port, Sock, _} -> {error, closed} end;
+                   (Sock, Length, Timeout) ->
+                       meck:passthrough([Sock, Length, Timeout])
+               end),
+        Timeout = 300,
+        T0 = erlang:monotonic_time(millisecond),
+        ?assertEqual(ok, rabbit_net:fast_close(S, Timeout)),
+        Elapsed = erlang:monotonic_time(millisecond) - T0,
+        %% The recv genuinely hung, so the forced path was taken (>= Timeout) and
+        %% it was bounded (< several seconds).
+        ?assert(Elapsed >= Timeout - 100),
+        ?assert(Elapsed < 3000),
+        %% The stuck recv was actually reached and intercepted.
+        ?assert(meck:num_calls(gen_tcp, recv, [TransportPort, 0, '_']) >= 1),
+        ?assertNot(erlang:is_process_alive(ConnPid))
+    after
+        meck:unload(gen_tcp)
+    end,
+    stop_client(Client),
+    ok.
+
+%% -------------------------------------------------------------------
+%% Helpers.
+%% -------------------------------------------------------------------
+
+new_tls_pair(Config, ExtraOpts) ->
+    CertFile = ?config(certfile, Config),
+    KeyFile = ?config(keyfile, Config),
+    {ok, L} = ssl:listen(0, [{certfile, CertFile}, {keyfile, KeyFile}, binary,
+                             {active, false}, {reuseaddr, true} | ExtraOpts]),
+    {ok, {_, Port}} = ssl:sockname(L),
+    Before = tls_server_connections(),
+    Parent = self(),
+    Client = spawn(fun () ->
+                           {ok, C} = ssl:connect(
+                                       "localhost", Port,
+                                       [binary, {active, false},
+                                        {verify, verify_none} | ExtraOpts], 5000),
+                           Parent ! {client_ready, self()},
+                           receive stop -> ssl:close(C) end
+                   end),
+    {ok, T} = ssl:transport_accept(L, 5000),
+    ok = ssl:close(L),
+    {ok, S} = ssl:handshake(T, 5000),
+    receive {client_ready, _} -> ok
+    after 5000 -> ct:fail(tls_client_did_not_connect)
+    end,
+    [ConnPid] = tls_server_connections() -- Before,
+    {S, Client, ConnPid}.
+
+stop_client(Client) ->
+    Client ! stop,
+    ok.
+
+flood(S) ->
+    case ssl:send(S, binary:copy(<<0>>, 4096)) of
+        ok     -> flood(S);
+        _Error -> ok
+    end.
+
+%% Wait until the flooding process stops making progress, i.e. it is blocked in
+%% ssl:send because the peer is not reading. Only then is the send actually
+%% stuck and the server's close will park.
+await_backpressure(Pid) ->
+    await_backpressure(Pid, reductions(Pid), 200).
+
+await_backpressure(_Pid, _Reds, 0) ->
+    ct:fail(backpressure_not_established);
+await_backpressure(Pid, Reds, N) ->
+    timer:sleep(20),
+    case reductions(Pid) of
+        Reds  -> ok;
+        Reds2 -> await_backpressure(Pid, Reds2, N - 1)
+    end.
+
+reductions(Pid) ->
+    case erlang:process_info(Pid, reductions) of
+        {reductions, R} -> R;
+        undefined       -> 0
+    end.
+
+tls_server_connections() ->
+    [P || P <- erlang:processes(),
+          case proc_lib:get_label(P) of
+              {tls, server, _}    -> true;
+              {tls, server, _, _} -> true;
+              _                   -> false
+          end].
+
+transport_port(ConnPid) ->
+    {links, Links} = erlang:process_info(ConnPid, links),
+    hd([P || P <- Links, is_port(P)]).

--- a/deps/rabbit_common/test/rabbit_net_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_net_SUITE.erl
@@ -39,6 +39,10 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
+end_per_testcase(_Testcase, Config) ->
+    catch meck:unload(gen_tcp),
+    Config.
+
 %% -------------------------------------------------------------------
 %% Test cases.
 %% -------------------------------------------------------------------
@@ -47,8 +51,8 @@ end_per_suite(Config) ->
 fast_close_plain_port(_Config) ->
     {ok, L} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
     {ok, Port} = inet:port(L),
-    {ok, _C} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 5000),
-    {ok, S} = gen_tcp:accept(L, 5000),
+    {ok, _C} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}], 30_000),
+    {ok, S} = gen_tcp:accept(L, 30_000),
     ?assertEqual(ok, rabbit_net:fast_close(S)),
     ?assertEqual(undefined, erlang:port_info(S)),
     ok = gen_tcp:close(L).
@@ -59,8 +63,8 @@ fast_close_healthy_tls(Config) ->
     T0 = erlang:monotonic_time(millisecond),
     ?assertEqual(ok, rabbit_net:fast_close(S)),
     Elapsed = erlang:monotonic_time(millisecond) - T0,
-    ?assert(Elapsed < 1000),
-    ?assertNot(erlang:is_process_alive(ConnPid)),
+    ?assert(Elapsed < 3000),
+    await_exit(ConnPid),
     stop_client(Client),
     ok.
 
@@ -90,7 +94,7 @@ fast_close_recovers_from_stuck_recv(Config) ->
         ?assert(Elapsed < 3000),
         %% The stuck `recv` was actually reached and intercepted.
         ?assert(meck:num_calls(gen_tcp, recv, [TransportPort, 0, '_']) >= 1),
-        ?assertNot(erlang:is_process_alive(ConnPid))
+        await_exit(ConnPid)
     after
         meck:unload(gen_tcp)
     end,
@@ -113,15 +117,15 @@ new_tls_pair(Config, ExtraOpts) ->
                            {ok, C} = ssl:connect(
                                        "localhost", Port,
                                        [binary, {active, false},
-                                        {verify, verify_none} | ExtraOpts], 5000),
+                                        {verify, verify_none} | ExtraOpts], 30_000),
                            Parent ! {client_ready, self()},
                            receive stop -> ssl:close(C) end
                    end),
-    {ok, T} = ssl:transport_accept(L, 5000),
+    {ok, T} = ssl:transport_accept(L, 30_000),
     ok = ssl:close(L),
-    {ok, S} = ssl:handshake(T, 5000),
+    {ok, S} = ssl:handshake(T, 30_000),
     receive {client_ready, _} -> ok
-    after 5000 -> ct:fail(tls_client_did_not_connect)
+    after 30_000 -> ct:fail(tls_client_did_not_connect)
     end,
     [ConnPid] = tls_server_connections() -- Before,
     {S, Client, ConnPid}.
@@ -129,6 +133,17 @@ new_tls_pair(Config, ExtraOpts) ->
 stop_client(Client) ->
     Client ! stop,
     ok.
+
+await_exit(Pid) ->
+    await_exit(Pid, 300).
+
+await_exit(Pid, 0) ->
+    ct:fail({still_alive, Pid});
+await_exit(Pid, N) ->
+    case erlang:is_process_alive(Pid) of
+        false -> ok;
+        true  -> timer:sleep(100), await_exit(Pid, N - 1)
+    end.
 
 tls_server_connections() ->
     [P || P <- erlang:processes(),

--- a/deps/rabbit_common/test/rabbit_net_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_net_SUITE.erl
@@ -17,7 +17,6 @@ all() ->
     [
      fast_close_plain_port,
      fast_close_healthy_tls,
-     fast_close_bounds_stuck_close,
      fast_close_recovers_from_stuck_recv
     ].
 
@@ -56,30 +55,12 @@ fast_close_plain_port(_Config) ->
 
 %% A healthy TLS socket is closed promptly, without paying the timeout.
 fast_close_healthy_tls(Config) ->
-    {S, Client, _ConnPid} = new_tls_pair(Config, []),
+    {S, Client, ConnPid} = new_tls_pair(Config, []),
     T0 = erlang:monotonic_time(millisecond),
     ?assertEqual(ok, rabbit_net:fast_close(S)),
     Elapsed = erlang:monotonic_time(millisecond) - T0,
     ?assert(Elapsed < 1000),
-    stop_client(Client),
-    ok.
-
-%% When the peer stops reading, the real `ssl:close/2` parks on the transport;
-%% `fast_close/2` must still return within its bound.
-fast_close_bounds_stuck_close(Config) ->
-    SmallBuffers = [{sndbuf, 4096}, {recbuf, 4096}, {buffer, 4096},
-                    {high_watermark, 2048}, {low_watermark, 1024}],
-    {S, Client, _ConnPid} = new_tls_pair(Config, SmallBuffers),
-    %% The peer never reads; fill the pipe so the server's close will park.
-    FloodPid = spawn(fun () -> flood(S) end),
-    await_backpressure(FloodPid),
-    Timeout = 300,
-    T0 = erlang:monotonic_time(millisecond),
-    ?assertEqual(ok, rabbit_net:fast_close(S, Timeout)),
-    Elapsed = erlang:monotonic_time(millisecond) - T0,
-    ?assert(Elapsed >= Timeout - 100),
-    ?assert(Elapsed < 3000),
-    exit(FloodPid, kill),
+    ?assertNot(erlang:is_process_alive(ConnPid)),
     stop_client(Client),
     ok.
 
@@ -148,32 +129,6 @@ new_tls_pair(Config, ExtraOpts) ->
 stop_client(Client) ->
     Client ! stop,
     ok.
-
-flood(S) ->
-    case ssl:send(S, binary:copy(<<0>>, 4096)) of
-        ok     -> flood(S);
-        _Error -> ok
-    end.
-
-%% Waits until the flood process stops accumulating reductions, that is, until
-%% it is blocked in `ssl:send/2` and the server's close will park.
-await_backpressure(Pid) ->
-    await_backpressure(Pid, reductions(Pid), 200).
-
-await_backpressure(_Pid, _Reds, 0) ->
-    ct:fail(backpressure_not_established);
-await_backpressure(Pid, Reds, N) ->
-    timer:sleep(20),
-    case reductions(Pid) of
-        Reds  -> ok;
-        Reds2 -> await_backpressure(Pid, Reds2, N - 1)
-    end.
-
-reductions(Pid) ->
-    case erlang:process_info(Pid, reductions) of
-        {reductions, R} -> R;
-        undefined       -> 0
-    end.
 
 tls_server_connections() ->
     [P || P <- erlang:processes(),

--- a/deps/rabbit_common/test/rabbit_net_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_net_SUITE.erl
@@ -64,10 +64,8 @@ fast_close_healthy_tls(Config) ->
     stop_client(Client),
     ok.
 
-%% When the peer stops reading, ssl:close/2 parks (waiting on the stuck
-%% transport). This exercises the real ssl:close/2 path, without mocks:
-%% fast_close/2 must force the transport port closed and return within its bound,
-%% well under the several seconds ssl:close/2 would otherwise take.
+%% When the peer stops reading, the real `ssl:close/2` parks on the transport;
+%% `fast_close/2` must still return within its bound.
 fast_close_bounds_stuck_close(Config) ->
     SmallBuffers = [{sndbuf, 4096}, {recbuf, 4096}, {buffer, 4096},
                     {high_watermark, 2048}, {low_watermark, 1024}],
@@ -81,23 +79,19 @@ fast_close_bounds_stuck_close(Config) ->
     Elapsed = erlang:monotonic_time(millisecond) - T0,
     ?assert(Elapsed >= Timeout - 100),
     ?assert(Elapsed < 3000),
-    %% Kill the flood process in case it is still blocked in ssl:send, so it does
-    %% not leak into later test cases.
     exit(FloodPid, kill),
     stop_client(Client),
     ok.
 
-%% Reproduce the "stuck port" Erlang VM bug: the recv in
-%% tls_gen_connection:close/4 never returns on its own (its timeout does not
-%% fire), and only returns once the transport port is closed. fast_close/2 must
-%% detect the stuck connection process, close its port, and return.
+%% Reproduces the stuck port VM bug: the `recv` in `tls_gen_connection:close/4`
+%% ignores its timeout and only returns once the transport port is closed.
 fast_close_recovers_from_stuck_recv(Config) ->
     {S, Client, ConnPid} = new_tls_pair(Config, []),
     TransportPort = transport_port(ConnPid),
     ok = meck:new(gen_tcp, [unstick, passthrough]),
     try
-        %% close/4 calls Transport:recv(Socket, 0, Timeout); make that recv hang
-        %% until the port terminates (mimicking the stuck transport port).
+        %% Hang the length 0 `recv` from `tls_gen_connection:close/4` until the
+        %% port terminates.
         ok = meck:expect(
                gen_tcp, recv,
                fun (Sock, 0, _Timeout) when Sock =:= TransportPort ->
@@ -110,11 +104,10 @@ fast_close_recovers_from_stuck_recv(Config) ->
         T0 = erlang:monotonic_time(millisecond),
         ?assertEqual(ok, rabbit_net:fast_close(S, Timeout)),
         Elapsed = erlang:monotonic_time(millisecond) - T0,
-        %% The recv genuinely hung, so the forced path was taken (>= Timeout) and
-        %% it was bounded (< several seconds).
+        %% The forced path was taken, and it stayed bounded.
         ?assert(Elapsed >= Timeout - 100),
         ?assert(Elapsed < 3000),
-        %% The stuck recv was actually reached and intercepted.
+        %% The stuck `recv` was actually reached and intercepted.
         ?assert(meck:num_calls(gen_tcp, recv, [TransportPort, 0, '_']) >= 1),
         ?assertNot(erlang:is_process_alive(ConnPid))
     after
@@ -162,9 +155,8 @@ flood(S) ->
         _Error -> ok
     end.
 
-%% Wait until the flooding process stops making progress, i.e. it is blocked in
-%% ssl:send because the peer is not reading. Only then is the send actually
-%% stuck and the server's close will park.
+%% Waits until the flood process stops accumulating reductions, that is, until
+%% it is blocked in `ssl:send/2` and the server's close will park.
 await_backpressure(Pid) ->
     await_backpressure(Pid, reductions(Pid), 200).
 

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1284,6 +1284,13 @@ close_sent(info, Msg, _StatemData) ->
     ?LOG_WARNING("Ignored unknown message ~tp in state ~ts",
                                   [Msg, ?FUNCTION_NAME]),
     keep_state_and_data;
+close_sent(cast, {queue_event, _, _}, _StatemData) ->
+    %% Ignore confirmations and offset notifications while closing.
+    keep_state_and_data;
+close_sent(cast, Msg, _StatemData) ->
+    ?LOG_WARNING("Ignored unknown cast ~tp in state ~ts",
+                                  [Msg, ?FUNCTION_NAME]),
+    keep_state_and_data;
 close_sent({call, From}, {info, _Items}, _StateData) ->
     %% must be a CLI call, returning no information
     {keep_state_and_data, {reply, From, []}}.

--- a/deps/rabbitmq_web_dispatch/test/system_SUITE.erl
+++ b/deps/rabbitmq_web_dispatch/test/system_SUITE.erl
@@ -118,6 +118,7 @@ parse_ip_test1(Port) ->
     ?assertEqual(
        1, length([ok || {"/parse_ip", _, _} <-
                             rabbit_web_dispatch_registry:list_all()])),
+    rabbit_web_dispatch_registry:remove(parse_ip),
     passed.
 
 


### PR DESCRIPTION
This is #17313 by @gomoripeti with a rebase on top of `main` and some tweaks from me: a minor simplification, less verbose, cryptic comments.

And a number of known test flake patterns fixed.