### PR TITLE
Avoid sending internal error details to AMQP 1.0 clients

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -325,17 +325,14 @@ handle_session_exit(ChannelNum, SessionPid, Reason, State0) ->
             true ->
                 State;
             false ->
-                R = case Reason of
-                        {RealReason, Trace} ->
-                            error_frame(?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                        "Session error: ~tp~n~tp",
-                                        [RealReason, Trace]);
-                        _ ->
-                            error_frame(?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                        "Session error: ~tp",
-                                        [Reason])
-                    end,
-                handle_exception(State, ChannelNum, R)
+                Detail = case Reason of
+                             {RealReason, Trace} ->
+                                 rabbit_misc:format("Session error: ~tp~n~tp",
+                                                     [RealReason, Trace]);
+                             _ ->
+                                 rabbit_misc:format("Session error: ~tp", [Reason])
+                         end,
+                handle_exception(State, ChannelNum, internal_error_frame(), Detail)
         end,
     maybe_close(S).
 
@@ -358,14 +355,27 @@ error_frame(Condition, Fmt, Args) ->
     #'v1_0.error'{condition = Condition,
                   description = {utf8, Description}}.
 
+%% An error whose description is safe to send to the peer: it carries no
+%% internal reason or stacktrace. Callers that catch an internal error log
+%% the caught detail themselves via handle_exception/4.
+internal_error_frame() ->
+    #'v1_0.error'{condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
+                  description = {utf8, <<"internal error">>}}.
+
 %% "A valid frame header cannot be formed from the incoming byte stream." [2.8.16]
 framing_error(State, Channel, Fmt, Args) ->
     Error = error_frame(?V_1_0_CONNECTION_ERROR_FRAMING_ERROR, Fmt, Args),
     handle_exception(State, Channel, Error).
 
