### PR TITLE
Harden exchange federation binding propagation against malformed input

### DIFF
--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -16,7 +16,8 @@
 -behaviour(gen_server2).
 
 -export([go/0, add_binding/3, remove_bindings/3]).
--export([list_routing_keys/1, hops/4]). %% For testing
+%% Exported for tests.
+-export([list_routing_keys/1, hops/4]).
 -export([all_local/0, disconnect_all/0, reconnect_all/0]).
 
 -export([start_link/1]).
@@ -509,8 +510,8 @@ bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments, Nowait) ->
 %% In other words, we count down to 0 from the link with the most
 %% restrictive max_hops we have yet passed through.
 %%
-%% The binding header is client-supplied, since it is an ordinary binding
-%% argument, so it is not trusted: hops/4 clamps it to a non-negative budget.
+%% The binding header is an ordinary binding argument, so clients can set
+%% it to anything. `hops/4` therefore never trusts it.
 
 update_binding(Args, #state{downstream_exchange = X,
                             upstream            = Upstream,
@@ -535,8 +536,8 @@ update_binding(Args, #state{downstream_exchange = X,
             rabbit_basic:prepend_table_header(?BINDING_HEADER, Info, Args)
     end.
 
-%% The binding header is client-supplied: any value that is not a positive
-%% hop count means the binding does not propagate any further.
+%% A header that does not carry a positive hop count stops propagation
+%% instead of being trusted.
 -spec hops(rabbit_framing:amqp_table(), integer(), binary() | unknown, binary()) ->
           non_neg_integer().
 hops(Args, MaxHops, UName, UVhost) ->

--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -16,7 +16,7 @@
 -behaviour(gen_server2).
 
 -export([go/0, add_binding/3, remove_bindings/3]).
--export([list_routing_keys/1]). %% For testing
+-export([list_routing_keys/1, hops/4]). %% For testing
 -export([all_local/0, disconnect_all/0, reconnect_all/0]).
 
 -export([start_link/1]).
@@ -434,10 +434,10 @@ binding_op(UpdateFun, Cmd, B = #binding{args = Args},
            State = #state{cmd_channel = Ch}) ->
     {DoIt, State1} =
         case rabbit_misc:table_lookup(Args, ?BINDING_HEADER) of
-            undefined  -> UpdateFun(B, State);
-            {array, _} -> {Cmd =/= ignore, State}
+            undefined -> UpdateFun(B, State);
+            _         -> {true, State}
         end,
-    case DoIt of
+    case DoIt andalso Cmd =/= ignore of
         true  -> amqp_channel:call(Ch, Cmd);
         false -> ok
     end,
@@ -508,6 +508,9 @@ bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments, Nowait) ->
 %%
 %% In other words, we count down to 0 from the link with the most
 %% restrictive max_hops we have yet passed through.
+%%
+%% The binding header is client-supplied, since it is an ordinary binding
+%% argument, so it is not trusted: hops/4 clamps it to a non-negative budget.
 
 update_binding(Args, #state{downstream_exchange = X,
                             upstream            = Upstream,
@@ -515,32 +518,43 @@ update_binding(Args, #state{downstream_exchange = X,
                             upstream_name       = UName}) ->
     #upstream{max_hops = MaxHops} = Upstream,
     UVhost = vhost(UpstreamX),
-    Hops = case rabbit_misc:table_lookup(Args, ?BINDING_HEADER) of
-               undefined    -> MaxHops;
-               {array, All} -> [{table, Prev} | _] = All,
-                               PrevHops = get_hops(Prev),
-                               case rabbit_federation_util:already_seen(
-                                      UName, UVhost, All) of
-                                   true  -> 0;
-                                   false -> lists:min([PrevHops - 1, MaxHops])
-                               end
-           end,
-    case Hops of
-        0 -> ignore;
-        _ -> Cluster = rabbit_nodes:cluster_name(),
-             ABSuffix = rabbit_federation_db:get_active_suffix(
-                          X, Upstream, <<"A">>),
-             DVhost = vhost(X),
-             DName = name(X),
-             Down = <<DVhost/binary,":", DName/binary, " ", ABSuffix/binary>>,
-             Info = [{<<"cluster-name">>, longstr, Cluster},
-                     {<<"vhost">>,        longstr, DVhost},
-                     {<<"exchange">>,     longstr, Down},
-                     {<<"hops">>,         short,   Hops}],
-             rabbit_basic:prepend_table_header(?BINDING_HEADER, Info, Args)
+    case hops(Args, MaxHops, UName, UVhost) of
+        0 ->
+            ignore;
+        Hops ->
+            Cluster = rabbit_nodes:cluster_name(),
+            ABSuffix = rabbit_federation_db:get_active_suffix(
+                         X, Upstream, <<"A">>),
+            DVhost = vhost(X),
+            DName = name(X),
+            Down = <<DVhost/binary,":", DName/binary, " ", ABSuffix/binary>>,
+            Info = [{<<"cluster-name">>, longstr, Cluster},
+                    {<<"vhost">>,        longstr, DVhost},
+                    {<<"exchange">>,     longstr, Down},
+                    {<<"hops">>,         short,   Hops}],
+            rabbit_basic:prepend_table_header(?BINDING_HEADER, Info, Args)
     end.
 
+%% The binding header is client-supplied: any value that is not a positive
+%% hop count means the binding does not propagate any further.
+-spec hops(rabbit_framing:amqp_table(), integer(), binary() | unknown, binary()) ->
+          non_neg_integer().
+hops(Args, MaxHops, UName, UVhost) ->
+    Hops = case rabbit_misc:table_lookup(Args, ?BINDING_HEADER) of
+               undefined ->
+                   MaxHops;
+               {array, All} ->
+                   case rabbit_federation_util:already_seen(UName, UVhost, All) of
+                       true  -> 0;
+                       false -> lists:min([previous_hops(All) - 1, MaxHops])
+                   end;
+               _ ->
+                   0
+           end,
+    erlang:max(0, Hops).
 
+previous_hops([{table, Prev} | _]) -> get_hops(Prev);
+previous_hops(_)                   -> 0.
 
 key(#binding{key = Key, args = Args}) -> {Key, Args}.
 
@@ -800,17 +814,10 @@ header_for_upstream_vhost(unknown) -> [];
 header_for_upstream_vhost(Name)    -> [{<<"vhost">>, longstr, Name}].
 
 get_hops(Table) ->
-  case rabbit_misc:table_lookup(Table, <<"hops">>) of
-    %% see rabbit_binary_generator
-    {short, N}         -> N;
-    {long, N}          -> N;
-    {byte, N}          -> N;
-    {signedint, N}     -> N;
-    {unsignedbyte, N}  -> N;
-    {unsignedshort, N} -> N;
-    {unsignedint, N}   -> N;
-    {_, N} when is_integer(N) andalso N >= 0 -> N
-  end.
+    case rabbit_misc:table_lookup(Table, <<"hops">>) of
+        {_, N} when is_integer(N) andalso N > 0 -> N;
+        _                                       -> 0
+    end.
 
 handle_down(DCh, Reason, _Ch, _CmdCh, DCh, Args, State) ->
     rabbit_federation_link_util:handle_downstream_down(Reason, Args, State);

--- a/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 
 -include("rabbit_exchange_federation.hrl").
+-include_lib("rabbitmq_federation_common/include/rabbit_federation.hrl").
 
 -compile(export_all).
 
@@ -30,7 +31,7 @@ all() ->
 groups() ->
     [
      {essential, [], essential()},
-     {cluster_size_3, [], [max_hops]},
+     {cluster_size_3, [], [max_hops, forged_hops_does_not_bypass_max_hops]},
      {rolling_upgrade, [], [child_id_format]},
      {cycle_protection, [], [
                              %% TBD: port from v3.10.x in an Erlang 25-compatible way
@@ -56,7 +57,9 @@ essential() ->
       unbind_on_client_unbind,
       exchange_federation_link_status,
       lookup_exchange_status,
-      supervisor_shutdown_concurrency_safety
+      supervisor_shutdown_concurrency_safety,
+      forged_binding_header_does_not_crash_link,
+      invalid_persisted_max_hops_does_not_crash_link
     ].
 
 suite() ->
@@ -526,6 +529,79 @@ max_hops(Config) ->
       {skip, "Should not run in mixed version environments"}
   end.
 
+%% A chain rather than a ring, so that cycle detection cannot mask the
+%% result: A is the original source, B consumes from A, C consumes from B.
+%% A forged x-bound-from header used to make the hop counter negative,
+%% which never reaches 0 through ordinary arithmetic, so a binding kept
+%% propagating through the whole chain regardless of max-hops. With the
+%% fix, a header carrying a non-positive hop count means "do not
+%% propagate any further", so the forged binding never leaves the node it
+%% was declared on.
+forged_hops_does_not_bypass_max_hops(Config) ->
+  case rabbit_ct_helpers:is_mixed_versions() of
+    false ->
+      [NodeA, NodeB, NodeC] = rabbit_ct_broker_helpers:get_node_configs(
+        Config, nodename),
+      await_credentials_obfuscation_seeding_on_two_nodes(Config),
+
+      UpX = <<"chain">>,
+
+      %% B consumes from A
+      rabbit_ct_broker_helpers:set_parameter(
+        Config, NodeB, <<"federation-upstream">>, <<"upstream">>,
+        [
+          {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeA)},
+          {<<"exchange">>, UpX},
+          {<<"max-hops">>, 1}
+        ]),
+      %% C consumes from B
+      rabbit_ct_broker_helpers:set_parameter(
+        Config, NodeC, <<"federation-upstream">>, <<"upstream">>,
+        [
+          {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeB)},
+          {<<"exchange">>, UpX},
+          {<<"max-hops">>, 1}
+        ]),
+
+      [begin
+        rabbit_ct_broker_helpers:set_policy(
+          Config, Node,
+          <<"fed.x">>, <<"^chain">>, <<"exchanges">>,
+          [
+            {<<"federation-upstream">>, <<"upstream">>}
+          ])
+       end || Node <- [NodeB, NodeC]],
+
+      NodeACh = rabbit_ct_client_helpers:open_channel(Config, NodeA),
+      NodeBCh = rabbit_ct_client_helpers:open_channel(Config, NodeB),
+      NodeCCh = rabbit_ct_client_helpers:open_channel(Config, NodeC),
+
+      X = exchange_declare_method(UpX),
+      declare_exchange(NodeACh, X),
+      declare_exchange(NodeBCh, X),
+      declare_exchange(NodeCCh, X),
+
+      %% Baseline: an ordinary binding created on C reaches B, one hop
+      %% away, confirming the chain and the propagation path both work.
+      _ = declare_and_bind_queue(NodeCCh, UpX, <<"baseline">>),
+      await_binding(Config, NodeB, UpX, <<"baseline">>),
+
+      ForgedArgs = [{?BINDING_HEADER, array,
+                     [{table, [{<<"hops">>, short, -100},
+                               {<<"cluster-name">>, longstr, <<"nonexistent">>},
+                               {<<"vhost">>, longstr, <<"x">>}]}]}],
+      _ = declare_and_bind_queue(NodeCCh, UpX, <<"forged">>, ForgedArgs),
+
+      %% Give propagation a chance to happen before asserting its absence.
+      timer:sleep(5000),
+      [] = bound_keys_from(Config, NodeB, <<"/">>, UpX, <<"forged">>),
+      [] = bound_keys_from(Config, NodeA, <<"/">>, UpX, <<"forged">>),
+
+      clean_up_federation_related_bits(Config);
+    true ->
+      {skip, "Should not run in mixed version environments"}
+  end.
+
 exchange_federation_link_status(Config) ->
   FedX = <<"single_upstream.federated">>,
   UpX = <<"single_upstream.upstream.x">>,
@@ -662,6 +738,87 @@ supervisor_shutdown_concurrency_safety(Config) ->
   %% Verify federation still works after recovery
   await_binding(Config, 0, UpX, RK),
   publish_expect(Ch, UpX, RK, Q, <<"after_recovery">>),
+
+  clean_up_federation_related_bits(Config).
+
+%% A forged x-bound-from binding argument used to crash the link, and the
+%% crash repeated indefinitely because the poisoned binding is replayed on
+%% every restart.
+forged_binding_header_does_not_crash_link(Config) ->
+  FedX = <<"forged_binding_header.federated">>,
+  UpX = <<"forged_binding_header.upstream.x">>,
+  rabbit_ct_broker_helpers:set_parameter(
+    Config, 0, <<"federation-upstream">>, <<"localhost">>,
+    [
+      {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, 0)},
+      {<<"exchange">>, UpX}
+    ]),
+  rabbit_ct_broker_helpers:set_policy(
+    Config, 0,
+    <<"fed.x">>, <<"^forged_binding_header.federated">>, <<"exchanges">>,
+    [
+      {<<"federation-upstream">>, <<"localhost">>}
+    ]),
+
+  Ch = rabbit_ct_client_helpers:open_channel(Config, 0),
+
+  Xs = [
+    exchange_declare_method(FedX)
+  ],
+  declare_exchanges(Ch, Xs),
+
+  _ = declare_and_bind_queue(Ch, FedX, <<"not-an-array">>,
+                             [{?BINDING_HEADER, longstr, <<"nope">>}]),
+  _ = declare_and_bind_queue(Ch, FedX, <<"no-hops">>,
+                             [{?BINDING_HEADER, array,
+                               [{table, [{<<"cluster-name">>, longstr, <<"x">>}]}]}]),
+
+  RK = <<"key">>,
+  Q = declare_and_bind_queue(Ch, FedX, RK),
+  await_binding(Config, 0, UpX, RK),
+  publish_expect(Ch, UpX, RK, Q, <<"forged_binding_header payload">>),
+
+  [Link] = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                        rabbit_federation_status, status,
+                                        []),
+  running = proplists:get_value(status, Link),
+
+  clean_up_federation_related_bits(Config).
+
+%% `max-hops` is only checked when the parameter is set, so a value persisted
+%% by an earlier version, which accepted any number, is read back as is. A
+%% fractional value used to crash the link, since it cannot be encoded into
+%% the integer fields that carry the hop count.
+invalid_persisted_max_hops_does_not_crash_link(Config) ->
+  FedX = <<"invalid_persisted_max_hops.federated">>,
+  UpX = <<"invalid_persisted_max_hops.upstream.x">>,
+  Definition = [
+    {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, 0)},
+    {<<"exchange">>, UpX},
+    {<<"max-hops">>, 2.5}
+  ],
+  ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE,
+                                    set_upstream_without_validation,
+                                    [<<"legacy">>, Definition]),
+  rabbit_ct_broker_helpers:set_policy(
+    Config, 0,
+    <<"fed.x">>, <<"^invalid_persisted_max_hops.federated">>, <<"exchanges">>,
+    [
+      {<<"federation-upstream">>, <<"legacy">>}
+    ]),
+
+  Ch = rabbit_ct_client_helpers:open_channel(Config, 0),
+  declare_exchange(Ch, exchange_declare_method(FedX)),
+
+  RK = <<"key">>,
+  Q = declare_and_bind_queue(Ch, FedX, RK),
+  await_binding(Config, 0, UpX, RK),
+  publish_expect(Ch, UpX, RK, Q, <<"invalid_persisted_max_hops payload">>),
+
+  [Link] = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                        rabbit_federation_status, status,
+                                        []),
+  running = proplists:get_value(status, Link),
 
   clean_up_federation_related_bits(Config).
 
