### PR TITLE
Filter cross-vhost queue names out of quorum health checks

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
@@ -60,15 +60,7 @@ failure(Message, Qs, ReqData, Context) ->
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).
 
-%% Qs are #{binary() => any()} maps keyed by <<"virtual_host">>, not the
-%% atom-keyed proplists filter_vhost/3 expects, so tag and untag around it.
-%% Critical components (rabbit_stream_coordinator, rabbitmq_metadata) are
-%% cluster-wide, not vhost-scoped, and must pass through unfiltered rather
-%% than be dropped for everyone. They are marked with `type => process`
-%% (rabbit_upgrade_preparation:list_with_minimum_quorum_for_cli/0); vhost
-%% names are arbitrary binaries, so matching on the display-only
-%% virtual_host value of "(not applicable)" could be spoofed by a real
-%% vhost of that name.
+%% Critical components of type `process` are never filtered.
 filter_vhost(Qs, ReqData, Context) ->
     IsVhostScoped = fun(Q) -> maps:get(<<"type">>, Q) =/= process end,
     {VhostScoped, NotVhostScoped} = lists:partition(IsVhostScoped, Qs),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
@@ -38,16 +38,17 @@ to_json(ReqData, Context) ->
                 [] ->
                     rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
                 Qs when length(Qs) > 0 ->
-                    FilteredQs = filter_vhost(Qs, ReqData, Context),
-                    case FilteredQs of
-                        [] ->
-                            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
-                        _ ->
-                            Msg = <<"There are quorum queues that would lose their quorum if the target node is shut down">>,
-                            failure(Msg, FilteredQs, ReqData, Context)
-                    end
+                    reply_for_quorum_critical_queues(
+                      filter_vhost(Qs, ReqData, Context), ReqData, Context)
             end
     end.
+
+reply_for_quorum_critical_queues([], ReqData, Context) ->
+    rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+reply_for_quorum_critical_queues(Qs, ReqData, Context) ->
+    Msg = <<"There are quorum queues that would lose their "
+            "quorum if the target node is shut down">>,
+    failure(Msg, Qs, ReqData, Context).
 
 failure(Message, Qs, ReqData, Context) ->
     Body = #{status => failed,
@@ -65,8 +66,10 @@ is_authorized(ReqData, Context) ->
 %% cluster-wide, not vhost-scoped: their virtual_host is "(not applicable)"
 %% and they must pass through unfiltered rather than be dropped for everyone.
 filter_vhost(Qs, ReqData, Context) ->
-    {NotVhostScoped, VhostScoped} =
-        lists:partition(fun(Q) -> maps:get(<<"virtual_host">>, Q) =:= <<"(not applicable)">> end, Qs),
-    Tagged = [maps:put(vhost, maps:get(<<"virtual_host">>, Q), Q) || Q <- VhostScoped],
-    Filtered = [maps:remove(vhost, Q) || Q <- rabbit_mgmt_util:filter_vhost(Tagged, ReqData, Context)],
-    NotVhostScoped ++ Filtered.
+    IsVhostScoped =
+        fun(Q) -> maps:get(<<"virtual_host">>, Q) =/= <<"(not applicable)">> end,
+    {VhostScoped, NotVhostScoped} = lists:partition(IsVhostScoped, Qs),
+    Tagged = [maps:put(vhost, maps:get(<<"virtual_host">>, Q), Q)
+              || Q <- VhostScoped],
+    Filtered = rabbit_mgmt_util:filter_vhost(Tagged, ReqData, Context),
+    NotVhostScoped ++ [maps:remove(vhost, Q) || Q <- Filtered].

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
@@ -63,11 +63,14 @@ is_authorized(ReqData, Context) ->
 %% Qs are #{binary() => any()} maps keyed by <<"virtual_host">>, not the
 %% atom-keyed proplists filter_vhost/3 expects, so tag and untag around it.
 %% Critical components (rabbit_stream_coordinator, rabbitmq_metadata) are
