### PR TITLE
[auth cache backend]Redact password from the authorization cache key

### DIFF
--- a/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
+++ b/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
@@ -130,7 +130,8 @@ with_cache(BackendType, {F, A}, Fun) ->
 %% Keep plaintext credentials out of the cache key. The full args are still
 %% passed to the underlying backend; only the lookup key is redacted.
 -spec cache_key(atom(), [term()]) -> {atom(), [term()]}.
-cache_key(user_login_authentication = F, [Username, AuthProps]) ->
+cache_key(F, [Username, AuthProps])
+  when F =:= user_login_authentication; F =:= user_login_authorization ->
     {F, [Username, redact_credentials(AuthProps)]};
 cache_key(F, A) ->
     {F, A}.

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_counting_mock.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_counting_mock.erl
@@ -6,8 +6,8 @@
 %%
 
 %% Counting auth backend used by the cache plugin's tests. Tracks how
-%% many authentication requests reached the backend so tests can pin
-%% down cache hit/miss behaviour.
+%% many authentication and authorization requests reached the backend
+%% so tests can pin down cache hit/miss behaviour.
 %%
 %% Response modes:
 %%
@@ -27,9 +27,10 @@
          expiry_timestamp/1]).
 
 -export([init/0, reset/0, set_mode/1,
-         authentication_call_count/0]).
+         authentication_call_count/0, authorization_call_count/0]).
 
 -define(COUNTER_KEY, {?MODULE, authentication_calls}).
+-define(AUTHZ_COUNTER_KEY, {?MODULE, authorization_calls}).
 -define(MODE_KEY,    {?MODULE, response_mode}).
 
 init() ->
@@ -37,6 +38,7 @@ init() ->
 
 reset() ->
     persistent_term:put(?COUNTER_KEY, counters:new(1, [])),
+    persistent_term:put(?AUTHZ_COUNTER_KEY, counters:new(1, [])),
     persistent_term:put(?MODE_KEY, always_ok),
     ok.
 
@@ -47,6 +49,9 @@ set_mode(Mode) when Mode =:= always_ok;
 
 authentication_call_count() ->
     counters:get(persistent_term:get(?COUNTER_KEY), 1).
+
+authorization_call_count() ->
+    counters:get(persistent_term:get(?AUTHZ_COUNTER_KEY), 1).
 
 user_login_authentication(Username, AuthProps) ->
     counters:add(persistent_term:get(?COUNTER_KEY), 1, 1),
@@ -61,6 +66,7 @@ user_login_authentication(Username, AuthProps) ->
     end.
 
 user_login_authorization(_Username, _AuthProps) ->
+    counters:add(persistent_term:get(?AUTHZ_COUNTER_KEY), 1, 1),
     {ok, fun() -> none end, []}.
 
 check_vhost_access(#auth_user{}, _VHostPath, _AuthzData) ->

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_prop_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_prop_SUITE.erl
@@ -99,13 +99,14 @@ prop_different_usernames_yield_different_keys(Config) ->
       end, [], ?NUMTESTS).
 
 %% Security invariant: the plaintext password must not be a substring of
-%% the cache key, regardless of username and loopback flag.
+%% the cache key, regardless of username, loopback flag and login step.
 prop_password_is_absent_from_cache_key(Config) ->
     run_proper(
       fun() ->
-              ?FORALL({U, P, L},
-                      {username(), non_trivial_password(), boolean()},
-                      password_absent_from_key(Config, U, P, L))
+              ?FORALL({F, U, P, L},
+                      {login_function(), username(), non_trivial_password(),
+                       boolean()},
+                      password_absent_from_key(Config, F, U, P, L))
       end, [], ?NUMTESTS).
 
 %% Equality invariant: redacting the same AuthProps twice must produce
@@ -113,8 +114,9 @@ prop_password_is_absent_from_cache_key(Config) ->
 prop_redaction_is_deterministic(Config) ->
     run_proper(
       fun() ->
-              ?FORALL({U, P, L}, {username(), password(), boolean()},
-                      redaction_deterministic(Config, U, P, L))
+              ?FORALL({F, U, P, L},
+                      {login_function(), username(), password(), boolean()},
+                      redaction_deterministic(Config, F, U, P, L))
       end, [], ?NUMTESTS).
 
 %%%=========================================================================
@@ -146,15 +148,13 @@ distinct_username_count_two(Config, U1, U2, P) ->
     {ok, _} = login(Config, U2, [{password, P}]),
     2 =:= call_count(Config).
 
-password_absent_from_key(Config, U, P, L) ->
-    Key = cache_key(Config, user_login_authentication,
-                    [U, [{password, P}, {is_loopback, L}]]),
+password_absent_from_key(Config, F, U, P, L) ->
+    Key = cache_key(Config, F, [U, [{password, P}, {is_loopback, L}]]),
     binary:match(term_to_binary(Key), P) =:= nomatch.
 
-redaction_deterministic(Config, U, P, L) ->
+redaction_deterministic(Config, F, U, P, L) ->
     Args = [U, [{password, P}, {is_loopback, L}]],