@@ -862,6 +1019,13 @@ clean_up_federation_related_bits(Config) ->
     [delete_all_exchanges_on(Config, N) || N <- NodeIndices],
     ok.
 
+%% Writes the parameter straight to the store, the way a definition persisted
+%% before `max-hops` was validated as a bounded integer would be read back.
+set_upstream_without_validation(Name, Definition) ->
+  _ = rabbit_db_rtparams:set(<<"/">>, <<"federation-upstream">>, Name, Definition),
+  rabbit_federation_parameters:notify(<<"/">>, <<"federation-upstream">>, Name,
+                                      Definition, <<"acting-user">>).
+
 set_up_upstream(Config) ->
   rabbit_ct_broker_helpers:set_parameter(
     Config, 0, <<"federation-upstream">>, <<"localhost">>,
@@ -915,9 +1079,13 @@ declare_queue(Ch, Q) ->
   amqp_channel:call(Ch, Q).
 
 bind_queue(Ch, Q, X, Key) ->
+    bind_queue(Ch, Q, X, Key, []).
+
+bind_queue(Ch, Q, X, Key, Args) ->
     amqp_channel:call(Ch, #'queue.bind'{queue       = Q,
                                         exchange    = X,
-                                        routing_key = Key}).
+                                        routing_key = Key,
+                                        arguments   = Args}).
 
 unbind_queue(Ch, Q, X, Key) ->
     amqp_channel:call(Ch, #'queue.unbind'{queue       = Q,
@@ -932,6 +1100,11 @@ bind_exchange(Ch, D, S, Key) ->
 declare_and_bind_queue(Ch, X, Key) ->
     Q = declare_queue(Ch),
     bind_queue(Ch, Q, X, Key),
+    Q.
+
+declare_and_bind_queue(Ch, X, Key, Args) ->
+    Q = declare_queue(Ch),
+    bind_queue(Ch, Q, X, Key, Args),
     Q.
 
 

--- a/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
@@ -529,14 +529,12 @@ max_hops(Config) ->
       {skip, "Should not run in mixed version environments"}
   end.
 
-%% A chain rather than a ring, so that cycle detection cannot mask the
-%% result: A is the original source, B consumes from A, C consumes from B.
-%% A forged x-bound-from header used to make the hop counter negative,
-%% which never reaches 0 through ordinary arithmetic, so a binding kept
-%% propagating through the whole chain regardless of max-hops. With the
-%% fix, a header carrying a non-positive hop count means "do not
-%% propagate any further", so the forged binding never leaves the node it
-%% was declared on.
+%% Uses a chain (B consumes from A, C consumes from B) rather than a ring so
+%% that cycle detection cannot mask the result.
+%%
+%% A forged `x-bound-from` header with a negative hop count never reached 0
+%% by decrementing, so the binding propagated through the whole chain
+%% regardless of `max-hops`.
 forged_hops_does_not_bypass_max_hops(Config) ->
   case rabbit_ct_helpers:is_mixed_versions() of
     false ->
@@ -581,8 +579,8 @@ forged_hops_does_not_bypass_max_hops(Config) ->
       declare_exchange(NodeBCh, X),
       declare_exchange(NodeCCh, X),
 
-      %% Baseline: an ordinary binding created on C reaches B, one hop
-      %% away, confirming the chain and the propagation path both work.
+      %% An ordinary binding must reach B first, otherwise the absence of the
+      %% forged one below proves nothing.
       _ = declare_and_bind_queue(NodeCCh, UpX, <<"baseline">>),
       await_binding(Config, NodeB, UpX, <<"baseline">>),
 
@@ -592,7 +590,7 @@ forged_hops_does_not_bypass_max_hops(Config) ->
                                {<<"vhost">>, longstr, <<"x">>}]}]}],
       _ = declare_and_bind_queue(NodeCCh, UpX, <<"forged">>, ForgedArgs),
 
