### PR TITLE
Small fixes in follow-up to a few recent PRs (Sep 11, 2026) (round 2)

### DIFF
--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -1191,16 +1191,28 @@ frame_size_too_small_rejected(Config) ->
 
     ok = mock_server:set_steps(?config(mock_server, Config), Steps),
 
+    ok = logger:add_handler(?FUNCTION_NAME, ?MODULE, #{config => self()}),
     Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
     {ok, Connection} = amqp10_client:open_connection(Cfg),
 
-    %% The reader catches the bad offset math, crashes, and causes the connection to tear down
     receive
         {amqp10_event, {connection, Connection, {closed, _}}} ->
             ok
     after ?TIMEOUT ->
         exit(frame_size_too_small_assert_failed)
-    end.
+    end,
+    receive
+        {log, "AMQP 1.0 framing error: frame length (8) is smaller than header size (12)"} ->
+            ok
+    after ?TIMEOUT ->
+        exit(frame_size_too_small_not_logged)
+    end,
+    ok = logger:remove_handler(?FUNCTION_NAME).
+
+log(#{msg := {Fmt, Args}}, #{config := Pid}) ->
+    Pid ! {log, lists:flatten(io_lib:format(Fmt, Args))};
+log(_, _) ->
+    ok.
 
 
 max_frame_size_exceeded_rejected(Config) ->

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -1195,19 +1195,22 @@ frame_size_too_small_rejected(Config) ->
     Cfg = #{address => Hostname, port => Port, sasl => none, notify => self()},
     {ok, Connection} = amqp10_client:open_connection(Cfg),
 
-    receive
-        {amqp10_event, {connection, Connection, {closed, _}}} ->
-            ok
-    after ?TIMEOUT ->
-        exit(frame_size_too_small_assert_failed)
-    end,
-    receive
-        {log, "AMQP 1.0 framing error: frame length (8) is smaller than header size (12)"} ->
-            ok
-    after ?TIMEOUT ->
-        exit(frame_size_too_small_not_logged)
-    end,
-    ok = logger:remove_handler(?FUNCTION_NAME).
+    try
+        receive
+            {amqp10_event, {connection, Connection, {closed, _}}} ->
+                ok
+        after ?TIMEOUT ->
+            exit(frame_size_too_small_assert_failed)
+        end,
+        receive
+            {log, "AMQP 1.0 framing error: frame length (8) is smaller than header size (12)"} ->
+                ok
+        after ?TIMEOUT ->
+            exit(frame_size_too_small_not_logged)
+        end
+    after
+        ok = logger:remove_handler(?FUNCTION_NAME)
+    end.
 
 log(#{msg := {Fmt, Args}}, #{config := Pid}) ->
     Pid ! {log, lists:flatten(io_lib:format(Fmt, Args))};

--- a/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
@@ -1202,7 +1202,7 @@ state_enter(leader, #?MODULE{groups = Groups,
     [{monitor, node, N} || N <- lists:sort(maps:keys(Nodes))] ++
     [begin
          %% 10 seconds is arbitrary, nothing specific about the value
-         Time = max(10_000, DisTimeout - (ts() - Ts)),
+         Time = max(10_000, min(DisTimeout, DisTimeout - (ts() - Ts))),
          node_disconnected_timer_effect(P, Time)
      end || P := Ts <- maps:iterator(DisConns, ordered)];
 state_enter(_, _) ->

--- a/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
@@ -1201,15 +1201,8 @@ state_enter(leader, #?MODULE{groups = Groups,
     [{monitor, process, P} || P <- lists:sort(maps:keys(PidsGroups))] ++
     [{monitor, node, N} || N <- lists:sort(maps:keys(Nodes))] ++
     [begin
-         Time = case ts() - Ts of
-             T when T < 10_000 ->
-                    %% 10 seconds is arbitrary, nothing specific about the value
-                    10_000;
-             T when T > DisTimeout ->
-                 DisTimeout;
-             T ->
-                 T
-         end,
+         %% 10 seconds is arbitrary, nothing specific about the value
+         Time = max(10_000, DisTimeout - (ts() - Ts)),
          node_disconnected_timer_effect(P, Time)
      end || P := Ts <- maps:iterator(DisConns, ordered)];
 state_enter(_, _) ->

--- a/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
@@ -2017,14 +2017,23 @@ state_enter_test(_) ->
                                       Id1 => grp([csr(P1), csr(P1), csr(P1)]),
                                       Id2 => grp([csr(P0), csr(P1), csr(P1)])})),
 
-    ?assertEqual(lists:sort(mon_node_eff([N0, N1]) ++ mon_proc_eff([P0, P1]) ++ [timer_eff(P1)]),
-                 state_enter_leader(#{Id0 => grp([csr(P0), csr(P1, {disconnected, waiting})]),
-                                      Id2 => grp([csr(P0)])})),
+    %% The timer duration depends on elapsed time since disconnection, so it
+    %% is checked for presence here rather than for an exact value; the
+    %% duration itself is covered by the state_enter_disconnected_timer_*
+    %% tests below.
+    Effects3 = state_enter_leader(#{Id0 => grp([csr(P0), csr(P1, {disconnected, waiting})]),
+                                    Id2 => grp([csr(P0)])}),
+    assertNodeDisconnectedTimerEffectPresent(P1, Effects3),
+    ?assertEqual(lists:sort(mon_node_eff([N0, N1]) ++ mon_proc_eff([P0, P1])),
+                 lists:sort([E || E <- Effects3, not is_timer_eff(E)])),
 