+handle_exception(State, Channel, Error = #'v1_0.error'{description = {utf8, Desc}}) ->
+    handle_exception(State, Channel, Error, Desc);
+handle_exception(State, Channel, Error) ->
+    handle_exception(State, Channel, Error, "").
+
 handle_exception(State = #v1{connection_state = CS}, _Channel,
                  Error = #'v1_0.error'{description =
-                                       {utf8, <<"Connection forced: ", Explanation/binary>>}})
+                                       {utf8, <<"Connection forced: ", Explanation/binary>>}},
+                 _Detail)
   when (?IS_RUNNING(State)) orelse CS =:= closing ->
     %% Only ever raised by terminate/2 when the connection is deliberately
     %% closed by an operator or by the broker itself (e.g. rabbitmqctl
@@ -376,18 +386,18 @@ handle_exception(State = #v1{connection_state = CS}, _Channel,
     %% rabbit_reader:log_hard_error/3.
     ?LOG_WARNING("Closing AMQP 1.0 connection ~tp: ~ts", [self(), Explanation]),
     close(Error, State);
-handle_exception(State = #v1{connection_state = closed}, Channel,
-                 #'v1_0.error'{description = {utf8, Desc}}) ->
-    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~tp",
-               [self(), closed, Channel, Desc]),
+handle_exception(State = #v1{connection_state = closed}, Channel, _Error, Detail) ->
+    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+               [self(), closed, Channel, Detail]),
     State;
-handle_exception(State = #v1{connection_state = CS}, Channel,
-                 Error = #'v1_0.error'{description = {utf8, Desc}})
+handle_exception(State = #v1{connection_state = CS}, Channel, Error, Detail)
   when (?IS_RUNNING(State)) orelse CS =:= closing ->
-    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~tp",
-               [self(), CS, Channel, Desc]),
+    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+               [self(), CS, Channel, Detail]),
     close(Error, State);
-handle_exception(State, _Channel, Error) ->
+handle_exception(State, Channel, Error, Detail) ->
+    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+               [self(), State#v1.connection_state, Channel, Detail]),
     silent_close_delay(),
     throw({handshake_error, State#v1.connection_state, Error}).
 
@@ -424,10 +434,8 @@ handle_frame(Mode, Channel, Body, State) ->
         _:Reason:Trace ->
             handle_exception(State,
                              Channel,
-                             error_frame(
-                               ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                               "Reader error: ~tp~n~tp",
-                               [Reason, Trace]))
+                             internal_error_frame(),
+                             rabbit_misc:format("Reader error: ~tp~n~tp", [Reason, Trace]))
     end.
 
 handle_frame0(amqp, Channel, _Body,
@@ -1105,15 +1113,15 @@ set_credential0(Cred,
                                             credential_timer = NewTimer}}
             catch _:Reason ->
                       Error = error_frame(?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
-                                          "access to vhost ~s failed for new credential: ~p",
-                                          [Vhost, Reason]),
-                      handle_exception(State, 0, Error)
+                                          "access to vhost '~ts' failed for new credential",
+                                          [Vhost]),
+                      handle_exception(State, 0, Error,
+                                        rabbit_misc:format("~tp", [Reason]))
             end;
         Err ->
             Error = error_frame(?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
-                                "credential update failed: ~p",
-                                [Err]),
-            handle_exception(State, 0, Error)
+                                "credential update failed", []),
+            handle_exception(State, 0, Error, rabbit_misc:format("~tp", [Err]))
     end.
 
 maybe_start_credential_expiry_timer(User) ->

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -395,9 +395,14 @@ handle_exception(State = #v1{connection_state = CS}, Channel, Error, Detail)
     ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
                [self(), CS, Channel, Detail]),
     close(Error, State);
-handle_exception(State, Channel, Error, Detail) ->
-    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
-               [self(), State#v1.connection_state, Channel, Detail]),
+handle_exception(State, Channel, Error = #'v1_0.error'{description = Desc}, Detail) ->
+    case Desc =:= {utf8, Detail} of
+        true ->
+            ok;
+        false ->
+            ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+                       [self(), State#v1.connection_state, Channel, Detail])
+    end,
     silent_close_delay(),
     throw({handshake_error, State#v1.connection_state, Error}).
 

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -597,11 +597,10 @@ handle_cast({frame_body, FrameBody},
           exit:#'v1_0.error'{} = Error ->
               log_error_and_close_session(Error, State0);
           _:Reason:Stacktrace ->
-              Description = unicode:characters_to_binary(
-                              lists:flatten(io_lib:format("~tp~n~tp", [Reason, Stacktrace]))),
               Err = #'v1_0.error'{condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                  description = {utf8, Description}},
-              log_error_and_close_session(Err, State0)
+                                  description = {utf8, <<"internal error">>}},
+              log_error_and_close_session(
+                Err, rabbit_misc:format("~tp~n~tp", [Reason, Stacktrace]), State0)
     end;
 handle_cast({queue_event, _, _} = QEvent, State0) ->
     try handle_queue_event(QEvent, State0) of
@@ -666,12 +665,15 @@ handle_cast({reset_authz, User}, #state{cfg = Cfg} = State0) ->
 handle_cast(shutdown, State) ->
     {stop, normal, State}.
 
+log_error_and_close_session(Error = #'v1_0.error'{description = {utf8, Desc}}, State) ->
+    log_error_and_close_session(Error, Desc, State).
+
 log_error_and_close_session(
-  Error, State = #state{cfg = #cfg{reader_pid = ReaderPid,
-                                   writer_pid = WriterPid,
-                                   channel_num = Ch}}) ->
-    ?LOG_WARNING("Closing session for connection ~p: ~tp",
-                 [ReaderPid, Error]),
+  Error, Detail, State = #state{cfg = #cfg{reader_pid = ReaderPid,
+                                           writer_pid = WriterPid,
+                                           channel_num = Ch}}) ->
+    ?LOG_WARNING("Closing session for connection ~p: ~ts",
+                 [ReaderPid, Detail]),
     rabbit_amqp_reader:notify_session_ending(ReaderPid, self(), Ch),
     ok = rabbit_amqp_writer:send_command_sync(
            WriterPid, Ch, #'v1_0.end'{error = Error}),

--- a/deps/rabbit/test/unit_amqp_reader_SUITE.erl
+++ b/deps/rabbit/test/unit_amqp_reader_SUITE.erl
@@ -8,6 +8,7 @@
 -module(unit_amqp_reader_SUITE).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit/include/rabbit_amqp_reader.hrl").
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
 
@@ -15,7 +16,8 @@
 
 all() ->
     [
-     {group, tests}
+     {group, tests},
+     {group, credential_tests}
     ].
 
 groups() ->
@@ -32,9 +34,28 @@ groups() ->
        empty_frame,
        empty_frame_with_extended_header,
        valid_frame_header,
-       close_frame_on_framing_error
+       close_frame_on_framing_error,
+       close_frame_on_internal_error,
+       close_frame_on_abnormal_session_exit
+      ]},
+     %% Run sequentially: each test case mocks the global rabbit_access_control module.
+     {credential_tests, [],
+      [
+       close_frame_on_credential_update_state_error,
+       close_frame_on_credential_check_vhost_access_error
       ]}
     ].
+
+init_per_group(credential_tests, Config) ->
+    ok = meck:new(rabbit_access_control, [no_link]),
+    Config;
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(credential_tests, _Config) ->
+    ok = meck:unload(rabbit_access_control);
+end_per_group(_Group, _Config) ->
+    ok.
 
 %% -------------------------------------------------------------------
 %% Test Cases
@@ -126,19 +147,98 @@ close_frame_on_framing_error(_Config) ->
 
     ?assertMatch(#v1{connection_state = closed},
                  rabbit_amqp_reader:handle_input(<<0:32, 2, 0, 0:16>>, State)),
-
-    {ok, <<Size:32, 2, 0, 0:16>>} = gen_tcp:recv(Client, 8, 5000),
-    {ok, Body} = gen_tcp:recv(Client, Size - 8, 5000),
-    {Described, _BytesParsed} = amqp10_binary_parser:parse(Body),
     ?assertMatch(
        #'v1_0.close'{
           error = #'v1_0.error'{
                      condition = ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR}},
-       amqp10_framing:decode(Described)),
+       receive_close(Client)),
 
     ok = gen_tcp:close(Client),
     ok = gen_tcp:close(Server),
     ok = gen_tcp:close(Listener),