-      %% Give propagation a chance to happen before asserting its absence.
+      %% Propagation is asynchronous, so allow it time before asserting its absence.
       timer:sleep(5000),
       [] = bound_keys_from(Config, NodeB, <<"/">>, UpX, <<"forged">>),
       [] = bound_keys_from(Config, NodeA, <<"/">>, UpX, <<"forged">>),
@@ -741,9 +739,8 @@ supervisor_shutdown_concurrency_safety(Config) ->
 
   clean_up_federation_related_bits(Config).
 
-%% A forged x-bound-from binding argument used to crash the link, and the
-%% crash repeated indefinitely because the poisoned binding is replayed on
-%% every restart.
+%% A malformed `x-bound-from` binding argument used to crash the link on
+%% every restart, since the binding is replayed each time.
 forged_binding_header_does_not_crash_link(Config) ->
   FedX = <<"forged_binding_header.federated">>,
   UpX = <<"forged_binding_header.upstream.x">>,
@@ -785,10 +782,9 @@ forged_binding_header_does_not_crash_link(Config) ->
 
   clean_up_federation_related_bits(Config).
 
-%% `max-hops` is only checked when the parameter is set, so a value persisted
-%% by an earlier version, which accepted any number, is read back as is. A
-%% fractional value used to crash the link, since it cannot be encoded into
-%% the integer fields that carry the hop count.
+%% Earlier versions accepted any number for `max-hops`, and a persisted
+%% fractional value used to crash the link when the hop count was encoded
+%% into an integer field.
 invalid_persisted_max_hops_does_not_crash_link(Config) ->
   FedX = <<"invalid_persisted_max_hops.federated">>,
   UpX = <<"invalid_persisted_max_hops.upstream.x">>,