-%% cluster-wide, not vhost-scoped: their virtual_host is "(not applicable)"
-%% and they must pass through unfiltered rather than be dropped for everyone.
+%% cluster-wide, not vhost-scoped, and must pass through unfiltered rather
+%% than be dropped for everyone. They are marked with `type => process`
+%% (rabbit_upgrade_preparation:list_with_minimum_quorum_for_cli/0); vhost
+%% names are arbitrary binaries, so matching on the display-only
+%% virtual_host value of "(not applicable)" could be spoofed by a real
+%% vhost of that name.
 filter_vhost(Qs, ReqData, Context) ->
-    IsVhostScoped =
-        fun(Q) -> maps:get(<<"virtual_host">>, Q) =/= <<"(not applicable)">> end,
+    IsVhostScoped = fun(Q) -> maps:get(<<"type">>, Q) =/= process end,
     {VhostScoped, NotVhostScoped} = lists:partition(IsVhostScoped, Qs),
     Tagged = [maps:put(vhost, maps:get(<<"virtual_host">>, Q), Q)
               || Q <- VhostScoped],

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
@@ -38,8 +38,14 @@ to_json(ReqData, Context) ->
                 [] ->
                     rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
                 Qs when length(Qs) > 0 ->
-                    Msg = <<"There are quorum queues that would lose their quorum if the target node is shut down">>,
-                    failure(Msg, Qs, ReqData, Context)
+                    FilteredQs = filter_vhost(Qs, ReqData, Context),
+                    case FilteredQs of
+                        [] ->
+                            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+                        _ ->
+                            Msg = <<"There are quorum queues that would lose their quorum if the target node is shut down">>,
+                            failure(Msg, FilteredQs, ReqData, Context)
+                    end
             end
     end.
 
@@ -52,3 +58,15 @@ failure(Message, Qs, ReqData, Context) ->
 
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).
+
+%% Qs are #{binary() => any()} maps keyed by <<"virtual_host">>, not the
+%% atom-keyed proplists filter_vhost/3 expects, so tag and untag around it.
+%% Critical components (rabbit_stream_coordinator, rabbitmq_metadata) are
+%% cluster-wide, not vhost-scoped: their virtual_host is "(not applicable)"
+%% and they must pass through unfiltered rather than be dropped for everyone.
+filter_vhost(Qs, ReqData, Context) ->
+    {NotVhostScoped, VhostScoped} =
+        lists:partition(fun(Q) -> maps:get(<<"virtual_host">>, Q) =:= <<"(not applicable)">> end, Qs),
+    Tagged = [maps:put(vhost, maps:get(<<"virtual_host">>, Q), Q) || Q <- VhostScoped],
+    Filtered = [maps:remove(vhost, Q) || Q <- rabbit_mgmt_util:filter_vhost(Tagged, ReqData, Context)],
+    NotVhostScoped ++ Filtered.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
@@ -36,8 +36,14 @@ to_json(ReqData, Context) ->
         [] ->
             rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
         Qs when length(Qs) > 0 ->
-            Msg = <<"Detected quorum queues without an elected leader">>,
-            failure(Msg, Qs, ReqData, Context)
+            FilteredQs = filter_vhost(Qs, ReqData, Context),
+            case FilteredQs of
+                [] ->
+                    rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+                _ ->
+                    Msg = <<"Detected quorum queues without an elected leader">>,
+                    failure(Msg, FilteredQs, ReqData, Context)
+            end
     end.
 
 failure(Message, Qs, ReqData, Context) ->
@@ -59,3 +65,9 @@ pattern(ReqData) ->
         none  -> ?DEFAULT_PATTERN;
         Other -> Other
     end.
+
+%% Qs are #{binary() => any()} maps keyed by <<"virtual_host">>, not the
+%% atom-keyed proplists filter_vhost/3 expects, so tag and untag around it.
+filter_vhost(Qs, ReqData, Context) ->
+    Tagged = [maps:put(vhost, maps:get(<<"virtual_host">>, Q), Q) || Q <- Qs],
+    [maps:remove(vhost, Q) || Q <- rabbit_mgmt_util:filter_vhost(Tagged, ReqData, Context)].

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
@@ -66,8 +66,6 @@ pattern(ReqData) ->
         Other -> Other
     end.
 