+    passed.
+
+%% An unhandled exception while parsing a frame body must not leak the
+%% caught reason and stacktrace to the peer; the description must be the
+%% redacted, constant one.
+close_frame_on_internal_error(_Config) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listener),
+    State0 = (test_state())#v1{connection_state = running,
+                               callback = {frame_header, amqp},
+                               sock = Server},
+
+    %% Frame header for a 1-byte body carrying a type code that
+    %% amqp10_binary_parser:parse/1 does not support.
+    State1 = rabbit_amqp_reader:handle_input(<<9:32, 2, 0, 0:16>>, State0),
+    ?assertMatch(#v1{connection_state = closed},
+                 rabbit_amqp_reader:handle_input(<<255>>, State1)),
+    ?assertMatch(
+       #'v1_0.close'{
+          error = #'v1_0.error'{
+                     condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
+                     description = {utf8, <<"internal error">>}}},
+       receive_close(Client)),
+
+    ok = gen_tcp:close(Client),
+    ok = gen_tcp:close(Server),
+    ok = gen_tcp:close(Listener),
+    passed.
+
+%% An abnormal session exit must not leak the caught reason and stacktrace
+%% to the peer; the description must be the redacted, constant one.
+close_frame_on_abnormal_session_exit(_Config) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listener),
+    ChannelNum = 7,
+    SessionPid = spawn(fun() -> ok end),
+    State0 = (test_state())#v1{connection_state = running,
+                               sock = Server,
+                               tracked_channels = #{ChannelNum => SessionPid}},
+
+    ?assertMatch(#v1{connection_state = closed},
+                 rabbit_amqp_reader:handle_other(
+                   {{'DOWN', ChannelNum}, make_ref(), process, SessionPid,
+                    {some_internal_reason, [{some_module, some_fun, 0, []}]}},
+                   State0)),
+    ?assertMatch(#'v1_0.close'{
+                    error = #'v1_0.error'{
+                               condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
+                               description = {utf8, <<"internal error">>}}},
+                 receive_close(Client)),
+
+    ok = gen_tcp:close(Client),
+    ok = gen_tcp:close(Server),
+    ok = gen_tcp:close(Listener),
+    passed.
+
+%% A failure to apply a renewed credential (`update_state/2` returns an
+%% error) must not leak the returned reason to the peer.
+close_frame_on_credential_update_state_error(_Config) ->
+    ok = meck:expect(rabbit_access_control, update_state,
+                     fun(_User, _Cred) -> {error, invalid_credentials} end),
+    ?assertMatch(#'v1_0.error'{
+                    condition = ?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
+                    description = {utf8, <<"credential update failed">>}},
+                 assert_credential_update_closes(<<"new-token">>)),
+    passed.
+
+%% A failure to check vhost access with the renewed credential (an
+%% exception raised by `check_vhost_access/4`) must not leak the caught
+%% reason to the peer.
+close_frame_on_credential_check_vhost_access_error(_Config) ->
+    ok = meck:expect(rabbit_access_control, update_state,
+                     fun(User, _Cred) -> {ok, User} end),
+    ok = meck:expect(rabbit_access_control, check_vhost_access,
+                     fun(_User, _Vhost, _AuthzData, _Ctx) -> error(access_denied) end),
+    ?assertMatch(#'v1_0.error'{
+                    condition = ?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
+                    description = {utf8, <<"access to vhost 'test-vhost' failed for new credential">>}},
+                 assert_credential_update_closes(<<"new-token">>)),
     passed.
 
 %% -------------------------------------------------------------------
