### PR TITLE
DO NOT MERGE Guard policy re-evaluation against concurrent queue/exchange writes

### DIFF
--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -40,6 +40,7 @@
          delete_in_khepri/3,
          get_in_khepri_tx/1,
          update_in_khepri_tx/2,
+         update_in_khepri_tx/3,
          clear_exchanges_in_khepri/0,
          clear_exchange_serials_in_khepri/0,
          put_options/1
@@ -259,6 +260,42 @@ update_in_khepri_tx(Name, Fun) ->
             X1 = Fun(X),
             ok = khepri_tx:put(Path, X1),
             X1;
+        _ -> not_found
+    end.
+
+%% -------------------------------------------------------------------
+%% update_in_khepri_tx().
+%% -------------------------------------------------------------------
+
+-spec update_in_khepri_tx(ExchangeName, Vsn, UpdateFun) -> Ret when
+      ExchangeName :: rabbit_exchange:name(),
+      Vsn :: khepri:payload_version(),
+      Exchange :: rabbit_types:exchange(),
+      UpdateFun :: fun((Exchange) -> Exchange),
+      Ret :: not_found | Exchange.
+%% @doc Same as `update_in_khepri_tx/2', but only applies `UpdateFun' if
+%% the record hasn't changed since the version `Vsn' was read, aborting
+%% the enclosing transaction with `mismatching_node' otherwise. Use this
+%% when `Vsn' was read outside of the transaction, e.g. to decide
+%% `UpdateFun' itself from data that could since have gone stale.
+
+update_in_khepri_tx(Name, Vsn, Fun) ->
+    Path = khepri_exchange_path(Name),
+    case khepri_tx:get(Path) of
+        {ok, X} ->
+            X1 = Fun(X),
+            UpdatePath = khepri_path:combine_with_conditions(
+                           Path, [#if_payload_version{version = Vsn}]),
+            %% A mismatching_node condition failure must abort the whole
+            %% enclosing transaction, discarding any puts already made
+            %% during this attempt: khepri_tx:abort/1 does this via an
+            %% exception, unlike returning the failure as an ordinary
+            %% {error, _} value, which khepri would otherwise still
+            %% commit up to this point.
+            case khepri_tx:put(UpdatePath, X1) of
+                ok -> X1;
+                {error, Reason} -> khepri_tx:abort(Reason)
+            end;
         _ -> not_found
     end.
 

--- a/deps/rabbit/src/rabbit_db_policy.erl
+++ b/deps/rabbit/src/rabbit_db_policy.erl
@@ -7,6 +7,7 @@
 
 -module(rabbit_db_policy).
 
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("amqqueue.hrl").
 
@@ -26,30 +27,81 @@
                                      update_function => fun((Queue) -> Queue)}),
       Ret :: {[{Exchange, Exchange}], [{Queue, Queue}]}.
 
+%% `UpdateXFun'/`UpdateQFun' decide the new policy to apply from a
+%% snapshot of the vhost's exchanges/queues read here, outside of the
+%% transaction below. If a *different* concurrent policy update commits
+%% first, that snapshot is stale by the time this transaction runs: the
+%% payload_version guard on each write (see rabbit_db_exchange/queue's
+%% update_in_khepri_tx/3) detects that and aborts the whole transaction
+%% -- discarding any puts already made during this attempt, since
+%% khepri_tx:abort/1 unwinds via an exception rather than returning an
+%% ordinary value the transaction would otherwise still commit -- and
+%% retrying from scratch re-reads the now-current state instead of
+%% blindly overwriting the concurrent update's effect.
 update(VHost, GetUpdatedExchangeFun, GetUpdatedQueueFun) ->