-%% Qs are #{binary() => any()} maps keyed by <<"virtual_host">>, not the
-%% atom-keyed proplists filter_vhost/3 expects, so tag and untag around it.
 filter_vhost(Qs, ReqData, Context) ->
     Tagged = [maps:put(vhost, maps:get(<<"virtual_host">>, Q), Q) || Q <- Qs],
     Filtered = rabbit_mgmt_util:filter_vhost(Tagged, ReqData, Context),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
@@ -36,15 +36,15 @@ to_json(ReqData, Context) ->
         [] ->
             rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
         Qs when length(Qs) > 0 ->
-            FilteredQs = filter_vhost(Qs, ReqData, Context),
-            case FilteredQs of
-                [] ->
-                    rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
-                _ ->
-                    Msg = <<"Detected quorum queues without an elected leader">>,
-                    failure(Msg, FilteredQs, ReqData, Context)
-            end
+            reply_for_leaderless_queues(
+              filter_vhost(Qs, ReqData, Context), ReqData, Context)
     end.
+
+reply_for_leaderless_queues([], ReqData, Context) ->
+    rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+reply_for_leaderless_queues(Qs, ReqData, Context) ->
+    Msg = <<"Detected quorum queues without an elected leader">>,
+    failure(Msg, Qs, ReqData, Context).
 
 failure(Message, Qs, ReqData, Context) ->
     Body = #{status => failed,
@@ -70,4 +70,5 @@ pattern(ReqData) ->
 %% atom-keyed proplists filter_vhost/3 expects, so tag and untag around it.
 filter_vhost(Qs, ReqData, Context) ->
     Tagged = [maps:put(vhost, maps:get(<<"virtual_host">>, Q), Q) || Q <- Qs],
-    [maps:remove(vhost, Q) || Q <- rabbit_mgmt_util:filter_vhost(Tagged, ReqData, Context)].
+    Filtered = rabbit_mgmt_util:filter_vhost(Tagged, ReqData, Context),
+    [maps:remove(vhost, Q) || Q <- Filtered].

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -47,7 +47,8 @@ groups() ->
                         is_quorum_critical_single_node_test,
                         quorum_queues_without_elected_leader_single_node_test,
                         quorum_queues_without_elected_leader_across_all_virtual_hosts_single_node_test,
-                        quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_test
+                        quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_test,
+                        quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_access_single_node_test
      ]}
     ].
 
@@ -289,6 +290,32 @@ is_quorum_critical_test(Config) ->
             QName =:= maps:get(<<"name">>, Item)
         end, Queues)),
 
+    %% A management-tagged user without access to the default vhost must not
+    %% learn that it has a quorum-critical queue. Cluster-wide critical
+    %% components (e.g. rabbitmq_metadata) aren't vhost-scoped, so they may
+    %% still legitimately show up for this user; only the per-vhost queue
+    %% must be hidden.
+    VHost = <<"is_quorum_critical_test-vh">>,
+    User = <<"is_quorum_critical_test-user">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VHost),
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
+
+    {ok, {{_, RestrictedCode, _}, _, RestrictedResBody}} =
+        req(Config, get, EndpointPath,
+            [auth_header(binary_to_list(User), binary_to_list(User))]),
+    ?assert(lists:member(RestrictedCode, [?OK, ?HEALTH_CHECK_FAILURE_STATUS])),
+    RestrictedBody = rabbit_json:decode(rabbit_data_coercion:to_binary(RestrictedResBody)),
+    RestrictedQueues = maps:get(<<"queues">>, RestrictedBody, []),
+    ?assertEqual(false, lists:any(
+        fun(Item) ->
+            QName =:= maps:get(<<"name">>, Item)
+        end, RestrictedQueues)),
+
+    rabbit_ct_broker_helpers:delete_user(Config, User),
+    rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
+
     passed.
 
 quorum_queues_without_elected_leader_single_node_test(Config) ->
