### PR TITLE
Redact upstream connection parameters before debug logging

### DIFF
--- a/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
@@ -365,7 +365,8 @@ disposable_connection_call(Params, Method, ErrFun) ->
 
 disposable_connection_call(Params, Method, ErrFun, Timeout) ->
     try
-        ?LOG_DEBUG("Disposable connection parameters: ~tp", [Params]),
+        ?LOG_DEBUG("Disposable connection parameters: ~tp",
+                   [rabbit_federation_util:redact_params(Params)]),
         case open(Params, <<"Disposable exchange federation link connection">>) of
             {ok, Conn, Ch} ->
                 try

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_util.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_util.erl
@@ -14,7 +14,8 @@
 
 -export([should_forward/4, find_upstreams/2, already_seen/3]).
 -export([validate_arg/3, fail/2, name/1, vhost/1, r/1, pgname/1]).
--export([obfuscate_upstream/1, deobfuscate_upstream/1, obfuscate_upstream_params/1, deobfuscate_upstream_params/1]).
+-export([obfuscate_upstream/1, deobfuscate_upstream/1, obfuscate_upstream_params/1,
+         deobfuscate_upstream_params/1, redact_params/1]).
 -export([log_skipped_link/3]).
 
 -import(rabbit_misc, [pget_or_die/2, pget/3]).
@@ -110,3 +111,20 @@ deobfuscate_upstream_params(#upstream_params{uri = EncryptedUri, params = #amqp_
         uri = credentials_obfuscation:decrypt(EncryptedUri),
         params = Params#amqp_params_direct{password = credentials_obfuscation:decrypt(EncryptedPassword)}
     }.
+
+%% Connection parameters carry the deobfuscated upstream password, and
+%% `ssl_options` can carry a private key password. Replace both before the
+%% parameters reach the logs.
+redact_params(#amqp_params_network{ssl_options = SslOpts} = Params) ->
+    Params#amqp_params_network{password = redacted,
+                                ssl_options = redact_ssl_options(SslOpts)};
+redact_params(#amqp_params_direct{} = Params) ->
+    Params#amqp_params_direct{password = redacted}.
+
+redact_ssl_options(SslOpts) when is_list(SslOpts) ->
+    [case Opt of
+         {password, _} -> {password, redacted};
+         Other         -> Other
+     end || Opt <- SslOpts];
+redact_ssl_options(SslOpts) ->
+    SslOpts.

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -31,7 +31,11 @@ all() -> [
     to_params_error_strips_credentials,
     to_params_error_on_malformed_uri_strips_credentials,
     to_params_falls_back_to_valid_uri,
-    to_params_error_redacts_query_secrets
+    to_params_error_redacts_query_secrets,
+    redact_params_network,
+    redact_params_direct,
+    redact_params_ssl_options_password,
+    redact_params_ssl_options_none
 ].
 
 init_per_suite(Config) ->
@@ -260,4 +264,40 @@ to_params_error_redacts_query_secrets(_Config) ->
         rabbit_federation_upstream:to_params(Upstream, XorQ),
     ?assertEqual(nomatch, binary:match(iolist_to_binary(io_lib:format("~tp", [Info])),
                                        <<"s3cret">>)),
+    ok.
+
+%% -------------------------------------------------------------------
+%% rabbit_federation_util:redact_params/1
+%% -------------------------------------------------------------------
+
+redact_params_network(_Config) ->
+    Params = #amqp_params_network{username = <<"fed">>, password = <<"s3cret">>,
+                                  host = "localhost"},
+    Redacted = rabbit_federation_util:redact_params(Params),
+    Formatted = iolist_to_binary(io_lib:format("~tp", [Redacted])),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"s3cret">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"fed">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"localhost">>)),
+    ok.
+
+redact_params_direct(_Config) ->
+    Params = #amqp_params_direct{username = <<"fed">>, password = <<"s3cret">>},
+    Redacted = rabbit_federation_util:redact_params(Params),
+    Formatted = iolist_to_binary(io_lib:format("~tp", [Redacted])),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"s3cret">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"fed">>)),
+    ok.
+
+redact_params_ssl_options_password(_Config) ->
+    Params = #amqp_params_network{ssl_options = [{password, "kp"}, {verify, verify_peer}]},
+    Redacted = rabbit_federation_util:redact_params(Params),
+    Formatted = iolist_to_binary(io_lib:format("~tp", [Redacted])),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"kp">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"verify_peer">>)),
+    ok.
+
+redact_params_ssl_options_none(_Config) ->
+    Params = #amqp_params_network{ssl_options = none},
+    ?assertMatch(#amqp_params_network{ssl_options = none},
+                 rabbit_federation_util:redact_params(Params)),
     ok.


### PR DESCRIPTION
The disposable-connection debug log line formatted the full connection parameters record, which carries the deobfuscated upstream password and, for TLS upstreams, a private key password embedded in ssl_options.

Add a redaction helper that replaces both before the record reaches the logs, keeping the line useful for troubleshooting without depending on obfuscation configuration being enabled.