@@ -160,3 +260,34 @@ assert_framing_error(FrameHeader) ->
         #'v1_0.error'{condition = ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR}},
        rabbit_amqp_reader:handle_input(FrameHeader, test_state())),
     passed.
+
+%% Reads a `close` frame off Client and decodes its performative.
+receive_close(Client) ->
+    {ok, <<Size:32, 2, 0, 0:16>>} = gen_tcp:recv(Client, 8, 5000),
+    {ok, Body} = gen_tcp:recv(Client, Size - 8, 5000),
+    {Described, _BytesParsed} = amqp10_binary_parser:parse(Body),
+    #'v1_0.close'{} = amqp10_framing:decode(Described).
+
+%% Drives `handle_other({set_credential, Cred}, State)` on a running
+%% connection and returns the resulting close frame's error.
+assert_credential_update_closes(Cred) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listener),
+    State0 = (test_state())#v1{connection_state = running,
+                               sock = Server,
+                               connection = #v1_connection{
+                                              vhost = <<"test-vhost">>,
+                                              user = #user{username = <<"guest">>,
+                                                          tags = [],
+                                                          authz_backends = []}}},
+
+    ?assertMatch(#v1{connection_state = closed},
+                 rabbit_amqp_reader:handle_other({set_credential, Cred}, State0)),
+    #'v1_0.close'{error = Error} = receive_close(Client),
+
+    ok = gen_tcp:close(Client),
+    ok = gen_tcp:close(Server),
+    ok = gen_tcp:close(Listener),
+    Error.


### PR DESCRIPTION
Unhandled exceptions while processing a frame, and abnormal session exits, formatted the caught reason and stacktrace directly into the error description sent to the peer in the close/end performative. Replace that description with a constant and log the caught detail server-side instead, matching how the AMQP 0-9-1 reader already handles this. Also stop echoing the raw update_state/check_vhost_access error term when a credential update fails.