@@ -429,6 +456,60 @@ quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_te
 
     rabbit_ct_broker_helpers:delete_user(Config, User),
     rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
+
+    passed.
+
+quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_access_single_node_test(Config) ->
+    EndpointPath = "/health/checks/quorum-queues-without-elected-leaders/all-vhosts/",
+
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Args = [{<<"x-queue-type">>, longstr, <<"quorum">>},
+            {<<"x-quorum-initial-group-size">>, long, 3}],
+    QName = <<"quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_access">>,
+    ?assertEqual({'queue.declare_ok', QName, 0, 0},
+        amqp_channel:call(Ch, #'queue.declare'{
+            queue       = QName,
+            durable     = true,
+            auto_delete = false,
+            arguments   = Args
+        })),
+
+    RaSystem = quorum_queues,
+    QResource = rabbit_misc:r(<<"/">>, queue, QName),
+    {ok, Q1} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, get, [QResource]),
+    _ = rabbit_ct_broker_helpers:rpc(Config, 0, ra, stop_server, [RaSystem, amqqueue:get_pid(Q1)]),
+
+    %% guest is an administrator and sees the leaderless queue across all vhosts.
+    AdminBody = http_get_failed(Config, EndpointPath),
+    AdminQueues = maps:get(<<"queues">>, AdminBody),
+    ?assert(lists:any(fun(Item) -> QName =:= maps:get(<<"name">>, Item) end, AdminQueues)),
+
+    %% A management-tagged user without access to the default vhost must not
+    %% learn that another vhost has a leaderless queue.
+    VHost = <<"quorum_queues_without_elected_leader_across_all_vhosts-vh">>,
+    User = <<"quorum_queues_without_elected_leader_across_all_vhosts-user">>,
+    rabbit_ct_broker_helpers:add_vhost(Config, VHost),
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
+
+    RestrictedCheck = http_get(Config, EndpointPath, User, User, ?OK),
+    ?assertEqual(<<"ok">>, maps:get(status, RestrictedCheck)),
+
+    rabbit_ct_broker_helpers:delete_user(Config, User),
+    rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
+
+    _ = rabbit_ct_broker_helpers:rpc(Config, 0, ra, restart_server, [RaSystem, amqqueue:get_pid(Q1)]),
+    rabbit_ct_helpers:await_condition(
+        fun() ->
+            try
+                Check = http_get(Config, EndpointPath, ?OK),
+                false =:= maps:is_key(reason, Check)
+            catch _:_ ->
+                false
+            end
+        end),
 
     passed.
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -48,7 +48,7 @@ groups() ->
                         quorum_queues_without_elected_leader_single_node_test,
                         quorum_queues_without_elected_leader_across_all_virtual_hosts_single_node_test,
                         quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_test,
-                        quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_access_single_node_test
+                        quorum_queues_leaderless_all_vhosts_vhost_access_single_node_test
      ]}
     ].
 
@@ -306,7 +306,8 @@ is_quorum_critical_test(Config) ->
         req(Config, get, EndpointPath,
             [auth_header(binary_to_list(User), binary_to_list(User))]),
     ?assert(lists:member(RestrictedCode, [?OK, ?HEALTH_CHECK_FAILURE_STATUS])),
