### PR TITLE
Revert "Local shovel: enforce read/write ACLs on source/destination (backport #17408)"

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
@@ -15,12 +15,6 @@
 -include_lib("rabbit/include/rabbit_queue_type.hrl").
 -include("rabbit_shovel.hrl").
 
-%% Same size as the rabbit_channel permission cache.
--define(MAX_PERMISSION_CACHE_SIZE, 12).
-%% A permission change does not reach a running shovel, so the cache
-%% expires on a timer.
--define(PERMISSION_CACHE_TTL, 60000).
-
 -rabbit_boot_step({rabbit_global_local_shovel_counters,
                    [{description, "global local shovel counters"},
                     {mfa,         {?MODULE, boot_step,
@@ -295,7 +289,6 @@ connect_dest(State = #{dest := Dest = #{resource_decl := {M, F, MFArgs},
           on_confirm ->
               State#{dest => Dest#{current => #{queue_states => QState,
                                                 delivery_id => 1,
-                                                user => User,
                                                 vhost => VHost},
                                    unconfirmed => rabbit_shovel_confirms:init(),
                                    rejected => [],
@@ -304,7 +297,6 @@ connect_dest(State = #{dest := Dest = #{resource_decl := {M, F, MFArgs},
                                    confirmed_count => 0}};
           _ ->
               State#{dest => Dest#{current => #{queue_states => QState,
-                                                user => User,
                                                 vhost => VHost},
                                    unconfirmed => rabbit_shovel_confirms:init(),
                                    confirmed => [],
@@ -324,13 +316,9 @@ init_source(State = #{source := #{queue_r := QName,
                                   consumer_args := Args,
                                   consumer_name := CTag0,
                                   current := #{queue_states := QState0,
-                                               user := User,
                                                vhost := VHost} = Current} = Src,
                       name := Name,
                       ack_mode := AckMode}) ->
-    %% The consume below bypasses rabbit_channel, so the read check that
-    %% basic.consume performs there has to happen here.
-    ok = check_resource_access(User, QName, read),
     Mode = {credited, ?INITIAL_DELIVERY_COUNT},
     MaxLinkCredit = max_link_credit(),
     CTag = case CTag0 of
