### PR TITLE
amqp_client: enhance frame size and boundary validation

### DIFF
--- a/deps/amqp_client/include/amqp_client_internal.hrl
+++ b/deps/amqp_client/include/amqp_client_internal.hrl
@@ -26,3 +26,8 @@
 
 -define(DIRECT_OPERATION_TIMEOUT,  120000).
 -define(CALL_TIMEOUT_DEVIATION,    10000).
+
+%% Frame size ceiling enforced by amqp_main_reader before frame_max is
+%% negotiated. It is the RabbitMQ default frame_max, comfortably above any
+%% realistic connection.start.
+-define(HANDSHAKE_FRAME_MAX, 131072).

--- a/deps/amqp_client/src/amqp_connection_type_sup.erl
+++ b/deps/amqp_client/src/amqp_connection_type_sup.erl
@@ -78,7 +78,7 @@ start_infrastructure_fun(Sup, Conn, network) ->
                 ok ->
                     case amqp_main_reader:post_init(Reader) of
                         ok ->
-                            {ok, ChMgr, Writer};
+                            {ok, ChMgr, Writer, Reader};
                         {error, Reason} ->
                             {error, Reason}
                     end;

--- a/deps/amqp_client/src/amqp_main_reader.erl
+++ b/deps/amqp_client/src/amqp_main_reader.erl
@@ -9,10 +9,11 @@
 -module(amqp_main_reader).
 
 -include("amqp_client_internal.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -behaviour(gen_server).
 
--export([start_link/5, post_init/1]).
+-export([start_link/5, post_init/1, set_frame_max/2]).
 -export([init/1, terminate/2, code_change/3, handle_call/3, handle_cast/2,
          handle_info/2]).
 
@@ -21,7 +22,8 @@
                 connection,
                 channels_manager,
                 astate,
-                message = none %% none | {Type, Channel, Length}
+                frame_max = ?HANDSHAKE_FRAME_MAX,
+                message = none %% none | {expecting_header, Buf} | {Type, Channel, Length, Buf}
                }).
 
 %%---------------------------------------------------------------------------
@@ -38,6 +40,18 @@ post_init(Reader) ->
     catch
       exit:{timeout, Timeout} ->
         {error, {timeout, Timeout}}
+    end.
+
+%% Synchronous: the caller sends connection.tune_ok right after, and the
+%% new limit must be in effect before the peer can send a post-negotiation
+%% frame. A dead reader means the connection is already failing, so the
+%% error is left for the caller's own socket error handling.
+set_frame_max(Reader, FrameMax) ->
+    try
+        gen_server:call(Reader, {set_frame_max, FrameMax},
+                        amqp_util:call_timeout())
+    catch
+        exit:{Reason, _} -> {error, Reason}
     end.
 
 %%---------------------------------------------------------------------------