-    RestrictedBody = rabbit_json:decode(rabbit_data_coercion:to_binary(RestrictedResBody)),
+    RestrictedBody = rabbit_json:decode(
+                        rabbit_data_coercion:to_binary(RestrictedResBody)),
     RestrictedQueues = maps:get(<<"queues">>, RestrictedBody, []),
     ?assertEqual(false, lists:any(
         fun(Item) ->
@@ -459,14 +460,15 @@ quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_te
 
     passed.
 
-quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_access_single_node_test(Config) ->
-    EndpointPath = "/health/checks/quorum-queues-without-elected-leaders/all-vhosts/",
+quorum_queues_leaderless_all_vhosts_vhost_access_single_node_test(Config) ->
+    EndpointPath =
+        "/health/checks/quorum-queues-without-elected-leaders/all-vhosts/",
 
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Args = [{<<"x-queue-type">>, longstr, <<"quorum">>},
             {<<"x-quorum-initial-group-size">>, long, 3}],
-    QName = <<"quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_access">>,
+    QName = <<"quorum_queues_leaderless_all_vhosts_vhost_access">>,
     ?assertEqual({'queue.declare_ok', QName, 0, 0},
         amqp_channel:call(Ch, #'queue.declare'{
             queue       = QName,
@@ -477,18 +479,22 @@ quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_acc
 
     RaSystem = quorum_queues,
     QResource = rabbit_misc:r(<<"/">>, queue, QName),
-    {ok, Q1} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, get, [QResource]),
-    _ = rabbit_ct_broker_helpers:rpc(Config, 0, ra, stop_server, [RaSystem, amqqueue:get_pid(Q1)]),
+    {ok, Q1} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, get,
+                                             [QResource]),
+    _ = rabbit_ct_broker_helpers:rpc(Config, 0, ra, stop_server,
+                                      [RaSystem, amqqueue:get_pid(Q1)]),
 
-    %% guest is an administrator and sees the leaderless queue across all vhosts.
+    %% guest is an administrator and sees the leaderless queue across
+    %% all vhosts.
     AdminBody = http_get_failed(Config, EndpointPath),
     AdminQueues = maps:get(<<"queues">>, AdminBody),
-    ?assert(lists:any(fun(Item) -> QName =:= maps:get(<<"name">>, Item) end, AdminQueues)),
+    ?assert(lists:any(
+        fun(Item) -> QName =:= maps:get(<<"name">>, Item) end, AdminQueues)),
 
     %% A management-tagged user without access to the default vhost must not
     %% learn that another vhost has a leaderless queue.
-    VHost = <<"quorum_queues_without_elected_leader_across_all_vhosts-vh">>,
-    User = <<"quorum_queues_without_elected_leader_across_all_vhosts-user">>,
+    VHost = <<"quorum_queues_leaderless_all_vhosts_vhost_access-vh">>,
+    User = <<"quorum_queues_leaderless_all_vhosts_vhost_access-user">>,
     rabbit_ct_broker_helpers:add_vhost(Config, VHost),
     rabbit_ct_broker_helpers:add_user(Config, User, User),
     rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
@@ -500,7 +506,8 @@ quorum_queues_without_elected_leader_across_all_vhosts_requires_virtual_host_acc
     rabbit_ct_broker_helpers:delete_user(Config, User),
     rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
 
-    _ = rabbit_ct_broker_helpers:rpc(Config, 0, ra, restart_server, [RaSystem, amqqueue:get_pid(Q1)]),
+    _ = rabbit_ct_broker_helpers:rpc(Config, 0, ra, restart_server,
+                                      [RaSystem, amqqueue:get_pid(Q1)]),
     rabbit_ct_helpers:await_condition(
         fun() ->
             try

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -293,11 +293,9 @@ is_quorum_critical_test(Config) ->
             QName =:= maps:get(<<"name">>, Item)
         end, Queues)),
 
-    %% A management-tagged user without access to the default vhost must not
-    %% learn that it has a quorum-critical queue. Cluster-wide critical
-    %% components (e.g. rabbitmq_metadata) aren't vhost-scoped, so they may
-    %% still legitimately show up for this user; only the per-vhost queue
-    %% must be hidden.
+    %% Cluster-wide components such as `rabbitmq_metadata` are not vhost-scoped
+    %% and can still be listed for a user without access to "/"; only the
+    %% queue must be hidden.
     VHost = <<"is_quorum_critical_test-vh">>,
     User = <<"is_quorum_critical_test-user">>,
     rabbit_ct_broker_helpers:add_vhost(Config, VHost),
@@ -305,18 +303,21 @@ is_quorum_critical_test(Config) ->
     rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
     rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
 
-    {ok, {{_, RestrictedCode, _}, _, RestrictedResBody}} =
-        req(Config, get, EndpointPath,
-            [auth_header(binary_to_list(User), binary_to_list(User))]),
-    ?assert(lists:member(RestrictedCode, [?OK, ?HEALTH_CHECK_FAILURE_STATUS])),
-    RestrictedBody = rabbit_json:decode(
-                        rabbit_data_coercion:to_binary(RestrictedResBody)),
-    RestrictedQueues = maps:get(<<"queues">>, RestrictedBody, []),
-    ?assertEqual(false, lists:any(
-        fun(Item) ->
-            QName =:= maps:get(<<"name">>, Item)
-        end, RestrictedQueues)),
+    ?assertNot(queue_visible(Config, EndpointPath, User, QName)),
 
+    rabbit_ct_broker_helpers:set_full_permissions(Config, User, <<"/">>),
+    ?assert(queue_visible(Config, EndpointPath, User, QName)),
+
+    %% Monitoring users are filtered by vhost permissions like
+    %% `GET /api/queues` does.
+    Monitor = <<"is_quorum_critical_test-monitor">>,
+    rabbit_ct_broker_helpers:add_user(Config, Monitor, Monitor),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, Monitor, [monitoring]),
+    ?assertNot(queue_visible(Config, EndpointPath, Monitor, QName)),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, Monitor, <<"/">>),
+    ?assert(queue_visible(Config, EndpointPath, Monitor, QName)),
+
+    rabbit_ct_broker_helpers:delete_user(Config, Monitor),
     rabbit_ct_broker_helpers:delete_user(Config, User),
     rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
 