-    cache_key(Config, user_login_authentication, Args)
-        =:= cache_key(Config, user_login_authentication, Args).
+    cache_key(Config, F, Args) =:= cache_key(Config, F, Args).
 
 %%%=========================================================================
 %%% Helpers
@@ -181,6 +181,9 @@ rpc(Config, M, F, A) ->
 %%%=========================================================================
 %%% Generators
 %%%=========================================================================
+
+login_function() ->
+    oneof([user_login_authentication, user_login_authorization]).
 
 username() ->
     non_empty(binary()).

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
@@ -30,7 +30,9 @@ all() ->
      different_passwords_still_miss_the_cache,
      non_password_authprops_pass_through_unchanged,
      identical_passwords_still_hit_the_authorization_cache,
-     different_passwords_still_miss_the_authorization_cache
+     different_passwords_still_miss_the_authorization_cache,
+     non_password_authprops_pass_through_unchanged_for_authorization,
+     check_user_login_stores_redacted_authorization_key
     ].
 
 init_per_suite(Config) ->
@@ -89,9 +91,8 @@ password_is_not_present_in_authorization_cache_key_for_map_authprops(Config) ->
     Key = cache_key(Config, user_login_authorization, [<<"u">>, Props]),
     false = contains_binary(Key, Password).
 
-%% Only calls carrying `[Username, AuthProps]' need redaction; other
-%% call sites must be pass-through to avoid changing established cache
-%% semantics.
+%% Other call sites must stay pass-through so established cache
+%% semantics do not change.
 non_authn_calls_are_not_redacted(Config) ->
     Args = [a, b, c],
     {check_vhost_access, Args} =
@@ -131,6 +132,25 @@ different_passwords_still_miss_the_authorization_cache(Config) ->
     {ok, _, _} = authorize(Config, <<"u">>, [{password, <<"p2">>}]),
     2 = authz_call_count(Config).
 
+non_password_authprops_pass_through_unchanged_for_authorization(Config) ->
+    {ok, _, _} = authorize(Config, <<"u">>,
+                           [{password, <<"p">>}, {is_loopback, true}]),
+    {ok, _, _} = authorize(Config, <<"u">>,
+                           [{password, <<"p">>}, {is_loopback, false}]),
+    2 = authz_call_count(Config).
+
+%% With the cache as the only configured backend,
+%% `rabbit_access_control:check_user_login/2' runs both steps through it
+%% with the same AuthProps.
+check_user_login_stores_redacted_authorization_key(Config) ->
+    Password = <<"e2e-secret-marker-c4a1">>,
+    Args = [<<"u">>, [{password, Password}]],
+    {ok, _} = rpc(Config, rabbit_access_control, check_user_login, Args),
+    1 = authz_call_count(Config),
+    {ok, _} = cache_get(Config, cache_key(Config, user_login_authorization, Args)),
+    {error, not_found} = cache_get(Config, {user_login_authorization, Args}),
+    {error, not_found} = cache_get(Config, {user_login_authentication, Args}).
+
 login(Config, Username, AuthProps) ->
     rpc(Config, rabbit_auth_backend_cache, user_login_authentication,
         [Username, AuthProps]).
@@ -149,6 +169,11 @@ authz_call_count(Config) ->
 
 cache_key(Config, F, A) ->
     rpc(Config, rabbit_auth_backend_cache, cache_key, [F, A]).
+
+cache_get(Config, Key) ->
+    {ok, Mod} = rpc(Config, application, get_env,
+                    [rabbitmq_auth_backend_cache, cache_module]),
+    rpc(Config, Mod, get, [Key]).
 
 contains_binary(Term, Needle) when is_binary(Needle) ->
     binary:match(term_to_binary(Term), Needle) =/= nomatch.

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
@@ -5,8 +5,8 @@
 %% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
-%% Tests that the plaintext password never reaches the auth cache key.
-%% Two angles are covered:
+%% Tests that the plaintext password never reaches the auth cache key,
+%% for both authentication and authorization. Two angles are covered:
 %%
 %%  * direct inspection of the key produced by `cache_key/2', confirming
 %%    the password is absent in proplist and map shapes
@@ -23,7 +23,8 @@ all() ->
     [
      password_is_not_present_in_cache_key_for_proplist_authprops,
      password_is_not_present_in_cache_key_for_map_authprops,
-     password_is_not_present_in_authorization_cache_key,
+     password_is_not_present_in_authorization_cache_key_for_proplist_authprops,
+     password_is_not_present_in_authorization_cache_key_for_map_authprops,
      non_authn_calls_are_not_redacted,
      identical_passwords_still_hit_the_cache,
      different_passwords_still_miss_the_cache,
@@ -76,11 +77,15 @@ password_is_not_present_in_cache_key_for_map_authprops(Config) ->
     Key = cache_key(Config, user_login_authentication, [<<"u">>, Props]),
     false = contains_binary(Key, Password).
 
-%% Security invariant: the plaintext password must not appear in the key
-%% produced by `cache_key/2' for authorization either.
-password_is_not_present_in_authorization_cache_key(Config) ->
+password_is_not_present_in_authorization_cache_key_for_proplist_authprops(Config) ->
     Password = <<"authz-secret-marker-5e2d">>,
     Props = [{password, Password}, {is_loopback, false}],
