### PR TITLE
Bound peer-controlled disposition delivery ID ranges

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -361,7 +361,13 @@ mapped(cast,
        #state{links = Links} = State0) ->
     case Links of
         #{OutputHandle := Link0 = #link{incoming_unsettled = Unsettled0}} ->
-            Unsettled = serial_number:foldl(fun maps:remove/2, Unsettled0, First, Last),
+            Unsettled = case serial_number:range_size(First, Last) of
+                            undefined ->
+                                Unsettled0;
+                            _RangeSize ->
+                                serial_number:foldl(fun maps:remove/2,
+                                                    Unsettled0, First, Last)
+                        end,
             Link = Link0#link{incoming_unsettled = Unsettled},
             State1 = State0#state{links = Links#{OutputHandle := Link}},
             State = auto_flow(Link, State1),
@@ -532,74 +538,78 @@ mapped(cast, #'v1_0.disposition'{role = ?AMQP_ROLE_RECEIVER,
                                  first = {uint, First},
                                  state = DeliveryState} = Disp,
        #state{outgoing_unsettled = Unsettled0} = State) ->
-    % TODO: no good if the range becomes very large!! refactor
-    Unsettled = serial_number:foldl(
-                  fun(Id, Acc0) ->
-                          case maps:take(Id, Acc0) of
-                              {{DeliveryTag, Pid}, Acc} ->
-                                  %% TODO: currently all modified delivery states
-                                  %% will be translated to the old, `modified` atom.
-                                  %% At some point we should translate into the
-                                  %% full {modified, bool, bool, map) tuple.
-                                  S = translate_delivery_state(DeliveryState),
-                                  ok = notify_disposition(Pid, {S, DeliveryTag}),
-                                  Acc;
-                              error ->
-                                  Acc0
-                          end
-                  end, Unsettled0, First, get_disposition_last(Disp)),
-    {keep_state, State#state{outgoing_unsettled = Unsettled}};
+    Last = get_disposition_last(Disp),
+    case serial_number:range_size(First, Last) of
+        undefined ->
+            ?LOG_WARNING("amqp10_session: ignoring disposition with invalid "
+                         "delivery ID range (first ~b, last ~b)", [First, Last]),
+            keep_state_and_data;
+        RangeSize ->
+            %% TODO: currently all modified delivery states will be translated
+            %% to the old, `modified` atom. At some point we should translate
+            %% into the full {modified, bool, bool, map} tuple.
+            DS = translate_delivery_state(DeliveryState),
+            Unsettled = settle_outgoing(First, Last, RangeSize, DS, Unsettled0),
+            {keep_state, State#state{outgoing_unsettled = Unsettled}}
+    end;
 mapped(cast, #'v1_0.disposition'{role = ?AMQP_ROLE_SENDER,
                                  settled = Settled,
                                  first = {uint, First},
                                  state = DeliveryState} = Disp,
        #state{links = Links} = State0) ->
     Last = get_disposition_last(Disp),
-    DS = translate_delivery_state(DeliveryState),
-    State = maps:fold(
-              fun(_OutputHandle, #link{role = receiver,
-                                       incoming_unsettled = Unsettled0,
-                                       notify = Pid,
-                                       ref = Ref} = Link0, Acc) ->
-                      {Ids, Unsettled} =
-                      maps:fold(
-                        fun(Id, _, {Ids0, U} = Acc0) ->
-                                case serial_number:in_range(Id, First, Last) of
-                                    true ->
-                                        {[Id | Ids0], maps:remove(Id, U)};
-                                    false ->
-                                        Acc0
-                                end
-                        end, {[], Unsettled0}, Unsettled0),
-                      case Ids of
-                          [] ->
-                              Acc;
-                          _ ->
-                              _ = [Pid ! {amqp10_event, {link, Ref, {disposition, DS, Id}}}
-                                   || Id <- serial_number:usort(Ids)],
-                              Link = Link0#link{incoming_unsettled = Unsettled},
-                              auto_flow(Link, update_link(Link, Acc))
-                      end;
-                 (_OutHandle, _SenderLink, S) ->
-                      S
-              end, State0, Links),
-    case default(Settled, false) of
-        false ->
-            %% "In this case the sender [broker] SHOULD send a disposition to the
-            %% receiver [us], but not settle until the receiver [we] confirms, via a
-            %% disposition in the opposite direction, that it has updated the state
-            %% at its endpoint." [2.6.12]
-            %% Here, we send the disposition in the opposite direction.
-            D = #'v1_0.disposition'{role = ?AMQP_ROLE_RECEIVER,
-                                    first = {uint, First},
-                                    last = {uint, Last},
-                                    settled = true,
-                                    state = DeliveryState},
-            ok = send(D, State);
-        true ->
-            ok
-    end,
-    {keep_state, State};
+    case serial_number:range_size(First, Last) of
+        undefined ->
+            ?LOG_WARNING("amqp10_session: ignoring disposition with invalid "
+                         "delivery ID range (first ~b, last ~b)", [First, Last]),
+            keep_state_and_data;
+        _RangeSize ->
+            DS = translate_delivery_state(DeliveryState),
+            State = maps:fold(
+                      fun(_OutputHandle, #link{role = receiver,
+                                               incoming_unsettled = Unsettled0,
+                                               notify = Pid,
+                                               ref = Ref} = Link0, Acc) ->
+                              {Ids, Unsettled} =
+                              maps:fold(
+                                fun(Id, _, {Ids0, U} = Acc0) ->
+                                        case serial_number:in_range(Id, First, Last) of
+                                            true ->
+                                                {[Id | Ids0], maps:remove(Id, U)};
+                                            false ->
+                                                Acc0
+                                        end
+                                end, {[], Unsettled0}, Unsettled0),
+                              case Ids of
+                                  [] ->
+                                      Acc;
+                                  _ ->
+                                      _ = [Pid ! {amqp10_event, {link, Ref, {disposition, DS, Id}}}
+                                           || Id <- serial_number:usort(Ids)],
+                                      Link = Link0#link{incoming_unsettled = Unsettled},
+                                      auto_flow(Link, update_link(Link, Acc))
+                              end;
+                         (_OutHandle, _SenderLink, S) ->
+                              S
+                      end, State0, Links),
+            case default(Settled, false) of
+                false ->
+                    %% "In this case the sender [broker] SHOULD send a disposition to the
+                    %% receiver [us], but not settle until the receiver [we] confirms, via a
+                    %% disposition in the opposite direction, that it has updated the state
+                    %% at its endpoint." [2.6.12]
+                    %% Here, we send the disposition in the opposite direction.
+                    D = #'v1_0.disposition'{role = ?AMQP_ROLE_RECEIVER,
+                                            first = {uint, First},
+                                            last = {uint, Last},
+                                            settled = true,
+                                            state = DeliveryState},
+                    ok = send(D, State);
+                true ->
+                    ok
+            end,
+            {keep_state, State}
+    end;
 mapped(cast, Frame, State) ->
     ?LOG_WARNING("Unhandled session frame ~tp in state ~tp",
                  [Frame, State]),