@@ -326,9 +327,10 @@ is_quorum_critical_test(Config) ->
     passed.
 
 is_quorum_critical_vhost_named_not_applicable_test(Config) ->
-    %% A vhost literally named "(not applicable)" must not be mistaken for
-    %% the cluster-wide critical-component placeholder value used by
-    %% rabbit_upgrade_preparation:list_with_minimum_quorum_for_cli/0.
+    %% "(not applicable)" is the placeholder vhost name that
+    %% `rabbit_upgrade_preparation:list_with_minimum_quorum_for_cli/0` gives
+    %% cluster-wide components; a real vhost with that name must still be
+    %% filtered.
     EndpointPath = "/health/checks/node-is-quorum-critical",
     VHost = <<"(not applicable)">>,
     User = <<"is_quorum_critical_vhost_named_not_applicable_test-user">>,
@@ -363,19 +365,7 @@ is_quorum_critical_vhost_named_not_applicable_test(Config) ->
     ?assert(lists:any(
         fun(Item) -> QName =:= maps:get(<<"name">>, Item) end, Queues)),
 
-    %% The restricted user only has access to "/", not the vhost named
-    %% "(not applicable)", and must not see this queue just because its
-    %% vhost name matches the critical-component placeholder string.
-    {ok, {{_, RestrictedCode, _}, _, RestrictedResBody}} =
-        req(Config, get, EndpointPath,
-            [auth_header(binary_to_list(User), binary_to_list(User))]),
-    ?assert(lists:member(RestrictedCode, [?OK, ?HEALTH_CHECK_FAILURE_STATUS])),
-    RestrictedBody = rabbit_json:decode(
-                        rabbit_data_coercion:to_binary(RestrictedResBody)),
-    RestrictedQueues = maps:get(<<"queues">>, RestrictedBody, []),
-    ?assertEqual(false, lists:any(
-        fun(Item) -> QName =:= maps:get(<<"name">>, Item) end,
-        RestrictedQueues)),
+    ?assertNot(queue_visible(Config, EndpointPath, User, QName)),
 
     rabbit_ct_client_helpers:close_connection(Conn),
     rabbit_ct_broker_helpers:delete_user(Config, User),
@@ -551,15 +541,12 @@ quorum_queues_leaderless_all_vhosts_vhost_access_single_node_test(Config) ->
     _ = rabbit_ct_broker_helpers:rpc(Config, 0, ra, stop_server,
                                       [RaSystem, amqqueue:get_pid(Q1)]),
 