@@ -1019,8 +1015,8 @@ clean_up_federation_related_bits(Config) ->
     [delete_all_exchanges_on(Config, N) || N <- NodeIndices],
     ok.
 
-%% Writes the parameter straight to the store, the way a definition persisted
-%% before `max-hops` was validated as a bounded integer would be read back.
+%% Bypasses validation to reproduce a definition persisted by a version that
+%% did not validate `max-hops`.
 set_upstream_without_validation(Name, Definition) ->
   _ = rabbit_db_rtparams:set(<<"/">>, <<"federation-upstream">>, Name, Definition),
   rabbit_federation_parameters:notify(<<"/">>, <<"federation-upstream">>, Name,

--- a/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -include("rabbit_exchange_federation.hrl").
+-include_lib("rabbitmq_federation_common/include/rabbit_federation.hrl").
 
 -compile(export_all).
 
@@ -19,7 +20,18 @@ all() -> [
     reconnect_all_broadcasts_to_members,
     adjust_when_supervisor_not_running,
     adjust_clear_upstream_when_supervisor_not_running,
-    start_child_handles_already_present
+    start_child_handles_already_present,
+    hops_no_header_returns_max_hops,
+    hops_larger_than_max_hops_is_clamped,
+    hops_of_one_returns_zero,
+    hops_of_zero_or_negative_returns_zero,
+    hops_missing_from_head_table_returns_zero,
+    hops_with_non_integer_value_returns_zero,
+    hops_header_not_an_array_returns_zero,
+    hops_empty_array_or_non_table_head_returns_zero,
+    hops_accepts_long_and_unsignedbyte,
+    hops_cycle_detection_returns_zero,
+    hops_with_non_positive_max_hops_returns_zero
 ].
 
 init_per_suite(Config) ->
@@ -97,3 +109,57 @@ start_child_handles_already_present(_Config) ->
     after
         ok = meck:unload(mirrored_supervisor)
     end.
+
+%% hops/4 is pure: no header, cluster name and vhost are just used for
+%% cycle detection and are otherwise arbitrary here.
+-define(UNAME, <<"upstream-cluster">>).
+-define(UVHOST, <<"/">>).
+
+hops_no_header_returns_max_hops(_Config) ->
+    ?assertEqual(5, rabbit_federation_exchange_link:hops([], 5, ?UNAME, ?UVHOST)).
+
+hops_larger_than_max_hops_is_clamped(_Config) ->
+    ?assertEqual(3, rabbit_federation_exchange_link:hops(header_with_hops(10), 3, ?UNAME, ?UVHOST)).
+
+hops_of_one_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(header_with_hops(1), 5, ?UNAME, ?UVHOST)).
+
+hops_of_zero_or_negative_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(header_with_hops(0), 5, ?UNAME, ?UVHOST)),
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(header_with_hops(-100), 5, ?UNAME, ?UVHOST)).
+
+hops_missing_from_head_table_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, array, [{table, [{<<"cluster-name">>, longstr, <<"x">>}]}]}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_with_non_integer_value_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, array, [{table, [{<<"hops">>, longstr, <<"5">>}]}]}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_header_not_an_array_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, longstr, <<"nope">>}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_empty_array_or_non_table_head_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([{?BINDING_HEADER, array, []}], 5, ?UNAME, ?UVHOST)),
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([{?BINDING_HEADER, array, [{longstr, <<"x">>}]}], 5, ?UNAME, ?UVHOST)).
+
+hops_accepts_long_and_unsignedbyte(_Config) ->
+    LongArgs = [{?BINDING_HEADER, array, [{table, [{<<"hops">>, long, 3}]}]}],
+    ?assertEqual(2, rabbit_federation_exchange_link:hops(LongArgs, 5, ?UNAME, ?UVHOST)),
+    ByteArgs = [{?BINDING_HEADER, array, [{table, [{<<"hops">>, unsignedbyte, 3}]}]}],
+    ?assertEqual(2, rabbit_federation_exchange_link:hops(ByteArgs, 5, ?UNAME, ?UVHOST)).
+
+hops_cycle_detection_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, array,
+             [{table, [{<<"hops">>, short, 5},
+                       {<<"cluster-name">>, longstr, ?UNAME},
+                       {<<"vhost">>, longstr, ?UVHOST}]}]}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_with_non_positive_max_hops_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([], 0, ?UNAME, ?UVHOST)),
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([], -1, ?UNAME, ?UVHOST)).
+
+header_with_hops(Hops) ->
+    [{?BINDING_HEADER, array, [{table, [{<<"hops">>, short, Hops}]}]}].