@@ -1246,6 +1256,41 @@ notify_session_ended(Perf = #'v1_0.end'{error = Err},
 notify_disposition(Pid, DeliveryStateDeliveryTag) ->
     Pid ! {amqp10_disposition, DeliveryStateDeliveryTag},
     ok.
+
+%% The peer chooses the delivery ID range, so iterate over whichever of the
+%% range and the unsettled map is smaller.
+settle_outgoing(First, Last, RangeSize, DeliveryState, Unsettled) ->
+    case map_size(Unsettled) of
+        0 ->
+            Unsettled;
+        MapSize when RangeSize =< MapSize ->
+            serial_number:foldl(
+              fun(Id, Acc0) ->
+                      case maps:take(Id, Acc0) of
+                          {{DeliveryTag, Pid}, Acc} ->
+                              ok = notify_disposition(
+                                     Pid, {DeliveryState, DeliveryTag}),
+                              Acc;
+                          error ->
+                              Acc0
+                      end
+              end, Unsettled, First, Last);
+        _ ->
+            Iter = maps:iterator(
+                     Unsettled,
+                     fun(A, B) -> serial_number:compare(A, B) =/= greater end),
+            maps:fold(
+              fun(Id, {DeliveryTag, Pid}, Acc) ->
+                      case serial_number:in_range(Id, First, Last) of
+                          true ->
+                              ok = notify_disposition(
+                                     Pid, {DeliveryState, DeliveryTag}),
+                              maps:remove(Id, Acc);
+                          false ->
+                              Acc
+                      end
+              end, Unsettled, Iter)
+    end.
 
 book_transfer_send(Num, #link{output_handle = Handle} = Link,
                    #state{next_outgoing_id = NextOutgoingId,

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -364,9 +364,8 @@ mapped(cast,
             Unsettled = case serial_number:range_size(First, Last) of
                             undefined ->
                                 Unsettled0;
-                            _RangeSize ->
-                                serial_number:foldl(fun maps:remove/2,
-                                                    Unsettled0, First, Last)
+                            RangeSize ->
+                                remove_range(First, Last, RangeSize, Unsettled0)
                         end,
             Link = Link0#link{incoming_unsettled = Unsettled},
             State1 = State0#state{links = Links#{OutputHandle := Link}},
@@ -563,7 +562,7 @@ mapped(cast, #'v1_0.disposition'{role = ?AMQP_ROLE_SENDER,
             ?LOG_WARNING("amqp10_session: ignoring disposition with invalid "
                          "delivery ID range (first ~b, last ~b)", [First, Last]),
             keep_state_and_data;
-        _RangeSize ->
+        RangeSize ->
             DS = translate_delivery_state(DeliveryState),
             State = maps:fold(
                       fun(_OutputHandle, #link{role = receiver,
@@ -573,10 +572,10 @@ mapped(cast, #'v1_0.disposition'{role = ?AMQP_ROLE_SENDER,
                               {Ids, Unsettled} =
                               maps:fold(
                                 fun(Id, _, {Ids0, U} = Acc0) ->
-                                        case serial_number:in_range(Id, First, Last) of
-                                            true ->
+                                        case serial_number:range_size(First, Id) of
+                                            IdRangeSize when IdRangeSize =< RangeSize ->
                                                 {[Id | Ids0], maps:remove(Id, U)};
-                                            false ->
+                                            _ ->
                                                 Acc0
                                         end
                                 end, {[], Unsettled0}, Unsettled0),
@@ -1257,6 +1256,22 @@ notify_disposition(Pid, DeliveryStateDeliveryTag) ->
     Pid ! {amqp10_disposition, DeliveryStateDeliveryTag},
     ok.
 
+%% Removes every key in the First..Last range from Map, iterating over
+%% whichever of the range and the map is smaller.
+remove_range(First, Last, RangeSize, Map) ->
+    case map_size(Map) of
+        MapSize when RangeSize =< MapSize ->
+            serial_number:foldl(fun maps:remove/2, Map, First, Last);
+        _ ->
+            maps:filter(
+              fun(Id, _) ->
+                      case serial_number:range_size(First, Id) of
+                          IdRangeSize when IdRangeSize =< RangeSize -> false;
+                          _ -> true
+                      end
+              end, Map)
+    end.
+
 %% The peer chooses the delivery ID range, so iterate over whichever of the
 %% range and the unsettled map is smaller.
 settle_outgoing(First, Last, RangeSize, DeliveryState, Unsettled) ->
@@ -1281,12 +1296,12 @@ settle_outgoing(First, Last, RangeSize, DeliveryState, Unsettled) ->
                      fun(A, B) -> serial_number:compare(A, B) =/= greater end),
             maps:fold(
               fun(Id, {DeliveryTag, Pid}, Acc) ->
-                      case serial_number:in_range(Id, First, Last) of
-                          true ->
+                      case serial_number:range_size(First, Id) of
+                          IdRangeSize when IdRangeSize =< RangeSize ->
                               ok = notify_disposition(
                                      Pid, {DeliveryState, DeliveryTag}),
                               maps:remove(Id, Acc);
-                          false ->
+                          _ ->
                               Acc
                       end
               end, Unsettled, Iter)

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -1277,8 +1277,7 @@ notify_disposition(Pid, DeliveryStateDeliveryTag) ->
     Pid ! {amqp10_disposition, DeliveryStateDeliveryTag},
     ok.
 
-%% Removes every key in the First..Last range from Map, iterating over
-%% whichever of the range and the map is smaller.
+%% Iterates over whichever of the range and the map is smaller.
 remove_range(First, Last, RangeSize, Map) ->
     case map_size(Map) of
         MapSize when RangeSize =< MapSize ->
@@ -1293,8 +1292,7 @@ remove_range(First, Last, RangeSize, Map) ->
               end, Map)
     end.
 
-%% The peer chooses the delivery ID range, so iterate over whichever of the
-%% range and the unsettled map is smaller.
+%% Same as remove_range/4, plus disposition notifications.
 settle_outgoing(First, Last, RangeSize, DeliveryState, Unsettled) ->
     case map_size(Unsettled) of
         0 ->

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -53,8 +53,7 @@
         ]).
 
 -import(serial_number,
-        [add/2,
-         diff/2]).
+        [add/2]).
 
 %% By default, we want to keep the server's remote-incoming-window large at all times.
 -define(DEFAULT_MAX_INCOMING_WINDOW, 100_000).
@@ -457,7 +456,18 @@ mapped(cast, #'v1_0.flow'{handle = {uint, InHandle}} = Flow,
     {ok, #link{output_handle = OutHandle} = Link0} =
         find_link_by_input_handle(InHandle, State),
 
-    {ok, Link1} = handle_link_flow(Flow, Link0),
+    Link1 = case handle_link_flow(Flow, Link0) of
+                {ok, L} ->
+                    L;
+                {send_flow, #link{output_handle = H, delivery_count = DC} = L} ->
+                    Reply = #'v1_0.flow'{handle = uint(H),
+                                         delivery_count = uint(DC),
+                                         link_credit = uint(0),
+                                         available = uint(0),
+                                         drain = true},
+                    ok = send(set_flow_session_fields(Reply, State), State),
+                    L
+            end,
     ok = maybe_notify_link_credit(Link0, Link1),
     Link = maybe_notify_link_state_properties(Flow, Link1),
     Links1 = Links#{OutHandle := Link},
@@ -1066,13 +1076,24 @@ handle_session_flow(#'v1_0.flow'{next_incoming_id = MaybeNII,
               {uint, N} -> N;
               undefined -> ?INITIAL_OUTGOING_TRANSFER_ID
           end,
-    RemoteIncomingWindow = diff(add(NII, InWin), OurNOI), % see: 2.5.6
+    RemoteIncomingWindow =
+        case serial_number:range_size(NII, OurNOI) of
+            undefined ->
+                ?LOG_WARNING("amqp10_session: ignoring FLOW next-incoming-id ~b "
+                             "leading next-outgoing-id ~b", [NII, OurNOI]),
+                State#state.remote_incoming_window;
+            Size ->
+                max(0, InWin - (Size - 1))
+        end,
     State#state{next_incoming_id = NOI,
                 remote_incoming_window = RemoteIncomingWindow,
                 remote_outgoing_window = OutWin}.
 
 
 -spec handle_link_flow(#'v1_0.flow'{}, #link{}) -> {ok | send_flow, #link{}}.
+handle_link_flow(#'v1_0.flow'{link_credit = {uint, Credit}} = Flow, Link)
+  when Credit > 16#7fffffff ->
+    handle_link_flow(Flow#'v1_0.flow'{link_credit = {uint, 16#7fffffff}}, Link);
 handle_link_flow(#'v1_0.flow'{drain = true,
                               link_credit = {uint, TheirCredit}},
                  Link = #link{role = sender,
@@ -1668,6 +1689,17 @@ handle_link_flow_sender_drain_test() ->
     ExpectedDC = SndDeliveryCount + RcvLinkCredit,
     ExpectedDC = Outcome#link.delivery_count.
 
+
+handle_link_flow_sender_drain_max_credit_test() ->
+    Link = #link{role = sender, output_handle = 99,
+                 available = 0, link_credit = 20,
+                 delivery_count = 55},
+    Flow = #'v1_0.flow'{handle = {uint, 45},
+                        link_credit = {uint, 16#ffffffff},
+                        drain = true},
+    {send_flow, Outcome} = handle_link_flow(Flow, Link),
+    0 = Outcome#link.link_credit,
+    ?assertEqual(55 + 16#7fffffff, Outcome#link.delivery_count).
 
 handle_link_flow_receiver_test() ->
     Handle = 45,

--- a/deps/amqp10_client/test/session_SUITE.erl
+++ b/deps/amqp10_client/test/session_SUITE.erl
@@ -205,8 +205,7 @@ disposition_after_link_removed(_Config) ->
     ?assert(is_process_alive(Sup)),
     ok = stop_sup(Sup, Sockets).
 
-%% A peer-controlled disposition range must not turn the session into a
-%% multi-billion-iteration loop against an empty unsettled map.
+%% A huge disposition range must not be walked when nothing is unsettled.
 disposition_large_range(_Config) ->
     {Sup, Session, Sockets} = start_session_in(mapped, 0),
     gen_statem:cast(Session,
@@ -245,7 +244,7 @@ flow_max_incoming_window(_Config) ->
     ?assert(is_process_alive(Sup)),
     ok = stop_sup(Sup, Sockets).
 
-%% A next-incoming-id ahead of our next-outgoing-id must not crash the session.
+%% A next-incoming-id ahead of ours must not crash the session.
 flow_next_incoming_id_leads(_Config) ->
     {Sup, Session, Sockets} = start_session_in(mapped, 0),
     {mapped, #{remote_incoming_window := Window}} = session_state(Session),

--- a/deps/amqp10_client/test/session_SUITE.erl
+++ b/deps/amqp10_client/test/session_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
+-include_lib("amqp10_common/include/amqp10_types.hrl").
 -include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 
 -compile([export_all, nowarn_export_all]).
@@ -37,7 +38,9 @@ groups() ->
                          ]},
      {mapped, [], [
                    flow_link_after_link_removed,
-                   disposition_after_link_removed
+                   disposition_after_link_removed,
+                   disposition_large_range,
+                   disposition_reversed_range
                   ]}
     ].
 
@@ -197,6 +200,33 @@ disposition_after_link_removed(_Config) ->
     {Sup, Session, Sockets} = start_session_in(mapped, 0),
     gen_statem:cast(Session, {disposition, 0, 1, 1, true, accepted}),
     ?assertMatch({mapped, _}, sys:get_state(Session)),
+    ?assert(is_process_alive(Sup)),
+    ok = stop_sup(Sup, Sockets).
+
+%% A peer-controlled disposition range must not turn the session into a
+%% multi-billion-iteration loop against an empty unsettled map.
+disposition_large_range(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(mapped, 0),
+    gen_statem:cast(Session,
+                    #'v1_0.disposition'{role = ?AMQP_ROLE_RECEIVER,
+                                        settled = true,
+                                        first = {uint, 0},
+                                        last = {uint, 16#7fffffff},
+                                        state = #'v1_0.accepted'{}}),
+    ?assertMatch({mapped, _}, sys:get_state(Session, 1000)),
+    ?assert(is_process_alive(Sup)),
+    ok = stop_sup(Sup, Sockets).
+
+%% A reversed delivery ID range must not crash the session.
+disposition_reversed_range(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(mapped, 0),
+    gen_statem:cast(Session,
+                    #'v1_0.disposition'{role = ?AMQP_ROLE_RECEIVER,
+                                        settled = true,
+                                        first = {uint, 100},
+                                        last = {uint, 5},
+                                        state = #'v1_0.accepted'{}}),
+    ?assertMatch({mapped, _}, sys:get_state(Session, 1000)),
     ?assert(is_process_alive(Sup)),
     ok = stop_sup(Sup, Sockets).
 

--- a/deps/amqp10_client/test/session_SUITE.erl
+++ b/deps/amqp10_client/test/session_SUITE.erl
@@ -40,7 +40,9 @@ groups() ->
                    flow_link_after_link_removed,
                    disposition_after_link_removed,
                    disposition_large_range,
-                   disposition_reversed_range
+                   disposition_reversed_range,
+                   flow_max_incoming_window,
+                   flow_next_incoming_id_leads
                   ]}
     ].
 
@@ -230,9 +232,43 @@ disposition_reversed_range(_Config) ->
     ?assert(is_process_alive(Sup)),
     ok = stop_sup(Sup, Sockets).
 
+%% A peer may advertise the largest uint as its incoming window.
+flow_max_incoming_window(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(mapped, 0),
+    gen_statem:cast(Session,
+                    #'v1_0.flow'{next_incoming_id = {uint, 16#fffffffe},
+                                 incoming_window = {uint, 16#ffffffff},
+                                 next_outgoing_id = {uint, 1},
+                                 outgoing_window = {uint, 1000}}),
+    ?assertMatch({mapped, #{remote_incoming_window := 16#ffffffff}},
+                 session_state(Session)),
+    ?assert(is_process_alive(Sup)),
+    ok = stop_sup(Sup, Sockets).
+
+%% A next-incoming-id ahead of our next-outgoing-id must not crash the session.
+flow_next_incoming_id_leads(_Config) ->
+    {Sup, Session, Sockets} = start_session_in(mapped, 0),
+    {mapped, #{remote_incoming_window := Window}} = session_state(Session),
+    gen_statem:cast(Session,
+                    #'v1_0.flow'{next_incoming_id = {uint, 16#7ffffffe},
+                                 incoming_window = {uint, 0},
+                                 next_outgoing_id = {uint, 1},
+                                 outgoing_window = {uint, 1000}}),
+    ?assertMatch({mapped, #{remote_incoming_window := Window,
+                            next_incoming_id := 1,
+                            remote_outgoing_window := 1000}},
+                 session_state(Session)),
+    ?assert(is_process_alive(Sup)),
+    ok = stop_sup(Sup, Sockets).
+
 %% -------------------------------------------------------------------
 %% Helpers.
 %% -------------------------------------------------------------------
+
+session_state(Session) ->
+    {StateName, Data0} = sys:get_state(Session, 1000),
+    #{data := Data} = amqp10_client_session:format_status(#{data => Data0}),
+    {StateName, Data}.
 
 start_session_in(unmapped, Channel) ->
     Sup = start_sup(),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -59,7 +59,9 @@ groups() ->
                  multi_transfer_without_delivery_id,
                  frame_size_too_small_rejected,
                  max_frame_size_exceeded_rejected,
-                 disposition_large_range_settles_outgoing
+                 disposition_large_range_settles_outgoing,
+                 link_credit_max,
+                 drain_with_nothing_available
                 ]}
     ].
 
@@ -970,6 +972,136 @@ disposition_large_range_settles_outgoing(Config) ->
 
     ?assertEqual({accepted, <<"tag-1">>}, await_disposition()),
     ?assertEqual({accepted, <<"tag-2">>}, await_disposition()),
+
+    ok = amqp10_client:end_session(Session),
+    ok = amqp10_client:close_connection(Connection),
+    ok.
+
+%% A peer may grant the largest uint as link credit.
+link_credit_max(Config) ->
+    Hostname = ?config(mock_host, Config),
+    Port = ?config(mock_port, Config),
+    OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
+                       {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
+               end,
+    BeginStep = fun({0 = Ch, #'v1_0.begin'{}, _Pay}) ->
+                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, Ch},
+                                             next_outgoing_id = {uint, 1},
+                                             incoming_window = {uint, 1000},
+                                             outgoing_window = {uint, 1000}}
+                                             ]}
+                end,
+    AttachStep = fun({0 = Ch, #'v1_0.attach'{name = Name,
+                                             role = false,
+                                             target = Target}, <<>>}) ->
+                         Attach = #'v1_0.attach'{name = Name,
+                                                 handle = {uint, 99},
+                                                 role = true,
+                                                 target = Target},
+                         Flow = #'v1_0.flow'{handle = {uint, 99},
+                                             next_incoming_id = {uint, 1},
+                                             incoming_window = {uint, 1000},
+                                             next_outgoing_id = {uint, 1},
+                                             outgoing_window = {uint, 1000},
+                                             link_credit = {uint, 16#ffffffff}},
+                         {Ch, {multi, [[Attach], [Flow]]}}
+                 end,
+    TransferStep = fun({0 = Ch, #'v1_0.transfer'{handle = {uint, 0}}, _Pay}) ->
+                           Disposition = #'v1_0.disposition'{
+                                            role = ?AMQP_ROLE_RECEIVER,
+                                            settled = true,
+                                            first = {uint, 4294967295},
+                                            state = #'v1_0.accepted'{}},
+                           {Ch, [Disposition]}
+                   end,
+    Steps = [fun mock_server:recv_amqp_header_step/1,
+             fun mock_server:send_amqp_header_step/1,
+             mock_server:amqp_step(OpenStep),
+             mock_server:amqp_step(BeginStep),
+             mock_server:amqp_step(AttachStep),
+             mock_server:amqp_step(TransferStep)
+            ],
+    ok = mock_server:set_steps(?config(mock_server, Config), Steps),
+
+    Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
+    {ok, Connection} = amqp10_client:open_connection(Cfg),
+    {ok, Session} = amqp10_client:begin_session_sync(Connection),
+    {ok, Sender} = amqp10_client:attach_sender_link(Session, <<"mock1-sender">>,
+                                                    <<"test">>),
+    await_link(Sender, credited, link_credit_timeout),
+    ok = amqp10_client:send_msg(Sender, amqp10_msg:new(<<"tag-1">>, <<"one">>, false)),
+    ?assertEqual({accepted, <<"tag-1">>}, await_disposition()),
+
+    ok = amqp10_client:end_session(Session),
+    ok = amqp10_client:close_connection(Connection),
+    ok.
+
+%% A DRAIN on a sender link with nothing to send is answered with a FLOW
+%% that consumes the credit.
+drain_with_nothing_available(Config) ->
+    Hostname = ?config(mock_host, Config),
+    Port = ?config(mock_port, Config),
+    OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
+                       {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
+               end,
+    BeginStep = fun({0 = Ch, #'v1_0.begin'{}, _Pay}) ->
+                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, Ch},
+                                             next_outgoing_id = {uint, 1},
+                                             incoming_window = {uint, 1000},
+                                             outgoing_window = {uint, 1000}}
+                                             ]}
+                end,
+    SessionFlow = #'v1_0.flow'{handle = {uint, 99},
+                               next_incoming_id = {uint, 1},
+                               incoming_window = {uint, 1000},
+                               next_outgoing_id = {uint, 1},
+                               outgoing_window = {uint, 1000}},
+    AttachStep = fun({0 = Ch, #'v1_0.attach'{name = Name,
+                                             role = false,
+                                             target = Target}, <<>>}) ->
+                         Attach = #'v1_0.attach'{name = Name,
+                                                 handle = {uint, 99},
+                                                 role = true,
+                                                 target = Target},
+                         Flow = SessionFlow#'v1_0.flow'{link_credit = {uint, 2}},
+                         {Ch, {multi, [[Attach], [Flow]]}}
+                 end,
+    DrainStep = fun({0 = Ch, #'v1_0.transfer'{handle = {uint, 0}}, _Pay}) ->
+                        Flow = SessionFlow#'v1_0.flow'{
+                                 next_incoming_id = {uint, 2},
+                                 delivery_count = {uint, 16#fffffffe},
+                                 link_credit = {uint, 1},
+                                 drain = true},
+                        {Ch, [Flow]}
+                end,
+    DrainedStep = fun({0 = Ch, #'v1_0.flow'{handle = {uint, 0},
+                                            delivery_count = {uint, 16#ffffffff},
+                                            link_credit = {uint, 0},
+                                            drain = true}, <<>>}) ->
+                          Flow = SessionFlow#'v1_0.flow'{
+                                   next_incoming_id = {uint, 2},
+                                   delivery_count = {uint, 16#ffffffff},
+                                   link_credit = {uint, 5}},
+                          {Ch, [Flow]}
+                  end,
+    Steps = [fun mock_server:recv_amqp_header_step/1,
+             fun mock_server:send_amqp_header_step/1,
+             mock_server:amqp_step(OpenStep),
+             mock_server:amqp_step(BeginStep),
+             mock_server:amqp_step(AttachStep),
+             mock_server:amqp_step(DrainStep),
+             mock_server:amqp_step(DrainedStep)
+            ],
+    ok = mock_server:set_steps(?config(mock_server, Config), Steps),
+
+    Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
+    {ok, Connection} = amqp10_client:open_connection(Cfg),
+    {ok, Session} = amqp10_client:begin_session_sync(Connection),
+    {ok, Sender} = amqp10_client:attach_sender_link(Session, <<"mock1-sender">>,
+                                                    <<"test">>),
+    await_link(Sender, credited, link_credit_timeout),
+    ok = amqp10_client:send_msg(Sender, amqp10_msg:new(<<"tag-1">>, <<"one">>, true)),
+    await_link(Sender, credited, link_credit_timeout),
 
     ok = amqp10_client:end_session(Session),
     ok = amqp10_client:close_connection(Connection),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
+-include_lib("amqp10_common/include/amqp10_types.hrl").
 
 -compile([export_all, nowarn_export_all]).
 
@@ -57,7 +58,8 @@ groups() ->
                  incoming_heartbeat,
                  multi_transfer_without_delivery_id,
                  frame_size_too_small_rejected,
-                 max_frame_size_exceeded_rejected
+                 max_frame_size_exceeded_rejected,
+                 disposition_large_range_settles_outgoing
                 ]}
     ].
 
@@ -897,6 +899,89 @@ attach_refused(Config) ->
 
     ok = amqp10_client:end_session(Session),
     ok = amqp10_client:close_connection(Connection).
+
+%% A disposition covering a huge, peer-chosen delivery ID range must settle
+%% every message actually outstanding, using the outgoing-unsettled-map
+%% iteration branch (the range is far bigger than the map).
+disposition_large_range_settles_outgoing(Config) ->
+    Hostname = ?config(mock_host, Config),
+    Port = ?config(mock_port, Config),
+    OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
+                       {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
+               end,
+    BeginStep = fun({0 = Ch, #'v1_0.begin'{}, _Pay}) ->
+                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, Ch},
+                                             next_outgoing_id = {uint, 1},
+                                             incoming_window = {uint, 1000},
+                                             outgoing_window = {uint, 1000}}
+                                             ]}
+                end,
+    AttachStep = fun({0 = Ch, #'v1_0.attach'{name = Name,
+                                             role = false,
+                                             target = Target}, <<>>}) ->
+                         Attach = #'v1_0.attach'{name = Name,
+                                                 handle = {uint, 99},
+                                                 role = true,
+                                                 target = Target},
+                         Flow = #'v1_0.flow'{handle = {uint, 99},
+                                             next_incoming_id = {uint, 1},
+                                             incoming_window = {uint, 1000},
+                                             next_outgoing_id = {uint, 1},
+                                             outgoing_window = {uint, 1000},
+                                             link_credit = {uint, 2}},
+                         {Ch, {multi, [[Attach], [Flow]]}}
+                 end,
+    %% The two transfers get delivery IDs 4294967295 and 0: the client's
+    %% outgoing delivery ID counter starts at 2^32 - 1 and wraps. The
+    %% transfer's handle is the client's own (locally-assigned) handle, 0.
+    Transfer1Step = fun({0 = Ch, #'v1_0.transfer'{handle = {uint, 0}}, _Pay}) ->
+                             {Ch, []}
+                     end,
+    Transfer2Step = fun({0 = Ch, #'v1_0.transfer'{handle = {uint, 0}}, _Pay}) ->
+                             Disposition = #'v1_0.disposition'{
+                                              role = ?AMQP_ROLE_RECEIVER,
+                                              settled = true,
+                                              first = {uint, 4294967295},
+                                              last = {uint, 2147483645},
+                                              state = #'v1_0.accepted'{}},
+                             {Ch, [Disposition]}
+                     end,
+    Steps = [fun mock_server:recv_amqp_header_step/1,
+             fun mock_server:send_amqp_header_step/1,
+             mock_server:amqp_step(OpenStep),
+             mock_server:amqp_step(BeginStep),
+             mock_server:amqp_step(AttachStep),
+             mock_server:amqp_step(Transfer1Step),
+             mock_server:amqp_step(Transfer2Step)
+            ],
+    ok = mock_server:set_steps(?config(mock_server, Config), Steps),
+
+    Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
+    {ok, Connection} = amqp10_client:open_connection(Cfg),
+    {ok, Session} = amqp10_client:begin_session_sync(Connection),
+    {ok, Sender} = amqp10_client:attach_sender_link(Session, <<"mock1-sender">>,
+                                                    <<"test">>),
+    await_link(Sender, credited, link_credit_timeout),
+
+    Msg1 = amqp10_msg:new(<<"tag-1">>, <<"one">>, false),
+    Msg2 = amqp10_msg:new(<<"tag-2">>, <<"two">>, false),
+    ok = amqp10_client:send_msg(Sender, Msg1),
+    ok = amqp10_client:send_msg(Sender, Msg2),
+
+    ?assertEqual({accepted, <<"tag-1">>}, await_disposition()),
+    ?assertEqual({accepted, <<"tag-2">>}, await_disposition()),
+
+    ok = amqp10_client:end_session(Session),
+    ok = amqp10_client:close_connection(Connection),
+    ok.
+
+await_disposition() ->
+    receive
+        {amqp10_disposition, {DeliveryState, DeliveryTag}} ->
+            {DeliveryState, DeliveryTag}
+    after ?TIMEOUT ->
+              ct:fail(missing_disposition)
+    end.
 
 multi_transfer_without_delivery_id(Config) ->
     Hostname = ?config(mock_host, Config),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -902,9 +902,7 @@ attach_refused(Config) ->
     ok = amqp10_client:end_session(Session),
     ok = amqp10_client:close_connection(Connection).
 
-%% A disposition covering a huge, peer-chosen delivery ID range must settle
-%% every message actually outstanding, using the outgoing-unsettled-map
-%% iteration branch (the range is far bigger than the map).
+%% A huge disposition range must settle every outstanding message.
 disposition_large_range_settles_outgoing(Config) ->
     Hostname = ?config(mock_host, Config),
     Port = ?config(mock_port, Config),
@@ -933,9 +931,7 @@ disposition_large_range_settles_outgoing(Config) ->
                                              link_credit = {uint, 2}},
                          {Ch, {multi, [[Attach], [Flow]]}}
                  end,
-    %% The two transfers get delivery IDs 4294967295 and 0: the client's
-    %% outgoing delivery ID counter starts at 2^32 - 1 and wraps. The
-    %% transfer's handle is the client's own (locally-assigned) handle, 0.
+    %% Delivery IDs start at 2^32 - 1 and wrap, so the two transfers get 4294967295 and 0.
     Transfer1Step = fun({0 = Ch, #'v1_0.transfer'{handle = {uint, 0}}, _Pay}) ->
                              {Ch, []}
                      end,
@@ -1036,8 +1032,7 @@ link_credit_max(Config) ->
     ok = amqp10_client:close_connection(Connection),
     ok.
 
-%% A DRAIN on a sender link with nothing to send is answered with a FLOW
-%% that consumes the credit.
+%% Drain on a sender link with nothing to send is answered with a FLOW.
 drain_with_nothing_available(Config) ->
     Hostname = ?config(mock_host, Config),
     Port = ?config(mock_port, Config),

--- a/deps/amqp10_common/src/serial_number.erl
+++ b/deps/amqp10_common/src/serial_number.erl
@@ -114,9 +114,8 @@ diff(A, B) ->
            exit({undefined_serial_diff, A, B})
     end.
 
-%% Number of serial numbers in the inclusive range First..Last, or `undefined'
-%% if Last does not follow First. Unlike diff/2, this function does not exit for
-%% the difference RFC 1982 leaves undefined.
+%% Size of the inclusive range First..Last, or `undefined' if Last does not
+%% follow First. Unlike diff/2, never exits.
 -spec range_size(serial_number(), serial_number()) ->
     pos_integer() | undefined.
 range_size(First, Last) ->

--- a/deps/amqp10_common/src/serial_number.erl
+++ b/deps/amqp10_common/src/serial_number.erl
@@ -13,6 +13,7 @@
          ranges/1,
          in_range/3,
          diff/2,
+         range_size/2,
          foldl/4]).
 
 %% For tests.
@@ -111,6 +112,19 @@ diff(A, B) ->
            Diff;
        true ->
            exit({undefined_serial_diff, A, B})
+    end.
+
+%% Number of serial numbers in the inclusive range First..Last, or `undefined'
+%% if Last does not follow First. Unlike diff/2, this function does not exit for
+%% the difference RFC 1982 leaves undefined.
+-spec range_size(serial_number(), serial_number()) ->
+    pos_integer() | undefined.
+range_size(First, Last) ->
+    case (Last - First) band (?SERIAL_SPACE - 1) of
+        N when N < ?SERIAL_DIFF_BOUND ->
+            N + 1;
+        _ ->
+            undefined
     end.
 
 -spec foldl(Fun, Acc0, First, Last) -> Acc1 when

--- a/deps/amqp10_common/test/prop_SUITE.erl
+++ b/deps/amqp10_common/test/prop_SUITE.erl
@@ -30,7 +30,8 @@ groups() ->
        prop_strict_server_mode_rejects_malformed,
        prop_strict_server_mode_never_errors,
        prop_frame,
-       prop_array32_terminates
+       prop_array32_terminates,
+       prop_range_size
       ]}
     ].
 
@@ -229,6 +230,21 @@ prop_array32_terminates(_Config) ->
                  end
              end)
       end, [], 1000).
+
+%% range_size/2 must never exit, and whenever it returns a size, that size
+%% must equal diff(Last, First) + 1.
+prop_range_size(_Config) ->
+    run_proper(
+      fun() -> ?FORALL(
+                  {First, Last},
+                  {integer(0, 16#ffffffff), integer(0, 16#ffffffff)},
+                  case serial_number:range_size(First, Last) of
+                      undefined ->
+                          true;
+                      Size ->
+                          equals(Size, serial_number:diff(Last, First) + 1)
+                  end)
+      end, [], 10_000).
 
 %%%%%%%%%%%%%%%
 %%% Helpers %%%

--- a/deps/amqp10_common/test/prop_SUITE.erl
+++ b/deps/amqp10_common/test/prop_SUITE.erl
@@ -231,8 +231,7 @@ prop_array32_terminates(_Config) ->
              end)
       end, [], 1000).
 
-%% range_size/2 must never exit, and whenever it returns a size, that size
-%% must equal diff(Last, First) + 1.
+%% range_size/2 never exits and agrees with diff/2 where both are defined.
 prop_range_size(_Config) ->
     run_proper(
       fun() -> ?FORALL(

--- a/deps/amqp10_common/test/serial_number_SUITE.erl
+++ b/deps/amqp10_common/test/serial_number_SUITE.erl
@@ -148,12 +148,12 @@ test_range_size(_Config) ->
     ?assertEqual(4, range_size(16#fffffffe, 1)),
     %% Largest accepted range.
     ?assertEqual(16#80000000, range_size(0, 16#7fffffff)),
-    %% The difference RFC 1982 leaves undefined.
+    %% Undefined per RFC 1982.
     ?assertEqual(undefined, range_size(0, 16#80000000)),
     ?assertEqual(undefined, range_size(100, 5)),
     ?assertEqual(undefined, range_size(0, 16#ffffffff)),
 
-    %% Every accepted range must be safe to pass to compare/2.
+    %% Accepted ranges are safe for compare/2.
     lists:foreach(
       fun({First, Last}) ->
               case range_size(First, Last) of

--- a/deps/amqp10_common/test/serial_number_SUITE.erl
+++ b/deps/amqp10_common/test/serial_number_SUITE.erl
@@ -17,6 +17,7 @@
                         ranges/1,
                         in_range/3,
                         diff/2,
+                        range_size/2,
                         foldl/4]).
 
 all() -> [test_add,
@@ -25,6 +26,7 @@ all() -> [test_add,
           test_ranges,
           test_in_range,
           test_diff,
+          test_range_size,
           test_foldl].
 
 -dialyzer({nowarn_function, test_add/1}).
@@ -137,6 +139,32 @@ test_diff(_Config) ->
                 diff(0, 16#80000000)),
     ?assertExit({undefined_serial_diff, _, _},
                 diff(16#ffffffff, 16#7fffffff)).
+
+test_range_size(_Config) ->
+    ?assertEqual(1, range_size(5, 5)),
+    ?assertEqual(5, range_size(5, 9)),
+    %% Wraparound.
+    ?assertEqual(2, range_size(16#ffffffff, 0)),
+    ?assertEqual(4, range_size(16#fffffffe, 1)),
+    %% Largest accepted range.
+    ?assertEqual(16#80000000, range_size(0, 16#7fffffff)),
+    %% The difference RFC 1982 leaves undefined.
+    ?assertEqual(undefined, range_size(0, 16#80000000)),
+    ?assertEqual(undefined, range_size(100, 5)),
+    ?assertEqual(undefined, range_size(0, 16#ffffffff)),
+
+    %% Every accepted range must be safe to pass to compare/2.
+    lists:foreach(
+      fun({First, Last}) ->
+              case range_size(First, Last) of
+                  undefined ->
+                      ok;
+                  _Size ->
+                      ?assert(lists:member(compare(First, Last), [less, equal]))
+              end
+      end,
+      [{0, 0}, {0, 1}, {0, 16#7fffffff}, {0, 16#80000000},
+       {16#ffffffff, 0}, {5, 100}, {100, 5}, {0, 16#ffffffff}]).
 
 test_foldl(_Config) ->
     ?assertEqual(

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -325,17 +325,14 @@ handle_session_exit(ChannelNum, SessionPid, Reason, State0) ->
             true ->
                 State;
             false ->
-                R = case Reason of
-                        {RealReason, Trace} ->
-                            error_frame(?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                        "Session error: ~tp~n~tp",
-                                        [RealReason, Trace]);
-                        _ ->
-                            error_frame(?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                        "Session error: ~tp",
-                                        [Reason])
-                    end,
-                handle_exception(State, ChannelNum, R)
+                Detail = case Reason of
+                             {RealReason, Trace} ->
+                                 rabbit_misc:format("Session error: ~tp~n~tp",
+                                                     [RealReason, Trace]);
+                             _ ->
+                                 rabbit_misc:format("Session error: ~tp", [Reason])
+                         end,
+                handle_exception(State, ChannelNum, internal_error_frame(), Detail)
         end,
     maybe_close(S).
 
@@ -358,14 +355,27 @@ error_frame(Condition, Fmt, Args) ->
     #'v1_0.error'{condition = Condition,
                   description = {utf8, Description}}.
 
+%% An error whose description is safe to send to the peer: it carries no
+%% internal reason or stacktrace. Callers that catch an internal error log
+%% the caught detail themselves via handle_exception/4.
+internal_error_frame() ->
+    #'v1_0.error'{condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
+                  description = {utf8, <<"internal error">>}}.
+
 %% "A valid frame header cannot be formed from the incoming byte stream." [2.8.16]
 framing_error(State, Channel, Fmt, Args) ->
     Error = error_frame(?V_1_0_CONNECTION_ERROR_FRAMING_ERROR, Fmt, Args),
     handle_exception(State, Channel, Error).
 
+handle_exception(State, Channel, Error = #'v1_0.error'{description = {utf8, Desc}}) ->
+    handle_exception(State, Channel, Error, Desc);
+handle_exception(State, Channel, Error) ->
+    handle_exception(State, Channel, Error, "").
+
 handle_exception(State = #v1{connection_state = CS}, _Channel,
                  Error = #'v1_0.error'{description =
-                                       {utf8, <<"Connection forced: ", Explanation/binary>>}})
+                                       {utf8, <<"Connection forced: ", Explanation/binary>>}},
+                 _Detail)
   when (?IS_RUNNING(State)) orelse CS =:= closing ->
     %% Only ever raised by terminate/2 when the connection is deliberately
     %% closed by an operator or by the broker itself (e.g. rabbitmqctl
@@ -376,18 +386,18 @@ handle_exception(State = #v1{connection_state = CS}, _Channel,
     %% rabbit_reader:log_hard_error/3.
     ?LOG_WARNING("Closing AMQP 1.0 connection ~tp: ~ts", [self(), Explanation]),
     close(Error, State);
-handle_exception(State = #v1{connection_state = closed}, Channel,
-                 #'v1_0.error'{description = {utf8, Desc}}) ->
-    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~tp",
-               [self(), closed, Channel, Desc]),
+handle_exception(State = #v1{connection_state = closed}, Channel, _Error, Detail) ->
+    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+               [self(), closed, Channel, Detail]),
     State;
-handle_exception(State = #v1{connection_state = CS}, Channel,
-                 Error = #'v1_0.error'{description = {utf8, Desc}})
+handle_exception(State = #v1{connection_state = CS}, Channel, Error, Detail)
   when (?IS_RUNNING(State)) orelse CS =:= closing ->
-    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~tp",
-               [self(), CS, Channel, Desc]),
+    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+               [self(), CS, Channel, Detail]),
     close(Error, State);
-handle_exception(State, _Channel, Error) ->
+handle_exception(State, Channel, Error, Detail) ->
+    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+               [self(), State#v1.connection_state, Channel, Detail]),
     silent_close_delay(),
     throw({handshake_error, State#v1.connection_state, Error}).
 
@@ -424,10 +434,8 @@ handle_frame(Mode, Channel, Body, State) ->
         _:Reason:Trace ->
             handle_exception(State,
                              Channel,
-                             error_frame(
-                               ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                               "Reader error: ~tp~n~tp",
-                               [Reason, Trace]))
+                             internal_error_frame(),
+                             rabbit_misc:format("Reader error: ~tp~n~tp", [Reason, Trace]))
     end.
 
 handle_frame0(amqp, Channel, _Body,
@@ -1105,15 +1113,15 @@ set_credential0(Cred,
                                             credential_timer = NewTimer}}
             catch _:Reason ->
                       Error = error_frame(?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
-                                          "access to vhost ~s failed for new credential: ~p",
-                                          [Vhost, Reason]),
-                      handle_exception(State, 0, Error)
+                                          "access to vhost '~ts' failed for new credential",
+                                          [Vhost]),
+                      handle_exception(State, 0, Error,
+                                        rabbit_misc:format("~tp", [Reason]))
             end;
         Err ->
             Error = error_frame(?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
-                                "credential update failed: ~p",
-                                [Err]),
-            handle_exception(State, 0, Error)
+                                "credential update failed", []),
+            handle_exception(State, 0, Error, rabbit_misc:format("~tp", [Err]))
     end.
 
 maybe_start_credential_expiry_timer(User) ->

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -395,9 +395,14 @@ handle_exception(State = #v1{connection_state = CS}, Channel, Error, Detail)
     ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
                [self(), CS, Channel, Detail]),
     close(Error, State);
-handle_exception(State, Channel, Error, Detail) ->
-    ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
-               [self(), State#v1.connection_state, Channel, Detail]),
+handle_exception(State, Channel, Error = #'v1_0.error'{description = Desc}, Detail) ->
+    case Desc =:= {utf8, Detail} of
+        true ->
+            ok;
+        false ->
+            ?LOG_ERROR("Error on AMQP 1.0 connection ~tp (~tp), channel number ~b:~n~ts",
+                       [self(), State#v1.connection_state, Channel, Detail])
+    end,
     silent_close_delay(),
     throw({handshake_error, State#v1.connection_state, Error}).
 

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -1191,15 +1191,15 @@ handle_frame(#'v1_0.disposition'{role = ?AMQP_ROLE_RECEIVER,
                                                consumer_tag = Ctag,
                                                msg_id = MsgId} = Unsettled,
                            {SettledAcc, UnsettledAcc}) ->
-                              case serial_number:in_range(DeliveryId, First, Last) of
-                                  true ->
+                              case range_size(First, DeliveryId) of
+                                  IdRangeSize when IdRangeSize =< DispositionRangeSize ->
                                       SettledAcc1 = maps_update_with(
                                                       {QName, Ctag},
                                                       fun(MsgIds) -> [MsgId | MsgIds] end,
                                                       [MsgId],
                                                       SettledAcc),
                                       {SettledAcc1, UnsettledAcc};
-                                  false ->
+                                  _ ->
                                       {SettledAcc, [{DeliveryId, Unsettled} | UnsettledAcc]}
                               end
                       end,

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -129,7 +129,8 @@
 -import(serial_number,
         [add/2,
          diff/2,
-         compare/2]).
+         compare/2,
+         range_size/2]).
 -import(rabbit_misc,
         [queue_resource/2,
          exchange_resource/2]).
@@ -1158,12 +1159,20 @@ handle_frame(#'v1_0.disposition'{role = ?AMQP_ROLE_RECEIVER,
                    %% "If not set, this is taken to be the same as first." [2.7.6]
                    First
            end,
+    DispositionRangeSize = case range_size(First, Last) of
+                               undefined ->
+                                   protocol_error(
+                                     ?V_1_0_AMQP_ERROR_INVALID_FIELD,
+                                     "invalid disposition delivery ID range "
+                                     "(first ~b, last ~b)", [First, Last]);
+                               Size ->
+                                   Size
+                           end,
     UnsettledMapSize = map_size(UnsettledMap0),
     case UnsettledMapSize of
         0 ->
             reply_frames([], State0);
         _ ->
-            DispositionRangeSize = diff(Last, First) + 1,
             {Settled, UnsettledMap} =
             case DispositionRangeSize =< UnsettledMapSize of
                 true ->

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -597,11 +597,10 @@ handle_cast({frame_body, FrameBody},
           exit:#'v1_0.error'{} = Error ->
               log_error_and_close_session(Error, State0);
           _:Reason:Stacktrace ->
-              Description = unicode:characters_to_binary(
-                              lists:flatten(io_lib:format("~tp~n~tp", [Reason, Stacktrace]))),
               Err = #'v1_0.error'{condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                  description = {utf8, Description}},
-              log_error_and_close_session(Err, State0)
+                                  description = {utf8, <<"internal error">>}},
+              log_error_and_close_session(
+                Err, rabbit_misc:format("~tp~n~tp", [Reason, Stacktrace]), State0)
     end;
 handle_cast({queue_event, _, _} = QEvent, State0) ->
     try handle_queue_event(QEvent, State0) of
@@ -666,12 +665,15 @@ handle_cast({reset_authz, User}, #state{cfg = Cfg} = State0) ->
 handle_cast(shutdown, State) ->
     {stop, normal, State}.
 
+log_error_and_close_session(Error = #'v1_0.error'{description = {utf8, Desc}}, State) ->
+    log_error_and_close_session(Error, Desc, State).
+
 log_error_and_close_session(
-  Error, State = #state{cfg = #cfg{reader_pid = ReaderPid,
-                                   writer_pid = WriterPid,
-                                   channel_num = Ch}}) ->
-    ?LOG_WARNING("Closing session for connection ~p: ~tp",
-                 [ReaderPid, Error]),
+  Error, Detail, State = #state{cfg = #cfg{reader_pid = ReaderPid,
+                                           writer_pid = WriterPid,
+                                           channel_num = Ch}}) ->
+    ?LOG_WARNING("Closing session for connection ~p: ~ts",
+                 [ReaderPid, Detail]),
     rabbit_amqp_reader:notify_session_ending(ReaderPid, self(), Ch),
     ok = rabbit_amqp_writer:send_command_sync(
            WriterPid, Ch, #'v1_0.end'{error = Error}),

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -128,7 +128,6 @@
         [protocol_error/3]).
 -import(serial_number,
         [add/2,
-         diff/2,
          compare/2,
          range_size/2]).
 -import(rabbit_misc,
@@ -2304,29 +2303,19 @@ session_flow_control_received_flow(
   #state{next_outgoing_id = NextOutgoingId} = State) ->
 
     Seq = case FlowNextIncomingId of
-              ?UINT(Id) ->
-                  case compare(Id, NextOutgoingId) of
-                      greater ->
-                          protocol_error(
-                            ?V_1_0_SESSION_ERROR_WINDOW_VIOLATION,
-                            "next-incoming-id from FLOW (~b) leads next-outgoing-id (~b)",
-                            [Id, NextOutgoingId]);
-                      _ ->
-                          Id
-                  end;
-              undefined ->
-                  %% The AMQP client might not have yet received our #begin.next_outgoing_id
-                  ?INITIAL_OUTGOING_TRANSFER_ID
+              ?UINT(Id) -> Id;
+              undefined -> ?INITIAL_OUTGOING_TRANSFER_ID
           end,
-
-    RemoteIncomingWindow0 = diff(add(Seq, FlowIncomingWindow), NextOutgoingId),
-    %% RemoteIncomingWindow0 can be negative, for example if we sent a TRANSFER to the
-    %% client between the point in time the client sent us a FLOW with updated
-    %% incoming_window=0 and we received that FLOW. Whether 0 or negative doesn't matter:
-    %% In both cases we're blocked sending more TRANSFERs to the client until it sends us
-    %% a new FLOW with a positive incoming_window. For better understandibility
-    %% across the code base, we ensure a floor of 0 here.
-    RemoteIncomingWindow = max(0, RemoteIncomingWindow0),
+    InFlight = case range_size(Seq, NextOutgoingId) of
+                   undefined ->
+                       protocol_error(
+                         ?V_1_0_SESSION_ERROR_WINDOW_VIOLATION,
+                         "next-incoming-id from FLOW (~b) leads next-outgoing-id (~b)",
+                         [Seq, NextOutgoingId]);
+                   Size ->
+                       Size - 1
+               end,
+    RemoteIncomingWindow = max(0, FlowIncomingWindow - InFlight),
 
     State#state{next_incoming_id = FlowNextOutgoingId,
                 remote_outgoing_window = FlowOutgoingWindow,

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -149,6 +149,7 @@ groups() ->
        modified_quorum_queue_delivery_time,
        modified_quorum_queue_deferral_token,
        modified_quorum_queue_deferral_token_ranged_disposition,
+       disposition_reversed_range_rejected,
        modified_quorum_queue_deferral_token_precedes_backlog,
        modified_quorum_queue_deferral_token_survives_in_flight_credit_req,
        modified_quorum_queue_deferral_token_invalid_annotation_type,
@@ -1098,6 +1099,38 @@ modified_quorum_queue_deferral_token_ranged_disposition(Config) ->
     ?assertMatch({ok, #{message_count := 0}},
                  rabbitmq_amqp_client:delete_queue(LinkPair, QName)),
     ok = close(Init).
+
+%% A DISPOSITION whose delivery ID range is reversed (first after last) is
+%% malformed. The session must end with amqp:invalid-field instead of
+%% crashing with an internal error.
+disposition_reversed_range_rejected(Config) ->
+    QName = atom_to_binary(?FUNCTION_NAME),
+    {Connection, Session, LinkPair} = init(Config),
+    {ok, #{type := <<"quorum">>}} = rabbitmq_amqp_client:declare_queue(
+                                      LinkPair, QName,
+                                      #{arguments => #{<<"x-queue-type">> => {utf8, <<"quorum">>}}}),
+    Address = rabbitmq_amqp_address:queue(QName),
+    {ok, Sender} = amqp10_client:attach_sender_link(Session, <<"sender">>, Address),
+    ok = wait_for_credit(Sender),
+    ok = amqp10_client:send_msg(Sender, amqp10_msg:new(<<"t1">>, <<"m1">>, true)),
+    ok = amqp10_client:detach_link(Sender),
+
+    {ok, Receiver} = amqp10_client:attach_receiver_link(
+                       Session, <<"receiver">>, Address, unsettled),
+    {ok, M1} = amqp10_client:get_msg(Receiver),
+    DeliveryId = amqp10_msg:delivery_id(M1),
+
+    %% first is after last: a malformed range.
+    ok = amqp10_client_session:disposition(
+           Receiver, DeliveryId + 1, DeliveryId, true, accepted),
+    receive
+        {amqp10_event,
+         {session, Session,
+          {ended, #'v1_0.error'{condition = ?V_1_0_AMQP_ERROR_INVALID_FIELD}}}} -> ok
+    after 30000 -> flush(missing_ended),
+                   ct:fail("did not receive expected error")
+    end,
+    ok = close_connection_sync(Connection).
 
 %% Test that deferral tokens submitted in a FLOW while a previous credit
 %% request from the same link is still in flight are not dropped, but

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -1101,9 +1101,7 @@ modified_quorum_queue_deferral_token_ranged_disposition(Config) ->
                  rabbitmq_amqp_client:delete_queue(LinkPair, QName)),
     ok = close(Init).
 
-%% A DISPOSITION whose delivery ID range is reversed (first after last) is
-%% malformed. The session must end with amqp:invalid-field instead of
-%% crashing with an internal error.
+%% A reversed disposition range ends the session with amqp:invalid-field.
 disposition_reversed_range_rejected(Config) ->
     QName = atom_to_binary(?FUNCTION_NAME),
     {Connection, Session, LinkPair} = init(Config),
@@ -1121,7 +1119,7 @@ disposition_reversed_range_rejected(Config) ->
     {ok, M1} = amqp10_client:get_msg(Receiver),
     DeliveryId = amqp10_msg:delivery_id(M1),
 
-    %% first is after last: a malformed range.
+    %% first is after last.
     ok = amqp10_client_session:disposition(
            Receiver, DeliveryId + 1, DeliveryId, true, accepted),
     receive

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -150,6 +150,7 @@ groups() ->
        modified_quorum_queue_deferral_token,
        modified_quorum_queue_deferral_token_ranged_disposition,
        disposition_reversed_range_rejected,
+       session_flow_max_incoming_window,
        modified_quorum_queue_deferral_token_precedes_backlog,
        modified_quorum_queue_deferral_token_survives_in_flight_credit_req,
        modified_quorum_queue_deferral_token_invalid_annotation_type,
@@ -1131,6 +1132,26 @@ disposition_reversed_range_rejected(Config) ->
                    ct:fail("did not receive expected error")
     end,
     ok = close_connection_sync(Connection).
+
+%% A session FLOW may advertise the largest uint as its incoming window.
+session_flow_max_incoming_window(Config) ->
+    QName = atom_to_binary(?FUNCTION_NAME),
+    {_, Session, LinkPair} = Init = init(Config),
+    {ok, _} = rabbitmq_amqp_client:declare_queue(LinkPair, QName, #{}),
+    ok = amqp10_client_session:flow(Session, 16#ffffffff, never),
+    Address = rabbitmq_amqp_address:queue(QName),
+    {ok, Sender} = amqp10_client:attach_sender_link(Session, <<"sender">>, Address),
+    ok = wait_for_credit(Sender),
+    ok = amqp10_client:send_msg(Sender, amqp10_msg:new(<<"t1">>, <<"m1">>, false)),
+    ok = wait_for_accepted(<<"t1">>),
+    {ok, Receiver} = amqp10_client:attach_receiver_link(
+                       Session, <<"receiver">>, Address, settled),
+    {ok, Msg} = amqp10_client:get_msg(Receiver),
+    ?assertEqual([<<"m1">>], amqp10_msg:body(Msg)),
+    ok = amqp10_client:detach_link(Sender),
+    ok = amqp10_client:detach_link(Receiver),
+    {ok, _} = rabbitmq_amqp_client:delete_queue(LinkPair, QName),
+    ok = close(Init).
 
 %% Test that deferral tokens submitted in a FLOW while a previous credit
 %% request from the same link is still in flight are not dropped, but

--- a/deps/rabbit/test/unit_amqp_reader_SUITE.erl
+++ b/deps/rabbit/test/unit_amqp_reader_SUITE.erl
@@ -8,6 +8,7 @@
 -module(unit_amqp_reader_SUITE).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit/include/rabbit_amqp_reader.hrl").
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
 
@@ -15,7 +16,8 @@
 
 all() ->
     [
-     {group, tests}
+     {group, tests},
+     {group, credential_tests}
     ].
 
 groups() ->
@@ -32,9 +34,28 @@ groups() ->
        empty_frame,
        empty_frame_with_extended_header,
        valid_frame_header,
-       close_frame_on_framing_error
+       close_frame_on_framing_error,
+       close_frame_on_internal_error,
+       close_frame_on_abnormal_session_exit
+      ]},
+     %% Run sequentially: each test case mocks the global rabbit_access_control module.
+     {credential_tests, [],
+      [
+       close_frame_on_credential_update_state_error,
+       close_frame_on_credential_check_vhost_access_error
       ]}
     ].
+
+init_per_group(credential_tests, Config) ->
+    ok = meck:new(rabbit_access_control, [no_link]),
+    Config;
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(credential_tests, _Config) ->
+    ok = meck:unload(rabbit_access_control);
+end_per_group(_Group, _Config) ->
+    ok.
 
 %% -------------------------------------------------------------------
 %% Test Cases
@@ -126,19 +147,98 @@ close_frame_on_framing_error(_Config) ->
 
     ?assertMatch(#v1{connection_state = closed},
                  rabbit_amqp_reader:handle_input(<<0:32, 2, 0, 0:16>>, State)),
-
-    {ok, <<Size:32, 2, 0, 0:16>>} = gen_tcp:recv(Client, 8, 5000),
-    {ok, Body} = gen_tcp:recv(Client, Size - 8, 5000),
-    {Described, _BytesParsed} = amqp10_binary_parser:parse(Body),
     ?assertMatch(
        #'v1_0.close'{
           error = #'v1_0.error'{
                      condition = ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR}},
-       amqp10_framing:decode(Described)),
+       receive_close(Client)),
 
     ok = gen_tcp:close(Client),
     ok = gen_tcp:close(Server),
     ok = gen_tcp:close(Listener),
+    passed.
+
+%% An unhandled exception while parsing a frame body must not leak the
+%% caught reason and stacktrace to the peer; the description must be the
+%% redacted, constant one.
+close_frame_on_internal_error(_Config) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listener),
+    State0 = (test_state())#v1{connection_state = running,
+                               callback = {frame_header, amqp},
+                               sock = Server},
+
+    %% Frame header for a 1-byte body carrying a type code that
+    %% amqp10_binary_parser:parse/1 does not support.
+    State1 = rabbit_amqp_reader:handle_input(<<9:32, 2, 0, 0:16>>, State0),
+    ?assertMatch(#v1{connection_state = closed},
+                 rabbit_amqp_reader:handle_input(<<255>>, State1)),
+    ?assertMatch(
+       #'v1_0.close'{
+          error = #'v1_0.error'{
+                     condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
+                     description = {utf8, <<"internal error">>}}},
+       receive_close(Client)),
+
+    ok = gen_tcp:close(Client),
+    ok = gen_tcp:close(Server),
+    ok = gen_tcp:close(Listener),
+    passed.
+
+%% An abnormal session exit must not leak the caught reason and stacktrace
+%% to the peer; the description must be the redacted, constant one.
+close_frame_on_abnormal_session_exit(_Config) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listener),
+    ChannelNum = 7,
+    SessionPid = spawn(fun() -> ok end),
+    State0 = (test_state())#v1{connection_state = running,
+                               sock = Server,
+                               tracked_channels = #{ChannelNum => SessionPid}},
+
+    ?assertMatch(#v1{connection_state = closed},
+                 rabbit_amqp_reader:handle_other(
+                   {{'DOWN', ChannelNum}, make_ref(), process, SessionPid,
+                    {some_internal_reason, [{some_module, some_fun, 0, []}]}},
+                   State0)),
+    ?assertMatch(#'v1_0.close'{
+                    error = #'v1_0.error'{
+                               condition = ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
+                               description = {utf8, <<"internal error">>}}},
+                 receive_close(Client)),
+
+    ok = gen_tcp:close(Client),
+    ok = gen_tcp:close(Server),
+    ok = gen_tcp:close(Listener),
+    passed.
+
+%% A failure to apply a renewed credential (`update_state/2` returns an
+%% error) must not leak the returned reason to the peer.
+close_frame_on_credential_update_state_error(_Config) ->
+    ok = meck:expect(rabbit_access_control, update_state,
+                     fun(_User, _Cred) -> {error, invalid_credentials} end),
+    ?assertMatch(#'v1_0.error'{
+                    condition = ?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
+                    description = {utf8, <<"credential update failed">>}},
+                 assert_credential_update_closes(<<"new-token">>)),
+    passed.
+
+%% A failure to check vhost access with the renewed credential (an
+%% exception raised by `check_vhost_access/4`) must not leak the caught
+%% reason to the peer.
+close_frame_on_credential_check_vhost_access_error(_Config) ->
+    ok = meck:expect(rabbit_access_control, update_state,
+                     fun(User, _Cred) -> {ok, User} end),
+    ok = meck:expect(rabbit_access_control, check_vhost_access,
+                     fun(_User, _Vhost, _AuthzData, _Ctx) -> error(access_denied) end),
+    ?assertMatch(#'v1_0.error'{
+                    condition = ?V_1_0_AMQP_ERROR_UNAUTHORIZED_ACCESS,
+                    description = {utf8, <<"access to vhost 'test-vhost' failed for new credential">>}},
+                 assert_credential_update_closes(<<"new-token">>)),
     passed.
 
 %% -------------------------------------------------------------------
@@ -160,3 +260,34 @@ assert_framing_error(FrameHeader) ->
         #'v1_0.error'{condition = ?V_1_0_CONNECTION_ERROR_FRAMING_ERROR}},
        rabbit_amqp_reader:handle_input(FrameHeader, test_state())),
     passed.
+
+%% Reads a `close` frame off Client and decodes its performative.
+receive_close(Client) ->
+    {ok, <<Size:32, 2, 0, 0:16>>} = gen_tcp:recv(Client, 8, 5000),
+    {ok, Body} = gen_tcp:recv(Client, Size - 8, 5000),
+    {Described, _BytesParsed} = amqp10_binary_parser:parse(Body),
+    #'v1_0.close'{} = amqp10_framing:decode(Described).
+
+%% Drives `handle_other({set_credential, Cred}, State)` on a running
+%% connection and returns the resulting close frame's error.
+assert_credential_update_closes(Cred) ->
+    {ok, Listener} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, Port} = inet:port(Listener),
+    {ok, Client} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}]),
+    {ok, Server} = gen_tcp:accept(Listener),
+    State0 = (test_state())#v1{connection_state = running,
+                               sock = Server,
+                               connection = #v1_connection{
+                                              vhost = <<"test-vhost">>,
+                                              user = #user{username = <<"guest">>,
+                                                          tags = [],
+                                                          authz_backends = []}}},
+
+    ?assertMatch(#v1{connection_state = closed},
+                 rabbit_amqp_reader:handle_other({set_credential, Cred}, State0)),
+    #'v1_0.close'{error = Error} = receive_close(Client),
+
+    ok = gen_tcp:close(Client),
+    ok = gen_tcp:close(Server),
+    ok = gen_tcp:close(Listener),
+    Error.

--- a/deps/rabbit_common/src/rabbit_nodes_common.erl
+++ b/deps/rabbit_common/src/rabbit_nodes_common.erl
@@ -141,7 +141,7 @@ port_shutdown_loop(Port) ->
     end.
 
 cookie_hash() ->
-    base64:encode_to_string(erlang:md5(atom_to_list(erlang:get_cookie()))).
+    base64:encode_to_string(erlang:md5(atom_to_binary(erlang:get_cookie()))).
 
 diagnostics(Nodes) ->
     verbose_erlang_distribution(true),

--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -16,7 +16,8 @@
 -behaviour(gen_server2).
 
 -export([go/0, add_binding/3, remove_bindings/3]).
--export([list_routing_keys/1, hops/4]). %% For testing
+%% Exported for tests.
+-export([list_routing_keys/1, hops/4]).
 -export([all_local/0, disconnect_all/0, reconnect_all/0]).
 
 -export([start_link/1]).
@@ -509,8 +510,8 @@ bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments, Nowait) ->
 %% In other words, we count down to 0 from the link with the most
 %% restrictive max_hops we have yet passed through.
 %%
-%% The binding header is client-supplied, since it is an ordinary binding
-%% argument, so it is not trusted: hops/4 clamps it to a non-negative budget.
+%% The binding header is an ordinary binding argument, so clients can set
+%% it to anything. `hops/4` therefore never trusts it.
 
 update_binding(Args, #state{downstream_exchange = X,
                             upstream            = Upstream,
@@ -535,8 +536,8 @@ update_binding(Args, #state{downstream_exchange = X,
             rabbit_basic:prepend_table_header(?BINDING_HEADER, Info, Args)
     end.
 
-%% The binding header is client-supplied: any value that is not a positive
-%% hop count means the binding does not propagate any further.
+%% A header that does not carry a positive hop count stops propagation
+%% instead of being trusted.
 -spec hops(rabbit_framing:amqp_table(), integer(), binary() | unknown, binary()) ->
           non_neg_integer().
 hops(Args, MaxHops, UName, UVhost) ->

--- a/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_exchange_federation/src/rabbit_federation_exchange_link.erl
@@ -16,7 +16,7 @@
 -behaviour(gen_server2).
 
 -export([go/0, add_binding/3, remove_bindings/3]).
--export([list_routing_keys/1]). %% For testing
+-export([list_routing_keys/1, hops/4]). %% For testing
 -export([all_local/0, disconnect_all/0, reconnect_all/0]).
 
 -export([start_link/1]).
@@ -434,10 +434,10 @@ binding_op(UpdateFun, Cmd, B = #binding{args = Args},
            State = #state{cmd_channel = Ch}) ->
     {DoIt, State1} =
         case rabbit_misc:table_lookup(Args, ?BINDING_HEADER) of
-            undefined  -> UpdateFun(B, State);
-            {array, _} -> {Cmd =/= ignore, State}
+            undefined -> UpdateFun(B, State);
+            _         -> {true, State}
         end,
-    case DoIt of
+    case DoIt andalso Cmd =/= ignore of
         true  -> amqp_channel:call(Ch, Cmd);
         false -> ok
     end,
@@ -508,6 +508,9 @@ bind_cmd0(unbind, Source, Destination, RoutingKey, Arguments, Nowait) ->
 %%
 %% In other words, we count down to 0 from the link with the most
 %% restrictive max_hops we have yet passed through.
+%%
+%% The binding header is client-supplied, since it is an ordinary binding
+%% argument, so it is not trusted: hops/4 clamps it to a non-negative budget.
 
 update_binding(Args, #state{downstream_exchange = X,
                             upstream            = Upstream,
@@ -515,32 +518,43 @@ update_binding(Args, #state{downstream_exchange = X,
                             upstream_name       = UName}) ->
     #upstream{max_hops = MaxHops} = Upstream,
     UVhost = vhost(UpstreamX),
-    Hops = case rabbit_misc:table_lookup(Args, ?BINDING_HEADER) of
-               undefined    -> MaxHops;
-               {array, All} -> [{table, Prev} | _] = All,
-                               PrevHops = get_hops(Prev),
-                               case rabbit_federation_util:already_seen(
-                                      UName, UVhost, All) of
-                                   true  -> 0;
-                                   false -> lists:min([PrevHops - 1, MaxHops])
-                               end
-           end,
-    case Hops of
-        0 -> ignore;
-        _ -> Cluster = rabbit_nodes:cluster_name(),
-             ABSuffix = rabbit_federation_db:get_active_suffix(
-                          X, Upstream, <<"A">>),
-             DVhost = vhost(X),
-             DName = name(X),
-             Down = <<DVhost/binary,":", DName/binary, " ", ABSuffix/binary>>,
-             Info = [{<<"cluster-name">>, longstr, Cluster},
-                     {<<"vhost">>,        longstr, DVhost},
-                     {<<"exchange">>,     longstr, Down},
-                     {<<"hops">>,         short,   Hops}],
-             rabbit_basic:prepend_table_header(?BINDING_HEADER, Info, Args)
+    case hops(Args, MaxHops, UName, UVhost) of
+        0 ->
+            ignore;
+        Hops ->
+            Cluster = rabbit_nodes:cluster_name(),
+            ABSuffix = rabbit_federation_db:get_active_suffix(
+                         X, Upstream, <<"A">>),
+            DVhost = vhost(X),
+            DName = name(X),
+            Down = <<DVhost/binary,":", DName/binary, " ", ABSuffix/binary>>,
+            Info = [{<<"cluster-name">>, longstr, Cluster},
+                    {<<"vhost">>,        longstr, DVhost},
+                    {<<"exchange">>,     longstr, Down},
+                    {<<"hops">>,         short,   Hops}],
+            rabbit_basic:prepend_table_header(?BINDING_HEADER, Info, Args)
     end.
 
+%% The binding header is client-supplied: any value that is not a positive
+%% hop count means the binding does not propagate any further.
+-spec hops(rabbit_framing:amqp_table(), integer(), binary() | unknown, binary()) ->
+          non_neg_integer().
+hops(Args, MaxHops, UName, UVhost) ->
+    Hops = case rabbit_misc:table_lookup(Args, ?BINDING_HEADER) of
+               undefined ->
+                   MaxHops;
+               {array, All} ->
+                   case rabbit_federation_util:already_seen(UName, UVhost, All) of
+                       true  -> 0;
+                       false -> lists:min([previous_hops(All) - 1, MaxHops])
+                   end;
+               _ ->
+                   0
+           end,
+    erlang:max(0, Hops).
 
+previous_hops([{table, Prev} | _]) -> get_hops(Prev);
+previous_hops(_)                   -> 0.
 
 key(#binding{key = Key, args = Args}) -> {Key, Args}.
 
@@ -800,17 +814,10 @@ header_for_upstream_vhost(unknown) -> [];
 header_for_upstream_vhost(Name)    -> [{<<"vhost">>, longstr, Name}].
 
 get_hops(Table) ->
-  case rabbit_misc:table_lookup(Table, <<"hops">>) of
-    %% see rabbit_binary_generator
-    {short, N}         -> N;
-    {long, N}          -> N;
-    {byte, N}          -> N;
-    {signedint, N}     -> N;
-    {unsignedbyte, N}  -> N;
-    {unsignedshort, N} -> N;
-    {unsignedint, N}   -> N;
-    {_, N} when is_integer(N) andalso N >= 0 -> N
-  end.
+    case rabbit_misc:table_lookup(Table, <<"hops">>) of
+        {_, N} when is_integer(N) andalso N > 0 -> N;
+        _                                       -> 0
+    end.
 
 handle_down(DCh, Reason, _Ch, _CmdCh, DCh, Args, State) ->
     rabbit_federation_link_util:handle_downstream_down(Reason, Args, State);

--- a/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 
 -include("rabbit_exchange_federation.hrl").
+-include_lib("rabbitmq_federation_common/include/rabbit_federation.hrl").
 
 -compile(export_all).
 
@@ -30,7 +31,7 @@ all() ->
 groups() ->
     [
      {essential, [], essential()},
-     {cluster_size_3, [], [max_hops]},
+     {cluster_size_3, [], [max_hops, forged_hops_does_not_bypass_max_hops]},
      {rolling_upgrade, [], [child_id_format]},
      {cycle_protection, [], [
                              %% TBD: port from v3.10.x in an Erlang 25-compatible way
@@ -56,7 +57,9 @@ essential() ->
       unbind_on_client_unbind,
       exchange_federation_link_status,
       lookup_exchange_status,
-      supervisor_shutdown_concurrency_safety
+      supervisor_shutdown_concurrency_safety,
+      forged_binding_header_does_not_crash_link,
+      invalid_persisted_max_hops_does_not_crash_link
     ].
 
 suite() ->
@@ -526,6 +529,79 @@ max_hops(Config) ->
       {skip, "Should not run in mixed version environments"}
   end.
 
+%% A chain rather than a ring, so that cycle detection cannot mask the
+%% result: A is the original source, B consumes from A, C consumes from B.
+%% A forged x-bound-from header used to make the hop counter negative,
+%% which never reaches 0 through ordinary arithmetic, so a binding kept
+%% propagating through the whole chain regardless of max-hops. With the
+%% fix, a header carrying a non-positive hop count means "do not
+%% propagate any further", so the forged binding never leaves the node it
+%% was declared on.
+forged_hops_does_not_bypass_max_hops(Config) ->
+  case rabbit_ct_helpers:is_mixed_versions() of
+    false ->
+      [NodeA, NodeB, NodeC] = rabbit_ct_broker_helpers:get_node_configs(
+        Config, nodename),
+      await_credentials_obfuscation_seeding_on_two_nodes(Config),
+
+      UpX = <<"chain">>,
+
+      %% B consumes from A
+      rabbit_ct_broker_helpers:set_parameter(
+        Config, NodeB, <<"federation-upstream">>, <<"upstream">>,
+        [
+          {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeA)},
+          {<<"exchange">>, UpX},
+          {<<"max-hops">>, 1}
+        ]),
+      %% C consumes from B
+      rabbit_ct_broker_helpers:set_parameter(
+        Config, NodeC, <<"federation-upstream">>, <<"upstream">>,
+        [
+          {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeB)},
+          {<<"exchange">>, UpX},
+          {<<"max-hops">>, 1}
+        ]),
+
+      [begin
+        rabbit_ct_broker_helpers:set_policy(
+          Config, Node,
+          <<"fed.x">>, <<"^chain">>, <<"exchanges">>,
+          [
+            {<<"federation-upstream">>, <<"upstream">>}
+          ])
+       end || Node <- [NodeB, NodeC]],
+
+      NodeACh = rabbit_ct_client_helpers:open_channel(Config, NodeA),
+      NodeBCh = rabbit_ct_client_helpers:open_channel(Config, NodeB),
+      NodeCCh = rabbit_ct_client_helpers:open_channel(Config, NodeC),
+
+      X = exchange_declare_method(UpX),
+      declare_exchange(NodeACh, X),
+      declare_exchange(NodeBCh, X),
+      declare_exchange(NodeCCh, X),
+
+      %% Baseline: an ordinary binding created on C reaches B, one hop
+      %% away, confirming the chain and the propagation path both work.
+      _ = declare_and_bind_queue(NodeCCh, UpX, <<"baseline">>),
+      await_binding(Config, NodeB, UpX, <<"baseline">>),
+
+      ForgedArgs = [{?BINDING_HEADER, array,
+                     [{table, [{<<"hops">>, short, -100},
+                               {<<"cluster-name">>, longstr, <<"nonexistent">>},
+                               {<<"vhost">>, longstr, <<"x">>}]}]}],
+      _ = declare_and_bind_queue(NodeCCh, UpX, <<"forged">>, ForgedArgs),
+
+      %% Give propagation a chance to happen before asserting its absence.
+      timer:sleep(5000),
+      [] = bound_keys_from(Config, NodeB, <<"/">>, UpX, <<"forged">>),
+      [] = bound_keys_from(Config, NodeA, <<"/">>, UpX, <<"forged">>),
+
+      clean_up_federation_related_bits(Config);
+    true ->
+      {skip, "Should not run in mixed version environments"}
+  end.
+
 exchange_federation_link_status(Config) ->
   FedX = <<"single_upstream.federated">>,
   UpX = <<"single_upstream.upstream.x">>,
@@ -662,6 +738,87 @@ supervisor_shutdown_concurrency_safety(Config) ->
   %% Verify federation still works after recovery
   await_binding(Config, 0, UpX, RK),
   publish_expect(Ch, UpX, RK, Q, <<"after_recovery">>),
+
+  clean_up_federation_related_bits(Config).
+
+%% A forged x-bound-from binding argument used to crash the link, and the
+%% crash repeated indefinitely because the poisoned binding is replayed on
+%% every restart.
+forged_binding_header_does_not_crash_link(Config) ->
+  FedX = <<"forged_binding_header.federated">>,
+  UpX = <<"forged_binding_header.upstream.x">>,
+  rabbit_ct_broker_helpers:set_parameter(
+    Config, 0, <<"federation-upstream">>, <<"localhost">>,
+    [
+      {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, 0)},
+      {<<"exchange">>, UpX}
+    ]),
+  rabbit_ct_broker_helpers:set_policy(
+    Config, 0,
+    <<"fed.x">>, <<"^forged_binding_header.federated">>, <<"exchanges">>,
+    [
+      {<<"federation-upstream">>, <<"localhost">>}
+    ]),
+
+  Ch = rabbit_ct_client_helpers:open_channel(Config, 0),
+
+  Xs = [
+    exchange_declare_method(FedX)
+  ],
+  declare_exchanges(Ch, Xs),
+
+  _ = declare_and_bind_queue(Ch, FedX, <<"not-an-array">>,
+                             [{?BINDING_HEADER, longstr, <<"nope">>}]),
+  _ = declare_and_bind_queue(Ch, FedX, <<"no-hops">>,
+                             [{?BINDING_HEADER, array,
+                               [{table, [{<<"cluster-name">>, longstr, <<"x">>}]}]}]),
+
+  RK = <<"key">>,
+  Q = declare_and_bind_queue(Ch, FedX, RK),
+  await_binding(Config, 0, UpX, RK),
+  publish_expect(Ch, UpX, RK, Q, <<"forged_binding_header payload">>),
+
+  [Link] = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                        rabbit_federation_status, status,
+                                        []),
+  running = proplists:get_value(status, Link),
+
+  clean_up_federation_related_bits(Config).
+
+%% `max-hops` is only checked when the parameter is set, so a value persisted
+%% by an earlier version, which accepted any number, is read back as is. A
+%% fractional value used to crash the link, since it cannot be encoded into
+%% the integer fields that carry the hop count.
+invalid_persisted_max_hops_does_not_crash_link(Config) ->
+  FedX = <<"invalid_persisted_max_hops.federated">>,
+  UpX = <<"invalid_persisted_max_hops.upstream.x">>,
+  Definition = [
+    {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, 0)},
+    {<<"exchange">>, UpX},
+    {<<"max-hops">>, 2.5}
+  ],
+  ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE,
+                                    set_upstream_without_validation,
+                                    [<<"legacy">>, Definition]),
+  rabbit_ct_broker_helpers:set_policy(
+    Config, 0,
+    <<"fed.x">>, <<"^invalid_persisted_max_hops.federated">>, <<"exchanges">>,
+    [
+      {<<"federation-upstream">>, <<"legacy">>}
+    ]),
+
+  Ch = rabbit_ct_client_helpers:open_channel(Config, 0),
+  declare_exchange(Ch, exchange_declare_method(FedX)),
+
+  RK = <<"key">>,
+  Q = declare_and_bind_queue(Ch, FedX, RK),
+  await_binding(Config, 0, UpX, RK),
+  publish_expect(Ch, UpX, RK, Q, <<"invalid_persisted_max_hops payload">>),
+
+  [Link] = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                        rabbit_federation_status, status,
+                                        []),
+  running = proplists:get_value(status, Link),
 
   clean_up_federation_related_bits(Config).
 
@@ -862,6 +1019,13 @@ clean_up_federation_related_bits(Config) ->
     [delete_all_exchanges_on(Config, N) || N <- NodeIndices],
     ok.
 
+%% Writes the parameter straight to the store, the way a definition persisted
+%% before `max-hops` was validated as a bounded integer would be read back.
+set_upstream_without_validation(Name, Definition) ->
+  _ = rabbit_db_rtparams:set(<<"/">>, <<"federation-upstream">>, Name, Definition),
+  rabbit_federation_parameters:notify(<<"/">>, <<"federation-upstream">>, Name,
+                                      Definition, <<"acting-user">>).
+
 set_up_upstream(Config) ->
   rabbit_ct_broker_helpers:set_parameter(
     Config, 0, <<"federation-upstream">>, <<"localhost">>,
@@ -915,9 +1079,13 @@ declare_queue(Ch, Q) ->
   amqp_channel:call(Ch, Q).
 
 bind_queue(Ch, Q, X, Key) ->
+    bind_queue(Ch, Q, X, Key, []).
+
+bind_queue(Ch, Q, X, Key, Args) ->
     amqp_channel:call(Ch, #'queue.bind'{queue       = Q,
                                         exchange    = X,
-                                        routing_key = Key}).
+                                        routing_key = Key,
+                                        arguments   = Args}).
 
 unbind_queue(Ch, Q, X, Key) ->
     amqp_channel:call(Ch, #'queue.unbind'{queue       = Q,
@@ -932,6 +1100,11 @@ bind_exchange(Ch, D, S, Key) ->
 declare_and_bind_queue(Ch, X, Key) ->
     Q = declare_queue(Ch),
     bind_queue(Ch, Q, X, Key),
+    Q.
+
+declare_and_bind_queue(Ch, X, Key, Args) ->
+    Q = declare_queue(Ch),
+    bind_queue(Ch, Q, X, Key, Args),
     Q.
 
 

--- a/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/exchange_SUITE.erl
@@ -529,14 +529,12 @@ max_hops(Config) ->
       {skip, "Should not run in mixed version environments"}
   end.
 
-%% A chain rather than a ring, so that cycle detection cannot mask the
-%% result: A is the original source, B consumes from A, C consumes from B.
-%% A forged x-bound-from header used to make the hop counter negative,
-%% which never reaches 0 through ordinary arithmetic, so a binding kept
-%% propagating through the whole chain regardless of max-hops. With the
-%% fix, a header carrying a non-positive hop count means "do not
-%% propagate any further", so the forged binding never leaves the node it
-%% was declared on.
+%% Uses a chain (B consumes from A, C consumes from B) rather than a ring so
+%% that cycle detection cannot mask the result.
+%%
+%% A forged `x-bound-from` header with a negative hop count never reached 0
+%% by decrementing, so the binding propagated through the whole chain
+%% regardless of `max-hops`.
 forged_hops_does_not_bypass_max_hops(Config) ->
   case rabbit_ct_helpers:is_mixed_versions() of
     false ->
@@ -581,8 +579,8 @@ forged_hops_does_not_bypass_max_hops(Config) ->
       declare_exchange(NodeBCh, X),
       declare_exchange(NodeCCh, X),
 
-      %% Baseline: an ordinary binding created on C reaches B, one hop
-      %% away, confirming the chain and the propagation path both work.
+      %% An ordinary binding must reach B first, otherwise the absence of the
+      %% forged one below proves nothing.
       _ = declare_and_bind_queue(NodeCCh, UpX, <<"baseline">>),
       await_binding(Config, NodeB, UpX, <<"baseline">>),
 
@@ -592,7 +590,7 @@ forged_hops_does_not_bypass_max_hops(Config) ->
                                {<<"vhost">>, longstr, <<"x">>}]}]}],
       _ = declare_and_bind_queue(NodeCCh, UpX, <<"forged">>, ForgedArgs),
 
-      %% Give propagation a chance to happen before asserting its absence.
+      %% Propagation is asynchronous, so allow it time before asserting its absence.
       timer:sleep(5000),
       [] = bound_keys_from(Config, NodeB, <<"/">>, UpX, <<"forged">>),
       [] = bound_keys_from(Config, NodeA, <<"/">>, UpX, <<"forged">>),
@@ -741,9 +739,8 @@ supervisor_shutdown_concurrency_safety(Config) ->
 
   clean_up_federation_related_bits(Config).
 
-%% A forged x-bound-from binding argument used to crash the link, and the
-%% crash repeated indefinitely because the poisoned binding is replayed on
-%% every restart.
+%% A malformed `x-bound-from` binding argument used to crash the link on
+%% every restart, since the binding is replayed each time.
 forged_binding_header_does_not_crash_link(Config) ->
   FedX = <<"forged_binding_header.federated">>,
   UpX = <<"forged_binding_header.upstream.x">>,
@@ -785,10 +782,9 @@ forged_binding_header_does_not_crash_link(Config) ->
 
   clean_up_federation_related_bits(Config).
 
-%% `max-hops` is only checked when the parameter is set, so a value persisted
-%% by an earlier version, which accepted any number, is read back as is. A
-%% fractional value used to crash the link, since it cannot be encoded into
-%% the integer fields that carry the hop count.
+%% Earlier versions accepted any number for `max-hops`, and a persisted
+%% fractional value used to crash the link when the hop count was encoded
+%% into an integer field.
 invalid_persisted_max_hops_does_not_crash_link(Config) ->
   FedX = <<"invalid_persisted_max_hops.federated">>,
   UpX = <<"invalid_persisted_max_hops.upstream.x">>,
@@ -1019,8 +1015,8 @@ clean_up_federation_related_bits(Config) ->
     [delete_all_exchanges_on(Config, N) || N <- NodeIndices],
     ok.
 
-%% Writes the parameter straight to the store, the way a definition persisted
-%% before `max-hops` was validated as a bounded integer would be read back.
+%% Bypasses validation to reproduce a definition persisted by a version that
+%% did not validate `max-hops`.
 set_upstream_without_validation(Name, Definition) ->
   _ = rabbit_db_rtparams:set(<<"/">>, <<"federation-upstream">>, Name, Definition),
   rabbit_federation_parameters:notify(<<"/">>, <<"federation-upstream">>, Name,

--- a/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -include("rabbit_exchange_federation.hrl").
+-include_lib("rabbitmq_federation_common/include/rabbit_federation.hrl").
 
 -compile(export_all).
 
@@ -19,7 +20,18 @@ all() -> [
     reconnect_all_broadcasts_to_members,
     adjust_when_supervisor_not_running,
     adjust_clear_upstream_when_supervisor_not_running,
-    start_child_handles_already_present
+    start_child_handles_already_present,
+    hops_no_header_returns_max_hops,
+    hops_larger_than_max_hops_is_clamped,
+    hops_of_one_returns_zero,
+    hops_of_zero_or_negative_returns_zero,
+    hops_missing_from_head_table_returns_zero,
+    hops_with_non_integer_value_returns_zero,
+    hops_header_not_an_array_returns_zero,
+    hops_empty_array_or_non_table_head_returns_zero,
+    hops_accepts_long_and_unsignedbyte,
+    hops_cycle_detection_returns_zero,
+    hops_with_non_positive_max_hops_returns_zero
 ].
 
 init_per_suite(Config) ->
@@ -97,3 +109,57 @@ start_child_handles_already_present(_Config) ->
     after
         ok = meck:unload(mirrored_supervisor)
     end.
+
+%% hops/4 is pure: no header, cluster name and vhost are just used for
+%% cycle detection and are otherwise arbitrary here.
+-define(UNAME, <<"upstream-cluster">>).
+-define(UVHOST, <<"/">>).
+
+hops_no_header_returns_max_hops(_Config) ->
+    ?assertEqual(5, rabbit_federation_exchange_link:hops([], 5, ?UNAME, ?UVHOST)).
+
+hops_larger_than_max_hops_is_clamped(_Config) ->
+    ?assertEqual(3, rabbit_federation_exchange_link:hops(header_with_hops(10), 3, ?UNAME, ?UVHOST)).
+
+hops_of_one_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(header_with_hops(1), 5, ?UNAME, ?UVHOST)).
+
+hops_of_zero_or_negative_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(header_with_hops(0), 5, ?UNAME, ?UVHOST)),
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(header_with_hops(-100), 5, ?UNAME, ?UVHOST)).
+
+hops_missing_from_head_table_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, array, [{table, [{<<"cluster-name">>, longstr, <<"x">>}]}]}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_with_non_integer_value_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, array, [{table, [{<<"hops">>, longstr, <<"5">>}]}]}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_header_not_an_array_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, longstr, <<"nope">>}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_empty_array_or_non_table_head_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([{?BINDING_HEADER, array, []}], 5, ?UNAME, ?UVHOST)),
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([{?BINDING_HEADER, array, [{longstr, <<"x">>}]}], 5, ?UNAME, ?UVHOST)).
+
+hops_accepts_long_and_unsignedbyte(_Config) ->
+    LongArgs = [{?BINDING_HEADER, array, [{table, [{<<"hops">>, long, 3}]}]}],
+    ?assertEqual(2, rabbit_federation_exchange_link:hops(LongArgs, 5, ?UNAME, ?UVHOST)),
+    ByteArgs = [{?BINDING_HEADER, array, [{table, [{<<"hops">>, unsignedbyte, 3}]}]}],
+    ?assertEqual(2, rabbit_federation_exchange_link:hops(ByteArgs, 5, ?UNAME, ?UVHOST)).
+
+hops_cycle_detection_returns_zero(_Config) ->
+    Args = [{?BINDING_HEADER, array,
+             [{table, [{<<"hops">>, short, 5},
+                       {<<"cluster-name">>, longstr, ?UNAME},
+                       {<<"vhost">>, longstr, ?UVHOST}]}]}],
+    ?assertEqual(0, rabbit_federation_exchange_link:hops(Args, 5, ?UNAME, ?UVHOST)).
+
+hops_with_non_positive_max_hops_returns_zero(_Config) ->
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([], 0, ?UNAME, ?UVHOST)),
+    ?assertEqual(0, rabbit_federation_exchange_link:hops([], -1, ?UNAME, ?UVHOST)).
+
+header_with_hops(Hops) ->
+    [{?BINDING_HEADER, array, [{table, [{<<"hops">>, short, Hops}]}]}].

--- a/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/unit_SUITE.erl
@@ -110,8 +110,8 @@ start_child_handles_already_present(_Config) ->
         ok = meck:unload(mirrored_supervisor)
     end.
 
-%% hops/4 is pure: no header, cluster name and vhost are just used for
-%% cycle detection and are otherwise arbitrary here.
+%% `hops/4` only uses the cluster name and vhost for cycle detection, so any
+%% values will do.
 -define(UNAME, <<"upstream-cluster">>).
 -define(UVHOST, <<"/">>).
 

--- a/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
@@ -42,6 +42,11 @@
 %% Identifies a virtual host, used by exchange federation cycle detection
 -define(DOWNSTREAM_VHOST_ARG, <<"x-downstream-vhost">>).
 -define(DEF_PREFETCH, 1000).
+-define(DEF_MAX_HOPS, 1).
+-define(MIN_MAX_HOPS, 1).
+%% The hop counter is encoded into a `short` field on the wire by exchange
+%% federation, hence the upper bound on `max-hops`.
+-define(MAX_MAX_HOPS, 32767).
 
 -define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/docs/federation/">>).
 

--- a/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
@@ -44,8 +44,7 @@
 -define(DEF_PREFETCH, 1000).
 -define(DEF_MAX_HOPS, 1).
 -define(MIN_MAX_HOPS, 1).
-%% The hop counter is encoded into a `short` field on the wire by exchange
-%% federation, hence the upper bound on `max-hops`.
+%% Exchange federation encodes the hop counter as a `short` table field.
 -define(MAX_MAX_HOPS, 32767).
 
 -define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/docs/federation/">>).

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_link_util.erl
@@ -365,7 +365,8 @@ disposable_connection_call(Params, Method, ErrFun) ->
 
 disposable_connection_call(Params, Method, ErrFun, Timeout) ->
     try
-        ?LOG_DEBUG("Disposable connection parameters: ~tp", [Params]),
+        ?LOG_DEBUG("Disposable connection parameters: ~tp",
+                   [rabbit_federation_util:redact_params(Params)]),
         case open(Params, <<"Disposable exchange federation link connection">>) of
             {ok, Conn, Ch} ->
                 try

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_parameters.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_parameters.erl
@@ -82,7 +82,7 @@ shared_validation() ->
      {<<"consumer-tag">>,   fun rabbit_parameter_validation:binary/2, optional},
      {<<"prefetch-count">>, fun rabbit_parameter_validation:number/2, optional},
      {<<"reconnect-delay">>,fun rabbit_parameter_validation:number/2, optional},
-     {<<"max-hops">>,       fun rabbit_parameter_validation:number/2, optional},
+     {<<"max-hops">>,       fun validate_max_hops/2, optional},
      {<<"expires">>,        fun rabbit_parameter_validation:number/2, optional},
      {<<"message-ttl">>,    fun rabbit_parameter_validation:number/2, optional},
      {<<"trust-user-id">>,  fun rabbit_parameter_validation:boolean/2, optional},
@@ -95,6 +95,14 @@ shared_validation() ->
      {<<"bind-nowait">>,    fun rabbit_parameter_validation:boolean/2, optional},
      {<<"channel-use-mode">>, rabbit_parameter_validation:enum(
                               ['multiple', 'single']), optional}].
+
+validate_max_hops(_Name, Term) when is_integer(Term) andalso
+                                    Term >= ?MIN_MAX_HOPS andalso
+                                    Term =< ?MAX_MAX_HOPS ->
+    ok;
+validate_max_hops(Name, Term) ->
+    {error, "~ts should be an integer between ~b and ~b, actually was ~tp",
+     [Name, ?MIN_MAX_HOPS, ?MAX_MAX_HOPS, Term]}.
 
 validate_uri(User) ->
     fun (Name, Term) -> validate_uri(Name, Term, User) end.

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -174,11 +174,10 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               channel_use_mode      = to_atom(bget('channel-use-mode', US, U, multiple))
     }.
 
-%% `max-hops` is validated when the parameter is set, but parameters persisted
-%% by earlier versions were only checked for being a number, so they are read
-%% back as is. A fractional value used to crash the exchange federation link
-%% when it encoded the hop counter, and a value too large for that encoding was
-%% silently truncated to a negative one, hence the normalization here.
+%% Parameters persisted by earlier versions were only checked for being a
+%% number. A fractional value used to crash the exchange federation link when
+%% the hop counter was encoded as a `short`, and a value above the `short`
+%% range wrapped around to a negative one.
 -spec max_hops(term()) -> pos_integer().
 max_hops(N) when is_integer(N) andalso
                  N >= ?MIN_MAX_HOPS andalso

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -11,7 +11,7 @@
 -include_lib("rabbit/include/amqqueue.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 
--export([federate/1, for/1, for/2, params_to_string/1, to_params/2]).
+-export([federate/1, for/1, for/2, params_to_string/1, to_params/2, max_hops/1]).
 %% For testing
 -export([from_set/2, from_pattern/2, remove_credentials/1]).
 
@@ -162,7 +162,7 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               consumer_tag    = bget('consumer-tag',    US, U, <<"federation-link-", Name/binary>>),
               prefetch_count  = bget('prefetch-count',  US, U, ?DEF_PREFETCH),
               reconnect_delay = bget('reconnect-delay', US, U, 5),
-              max_hops        = bget('max-hops',        US, U, 1),
+              max_hops        = max_hops(bget('max-hops', US, U, ?DEF_MAX_HOPS)),
               expires         = bget(expires,           US, U, none),
               message_ttl     = bget('message-ttl',     US, U, none),
               trust_user_id   = bget('trust-user-id',   US, U, false),
@@ -173,6 +173,23 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               resource_cleanup_mode = to_atom(bget('resource-cleanup-mode', US, U, <<"default">>)),
               channel_use_mode      = to_atom(bget('channel-use-mode', US, U, multiple))
     }.
+
+%% `max-hops` is validated when the parameter is set, but parameters persisted
+%% by earlier versions were only checked for being a number, so they are read
+%% back as is. A fractional value used to crash the exchange federation link
+%% when it encoded the hop counter, and a value too large for that encoding was
+%% silently truncated to a negative one, hence the normalization here.
+-spec max_hops(term()) -> pos_integer().
+max_hops(N) when is_integer(N) andalso
+                 N >= ?MIN_MAX_HOPS andalso
+                 N =< ?MAX_MAX_HOPS ->
+    N;
+max_hops(N) when is_number(N) andalso N > ?MAX_MAX_HOPS ->
+    ?MAX_MAX_HOPS;
+max_hops(N) when is_number(N) andalso N > ?MIN_MAX_HOPS ->
+    trunc(N);
+max_hops(_N) ->
+    ?MIN_MAX_HOPS.
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_util.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_util.erl
@@ -14,7 +14,8 @@
 
 -export([should_forward/4, find_upstreams/2, already_seen/3]).
 -export([validate_arg/3, fail/2, name/1, vhost/1, r/1, pgname/1]).
--export([obfuscate_upstream/1, deobfuscate_upstream/1, obfuscate_upstream_params/1, deobfuscate_upstream_params/1]).
+-export([obfuscate_upstream/1, deobfuscate_upstream/1, obfuscate_upstream_params/1,
+         deobfuscate_upstream_params/1, redact_params/1]).
 -export([log_skipped_link/3]).
 
 -import(rabbit_misc, [pget_or_die/2, pget/3]).
@@ -110,3 +111,20 @@ deobfuscate_upstream_params(#upstream_params{uri = EncryptedUri, params = #amqp_
         uri = credentials_obfuscation:decrypt(EncryptedUri),
         params = Params#amqp_params_direct{password = credentials_obfuscation:decrypt(EncryptedPassword)}
     }.
+
+%% Connection parameters carry the deobfuscated upstream password, and
+%% `ssl_options` can carry a private key password. Replace both before the
+%% parameters reach the logs.
+redact_params(#amqp_params_network{ssl_options = SslOpts} = Params) ->
+    Params#amqp_params_network{password = redacted,
+                                ssl_options = redact_ssl_options(SslOpts)};
+redact_params(#amqp_params_direct{} = Params) ->
+    Params#amqp_params_direct{password = redacted}.
+
+redact_ssl_options(SslOpts) when is_list(SslOpts) ->
+    [case Opt of
+         {password, _} -> {password, redacted};
+         Other         -> Other
+     end || Opt <- SslOpts];
+redact_ssl_options(SslOpts) ->
+    SslOpts.

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -330,8 +330,8 @@ max_hops_keeps_valid_values(_Config) ->
         V <- [1, 2, 32766, 32767]],
     ok.
 
-%% Values persisted before `max-hops` was validated as a bounded integer are
-%% read back as is, so they have to be brought back into range here.
+%% Values persisted by versions that did not validate `max-hops` are read
+%% back as is.
 max_hops_normalizes_legacy_values(_Config) ->
     ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000)),
     ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000.5)),
@@ -342,8 +342,8 @@ max_hops_normalizes_legacy_values(_Config) ->
     ?assertEqual(1, rabbit_federation_upstream:max_hops(<<"many">>)),
     ok.
 
-%% Validated through the upstream set component: unlike the upstream one, it
-%% has no mandatory URI to validate, which keeps this a pure function call.
+%% Goes through the upstream set component because, unlike the upstream one,
+%% it has no mandatory URI to validate.
 validation_errors(MaxHops) ->
     Results = rabbit_federation_parameters:validate(
                 <<"/">>, <<"federation-upstream-set">>,

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -31,7 +31,11 @@ all() -> [
     to_params_error_strips_credentials,
     to_params_error_on_malformed_uri_strips_credentials,
     to_params_falls_back_to_valid_uri,
-    to_params_error_redacts_query_secrets
+    to_params_error_redacts_query_secrets,
+    redact_params_network,
+    redact_params_direct,
+    redact_params_ssl_options_password,
+    redact_params_ssl_options_none
 ].
 
 init_per_suite(Config) ->
@@ -260,4 +264,40 @@ to_params_error_redacts_query_secrets(_Config) ->
         rabbit_federation_upstream:to_params(Upstream, XorQ),
     ?assertEqual(nomatch, binary:match(iolist_to_binary(io_lib:format("~tp", [Info])),
                                        <<"s3cret">>)),
+    ok.
+
+%% -------------------------------------------------------------------
+%% rabbit_federation_util:redact_params/1
+%% -------------------------------------------------------------------
+
+redact_params_network(_Config) ->
+    Params = #amqp_params_network{username = <<"fed">>, password = <<"s3cret">>,
+                                  host = "localhost"},
+    Redacted = rabbit_federation_util:redact_params(Params),
+    Formatted = iolist_to_binary(io_lib:format("~tp", [Redacted])),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"s3cret">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"fed">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"localhost">>)),
+    ok.
+
+redact_params_direct(_Config) ->
+    Params = #amqp_params_direct{username = <<"fed">>, password = <<"s3cret">>},
+    Redacted = rabbit_federation_util:redact_params(Params),
+    Formatted = iolist_to_binary(io_lib:format("~tp", [Redacted])),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"s3cret">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"fed">>)),
+    ok.
+
+redact_params_ssl_options_password(_Config) ->
+    Params = #amqp_params_network{ssl_options = [{password, "kp"}, {verify, verify_peer}]},
+    Redacted = rabbit_federation_util:redact_params(Params),
+    Formatted = iolist_to_binary(io_lib:format("~tp", [Redacted])),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"kp">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"verify_peer">>)),
+    ok.
+
+redact_params_ssl_options_none(_Config) ->
+    Params = #amqp_params_network{ssl_options = none},
+    ?assertMatch(#amqp_params_network{ssl_options = none},
+                 rabbit_federation_util:redact_params(Params)),
     ok.

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -35,7 +35,12 @@ all() -> [
     redact_params_network,
     redact_params_direct,
     redact_params_ssl_options_password,
-    redact_params_ssl_options_none
+    redact_params_ssl_options_none,
+    validate_max_hops_accepts_bounds,
+    validate_max_hops_rejects_out_of_range,
+    validate_max_hops_rejects_non_integers,
+    max_hops_keeps_valid_values,
+    max_hops_normalizes_legacy_values
 ].
 
 init_per_suite(Config) ->
@@ -301,3 +306,47 @@ redact_params_ssl_options_none(_Config) ->
     ?assertMatch(#amqp_params_network{ssl_options = none},
                  rabbit_federation_util:redact_params(Params)),
     ok.
+
+%% -------------------------------------------------------------------
+%% max-hops validation and normalization
+%% -------------------------------------------------------------------
+
+validate_max_hops_accepts_bounds(_Config) ->
+    [?assertEqual([], validation_errors(V)) || V <- [1, 2, 32766, 32767]],
+    ok.
+
+validate_max_hops_rejects_out_of_range(_Config) ->
+    [?assertMatch([{error, _, _}], validation_errors(V)) ||
+        V <- [0, -1, -32768, 32768, 100000]],
+    ok.
+
+validate_max_hops_rejects_non_integers(_Config) ->
+    [?assertMatch([{error, _, _}], validation_errors(V)) ||
+        V <- [1.5, 1.0, <<"1">>, "1", true, undefined, [1], {1}]],
+    ok.
+
+max_hops_keeps_valid_values(_Config) ->
+    [?assertEqual(V, rabbit_federation_upstream:max_hops(V)) ||
+        V <- [1, 2, 32766, 32767]],
+    ok.
+
+%% Values persisted before `max-hops` was validated as a bounded integer are
+%% read back as is, so they have to be brought back into range here.
+max_hops_normalizes_legacy_values(_Config) ->
+    ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000)),
+    ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000.5)),
+    ?assertEqual(2, rabbit_federation_upstream:max_hops(2.7)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(0)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(0.5)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(-100)),
+    ?assertEqual(1, rabbit_federation_upstream:max_hops(<<"many">>)),
+    ok.
+
+%% Validated through the upstream set component: unlike the upstream one, it
+%% has no mandatory URI to validate, which keeps this a pure function call.
+validation_errors(MaxHops) ->
+    Results = rabbit_federation_parameters:validate(
+                <<"/">>, <<"federation-upstream-set">>,
+                <<"a-name">>, [[{<<"upstream">>, <<"an-upstream">>},
+                                {<<"max-hops">>, MaxHops}]], none),
+    [R || Rs <- Results, R <- Rs, R =/= ok].

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
@@ -7,6 +7,10 @@
 
 -export([setup/1]).
 
+-ifdef(TEST).
+-export([set_credentials_obfuscation_secret/0]).
+-endif.
+
 setup(#{nodename := Node, nodename_type := NameType} = Context) ->
     ?LOG_DEBUG(
        "~n== Erlang distribution ==", [],
@@ -142,7 +146,8 @@ set_credentials_obfuscation_secret() ->
     ok = credentials_obfuscation:refresh_config(),
     CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
     ?LOG_DEBUG(
-        "Setting credentials obfuscation secret to '~ts'", [CookieBin],
+        "Setting credentials obfuscation secret to Erlang cookie value (hash: '~ts')",
+        [rabbit_nodes_common:cookie_hash()],
         #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     ok = credentials_obfuscation:set_secret(CookieBin),
     Fallback = application:get_env(rabbit, 

--- a/deps/rabbitmq_prelaunch/test/rabbit_prelaunch_dist_SUITE.erl
+++ b/deps/rabbitmq_prelaunch/test/rabbit_prelaunch_dist_SUITE.erl
@@ -1,0 +1,97 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_prelaunch_dist_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [{group, tests}].
+
+all_tests() ->
+    [set_credentials_obfuscation_secret_redacts_cookie].
+
+groups() ->
+    [{tests, [], all_tests()}].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(credentials_obfuscation),
+    Config.
+
+end_per_suite(_Config) ->
+    _ = application:stop(credentials_obfuscation),
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+%% Must log the cookie hash, never the raw cookie.
+set_credentials_obfuscation_secret_redacts_cookie(_Config) ->
+    CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
+    CookieHash = rabbit_nodes_common:cookie_hash(),
+    Lines = capture_debug_log(
+              fun rabbit_prelaunch_dist:set_credentials_obfuscation_secret/0),
+    ?assertNot(log_contains(Lines, binary_to_list(CookieBin))),
+    ?assert(log_contains(Lines, CookieHash)).
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+%% Captures `?LOG_DEBUG` output via a temporary logger handler.
+capture_debug_log(Fun) ->
+    Ref = make_ref(),
+    HandlerId = list_to_atom(
+                  "rabbit_prelaunch_dist_SUITE_log_capture_" ++
+                  integer_to_list(erlang:unique_integer([positive]))),
+    #{level := PrevLevel} = logger:get_primary_config(),
+    ok = logger:set_primary_config(level, debug),
+    ok = logger:add_handler(
+           HandlerId, ?MODULE,
+           #{config => #{pid => self(), ref => Ref}, level => debug}),
+    try
+        Fun()
+    after
+        _ = logger:remove_handler(HandlerId),
+        ok = logger:set_primary_config(level, PrevLevel)
+    end,
+    [format_event(Event) || Event <- drain_log_events(Ref, [])].
+
+drain_log_events(Ref, Acc) ->
+    receive
+        {Ref, Event} -> drain_log_events(Ref, [Event | Acc])
+    after 500 ->
+        lists:reverse(Acc)
+    end.
+
+format_event(#{msg := {Fmt, Args}}) when is_list(Fmt) ->
+    lists:flatten(io_lib:format(Fmt, Args));
+format_event(_) ->
+    "".
+
+log_contains(Lines, Needle) ->
+    lists:any(fun(Line) -> string:find(Line, Needle) =/= nomatch end, Lines).
+
+%% Used by `capture_debug_log/1`.
+log(LogEvent, #{config := #{pid := Pid, ref := Ref}}) ->
+    Pid ! {Ref, LogEvent},
+    ok.


### PR DESCRIPTION
A DISPOSITION's delivery ID range comes entirely from the peer. The AMQP 1.0 client and the broker's AMQP 1.0 session both folded over that range without validating it or bounding its size, so a single frame could drive a session into an unbounded loop or crash it with a case_clause on a reversed range.

Add serial_number:range_size/2, a total function that returns the range size or `undefined` for a malformed range without ever exiting. Use it to bound client-side settlement by the smaller of the range and the outgoing unsettled map, and to have the broker reject a malformed range with amqp:invalid-field instead of miscomputing its size.