-    %% guest is an administrator and sees the leaderless queue across
-    %% all vhosts.
+    %% guest is an administrator, so it sees queues in every vhost.
     AdminBody = http_get_failed(Config, EndpointPath),
     AdminQueues = maps:get(<<"queues">>, AdminBody),
     ?assert(lists:any(
         fun(Item) -> QName =:= maps:get(<<"name">>, Item) end, AdminQueues)),
 
-    %% A management-tagged user without access to the default vhost must not
-    %% learn that another vhost has a leaderless queue.
     VHost = <<"quorum_queues_leaderless_all_vhosts_vhost_access-vh">>,
     User = <<"quorum_queues_leaderless_all_vhosts_vhost_access-user">>,
     rabbit_ct_broker_helpers:add_vhost(Config, VHost),
@@ -570,6 +557,20 @@ quorum_queues_leaderless_all_vhosts_vhost_access_single_node_test(Config) ->
     RestrictedCheck = http_get(Config, EndpointPath, User, User, ?OK),
     ?assertEqual(<<"ok">>, maps:get(status, RestrictedCheck)),
 
+    rabbit_ct_broker_helpers:set_full_permissions(Config, User, <<"/">>),
+    ?assert(queue_visible(Config, EndpointPath, User, QName)),
+
+    %% Monitoring users are filtered by vhost permissions like
+    %% `GET /api/queues` does.
+    Monitor = <<"quorum_queues_leaderless_all_vhosts_vhost_access-monitor">>,
+    rabbit_ct_broker_helpers:add_user(Config, Monitor, Monitor),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, Monitor, [monitoring]),
+    MonitorCheck = http_get(Config, EndpointPath, Monitor, Monitor, ?OK),
+    ?assertEqual(<<"ok">>, maps:get(status, MonitorCheck)),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, Monitor, <<"/">>),
+    ?assert(queue_visible(Config, EndpointPath, Monitor, QName)),
+
+    rabbit_ct_broker_helpers:delete_user(Config, Monitor),
     rabbit_ct_broker_helpers:delete_user(Config, User),
     rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
 
@@ -805,6 +806,17 @@ http_get_failed(Config, Path) ->
     ct:pal("GET ~s: ~w ~w", [Path, Code, ResBody]),
     ?assertEqual(Code, ?HEALTH_CHECK_FAILURE_STATUS),
     rabbit_json:decode(rabbit_data_coercion:to_binary(ResBody)).
