### PR TITLE
Require the monitoring tag for cluster-wide quorum queue health checks

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
@@ -51,4 +51,4 @@ failure(Message, Qs, ReqData, Context) ->
     {stop, cowboy_req:reply(503, #{}, Response, ReqData1), Context1}.
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized(ReqData, Context).
+    rabbit_mgmt_util:is_authorized_monitor(ReqData, Context).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts.erl
@@ -48,7 +48,7 @@ failure(Message, Qs, ReqData, Context) ->
     {stop, cowboy_req:reply(503, #{}, Response, ReqData1), Context1}.
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized(ReqData, Context).
+    rabbit_mgmt_util:is_authorized_monitor(ReqData, Context).
 
 %%
 %% Implementation

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -47,7 +47,9 @@ groups() ->
                         is_quorum_critical_single_node_test,
                         quorum_queues_without_elected_leader_single_node_test,
                         quorum_queues_without_elected_leader_across_all_virtual_hosts_single_node_test,
-                        quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_test
+                        quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_test,
+                        quorum_queues_without_elected_leader_across_all_vhosts_requires_monitor_tag_single_node_test,
+                        node_is_quorum_critical_requires_monitor_tag_single_node_test
      ]}
     ].
 
@@ -429,6 +431,38 @@ quorum_queues_without_elected_leader_requires_virtual_host_access_single_node_te
 
     rabbit_ct_broker_helpers:delete_user(Config, User),
     rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
+
+    passed.
+
+quorum_queues_without_elected_leader_across_all_vhosts_requires_monitor_tag_single_node_test(Config) ->
+    EndpointPath = "/health/checks/quorum-queues-without-elected-leaders/all-vhosts/",
+    User = <<"health-check-user">>,
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+
+    http_get(Config, EndpointPath, User, User, ?NOT_AUTHORISED),
+
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [monitoring]),
+    Check0 = http_get(Config, EndpointPath, User, User, ?OK),
+    ?assertEqual(<<"ok">>, maps:get(status, Check0)),
+
+    rabbit_ct_broker_helpers:delete_user(Config, User),
+
+    passed.
+
+node_is_quorum_critical_requires_monitor_tag_single_node_test(Config) ->
+    EndpointPath = "/health/checks/node-is-quorum-critical",
+    User = <<"health-check-user">>,
+    rabbit_ct_broker_helpers:add_user(Config, User, User),
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [management]),
+
+    http_get(Config, EndpointPath, User, User, ?NOT_AUTHORISED),
+
+    rabbit_ct_broker_helpers:set_user_tags(Config, 0, User, [monitoring]),
+    Check0 = http_get(Config, EndpointPath, User, User, ?OK),
+    ?assertEqual(<<"ok">>, maps:get(status, Check0)),
+
+    rabbit_ct_broker_helpers:delete_user(Config, User),
 
     passed.
 


### PR DESCRIPTION
The quorum-queues-without-elected-leaders/all-vhosts and node-is-quorum-critical health check endpoints returned queue names (with their virtual host) from every vhost on the cluster to any user with the management tag, via the weakest is_authorized gate.

This let a user with access to only one vhost enumerate quorum queue names in vhosts they have no permission on. The per-vhost variant of the first check was already fixed to use
is_authorized_vhost_visible_for_monitoring; these two endpoints report cluster-wide data, so they now require the monitoring tag via is_authorized_monitor, matching the precedent set by /api/nodes.