--- a/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
@@ -110,8 +110,8 @@ start_child_handles_already_present(_Config) ->
         ok = meck:unload(mirrored_supervisor)
     end.
 
-%% hops/4 is pure: no header, cluster name and vhost are just used for
-%% cycle detection and are otherwise arbitrary here.
+%% `hops/4` only uses the cluster name and vhost for cycle detection, so any
+%% values will do.
 -define(UNAME, <<"upstream-cluster">>).
 -define(UVHOST, <<"/">>).
 

--- a/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
@@ -42,6 +42,11 @@
 %% Identifies a virtual host, used by exchange federation cycle detection
 -define(DOWNSTREAM_VHOST_ARG, <<"x-downstream-vhost">>).
 -define(DEF_PREFETCH, 1000).
+-define(DEF_MAX_HOPS, 1).
+-define(MIN_MAX_HOPS, 1).
+%% The hop counter is encoded into a `short` field on the wire by exchange
+%% federation, hence the upper bound on `max-hops`.
+-define(MAX_MAX_HOPS, 32767).
 
 -define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/docs/federation/">>).
 

--- a/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
@@ -44,8 +44,7 @@
 -define(DEF_PREFETCH, 1000).
 -define(DEF_MAX_HOPS, 1).
 -define(MIN_MAX_HOPS, 1).
