### PR TITLE
Drop malformed x-opt-deaths entries on conversion

### DIFF
--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -570,28 +570,37 @@ deaths_to_headers(Deaths, Headers0) ->
     rabbit_misc:set_table_value(Headers0, <<"x-death">>, array, Infos).
 
 convert_from_amqp_deaths({array, map, Maps}) ->
-    L = lists:map(
-          fun({map, KvList}) ->
-                  {Ttl, KvList1} = case KvList of
-                                       [{{symbol, <<"ttl">>}, {uint, Ttl0}} | Tail] ->
-                                           {Ttl0, Tail};
-                                       _ ->
-                                           {undefined, KvList}
-                                   end,
-                  [
-                   {{symbol, <<"queue">>}, {utf8, Queue}},
-                   {{symbol, <<"reason">>}, {symbol, Reason}},
-                   {{symbol, <<"count">>}, {ulong, Count}},
-                   {{symbol, <<"first-time">>}, {timestamp, FirstTime}},
-                   {{symbol, <<"last-time">>}, {timestamp, _LastTime}},
-                   {{symbol, <<"exchange">>}, {utf8, Exchange}},
-                   {{symbol, <<"routing-keys">>}, {array, utf8, RKeys0}}
-                  ] = KvList1,
-                  RKeys = [Key || {utf8, Key} <- RKeys0],
-                  death_table(Queue, Reason, Exchange, RKeys, Count, FirstTime, Ttl)
-          end, Maps),
+    L = lists:filtermap(fun convert_death_entry/1, Maps),
     {true, {<<"x-death">>, array, L}};
 convert_from_amqp_deaths(_IgnoreUnknownValue) ->
+    false.
+
+convert_death_entry({map, KvList0}) ->
+    {Ttl, KvList} = case KvList0 of
+                        [{{symbol, <<"ttl">>}, {uint, Ttl0}} | Tail] ->
+                            {Ttl0, Tail};
+                        _ ->
+                            {undefined, KvList0}
+                    end,
+    case {lists:keyfind({symbol, <<"queue">>}, 1, KvList),
+          lists:keyfind({symbol, <<"reason">>}, 1, KvList),
+          lists:keyfind({symbol, <<"count">>}, 1, KvList),
+          lists:keyfind({symbol, <<"first-time">>}, 1, KvList),
+          lists:keyfind({symbol, <<"exchange">>}, 1, KvList),
+          lists:keyfind({symbol, <<"routing-keys">>}, 1, KvList)} of
+        {{_, {utf8, Queue}},
+         {_, {symbol, Reason}},
+         {_, {ulong, Count}},
+         {_, {timestamp, FirstTime}},
+         {_, {utf8, Exchange}},
+         {_, {array, utf8, RKeys0}}} ->
+            RKeys = [Key || {utf8, Key} <- RKeys0],
+            {true, death_table(Queue, Reason, Exchange, RKeys, Count, FirstTime, Ttl)};
+        %% Drop entries that are missing fields.
+        _ ->
+            false
+    end;
+convert_death_entry(_NotAMap) ->
     false.
 
 death_table({{QName, Reason},

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -42,6 +42,7 @@ all_tests() ->
      amqp_amqpl_message_id_large,
      amqp_amqpl_message_id_binary,
      amqp_amqpl_unsupported_values_not_converted,
+     amqp_amqpl_malformed_x_opt_deaths_dropped,
      amqp_to_amqpl_data_body,
      amqp_amqpl_amqp_bodies,
      amqpl_amqp_type_body_shapes,
@@ -569,6 +570,48 @@ amqp_amqpl_unsupported_values_not_converted(_Config) ->
     ?assertMatch(undefined, header(LongKey, HL)),
     %% RabbitMQ does not validate that keys are ascii as per spec
     %% that's ok after all who really cares?
+    ok.
+
+amqp_amqpl_malformed_x_opt_deaths_dropped(_Config) ->
+    Malformed = {map, [{{symbol, <<"queue">>}, {utf8, <<"q">>}}]},
+    WellFormed = {map, [
+                        {{symbol, <<"queue">>}, {utf8, <<"q2">>}},
+                        {{symbol, <<"reason">>}, {symbol, <<"rejected">>}},
+                        {{symbol, <<"count">>}, {ulong, 3}},
+                        {{symbol, <<"first-time">>}, {timestamp, 1000}},
+                        {{symbol, <<"last-time">>}, {timestamp, 2000}},
+                        {{symbol, <<"exchange">>}, {utf8, <<"ex">>}},
+                        {{symbol, <<"routing-keys">>},
+                         {array, utf8, [{utf8, <<"rk1">>}]}}
+                       ]},
+    MAC = [
+           {{symbol, <<"x-opt-deaths">>},
+            {array, map, [Malformed, WellFormed]}},
+           {{symbol, <<"x-other">>}, {utf8, <<"still-here">>}}
+          ],
+    M = #'v1_0.message_annotations'{content = MAC},
+    D = #'v1_0.data'{content = <<"data">>},
+    Payload = serialize_sections([M, D]),
+
+    Msg = mc:init(mc_amqp, Payload, annotations()),
+    MsgL = mc:convert(mc_amqpl, Msg),
+    #content{properties = #'P_basic'{headers = HL}} = mc:protocol_state(MsgL),
+    %% the malformed entry is dropped, but the well-formed entry alongside
+    %% it, and every other x- annotation on the message, still convert
+    {_, array, [{table, T}]} = header(<<"x-death">>, HL),
+    ?assertMatch({_, longstr, <<"q2">>}, header(<<"queue">>, T)),
+    ?assertMatch({_, longstr, <<"rejected">>}, header(<<"reason">>, T)),
+    ?assertMatch({_, long, 3}, header(<<"count">>, T)),
+    ?assertMatch({_, longstr, <<"still-here">>}, header(<<"x-other">>, HL)),
+
+    %% a message whose sole death entry is malformed converts to an empty
+    %% x-death array rather than being rejected outright
+    MAC1 = [{{symbol, <<"x-opt-deaths">>}, {array, map, [Malformed]}}],
+    Payload1 = serialize_sections([#'v1_0.message_annotations'{content = MAC1}, D]),
+    Msg1 = mc:init(mc_amqp, Payload1, annotations()),
+    MsgL1 = mc:convert(mc_amqpl, Msg1),
+    #content{properties = #'P_basic'{headers = HL1}} = mc:protocol_state(MsgL1),
+    ?assertMatch({_, array, []}, header(<<"x-death">>, HL1)),
     ok.
 
 amqp_amqpl_amqp_uuid_correlation_id(_Config) ->


### PR DESCRIPTION
Clients can set x-opt-deaths message annotations.