+    Key = cache_key(Config, user_login_authorization, [<<"u">>, Props]),
+    false = contains_binary(Key, Password).
+
+password_is_not_present_in_authorization_cache_key_for_map_authprops(Config) ->
+    Password = <<"authz-secret-marker-2b6f">>,
+    Props = #{password => Password, is_loopback => true},
     Key = cache_key(Config, user_login_authorization, [<<"u">>, Props]),
     false = contains_binary(Key, Password).
 
@@ -115,9 +120,6 @@ non_password_authprops_pass_through_unchanged(Config) ->
                     [{password, <<"p">>}, {is_loopback, false}]),
     2 = call_count(Config).
 
-%% Equality and distinguishability invariants must hold for authorization
-%% too: the redaction fix must not turn every login into a cache miss,
-%% nor collapse distinct passwords into the same key.
 identical_passwords_still_hit_the_authorization_cache(Config) ->
     Props = [{password, <<"p">>}, {is_loopback, false}],
     {ok, _, _} = authorize(Config, <<"u">>, Props),

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_redaction_SUITE.erl
@@ -23,10 +23,13 @@ all() ->
     [
      password_is_not_present_in_cache_key_for_proplist_authprops,
      password_is_not_present_in_cache_key_for_map_authprops,
+     password_is_not_present_in_authorization_cache_key,
      non_authn_calls_are_not_redacted,
      identical_passwords_still_hit_the_cache,
      different_passwords_still_miss_the_cache,
-     non_password_authprops_pass_through_unchanged
+     non_password_authprops_pass_through_unchanged,
+     identical_passwords_still_hit_the_authorization_cache,
+     different_passwords_still_miss_the_authorization_cache
     ].
 
 init_per_suite(Config) ->
@@ -73,8 +76,17 @@ password_is_not_present_in_cache_key_for_map_authprops(Config) ->
     Key = cache_key(Config, user_login_authentication, [<<"u">>, Props]),
     false = contains_binary(Key, Password).
 
-%% Only authentication carries a password; other call sites must be
-%% pass-through to avoid changing established cache semantics.
+%% Security invariant: the plaintext password must not appear in the key
+%% produced by `cache_key/2' for authorization either.
+password_is_not_present_in_authorization_cache_key(Config) ->
+    Password = <<"authz-secret-marker-5e2d">>,
+    Props = [{password, Password}, {is_loopback, false}],
+    Key = cache_key(Config, user_login_authorization, [<<"u">>, Props]),
+    false = contains_binary(Key, Password).
+
+%% Only calls carrying `[Username, AuthProps]' need redaction; other
+%% call sites must be pass-through to avoid changing established cache
+%% semantics.
 non_authn_calls_are_not_redacted(Config) ->
     Args = [a, b, c],
     {check_vhost_access, Args} =
@@ -103,13 +115,35 @@ non_password_authprops_pass_through_unchanged(Config) ->
                     [{password, <<"p">>}, {is_loopback, false}]),
     2 = call_count(Config).
 
+%% Equality and distinguishability invariants must hold for authorization
+%% too: the redaction fix must not turn every login into a cache miss,
+%% nor collapse distinct passwords into the same key.
+identical_passwords_still_hit_the_authorization_cache(Config) ->
+    Props = [{password, <<"p">>}, {is_loopback, false}],
+    {ok, _, _} = authorize(Config, <<"u">>, Props),
+    {ok, _, _} = authorize(Config, <<"u">>, Props),
+    1 = authz_call_count(Config).
+
+different_passwords_still_miss_the_authorization_cache(Config) ->
+    {ok, _, _} = authorize(Config, <<"u">>, [{password, <<"p1">>}]),
+    {ok, _, _} = authorize(Config, <<"u">>, [{password, <<"p2">>}]),
+    2 = authz_call_count(Config).
+
 login(Config, Username, AuthProps) ->
     rpc(Config, rabbit_auth_backend_cache, user_login_authentication,
+        [Username, AuthProps]).
+
+authorize(Config, Username, AuthProps) ->
+    rpc(Config, rabbit_auth_backend_cache, user_login_authorization,
         [Username, AuthProps]).
 
 call_count(Config) ->
     rpc(Config, rabbit_auth_backend_cache_counting_mock,
         authentication_call_count, []).
+
+authz_call_count(Config) ->
+    rpc(Config, rabbit_auth_backend_cache_counting_mock,
+        authorization_call_count, []).
 
 cache_key(Config, F, A) ->
     rpc(Config, rabbit_auth_backend_cache, cache_key, [F, A]).


### PR DESCRIPTION
## Proposed Changes

Passwords stored as keys in ETS were redacted for authentication request but not for authorization requests. 
This was reported by our internal security auditor.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