@@ -65,6 +79,17 @@ handle_call(post_init, _From, State = #state{sock = Sock}) ->
         ok              -> {reply, ok, set_timeout(State)};
         {error, Reason} -> handle_error(Reason, State)
     end;
+%% A frame header buffered under the handshake ceiling was never checked
+%% against the negotiated limit, so it is checked here.
+handle_call({set_frame_max, FrameMax}, _From,
+            State0 = #state{message = {_Type, _Channel, Length, _Buf}})
+  when Length > FrameMax ->
+    State = State0#state{frame_max = FrameMax},
+    {stop, Reason, State1} = handle_error({frame_too_large, Length, FrameMax},
+                                          State),
+    {stop, Reason, ok, State1};
+handle_call({set_frame_max, FrameMax}, _From, State) ->
+    {reply, ok, State#state{frame_max = FrameMax}};
 handle_call(Call, From, State) ->
     {stop, {unexpected_call, Call, From}, State}.
 
@@ -87,6 +112,16 @@ handle_info({Tag, Sock, Reason}, State = #state{sock = Sock})
 handle_info({timeout, _TimerRef, idle_timeout}, State) ->
     handle_error(timeout, State).
 
+%% Length is the payload size, frame_max the size of the whole frame. The
+%% payload is compared to frame_max rather than to frame_max minus
+%% ?EMPTY_FRAME_SIZE so that the client tolerates the same 8-byte overshoot
+%% the server does (see ?FRAME_SIZE_FUDGE in rabbit_reader).
+handle_data(<<Type:8, _Channel:16, Length:32, _/binary>>,
+            #state{message = none, frame_max = FrameMax} = State)
+  when (Type =:= ?FRAME_METHOD orelse Type =:= ?FRAME_HEADER orelse
+        Type =:= ?FRAME_BODY orelse Type =:= ?FRAME_HEARTBEAT) andalso
+       Length > FrameMax ->
+    handle_error({frame_too_large, Length, FrameMax}, State);
 handle_data(<<Type:8, Channel:16, Length:32, Payload:Length/binary, ?FRAME_END,
               More/binary>>,
             #state{message = none} = State) when
@@ -95,6 +130,12 @@ handle_data(<<Type:8, Channel:16, Length:32, Payload:Length/binary, ?FRAME_END,
     %% Optimisation for the direct match
     handle_data(
       More, process_frame(Type, Channel, Payload, State#state{message = none}));
+handle_data(<<Type:8, _Channel:16, Length:32, _:Length/binary, EndMarker,
+              _/binary>>,
+            #state{message = none} = State) when
+      Type =:= ?FRAME_METHOD; Type =:= ?FRAME_HEADER;
+      Type =:= ?FRAME_BODY;   Type =:= ?FRAME_HEARTBEAT ->
+    handle_error({invalid_frame_end_marker, EndMarker}, State);
 handle_data(<<Type:8, Channel:16, Length:32, Data/binary>>,
             #state{message = none} = State) when
       Type =:= ?FRAME_METHOD; Type =:= ?FRAME_HEADER;
@@ -114,15 +155,15 @@ handle_data(Data, #state{message = {Type, Channel, L, OldData}} = State) ->
             handle_data(More,
                         process_frame(Type, Channel, Payload,
                                             State#state{message = none}));
+        <<_:L/binary, EndMarker, _/binary>> ->
+            handle_error({invalid_frame_end_marker, EndMarker}, State);
         NotEnough ->
             %% Read in more data from the socket
             {noreply, State#state{message = {Type, Channel, L, NotEnough}}}
     end;
 handle_data(Data,
             #state{message = {expecting_header, Old}} = State) ->
-    handle_data(<<Old/binary, Data/binary>>, State#state{message = none});
-handle_data(<<>>, State) ->
-    {noreply, State}.
+    handle_data(<<Old/binary, Data/binary>>, State#state{message = none}).
 
 %%---------------------------------------------------------------------------
 %% Internal plumbing
@@ -174,7 +215,23 @@ handle_error({refused, Version},  State = #state{connection = Conn}) ->
 handle_error({malformed_header, Version},  State = #state{connection = Conn}) ->
     Conn ! {malformed_header, Version},
     {noreply, State};
-handle_error(Reason, State = #state{connection = Conn}) ->
+handle_error({frame_too_large, Length, FrameMax} = Reason,
+             State = #state{connection = Conn}) ->
+    ?LOG_WARNING("AMQP 0-9-1 client connection ~tp: peer sent a frame with a "
+                 "payload of ~tp bytes, exceeding the frame_max limit of "
+                 "~tp bytes; closing the connection",
+                 [Conn, Length, FrameMax]),
+    handle_socket_error(Reason, State);
+handle_error({invalid_frame_end_marker, EndMarker} = Reason,
+             State = #state{connection = Conn}) ->
+    ?LOG_WARNING("AMQP 0-9-1 client connection ~tp: peer sent an invalid "
+                 "frame end marker ~tp; closing the connection",
+                 [Conn, EndMarker]),
+    handle_socket_error(Reason, State);
+handle_error(Reason, State) ->
+    handle_socket_error(Reason, State).
+
+handle_socket_error(Reason, State = #state{connection = Conn}) ->
     Conn ! {socket_error, Reason},
     %% The connection stops as a consequence; a second, abnormal exit
     %% reason here would only add redundant crash and supervisor reports.

--- a/deps/amqp_client/src/amqp_network_connection.erl
+++ b/deps/amqp_client/src/amqp_network_connection.erl
@@ -24,6 +24,7 @@
                 name,
                 heartbeat,
                 writer0,
+                main_reader,
                 frame_max,
                 type_sup,
                 closing_reason, %% undefined | Reason
@@ -208,8 +209,8 @@ handshake(AmqpParams, SIF, State0 = #state{sock = Sock}) ->
 
 start_infrastructure(SIF, State = #state{sock = Sock, name = Name}) ->
     case SIF(Sock, Name) of
-      {ok, ChMgr, Writer} ->
-        {ok, ChMgr, State#state{writer0 = Writer}};
+      {ok, ChMgr, Writer, Reader} ->
+        {ok, ChMgr, State#state{writer0 = Writer, main_reader = Reader}};
       {error, Reason} ->
         {error, Reason}
     end.
@@ -226,6 +227,8 @@ network_handshake(AmqpParams = #amqp_params_network{virtual_host = VHost},
             Err;
         Tune ->
             {TuneOk, ChannelMax, State1} = tune(Tune, AmqpParams, State0),
+            amqp_main_reader:set_frame_max(State1#state.main_reader,
+                                           State1#state.frame_max),
             do2(TuneOk, State1),
             do2(#'connection.open'{virtual_host = VHost}, State1),
             Params = {ServerProperties, ChannelMax, ChMgr, State1},

--- a/deps/amqp_client/test/system_SUITE.erl
+++ b/deps/amqp_client/test/system_SUITE.erl
@@ -102,6 +102,7 @@ groups() ->
               basic_get_ipv6_ssl,
               pub_and_close,
               channel_tune_negotiation,
+              frame_max_negotiation,
               shortstr_overflow_property,
               shortstr_overflow_field,
               command_invalid_over_channel0
@@ -661,6 +662,26 @@ large_content(Config) ->
         = amqp_channel:call(Channel, #'queue.declare'{durable = true}),
     F = list_to_binary([rand:uniform(256)-1 || _ <- lists:seq(1, 1000)]),
     Payload = list_to_binary([F || _ <- lists:seq(1, 1000)]),
+    Publish = #'basic.publish'{exchange = <<>>, routing_key = Q},
+    amqp_channel:call(Channel, Publish, #amqp_msg{payload = Payload}),
+    get_and_assert_equals(Channel, Q, Payload),
+    teardown(Connection, Channel).
+
+%% -------------------------------------------------------------------
+
+%% Checks that content larger than the negotiated frame_max still round
+%% trips, that is that the reader's frame_max enforcement does not reject
+%% the frames a real broker sends for it. Enforcement itself is covered by
+%% unit_SUITE.
+frame_max_negotiation(Config) ->
+    Params = ?config(amqp_client_conn_params, Config),
+    FrameMax = 8192,
+    {ok, Connection} = amqp_connection:start(
+                          Params#amqp_params_network{frame_max = FrameMax}),
+    {ok, Channel} = amqp_connection:open_channel(Connection),
+    #'queue.declare_ok'{queue = Q}
+        = amqp_channel:call(Channel, #'queue.declare'{exclusive = true}),
+    Payload = list_to_binary(lists:duplicate(FrameMax * 2, $a)),
     Publish = #'basic.publish'{exchange = <<>>, routing_key = Q},
     amqp_channel:call(Channel, Publish, #amqp_msg{payload = Payload}),
     get_and_assert_equals(Channel, Q, Payload),

--- a/deps/amqp_client/test/unit_SUITE.erl
+++ b/deps/amqp_client/test/unit_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -include("amqp_client.hrl").
+-include("amqp_client_internal.hrl").
 
 -compile(export_all).
 
@@ -21,7 +22,15 @@ all() ->
       amqp_uri_remove_credentials,
       uri_parser_accepts_string_and_binaries,
       route_destination_parsing,
-      rabbit_channel_build_topic_variable_map
+      rabbit_channel_build_topic_variable_map,
+      main_reader_rejects_oversized_frame,
+      main_reader_enforces_negotiated_frame_max,
+      main_reader_accepts_frame_at_frame_max,
+      main_reader_rejects_invalid_frame_end_marker,
+      main_reader_rejects_invalid_frame_end_marker_in_one_packet,
+      main_reader_rejects_buffered_frame_above_negotiated_frame_max,
+      main_reader_assembles_frame_split_across_packets,
+      connection_closed_on_frame_above_negotiated_frame_max
     ].
 
 %% -------------------------------------------------------------------
@@ -393,3 +402,197 @@ rabbit_channel_build_topic_variable_map(_Config) ->
         [{amqp_params, AmqpParams3}], <<"default">>, <<"guest">>
     )),
     ok.
+
+%% -------------------------------------------------------------------
+%% amqp_main_reader frame_max enforcement.
+%% -------------------------------------------------------------------
+
+main_reader_rejects_oversized_frame(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    ok = gen_tcp:send(ServerSock,
+                       <<?FRAME_METHOD:8, 0:16, 16#FFFFFFFF:32>>),
+    ?assertEqual({socket_error, {frame_too_large, 4294967295, ?HANDSHAKE_FRAME_MAX}},
+                 receive_reader_message()),
+    wait_for_death(Reader),
+    ok.
+
+main_reader_enforces_negotiated_frame_max(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    ok = amqp_main_reader:set_frame_max(Reader, 4096),
+    ok = gen_tcp:send(ServerSock, <<?FRAME_METHOD:8, 0:16, 8192:32>>),
+    ?assertEqual({socket_error, {frame_too_large, 8192, 4096}},
+                 receive_reader_message()),
+    wait_for_death(Reader),
+    ok.
+
+main_reader_accepts_frame_at_frame_max(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    FrameMax = 4096,
+    ok = amqp_main_reader:set_frame_max(Reader, FrameMax),
+    Payload = binary:copy(<<0>>, FrameMax),
+    Frame = <<?FRAME_BODY:8, 0:16, FrameMax:32, Payload/binary, ?FRAME_END>>,
+    <<Part1:100/binary, Part2/binary>> = Frame,
+    ok = gen_tcp:send(ServerSock, Part1),
+    timer:sleep(100),
+    ?assert(is_process_alive(Reader)),
+    ok = gen_tcp:send(ServerSock, Part2),
+    timer:sleep(100),
+    ?assert(is_process_alive(Reader)),
+    ok.
+
+main_reader_rejects_invalid_frame_end_marker(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    ok = gen_tcp:send(ServerSock, <<?FRAME_BODY:8, 0:16, 4:32>>),
+    timer:sleep(50),
+    ok = gen_tcp:send(ServerSock, <<0:32, 0:8>>),
+    ?assertEqual({socket_error, {invalid_frame_end_marker, 0}},
+                 receive_reader_message()),
+    wait_for_death(Reader),
+    ok.
+
+%% The frame is complete in a single packet, so it never goes through the
+%% partial frame buffer.
+main_reader_rejects_invalid_frame_end_marker_in_one_packet(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    ok = gen_tcp:send(ServerSock, <<?FRAME_BODY:8, 0:16, 4:32, 0:32, 0:8>>),
+    ?assertEqual({socket_error, {invalid_frame_end_marker, 0}},
+                 receive_reader_message()),
+    wait_for_death(Reader),
+    ok.
+
+%% A header buffered under the handshake ceiling is re-checked when the
+%% negotiated limit is applied.
+main_reader_rejects_buffered_frame_above_negotiated_frame_max(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    Length = ?HANDSHAKE_FRAME_MAX - 1,
+    ok = gen_tcp:send(ServerSock, <<?FRAME_BODY:8, 0:16, Length:32>>),
+    timer:sleep(50),
+    ok = amqp_main_reader:set_frame_max(Reader, 4096),
+    ?assertEqual({socket_error, {frame_too_large, Length, 4096}},
+                 receive_reader_message()),
+    wait_for_death(Reader),
+    ok.
+
+main_reader_assembles_frame_split_across_packets(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    Payload = <<"hello">>,
+    Frame = <<?FRAME_BODY:8, 0:16, (byte_size(Payload)):32, Payload/binary,
+              ?FRAME_END>>,
+    [Part1, Part2, Part3] = split_into_3(Frame),
+    ok = gen_tcp:send(ServerSock, Part1),
+    timer:sleep(50),
+    ok = gen_tcp:send(ServerSock, Part2),
+    timer:sleep(50),
+    ?assert(is_process_alive(Reader)),
+    ok = gen_tcp:send(ServerSock, Part3),
+    timer:sleep(50),
+    ?assert(is_process_alive(Reader)),
+    ok.
+
+%% End-to-end: drives a real amqp_connection against a peer that completes
+%% the handshake and then sends a frame above the negotiated frame_max but
+%% below the handshake ceiling, which only fails if the negotiated value
+%% reached the reader.
+connection_closed_on_frame_above_negotiated_frame_max(_Config) ->
+    FrameMax = 8192,
+    Length = FrameMax + 1,
+    ?assert(Length < ?HANDSHAKE_FRAME_MAX),
+    {ok, _} = application:ensure_all_started(amqp_client),
+    {ok, ListenSock} = gen_tcp:listen(0, [binary, {active, false},
+                                          {packet, raw}, {reuseaddr, true}]),
+    {ok, Port} = inet:port(ListenSock),
+    Server = spawn_link(fun () -> fake_broker(ListenSock, FrameMax) end),
+    {ok, Connection} = amqp_connection:start(
+                         #amqp_params_network{port = Port,
+                                              frame_max = FrameMax,
+                                              heartbeat = 0}),
+    Ref = erlang:monitor(process, Connection),
+    Server ! {send_oversized_frame, Length},
+    receive
+        {'DOWN', Ref, process, Connection, Reason} ->
+            ?assertEqual({shutdown, {socket_error,
+                                     {frame_too_large, Length, FrameMax}}},
+                         Reason)
+    after 5000 ->
+        exit({timeout, waiting_for_connection_to_close})
+    end,
+    unlink(Server),
+    exit(Server, shutdown),
+    gen_tcp:close(ListenSock),
+    ok.
+
+fake_broker(ListenSock, FrameMax) ->
+    {ok, Sock} = gen_tcp:accept(ListenSock, 5000),
+    {ok, <<"AMQP", 0, 0, 9, 1>>} = gen_tcp:recv(Sock, 8, 5000),
+    ok = send_method(Sock, #'connection.start'{
+                              version_major = 0,
+                              version_minor = 9,
+                              server_properties = [],
+                              mechanisms = <<"PLAIN">>,
+                              locales = <<"en_US">>}),
+    {?FRAME_METHOD, 0, _StartOk} = recv_frame(Sock),
+    ok = send_method(Sock, #'connection.tune'{channel_max = 0,
+                                              frame_max = FrameMax,
+                                              heartbeat = 0}),
+    {?FRAME_METHOD, 0, _TuneOk} = recv_frame(Sock),
+    {?FRAME_METHOD, 0, _Open} = recv_frame(Sock),
+    ok = send_method(Sock, #'connection.open_ok'{}),
+    receive
+        {send_oversized_frame, Length} ->
+            Payload = binary:copy(<<0>>, Length),
+            ok = gen_tcp:send(Sock, <<?FRAME_METHOD:8, 0:16, Length:32,
+                                      Payload/binary, ?FRAME_END>>)
+    after 5000 ->
+        exit({timeout, waiting_for_send_instruction})
+    end,
+    %% The socket stays open until the test kills this process, so that the
+    %% connection fails on the oversized frame and not on a closed socket.
+    timer:sleep(30000),
+    gen_tcp:close(Sock).
+
+send_method(Sock, Method) ->
+    gen_tcp:send(Sock, rabbit_binary_generator:build_simple_method_frame(
+                         0, Method)).
+
+recv_frame(Sock) ->
+    {ok, <<Type:8, Channel:16, Length:32>>} = gen_tcp:recv(Sock, 7, 5000),
+    {ok, <<Payload:Length/binary, ?FRAME_END>>} =
+        gen_tcp:recv(Sock, Length + 1, 5000),
+    {Type, Channel, Payload}.
+
+start_reader() ->
+    {ok, ListenSock} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(ListenSock),
+    {ok, ClientSock} = gen_tcp:connect("localhost", Port, [binary, {active, false}]),
+    {ok, ServerSock} = gen_tcp:accept(ListenSock),
+    gen_tcp:close(ListenSock),
+    {ok, AState} = rabbit_command_assembler:init(),
+    {ok, Reader} = amqp_main_reader:start_link(
+                     ClientSock, self(), self(), AState, <<"test">>),
+    %% Not interested in the link start_link establishes: the reader is
+    %% expected to stop abnormally in several of these tests.
+    unlink(Reader),
+    ok = rabbit_net:controlling_process(ClientSock, Reader),
+    ok = amqp_main_reader:post_init(Reader),
+    {Reader, ServerSock}.
+
+receive_reader_message() ->
+    receive
+        Msg -> Msg
+    after 5000 ->
+        exit(timeout)
+    end.
+
+wait_for_death(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Ref, process, Pid, _Reason} -> ok
+    after 5000 ->
+        exit({timeout, waiting_for_death, Pid})
+    end.
+
+split_into_3(Bin) ->
+    Third = byte_size(Bin) div 3,
+    <<Part1:Third/binary, Rest/binary>> = Bin,
+    <<Part2:Third/binary, Part3/binary>> = Rest,
+    [Part1, Part2, Part3].

--- a/deps/amqp_client/test/unit_SUITE.erl
+++ b/deps/amqp_client/test/unit_SUITE.erl
@@ -24,6 +24,7 @@ all() ->
       route_destination_parsing,
       rabbit_channel_build_topic_variable_map,
       main_reader_rejects_oversized_frame,
+      main_reader_rejects_oversized_frame_with_split_header,
       main_reader_enforces_negotiated_frame_max,
       main_reader_accepts_frame_at_frame_max,
       main_reader_rejects_invalid_frame_end_marker,
@@ -416,6 +417,19 @@ main_reader_rejects_oversized_frame(_Config) ->
     wait_for_death(Reader),
     ok.
 
+main_reader_rejects_oversized_frame_with_split_header(_Config) ->
+    {Reader, ServerSock} = start_reader(),
+    <<Part1:3/binary, Part2/binary>> = <<?FRAME_METHOD:8, 0:16, 16#FFFFFFFF:32>>,
+    ok = gen_tcp:send(ServerSock, Part1),
+    %% we cannot observe socket state, so yeah, a good ol' `timer:sleep/1` to
+    %% give the original chunk some time to be consumed and processed.
+    timer:sleep(100),
+    ok = gen_tcp:send(ServerSock, Part2),
+    ?assertEqual({socket_error, {frame_too_large, 4294967295, ?HANDSHAKE_FRAME_MAX}},
+                 receive_reader_message()),
+    wait_for_death(Reader),
+    ok.
+
 main_reader_enforces_negotiated_frame_max(_Config) ->
     {Reader, ServerSock} = start_reader(),
     ok = amqp_main_reader:set_frame_max(Reader, 4096),
@@ -434,16 +448,14 @@ main_reader_accepts_frame_at_frame_max(_Config) ->
     <<Part1:100/binary, Part2/binary>> = Frame,
     ok = gen_tcp:send(ServerSock, Part1),
     timer:sleep(100),
-    ?assert(is_process_alive(Reader)),
     ok = gen_tcp:send(ServerSock, Part2),
-    timer:sleep(100),
-    ?assert(is_process_alive(Reader)),
+    ?assertMatch({channel_exit, 0, _}, receive_reader_message()),
     ok.
 
 main_reader_rejects_invalid_frame_end_marker(_Config) ->
     {Reader, ServerSock} = start_reader(),
     ok = gen_tcp:send(ServerSock, <<?FRAME_BODY:8, 0:16, 4:32>>),
-    timer:sleep(50),
+    timer:sleep(100),
     ok = gen_tcp:send(ServerSock, <<0:32, 0:8>>),
     ?assertEqual({socket_error, {invalid_frame_end_marker, 0}},
                  receive_reader_message()),
@@ -466,7 +478,7 @@ main_reader_rejects_buffered_frame_above_negotiated_frame_max(_Config) ->
     {Reader, ServerSock} = start_reader(),
     Length = ?HANDSHAKE_FRAME_MAX - 1,
     ok = gen_tcp:send(ServerSock, <<?FRAME_BODY:8, 0:16, Length:32>>),
-    timer:sleep(50),
+    timer:sleep(100),
     ok = amqp_main_reader:set_frame_max(Reader, 4096),
     ?assertEqual({socket_error, {frame_too_large, Length, 4096}},
                  receive_reader_message()),
@@ -480,13 +492,11 @@ main_reader_assembles_frame_split_across_packets(_Config) ->
               ?FRAME_END>>,
     [Part1, Part2, Part3] = split_into_3(Frame),
     ok = gen_tcp:send(ServerSock, Part1),
-    timer:sleep(50),
+    timer:sleep(100),
     ok = gen_tcp:send(ServerSock, Part2),
-    timer:sleep(50),
-    ?assert(is_process_alive(Reader)),
+    timer:sleep(100),
     ok = gen_tcp:send(ServerSock, Part3),
-    timer:sleep(50),
-    ?assert(is_process_alive(Reader)),
+    ?assertMatch({channel_exit, 0, _}, receive_reader_message()),
     ok.
 
 %% End-to-end: drives a real amqp_connection against a peer that completes


### PR DESCRIPTION
Update the AMQP 0-9-1 client reader to strictly enforce frame_max limits and validate frame end markers earlier in the processing pipeline.

Previously, the client relied on broader protocol handling to manage incoming frame boundaries. This change introduces an early check in amqp_main_reader to reject oversized frames immediately upon reading the header, improving connection teardown behavior when encountering non-compliant streams.

Additionally, the reader now explicitly validates the frame end marker during payload accumulation to ensure strict protocol compliance.

Changes:
* Define a sensible default ceiling during the handshake phase.
* Pass the negotiated frame_max from the connection to the reader.
* Immediately reject inbound frames that exceed the negotiated limit.
* Log and close connections when an invalid frame end marker is detected.