@@ -398,8 +386,6 @@ init_dest(#{name := Name,
             dest := #{add_forward_headers := AFH} = Dst} = State) ->
     rabbit_global_counters:publisher_created(?PROTOCOL),
     _TRef = erlang:send_after(1000, self(), send_confirms_and_nacks),
-    %% N.B. the source is checked once, in `init_source/1`.
-    _ = erlang:send_after(?PERMISSION_CACHE_TTL, self(), clear_permission_cache),
     Alarms0 = rabbit_alarm:register(self(), {?MODULE, conserve_resources, []}),
     Alarms = sets:from_list(Alarms0),
     case AFH of
@@ -442,7 +428,7 @@ dest_endpoint(#{dest := #{queue := Queue}}) ->
     [{dest_queue, Queue}];
 dest_endpoint(_Config) ->
     [].
-
+      
 close_dest(_State) ->
     rabbit_global_counters:publisher_deleted(?PROTOCOL),
     ok.
@@ -531,10 +517,6 @@ handle_dest({{'DOWN', #resource{kind = queue,
         {eol, QState1, _QRef} ->
             State0#{dest => Dest#{current => Current#{queue_states => QState1}}}
     end;
-handle_dest(clear_permission_cache, State) ->
-    _TRef = erlang:send_after(?PERMISSION_CACHE_TTL, self(), clear_permission_cache),
-    erase(local_shovel_permission_cache),
-    State;
 handle_dest({conserve_resources, Alarm, Conserve}, #{dest := #{alarms := Alarms0} = Dest} = State0) ->
     Alarms = case Conserve of
                  true -> sets:add_element(Alarm, Alarms0);
@@ -836,33 +818,6 @@ check_queue(QName, _QArgs, VHost, User) ->
                               passive = true},
     decl_fun([Method], VHost, User).
 
-%% Checks the URI user, not the ?SHOVEL_USER identity that performs the
-%% consume and the delivery. The result is cached because the destination
-%% check runs for every forwarded message.
-check_resource_access(User = #user{username = Username}, Resource, Permission) ->
-    Cache = case get(local_shovel_permission_cache) of
-                undefined -> [];
-                C         -> C
-            end,
-    Key = {Resource, Permission},
-    case lists:member(Key, Cache) of
-        true ->
-            ok;
-        false ->
-            try
-                ok = rabbit_access_control:check_resource_access(
-                       User, Resource, Permission, #{}),
-                CacheTail = lists:sublist(Cache, ?MAX_PERMISSION_CACHE_SIZE - 1),
-                put(local_shovel_permission_cache, [Key | CacheTail]),
-                ok
-            catch
-                exit:#amqp_error{name = access_refused} ->
-                    ?LOG_ERROR("Local shovel user ~ts was refused ~ts access to ~ts",
-                               [Username, Permission, rabbit_misc:rs(Resource)]),
-                    exit({shutdown, {access_refused, Username}})
-            end
-    end.
-
 get_user_vhost_from_amqp_param(Uri) ->
     {ok, AmqpParam} = amqp_uri:parse(Uri),
     {Username, Password, VHost} =
@@ -949,16 +904,11 @@ collect_acks(AcknowledgedAcc, RemainingAcc, UAMQ, DeliveryTag, Multiple) ->
            {AcknowledgedAcc, UAMQTail}
     end.
 
-%% In pass-through mode the destination exchange is only known per message,
-%% so the write check happens here rather than at connect time.
 route(_Msg, #{queue_r := QueueR,
-              queue := Queue,
-              current := #{user := User}}) when Queue =/= none ->
-    ok = check_resource_access(User, QueueR, write),
+              queue := Queue}) when Queue =/= none ->
     [QueueR];
-route(Msg, #{current := #{vhost := VHost, user := User}}) ->
+route(Msg, #{current := #{vhost := VHost}}) ->
     ExchangeName = rabbit_misc:r(VHost, exchange, mc:exchange(Msg)),
-    ok = check_resource_access(User, ExchangeName, write),
     Exchange = rabbit_exchange:lookup_or_die(ExchangeName),
     rabbit_exchange:route(Exchange, Msg, #{return_binding_keys => true}).
 

--- a/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
@@ -31,7 +31,7 @@
                             amqp10_expect_empty/2,
                             amqp10_subscribe/2,
                             make_uri/2, make_uri/3,
-                            make_uri/4, make_uri/5,
+                            make_uri/5,
                             await_no_shovel/2
                            ]).
 
@@ -55,17 +55,17 @@ groups() ->
      %% so it messes up all other parallel tests
      {amqp10, [], [{parallel, [parallel], tests()},
                    {sequential, [], [disk_alarm]}]},
-     {local, [parallel], tests() ++ local_src_tests() ++ local_dest_tests() ++ [disk_alarm]},
+     {local, [parallel], tests() ++ [disk_alarm]},
      {amqp091_to_amqp10, [], [{parallel, [parallel], tests()},
                               {sequential, [], [disk_alarm]}]},
-     {amqp091_to_local, [parallel], tests() ++ local_dest_tests() ++ [disk_alarm]},
+     {amqp091_to_local, [parallel], tests() ++ [disk_alarm]},
      {amqp10_to_amqp091, [], [{parallel, [parallel], tests()},
                               {sequential, [], [disk_alarm]}]},
-     {amqp10_to_local, [parallel], tests() ++ local_dest_tests()},
+     {amqp10_to_local, [parallel], tests()},
      {amqp10_to_local, [], [{parallel, [parallel], tests()},
                             {sequential, [], [disk_alarm]}]},
-     {local_to_amqp091, [parallel], tests() ++ local_src_tests() ++ [disk_alarm]},
-     {local_to_amqp10, [], [{parallel, [parallel], tests() ++ local_src_tests()},
+     {local_to_amqp091, [parallel], tests() ++ [disk_alarm]},
+     {local_to_amqp10, [], [{parallel, [parallel], tests()},
                             {sequential, [], [disk_alarm]}]}
     ].
 
@@ -118,20 +118,6 @@ tests() ->
      change_definition,
      consumer_tag
     ].
-
-%% Only meaningful for a local source. With an AMQP 0-9-1 or AMQP 1.0
-%% source, the protocol enforces read access when the consumer is set up,
-%% so the shovel fails to start either way but the local check is never
-%% reached.
-local_src_tests() ->
-    [no_read_access_on_source_queue].
-
-%% Only meaningful for a local destination, where write access is checked
-%% per message. With an AMQP 0-9-1 or AMQP 1.0 destination, the protocol
-%% enforces write access when the publisher is set up, so the shovel never
-%% reaches the running state.
-local_dest_tests() ->
-    [no_write_access_on_dest_queue].
 
 %% -------------------------------------------------------------------
 %% Testsuite setup/teardown.
@@ -575,56 +561,6 @@ no_user_access(Config) ->
            Config, 0, rabbit_runtime_parameters, set,
            [<<"/">>, <<"shovel">>, Param, ShovelArgs, none]),
     await_no_shovel(Config, Param).
-
-%% Grant configure and write but deny read, so only the source-side
-%% permission check can block the shovel from starting.
-no_read_access_on_source_queue(Config) ->
-    Param = ?config(param, Config),
-    RestrictedUser = <<"restricted_", Param/binary>>,
-    rabbit_ct_broker_helpers:add_user(Config, RestrictedUser, RestrictedUser),
-    rabbit_ct_broker_helpers:set_permissions(
-      Config, RestrictedUser, <<"/">>, <<".*">>, <<".*">>, <<"^$">>),
-    Uri = make_uri(Config, 0, RestrictedUser, RestrictedUser),
-    ExtraArgs = [{<<"src-uri">>, Uri}, {<<"dest-uri">>, [Uri]}],
-    ShovelArgs = ?config(shovel_args, Config) ++ ExtraArgs,
-    ok = rabbit_ct_broker_helpers:rpc(
-           Config, 0, rabbit_runtime_parameters, set,
-           [<<"/">>, <<"shovel">>, Param, ShovelArgs, none]),
-    try
-        await_no_shovel(Config, Param)
-    after
-        rabbit_ct_broker_helpers:delete_user(Config, RestrictedUser)
-    end.
-
-%% Grant configure and read but deny write: the shovel starts but must not
-%% forward a message.
-no_write_access_on_dest_queue(Config) ->
-    Src = ?config(srcq, Config),
-    Dest = ?config(destq, Config),
-    Param = ?config(param, Config),
-    RestrictedUser = <<"restricted_", Param/binary>>,
-    rabbit_ct_broker_helpers:add_user(Config, RestrictedUser, RestrictedUser),
-    rabbit_ct_broker_helpers:set_permissions(
-      Config, RestrictedUser, <<"/">>, <<".*">>, <<"^$">>, <<".*">>),
-    Uri = make_uri(Config, 0, RestrictedUser, RestrictedUser),
-    ExtraArgs = [{<<"src-uri">>, Uri}, {<<"dest-uri">>, [Uri]}],
-    ShovelArgs = ?config(shovel_args, Config) ++ ExtraArgs,
-    ok = rabbit_ct_broker_helpers:rpc(
-           Config, 0, rabbit_runtime_parameters, set,
-           [<<"/">>, <<"shovel">>, Param, ShovelArgs, none]),
-    try
-        shovel_test_utils:await_shovel(Config, 0, Param),
-        with_amqp10_session(
-          Config,
-          fun (Sess) ->
-                  SrcAddress = rabbitmq_amqp_address:queue(Src),
-                  DestAddress = rabbitmq_amqp_address:queue(Dest),
-                  amqp10_publish(Sess, SrcAddress, <<"leak-attempt">>, 1),
-                  amqp10_expect_empty(Sess, DestAddress)
-          end)
-    after
-        rabbit_ct_broker_helpers:delete_user(Config, RestrictedUser)
-    end.
 
 application_properties(Config) ->
     Src = ?config(srcq, Config),

--- a/deps/rabbitmq_shovel/test/shovel_test_utils.erl
+++ b/deps/rabbitmq_shovel/test/shovel_test_utils.erl
@@ -20,7 +20,7 @@
          await_running_shovel/1, await_running_shovel/2,
          await_terminated_shovel/1, await_terminated_shovel/2,
          clear_param/2, clear_param/3, make_uri/2,
-         make_uri/3, make_uri/4, make_uri/5,
+         make_uri/3, make_uri/5,
          await_no_shovel/2,
          delete_all_queues/0, delete_queues/1,
          with_amqp10_session/2, with_amqp10_session/3,
@@ -50,15 +50,6 @@ make_uri(Config, Node, VHost) ->
     Port = rabbit_ct_broker_helpers:get_node_config(Config, Node, tcp_port_amqp),
     list_to_binary(lists:flatten(io_lib:format("amqp://~ts:~b/~ts",
                                                [Hostname, Port, VHost]))).
-
-%% No vhost segment: amqp10_client:parse_uri/1 rejects a non-empty path,
-%% so this is the only URI shape for the default vhost that every shovel
-%% protocol accepts.
-make_uri(Config, Node, User, Password) ->
-    Hostname = ?config(rmq_hostname, Config),
-    Port = rabbit_ct_broker_helpers:get_node_config(Config, Node, tcp_port_amqp),
-    list_to_binary(lists:flatten(io_lib:format("amqp://~ts:~ts@~ts:~b",
-                                               [User, Password, Hostname, Port]))).
 
 make_uri(Config, Node, User, Password, VHost) ->
     Hostname = ?config(rmq_hostname, Config),


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-server#17418. Merged too early, it should wait for `4.3.7`.