-    ?assertEqual(lists:sort(mon_node_eff([N0, N1, N2]) ++ mon_proc_eff([P0, P1, P2]) ++ timer_eff([P1, P2])),
-                 state_enter_leader(#{Id0 => grp([csr(P0), csr(P1, {disconnected, waiting})]),
-                                      Id1 => grp([csr(P0), csr(P2, {disconnected, waiting})]),
-                                      Id2 => grp([csr(P0), csr(P1, {disconnected, waiting})])})),
+    Effects4 = state_enter_leader(#{Id0 => grp([csr(P0), csr(P1, {disconnected, waiting})]),
+                                    Id1 => grp([csr(P0), csr(P2, {disconnected, waiting})]),
+                                    Id2 => grp([csr(P0), csr(P1, {disconnected, waiting})])}),
+    assertNodeDisconnectedTimerEffectPresent(P1, Effects4),
+    assertNodeDisconnectedTimerEffectPresent(P2, Effects4),
+    ?assertEqual(lists:sort(mon_node_eff([N0, N1, N2]) ++ mon_proc_eff([P0, P1, P2])),
+                 lists:sort([E || E <- Effects4, not is_timer_eff(E)])),
 
     stop_node(N1Pid),
     stop_node(N2Pid),
@@ -2083,11 +2092,8 @@ mon_proc_eff(Pid) ->
     {monitor, process, Pid}.
 
 