-%% The hop counter is encoded into a `short` field on the wire by exchange
-%% federation, hence the upper bound on `max-hops`.
+%% Exchange federation encodes the hop counter as a `short` table field.
 -define(MAX_MAX_HOPS, 32767).
 
 -define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/docs/federation/">>).

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_parameters.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_parameters.erl
@@ -82,7 +82,7 @@ shared_validation() ->
      {<<"consumer-tag">>,   fun rabbit_parameter_validation:binary/2, optional},
      {<<"prefetch-count">>, fun rabbit_parameter_validation:number/2, optional},
      {<<"reconnect-delay">>,fun rabbit_parameter_validation:number/2, optional},
-     {<<"max-hops">>,       fun rabbit_parameter_validation:number/2, optional},
+     {<<"max-hops">>,       fun validate_max_hops/2, optional},
      {<<"expires">>,        fun rabbit_parameter_validation:number/2, optional},
      {<<"message-ttl">>,    fun rabbit_parameter_validation:number/2, optional},
      {<<"trust-user-id">>,  fun rabbit_parameter_validation:boolean/2, optional},
@@ -95,6 +95,14 @@ shared_validation() ->
      {<<"bind-nowait">>,    fun rabbit_parameter_validation:boolean/2, optional},
      {<<"channel-use-mode">>, rabbit_parameter_validation:enum(
                               ['multiple', 'single']), optional}].