+
+%% The user's password is its name. The status is not asserted because
+%% cluster-wide components can make `GET /health/checks/node-is-quorum-critical`
+%% fail regardless of vhost access.
+queue_visible(Config, Path, User, QName) ->
+    Auth = auth_header(binary_to_list(User), binary_to_list(User)),
+    {ok, {{_, Code, _}, _, ResBody}} = req(Config, get, Path, [Auth]),
+    ?assert(lists:member(Code, [?OK, ?HEALTH_CHECK_FAILURE_STATUS])),
+    Body = rabbit_json:decode(rabbit_data_coercion:to_binary(ResBody)),
+    lists:any(fun(Q) -> QName =:= maps:get(<<"name">>, Q) end,
+              maps:get(<<"queues">>, Body, [])).
 
 delete_queues() ->
     [rabbit_amqqueue:delete(Q, false, false, <<"dummy">>)

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -33,7 +33,8 @@ all() ->
 groups() ->
     [
      {cluster_size_3, [], all_tests()},
-     {cluster_size_5, [], [is_quorum_critical_test]},
+     {cluster_size_5, [], [is_quorum_critical_test,
+                           is_quorum_critical_vhost_named_not_applicable_test]},
      {single_node, [], [
                         alarms_test,
                         local_alarms_test,
@@ -99,7 +100,9 @@ end_per_group(_, Config) ->
     Steps = Teardown0 ++ Teardown1,
     rabbit_ct_helpers:run_teardown_steps(Config, Steps).
 
-init_per_testcase(Testcase, Config) when Testcase == is_quorum_critical_test ->
+init_per_testcase(Testcase, Config)
+  when Testcase == is_quorum_critical_test;
+       Testcase == is_quorum_critical_vhost_named_not_applicable_test ->
     case rabbit_ct_helpers:is_mixed_versions() of
         true ->
             {skip, "not mixed versions compatible"};
@@ -315,6 +318,70 @@ is_quorum_critical_test(Config) ->
         end, RestrictedQueues)),
 
     rabbit_ct_broker_helpers:delete_user(Config, User),
+    rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
+
+    ok = rabbit_ct_broker_helpers:start_broker(Config, Server2),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, Server3),
+
+    passed.
+
+is_quorum_critical_vhost_named_not_applicable_test(Config) ->
+    %% A vhost literally named "(not applicable)" must not be mistaken for
+    %% the cluster-wide critical-component placeholder value used by
+    %% rabbit_upgrade_preparation:list_with_minimum_quorum_for_cli/0.
+    EndpointPath = "/health/checks/node-is-quorum-critical",
+    VHost = <<"(not applicable)">>,
+    User = <<"is_quorum_critical_vhost_named_not_applicable_test-user">>,
+    add_vhost(Config, VHost),
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+    rabbit_ct_broker_helpers:set_full_permissions(Config, User, <<"/">>),
+
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, Server,
+                                                               VHost),
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+    Args = [{<<"x-queue-type">>, longstr, <<"quorum">>},
+            {<<"x-quorum-initial-group-size">>, long, 3}],
+    QName = <<"is_quorum_critical_vhost_named_not_applicable_test">>,
+    ?assertEqual({'queue.declare_ok', QName, 0, 0},
+                 amqp_channel:call(Ch, #'queue.declare'{queue     = QName,
+                                                        durable   = true,
+                                                        auto_delete = false,
+                                                        arguments = Args})),
+
+    QResource = rabbit_misc:r(VHost, queue, QName),
+    {ok, Q1} = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, get,
+                                             [QResource]),
+    {ok, [_, {_, Server2}, {_, Server3}], _} = ra:members(amqqueue:get_pid(Q1)),
+
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, Server2),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, Server3),
+
+    Body = http_get_failed(Config, EndpointPath),
+    Queues = maps:get(<<"queues">>, Body),
+    ?assert(lists:any(
+        fun(Item) -> QName =:= maps:get(<<"name">>, Item) end, Queues)),
+
+    %% The restricted user only has access to "/", not the vhost named
+    %% "(not applicable)", and must not see this queue just because its
+    %% vhost name matches the critical-component placeholder string.
+    {ok, {{_, RestrictedCode, _}, _, RestrictedResBody}} =
+        req(Config, get, EndpointPath,
+            [auth_header(binary_to_list(User), binary_to_list(User))]),
+    ?assert(lists:member(RestrictedCode, [?OK, ?HEALTH_CHECK_FAILURE_STATUS])),
+    RestrictedBody = rabbit_json:decode(
+                        rabbit_data_coercion:to_binary(RestrictedResBody)),
+    RestrictedQueues = maps:get(<<"queues">>, RestrictedBody, []),
+    ?assertEqual(false, lists:any(
+        fun(Item) -> QName =:= maps:get(<<"name">>, Item) end,
+        RestrictedQueues)),
+
+    rabbit_ct_client_helpers:close_connection(Conn),
+    rabbit_ct_broker_helpers:delete_user(Config, User),
+
+    ok = rabbit_ct_broker_helpers:start_broker(Config, Server2),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, Server3),
     rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
 
     passed.


### PR DESCRIPTION
`GET /health/checks/node-is-quorum-critical` and
`/health/checks/quorum-queues-without-elected-leaders/all-vhosts/` returned queue names and vhosts cluster-wide to any management-tagged user, ignoring that user's per-vhost permissions. Filter the queue list through `rabbit_mgmt_util:filter_vhost/3`, the same mechanism `/api/queues` uses.

filter_vhost/3 expects atom-keyed vhost entries, but these two endpoints return maps keyed by the binary <<"virtual_host">>, so results are tagged before filtering and untagged after. Cluster-wide critical components (rabbit_stream_coordinator, rabbitmq_metadata) aren't vhost-scoped and pass through unfiltered.