-timer_eff(Pids) when is_list(Pids) ->
-    lists:sort([timer_eff(Pid) || Pid <- Pids]);
-timer_eff(Pid) ->
-    {timer, {sac, node_disconnected,
-             #{connection_pid => Pid}}, 10_000}.
+is_timer_eff({timer, {sac, node_disconnected, _}, _}) -> true;
+is_timer_eff(_) -> false.
 
 state_enter_leader(MapState) ->
     lists:sort(?MOD:state_enter(leader, state(MapState))).

--- a/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
@@ -2052,7 +2052,9 @@ state_enter_disconnected_timer_between_bounds_test(_) ->
     ?assert(Time >= 10_000 andalso Time =< 60_000),
     ok.
 
-state_enter_disconnected_timer_over_timeout_test(_) ->
+%% a consumer disconnected for longer than the disconnected timeout gets
+%% the 10s floor, not a full fresh interval
+state_enter_disconnected_timer_past_timeout_test(_) ->
     N0 = node(),
     P0 = new_process(N0),
     P1 = new_process(N0),
@@ -2067,7 +2069,7 @@ state_enter_disconnected_timer_over_timeout_test(_) ->
 
     ?assertEqual(mon_node_eff(N0), MonNode),
     ?assertEqual(mon_proc_eff([P0, P1]), [MonP0, MonP1]),
-    ?assertEqual(60_000, Time),
+    ?assertEqual(10_000, Time),
     ok.
 
 mon_node_eff(Nodes) when is_list(Nodes) ->

--- a/deps/rabbit_common/src/rabbit_net.erl
+++ b/deps/rabbit_common/src/rabbit_net.erl
@@ -230,8 +230,8 @@ get_ssl_connection_pid(Pid) ->
         {monitors, Monitors} ->
             case [ConnPid || {process, ConnPid} <- Monitors,
                              has_linked_port(ConnPid)] of
-                [ConnPid] -> ConnPid;
-                []        -> undefined
+                [ConnPid | _] -> ConnPid;
+                []            -> undefined
             end;
         _ ->
             undefined

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -725,7 +725,7 @@ amqp_token_refresh_vhost_permission(Config) ->
     receive {amqp10_event,
              {connection, Connection,
               {closed, {unauthorized_access, Reason}}}} ->
-                ?assertMatch(<<"access to vhost / failed for new credential:", _/binary>>,
+                ?assertEqual(<<"access to vhost '/' failed for new credential">>,
                              Reason)
     after 5000 -> ct:fail({missing_event, ?LINE})
     end.

--- a/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation_common/include/rabbit_federation.hrl
@@ -43,7 +43,7 @@
 -define(DOWNSTREAM_VHOST_ARG, <<"x-downstream-vhost">>).
 -define(DEF_PREFETCH, 1000).
 -define(DEF_MAX_HOPS, 1).
--define(MIN_MAX_HOPS, 1).
+-define(MIN_MAX_HOPS, 0).
 %% Exchange federation encodes the hop counter as a `short` table field.
 -define(MAX_MAX_HOPS, 32767).
 

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_upstream.erl
@@ -178,7 +178,7 @@ from_upstream_or_set(US, Name, U, XorQ) ->
 %% number. A fractional value used to crash the exchange federation link when
 %% the hop counter was encoded as a `short`, and a value above the `short`
 %% range wrapped around to a negative one.
--spec max_hops(term()) -> pos_integer().
+-spec max_hops(term()) -> non_neg_integer().
 max_hops(N) when is_integer(N) andalso
                  N >= ?MIN_MAX_HOPS andalso
                  N =< ?MAX_MAX_HOPS ->

--- a/deps/rabbitmq_federation_common/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation_common/test/unit_SUITE.erl
@@ -312,12 +312,12 @@ redact_params_ssl_options_none(_Config) ->
 %% -------------------------------------------------------------------
 
 validate_max_hops_accepts_bounds(_Config) ->
-    [?assertEqual([], validation_errors(V)) || V <- [1, 2, 32766, 32767]],
+    [?assertEqual([], validation_errors(V)) || V <- [0, 1, 2, 32766, 32767]],
     ok.
 
 validate_max_hops_rejects_out_of_range(_Config) ->
     [?assertMatch([{error, _, _}], validation_errors(V)) ||
-        V <- [0, -1, -32768, 32768, 100000]],
+        V <- [-1, -32768, 32768, 100000]],
     ok.
 
 validate_max_hops_rejects_non_integers(_Config) ->
@@ -327,7 +327,7 @@ validate_max_hops_rejects_non_integers(_Config) ->
 
 max_hops_keeps_valid_values(_Config) ->
     [?assertEqual(V, rabbit_federation_upstream:max_hops(V)) ||
-        V <- [1, 2, 32766, 32767]],
+        V <- [0, 1, 2, 32766, 32767]],
     ok.
 
 %% Values persisted by versions that did not validate `max-hops` are read
@@ -336,10 +336,10 @@ max_hops_normalizes_legacy_values(_Config) ->
     ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000)),
     ?assertEqual(32767, rabbit_federation_upstream:max_hops(40000.5)),
     ?assertEqual(2, rabbit_federation_upstream:max_hops(2.7)),