+
+validate_max_hops(_Name, Term) when is_integer(Term) andalso
+                                    Term >= ?MIN_MAX_HOPS andalso
+                                    Term =< ?MAX_MAX_HOPS ->
+    ok;
+validate_max_hops(Name, Term) ->
+    {error, "~ts should be an integer between ~b and ~b, actually was ~tp",
+     [Name, ?MIN_MAX_HOPS, ?MAX_MAX_HOPS, Term]}.
 
 validate_uri(User) ->
     fun (Name, Term) -> validate_uri(Name, Term, User) end.

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -174,11 +174,10 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               channel_use_mode      = to_atom(bget('channel-use-mode', US, U, multiple))
     }.
 
-%% `max-hops` is validated when the parameter is set, but parameters persisted
-%% by earlier versions were only checked for being a number, so they are read
-%% back as is. A fractional value used to crash the exchange federation link
-%% when it encoded the hop counter, and a value too large for that encoding was
-%% silently truncated to a negative one, hence the normalization here.
+%% Parameters persisted by earlier versions were only checked for being a
+%% number. A fractional value used to crash the exchange federation link when
+%% the hop counter was encoded as a `short`, and a value above the `short`
+%% range wrapped around to a negative one.
 -spec max_hops(term()) -> pos_integer().
 max_hops(N) when is_integer(N) andalso
                  N >= ?MIN_MAX_HOPS andalso

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -11,7 +11,7 @@
 -include_lib("rabbit/include/amqqueue.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 
--export([federate/1, for/1, for/2, params_to_string/1, to_params/2]).
+-export([federate/1, for/1, for/2, params_to_string/1, to_params/2, max_hops/1]).
 %% For testing
 -export([from_set/2, from_pattern/2, remove_credentials/1]).
 
@@ -162,7 +162,7 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               consumer_tag    = bget('consumer-tag',    US, U, <<"federation-link-", Name/binary>>),
               prefetch_count  = bget('prefetch-count',  US, U, ?DEF_PREFETCH),
               reconnect_delay = bget('reconnect-delay', US, U, 5),
-              max_hops        = bget('max-hops',        US, U, 1),
+              max_hops        = max_hops(bget('max-hops', US, U, ?DEF_MAX_HOPS)),
               expires         = bget(expires,           US, U, none),
               message_ttl     = bget('message-ttl',     US, U, none),
               trust_user_id   = bget('trust-user-id',   US, U, false),
@@ -173,6 +173,23 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               resource_cleanup_mode = to_atom(bget('resource-cleanup-mode', US, U, <<"default">>)),
               channel_use_mode      = to_atom(bget('channel-use-mode', US, U, multiple))
     }.