-    Exchanges0 = rabbit_db_exchange:get_all(VHost),
-    Queues0 = rabbit_db_queue:get_all(VHost),
-    Exchanges = [GetUpdatedExchangeFun(X) || X <- Exchanges0],
-    Queues = [GetUpdatedQueueFun(Q) || Q <- Queues0],
-    rabbit_khepri:transaction(
-      fun() ->
-              {[update_exchange_policies(Map, fun rabbit_db_exchange:update_in_khepri_tx/2)
-                || Map <- Exchanges, is_map(Map)],
-               [update_queue_policies(Map, fun rabbit_db_queue:update_in_khepri_tx/2)
-                || Map <- Queues, is_map(Map)]}
-      end, rw).
+    case rabbit_khepri:adv_get_many(
+           rabbit_db_exchange:khepri_exchange_path(VHost, #if_has_data{})) of
+        {ok, ExchangeProps} ->
+            case rabbit_khepri:adv_get_many(
+                   rabbit_db_queue:khepri_queue_path(VHost, #if_has_data{})) of
+                {ok, QueueProps} ->
+                    update1(VHost, GetUpdatedExchangeFun, GetUpdatedQueueFun,
+                            ExchangeProps, QueueProps);
+                {error, _} = Error ->
+                    error(Error)
+            end;
+        {error, _} = Error ->
+            error(Error)
+    end.
+
+update1(VHost, GetUpdatedExchangeFun, GetUpdatedQueueFun,
+        ExchangeProps, QueueProps) ->
+    ExchangeVsns = maps:from_list(
+                     [{XName, Vsn}
+                      || #{data := #exchange{name = XName},
+                           payload_version := Vsn} <- maps:values(ExchangeProps)]),
+    QueueVsns = maps:from_list(
+                  [{amqqueue:get_name(Q), Vsn}
+                   || #{data := Q, payload_version := Vsn} <- maps:values(QueueProps),
+                      ?is_amqqueue(Q)]),
+    Exchanges = [GetUpdatedExchangeFun(X)
+                 || #{data := X} <- maps:values(ExchangeProps)],
+    Queues = [GetUpdatedQueueFun(Q)
+              || #{data := Q} <- maps:values(QueueProps), ?is_amqqueue(Q)],
+    %% rabbit_khepri:transaction/2 throws {error, Reason} (it doesn't
+    %% return it as a value) whenever the transaction fun aborts via
+    %% khepri_tx:abort/1, which is how update_in_khepri_tx/3 signals a
+    %% payload_version mismatch.
+    try
+        rabbit_khepri:transaction(
+          fun() ->
+                  {[update_exchange_policies(
+                      Map, ExchangeVsns,
+                      fun rabbit_db_exchange:update_in_khepri_tx/3)
+                    || Map <- Exchanges, is_map(Map)],
+                   [update_queue_policies(
+                      Map, QueueVsns,
+                      fun rabbit_db_queue:update_in_khepri_tx/3)
+                    || Map <- Queues, is_map(Map)]}
+          end, rw)
+    catch
+        throw:{error, {khepri, mismatching_node, _}} ->
+            update(VHost, GetUpdatedExchangeFun, GetUpdatedQueueFun)
+    end.
 
 update_exchange_policies(#{exchange := X = #exchange{name = XName},
-                           update_function := UpdateFun}, StoreFun) ->
-    NewExchange = StoreFun(XName, UpdateFun),
+                           update_function := UpdateFun}, Vsns, StoreFun) ->
+    Vsn = maps:get(XName, Vsns),
+    NewExchange = StoreFun(XName, Vsn, UpdateFun),
     case NewExchange of
         #exchange{} = X1 -> {X, X1};
         not_found        -> {X, X }
     end.
 
-update_queue_policies(#{queue := Q0, update_function := UpdateFun}, StoreFun) ->
+update_queue_policies(#{queue := Q0, update_function := UpdateFun}, Vsns, StoreFun) ->
     QName = amqqueue:get_name(Q0),
-    NewQueue = StoreFun(QName, UpdateFun),
+    Vsn = maps:get(QName, Vsns),
+    NewQueue = StoreFun(QName, Vsn, UpdateFun),
     case NewQueue of
         Q1 when ?is_amqqueue(Q1) ->
             {Q0, Q1};

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -62,6 +62,7 @@
 %% Used by other rabbit_db_* modules
 -export([
          update_in_khepri_tx/2,
+         update_in_khepri_tx/3,
          get_in_khepri_tx/1
         ]).
 
@@ -977,6 +978,45 @@ update_in_khepri_tx(Name, Fun) ->
             Q1 = Fun(Q),
             ok = khepri_tx:put(Path, Q1),
             Q1;
+        _  ->
+            not_found
+    end.
+
+%% -------------------------------------------------------------------
+%% update_in_khepri_tx().
+%% -------------------------------------------------------------------
+
+-spec update_in_khepri_tx(QName, Vsn, UpdateFun) -> Ret when
+      QName :: rabbit_amqqueue:name(),
+      Vsn :: khepri:payload_version(),
+      Queue :: amqqueue:amqqueue(),
+      UpdateFun :: fun((Queue) -> Queue),
+      Ret :: Queue | not_found.
+%% @doc Same as `update_in_khepri_tx/2', but only applies `UpdateFun' if
+%% the record hasn't changed since the version `Vsn' was read, aborting
+%% the enclosing transaction with `mismatching_node' otherwise. Use this
+%% when `Vsn' was read outside of the transaction, e.g. to decide
+%% `UpdateFun' itself from data that could since have gone stale.
+%%
+%% @private
+
+update_in_khepri_tx(Name, Vsn, Fun) ->
+    Path = khepri_queue_path(Name),
+    case khepri_tx:get(Path) of
+        {ok, Q} ->
+            Q1 = Fun(Q),
+            UpdatePath = khepri_path:combine_with_conditions(
+                           Path, [#if_payload_version{version = Vsn}]),
+            %% A mismatching_node condition failure must abort the whole
+            %% enclosing transaction, discarding any puts already made
+            %% during this attempt: khepri_tx:abort/1 does this via an
+            %% exception, unlike returning the failure as an ordinary
+            %% {error, _} value, which khepri would otherwise still
+            %% commit up to this point.
+            case khepri_tx:put(UpdatePath, Q1) of
+                ok -> Q1;
+                {error, Reason} -> khepri_tx:abort(Reason)
+            end;
         _  ->
             not_found
     end.

--- a/deps/rabbit/test/rabbit_db_policy_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_policy_SUITE.erl
@@ -25,7 +25,9 @@ groups() ->
 
 all_tests() ->
     [
-     update
+     update,
+     update_retries_on_concurrent_change,
+     update_retries_on_concurrent_change_exchange
     ].
 
 %% -------------------------------------------------------------------
@@ -55,10 +57,12 @@ end_per_group(_Group, Config) ->
 
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_exchange, clear, []),
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, clear, []),
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_exchange, clear, []),
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_queue, clear, []),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% ---------------------------------------------------------------------------
@@ -91,4 +95,113 @@ update1(_Config) ->
                                                        amqqueue:set_policy(Q0, random_policy)
                                                end}
                                end)),
+    passed.
+
+%% update/3 decides the new policy from a snapshot read before its own
+%% transaction. If a different concurrent write lands in the window
+%% between that read and the transaction, the payload_version guard must
+%% cause a retry rather than silently overwriting the concurrent write.
+update_retries_on_concurrent_change(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE, update_retries_on_concurrent_change1, [Config]).
+
+update_retries_on_concurrent_change1(_Config) ->
+    QName = rabbit_misc:r(?VHOST, queue, <<"test-queue-race">>),
+    Queue = amqqueue:new(QName, none, true, false, none, [], ?VHOST, #{},
+                         rabbit_classic_queue),
+    ?assertEqual({created, Queue}, rabbit_db_queue:create_or_get(Queue)),
+
+    %% Simulate a concurrent write landing in the window between
+    %% update/3's own snapshot read and its transaction: bump the
+    %% queue's version via a completely different field, from inside
+    %% the caller-supplied GetUpdatedQueueFun, exactly once.
+    %%
+    %% update_function below reapplies PrecomputedArgs -- a value
+    %% derived from Q0, the snapshot read *before* the bump -- the same
+    %% way the real rabbit_policy:get_updated_queue/2 precomputes
+    %% Decorators outside the transaction and blindly writes it back.
+    %% Without the payload_version guard forcing a retry (which
+    %% recomputes PrecomputedArgs from the now-current, post-bump
+    %% queue), this blind reapplication is exactly what would silently
+    %% clobber the concurrent write.
+    Invocations = counters:new(1, []),
+    Bumped = counters:new(1, []),
+    GetUpdatedQueueFun =
+        fun(Q0) ->
+                counters:add(Invocations, 1, 1),
+                PrecomputedArgs = amqqueue:get_arguments(Q0),
+                case counters:get(Bumped, 1) of
+                    0 ->
+                        counters:add(Bumped, 1, 1),
+                        _ = rabbit_db_queue:update(
+                              QName,
+                              fun(Q) ->
+                                      amqqueue:set_arguments(
+                                        Q, [{<<"x-concurrent">>, long, 1}])
+                              end);
+                    _ ->
+                        ok
+                end,
+                #{queue => Q0,
+                  update_function =>
+                      fun(Q) ->
+                              Q1 = amqqueue:set_policy(Q, new_policy),
+                              amqqueue:set_arguments(Q1, PrecomputedArgs)
+                      end}
+        end,
+    {[], [{_, NewQ}]} = rabbit_db_policy:update(
+                           ?VHOST, fun(_X) -> no_change end, GetUpdatedQueueFun),
+
+    %% Neither the concurrent write nor this policy update was dropped.
+    ?assertEqual(new_policy, amqqueue:get_policy(NewQ)),
+    ?assertEqual([{<<"x-concurrent">>, long, 1}], amqqueue:get_arguments(NewQ)),
+    %% GetUpdatedQueueFun ran again for the retry: once for the attempt
+    %% that hit the version mismatch, and again for the one that saw the
+    %% bump and succeeded.
+    ?assert(counters:get(Invocations, 1) >= 2),
+    passed.
+
+%% Same race as update_retries_on_concurrent_change/1, on the exchange
+%% side of update/3 instead of the queue side.
+update_retries_on_concurrent_change_exchange(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(
+               Config, 0, ?MODULE, update_retries_on_concurrent_change_exchange1,
+               [Config]).
+
+update_retries_on_concurrent_change_exchange1(_Config) ->
+    XName = rabbit_misc:r(?VHOST, exchange, <<"test-exchange-race">>),
+    Exchange = #exchange{name = XName, durable = true},
+    ?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(Exchange)),
+
+    Invocations = counters:new(1, []),
+    Bumped = counters:new(1, []),
+    GetUpdatedExchangeFun =
+        fun(X0) ->
+                counters:add(Invocations, 1, 1),
+                PrecomputedArgs = X0#exchange.arguments,
+                case counters:get(Bumped, 1) of
+                    0 ->
+                        counters:add(Bumped, 1, 1),
+                        _ = rabbit_db_exchange:update(
+                              XName,
+                              fun(X) ->
+                                      X#exchange{arguments =
+                                                     [{<<"x-concurrent">>, long, 1}]}
+                              end);
+                    _ ->
+                        ok
+                end,
+                #{exchange => X0,
+                  update_function =>
+                      fun(X) ->
+                              X#exchange{policy = new_policy,
+                                         arguments = PrecomputedArgs}
+                      end}
+        end,
+    {[{_, NewX}], []} = rabbit_db_policy:update(
+                           ?VHOST, GetUpdatedExchangeFun, fun(_Q) -> no_change end),
+
+    ?assertEqual(new_policy, NewX#exchange.policy),
+    ?assertEqual([{<<"x-concurrent">>, long, 1}], NewX#exchange.arguments),
+    ?assert(counters:get(Invocations, 1) >= 2),
     passed.


### PR DESCRIPTION
rabbit_db_policy:update/3 decided each queue/exchange's new policy from a snapshot read before its own transaction, then applied that decision inside the transaction with no check that the record hadn't changed since. Two policy changes racing on the same vhost could interleave so that the loser's transaction, built from a stale snapshot, silently overwrote whatever the winner's transaction had just committed.

Add update_in_khepri_tx/3 to rabbit_db_queue and rabbit_db_exchange, guarding the write with the payload_version read alongside the snapshot and aborting the transaction via khepri_tx:abort/1 on a mismatch (needed for the abort to actually discard puts already made in the same attempt, rather than let khepri commit them regardless). update/3 retries the whole operation from scratch on that abort, so the retry sees the concurrent write instead of overwriting it.