-    ?assertEqual(1, rabbit_federation_upstream:max_hops(0)),
-    ?assertEqual(1, rabbit_federation_upstream:max_hops(0.5)),
-    ?assertEqual(1, rabbit_federation_upstream:max_hops(-100)),
-    ?assertEqual(1, rabbit_federation_upstream:max_hops(<<"many">>)),
+    ?assertEqual(0, rabbit_federation_upstream:max_hops(0)),
+    ?assertEqual(0, rabbit_federation_upstream:max_hops(0.5)),
+    ?assertEqual(0, rabbit_federation_upstream:max_hops(-100)),
+    ?assertEqual(0, rabbit_federation_upstream:max_hops(<<"many">>)),
     ok.
 
 %% Goes through the upstream set component because, unlike the upstream one,

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1498,8 +1498,8 @@ function format(template, json) {
     try {
         var fn = COMPILED_TEMPLATES[template];
         if (!fn) throw new Error('Template not found: ' + template);
-        json.settings = window.app_settings;
-        return fn.call(json, json, json);
+        var model = Object.assign({}, json, {settings: window.app_settings});
+        return fn.call(model, model, model);
     } catch (err) {
         clearInterval(timer);
         console.log("Uncaught error: " + err);

--- a/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
@@ -953,8 +953,8 @@ collect_acks(AcknowledgedAcc, RemainingAcc, UAMQ, DeliveryTag, Multiple) ->
 %% so the write check happens here rather than at connect time.
 route(_Msg, #{queue_r := QueueR,
               queue := Queue,
-              current := #{user := User}}) when Queue =/= none ->
-    ok = check_resource_access(User, QueueR, write),
+              current := #{vhost := VHost, user := User}}) when Queue =/= none ->
+    ok = check_resource_access(User, rabbit_misc:r(VHost, exchange, <<>>), write),
     [QueueR];
 route(Msg, #{current := #{vhost := VHost, user := User}}) ->
     ExchangeName = rabbit_misc:r(VHost, exchange, mc:exchange(Msg)),

--- a/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
@@ -131,7 +131,8 @@ local_src_tests() ->
 %% enforces write access when the publisher is set up, so the shovel never
 %% reaches the running state.
 local_dest_tests() ->
-    [no_write_access_on_dest_queue].
+    [no_write_access_on_dest_queue,
+     write_access_on_default_exchange_only].
 
 %% -------------------------------------------------------------------
 %% Testsuite setup/teardown.
@@ -621,6 +622,34 @@ no_write_access_on_dest_queue(Config) ->
                   DestAddress = rabbitmq_amqp_address:queue(Dest),
                   amqp10_publish(Sess, SrcAddress, <<"leak-attempt">>, 1),
                   amqp10_expect_empty(Sess, DestAddress)
+          end)
+    after
+        rabbit_ct_broker_helpers:delete_user(Config, RestrictedUser)
+    end.
+
+write_access_on_default_exchange_only(Config) ->
+    Src = ?config(srcq, Config),
+    Dest = ?config(destq, Config),
+    Param = ?config(param, Config),
+    RestrictedUser = <<"restricted_", Param/binary>>,
+    rabbit_ct_broker_helpers:add_user(Config, RestrictedUser, RestrictedUser),
+    rabbit_ct_broker_helpers:set_permissions(
+      Config, RestrictedUser, <<"/">>, <<".*">>, <<"^amq\\.default$">>, <<".*">>),
+    Uri = make_uri(Config, 0, RestrictedUser, RestrictedUser),
+    ExtraArgs = [{<<"src-uri">>, Uri}, {<<"dest-uri">>, [Uri]}],
+    ShovelArgs = ?config(shovel_args, Config) ++ ExtraArgs,
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, rabbit_runtime_parameters, set,
+           [<<"/">>, <<"shovel">>, Param, ShovelArgs, none]),
+    try
+        shovel_test_utils:await_shovel(Config, 0, Param),
+        with_amqp10_session(
+          Config,
+          fun (Sess) ->
+                  SrcAddress = rabbitmq_amqp_address:queue(Src),
+                  DestAddress = rabbitmq_amqp_address:queue(Dest),
+                  amqp10_publish(Sess, SrcAddress, <<"hello">>, 1),
+                  _ = amqp10_expect_one(Sess, DestAddress)
           end)
     after
         rabbit_ct_broker_helpers:delete_user(Config, RestrictedUser)


### PR DESCRIPTION
Based on https://github.com/rabbitmq/rabbitmq-server/pull/17426 and introduces a JS commit that should not be backported because those "base" changes are for `main`/`4.4.0` only.

#17426 will be merged first.