+
+%% `max-hops` is validated when the parameter is set, but parameters persisted
+%% by earlier versions were only checked for being a number, so they are read
+%% back as is. A fractional value used to crash the exchange federation link
+%% when it encoded the hop counter, and a value too large for that encoding was
+%% silently truncated to a negative one, hence the normalization here.
+-spec max_hops(term()) -> pos_integer().
+max_hops(N) when is_integer(N) andalso
+                 N >= ?MIN_MAX_HOPS andalso
+                 N =< ?MAX_MAX_HOPS ->
+    N;
+max_hops(N) when is_number(N) andalso N > ?MAX_MAX_HOPS ->
+    ?MAX_MAX_HOPS;
+max_hops(N) when is_number(N) andalso N > ?MIN_MAX_HOPS ->
+    trunc(N);
+max_hops(_N) ->
+    ?MIN_MAX_HOPS.
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -330,8 +330,8 @@ max_hops_keeps_valid_values(_Config) ->
         V <- [1, 2, 32766, 32767]],
     ok.
 
-%% Values persisted before `max-hops` was validated as a bounded integer are
-%% read back as is, so they have to be brought back into range here.
+%% Values persisted by versions that did not validate `max-hops` are read
+%% back as is.
 max_hops_normalizes_legacy_values(_Config) ->
     ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000)),
     ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000.5)),
@@ -342,8 +342,8 @@ max_hops_normalizes_legacy_values(_Config) ->
     ?assertEqual(1, rabbit_federation_upstream:max_hops(<<"many">>)),
     ok.
 
-%% Validated through the upstream set component: unlike the upstream one, it
-%% has no mandatory URI to validate, which keeps this a pure function call.
+%% Goes through the upstream set component because, unlike the upstream one,
+%% it has no mandatory URI to validate.
 validation_errors(MaxHops) ->
     Results = rabbit_federation_parameters:validate(
                 <<"/">>, <<"federation-upstream-set">>,

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -35,7 +35,12 @@ all() -> [
     redact_params_network,
     redact_params_direct,
     redact_params_ssl_options_password,
-    redact_params_ssl_options_none
+    redact_params_ssl_options_none,
+    validate_max_hops_accepts_bounds,
+    validate_max_hops_rejects_out_of_range,
+    validate_max_hops_rejects_non_integers,
+    max_hops_keeps_valid_values,
+    max_hops_normalizes_legacy_values
 ].
 
 init_per_suite(Config) ->
@@ -301,3 +306,47 @@ redact_params_ssl_options_none(_Config) ->
     ?assertMatch(#amqp_params_network{ssl_options = none},
                  rabbit_federation_util:redact_params(Params)),
     ok.
+
+%% -------------------------------------------------------------------
+%% max-hops validation and normalization
+%% -------------------------------------------------------------------
+
+validate_max_hops_accepts_bounds(_Config) ->
+    [?assertEqual([], validation_errors(V)) || V <- [1, 2, 32766, 32767]],
+    ok.
+
+validate_max_hops_rejects_out_of_range(_Config) ->
+    [?assertMatch([{error, _, _}], validation_errors(V)) ||
+        V <- [0, -1, -32768, 32768, 100000]],
+    ok.
+
+validate_max_hops_rejects_non_integers(_Config) ->
+    [?assertMatch([{error, _, _}], validation_errors(V)) ||
+        V <- [1.5, 1.0, <<"1">>, "1", true, undefined, [1], {1}]],
+    ok.
+
+max_hops_keeps_valid_values(_Config) ->
+    [?assertEqual(V, rabbit_federation_upstream:max_hops(V)) ||
+        V <- [1, 2, 32766, 32767]],
+    ok.
+
+%% Values persisted before `max-hops` was validated as a bounded integer are
+%% read back as is, so they have to be brought back into range here.
+max_hops_normalizes_legacy_values(_Config) ->
+    ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000)),
+    ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000.5)),
+    ?assertEqual(2, rabbit_federation_upstream:max_hops(2.7)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(0)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(0.5)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(-100)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(<<"many">>)),
+    ok.
+
+%% Validated through the upstream set component: unlike the upstream one, it
+%% has no mandatory URI to validate, which keeps this a pure function call.
+validation_errors(MaxHops) ->
+    Results = rabbit_federation_parameters:validate(
+                <<"/">>, <<"federation-upstream-set">>,
+                <<"a-name">>, [[{<<"upstream">>, <<"an-upstream">>},
+                                {<<"max-hops">>, MaxHops}]], none),
+    [R || Rs <- Results, R <- Rs, R =/= ok].


### PR DESCRIPTION
The hop counter carried in binding arguments during federation binding propagation is client-controlled. Compute it with a pure, non-negative function instead of trusting the raw value, and validate `max-hops` as a bounded positive integer, so malformed or out-of-range input can no longer produce unbounded propagation or crash the link.